### PR TITLE
chore(docs): Add external link of storybook for Snackbar

### DIFF
--- a/docs/content/component/snackbar/component-meta.json
+++ b/docs/content/component/snackbar/component-meta.json
@@ -15,7 +15,7 @@
     },
     "react": {
       "status": "done",
-      "path": ""
+      "path": "https://sprout-storybook.vercel.app/?path=/docs/components-snackbar--docs"
     },
     "figma": {
       "status": "todo",


### PR DESCRIPTION
현황판에서 Snackbar 항목에 react done 버튼을 클릭하면 아무일도 발생하지 않아서 추가했어요.