### PR TITLE
`Edit this page on github`의 타이포를 수정해요.

### DIFF
--- a/docs/src/components/EditLink.tsx
+++ b/docs/src/components/EditLink.tsx
@@ -23,7 +23,7 @@ export default function DocumentEditLink({
       href={`https://github.com/daangn/seed-design/edit/feat/seed-design-web/web/content${slug}/${file}.mdx`}
     >
       <EditIcon width={20} />
-      <span>Edit this page on github</span>
+      <span>Edit this page on GitHub</span>
     </a>
   );
 }


### PR DESCRIPTION
(이삭 줍기)

`Edit this page on github` 버튼의 타이포를 고유 명사에 맞게 `GitHub`로 수정해요.