### PR TITLE
chore: Use setup-node action to cache dependencies

### DIFF
--- a/.github/workflows/deploy-docs-storybook.yml
+++ b/.github/workflows/deploy-docs-storybook.yml
@@ -19,11 +19,11 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: 18.12.1
+          cache: yarn
       
-      - name: 의존성을 설치해요
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: yarn install
+      - name: Install Dependencies
+        run: yarn install --immutable
 
       - name: seed-design/design-token 빌드해요
         working-directory: ./packages/design-token

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -17,11 +17,11 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.12.1'
+          node-version: 18.12.1
+          cache: yarn
       
-      - name: 의존성을 설치해요
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: yarn install
+      - name: Install Dependencies
+        run: yarn install --immutable
 
       - name: seed-design/design-token 빌드해요
         working-directory: ./packages/design-token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,14 +26,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
-          
-      - name: Use cached node_modules
-        uses: actions/cache@v3
-        with:
-          path: node_modules
-          key: nodeModules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            nodeModules-
+          cache: yarn
 
       - name: Install Dependencies
         run: yarn install --immutable


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Updated workflows to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data). `setup-node@v3` or newer has caching **built-in**.

### AS-IS

```yaml
- uses: actions/setup-node@v3
  with:
    node-version: 18.x

- name: Use cached node_modules
  uses: actions/cache@v3
  with:
    path: node_modules
    key: nodeModules-${{ hashFiles('**/yarn.lock') }}
    restore-keys: |
      nodeModules-
```

### TO-BE

```yml
- uses: actions/setup-node@v3
  with:
    node-version: 18.x
    cache: yarn
```

> It’s literally a one line change to pass the `cache: yarn` input parameter.

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)