### PR TITLE
SSR에서 navigator 에러 발생하는 문제 해결

### DIFF
--- a/packages/icon/src/templates/component-with-context.ts
+++ b/packages/icon/src/templates/component-with-context.ts
@@ -44,9 +44,18 @@ export function generateComponentWithContext({
       ref,
     ) => {
       const spriteUrl = React.useContext(SeedIconContext);
-      const isMobileSafari =
-        navigator.userAgent.match(/(iPod|iPhone|iPad)/) &&
-        navigator.userAgent.match(/AppleWebKit/);
+      const [isMobileSafari, setIsMobileSafari] = React.useState(false);
+
+      React.useEffect(() => {
+        if (navigator.userAgent.match(/(iPod|iPhone|iPad)/)) {
+          return;
+        }
+
+        if (navigator.userAgent.match(/AppleWebKit/)) {
+          setIsMobileSafari(true);
+        }
+      }, []);
+
       return  (
         <span
           ref={ref}
@@ -63,7 +72,7 @@ export function generateComponentWithContext({
         </span>
       );
     };
-    
+
     export default React.forwardRef(${componentFileName});
 
     type IconName = (

--- a/packages/icon/src/templates/component-with-context.ts
+++ b/packages/icon/src/templates/component-with-context.ts
@@ -47,11 +47,7 @@ export function generateComponentWithContext({
       const [isMobileSafari, setIsMobileSafari] = React.useState(false);
 
       React.useEffect(() => {
-        if (navigator.userAgent.match(/(iPod|iPhone|iPad)/)) {
-          return;
-        }
-
-        if (navigator.userAgent.match(/AppleWebKit/)) {
+        if (navigator.userAgent.match(/(iPod|iPhone|iPad)/) && navigator.userAgent.match(/AppleWebKit/)) {
           setIsMobileSafari(true);
         }
       }, []);


### PR DESCRIPTION
- seed-design-plugin을 사용할 때 node 환경에서 navigator가 없어서 빌드 에러가 발생했어요.
`"navigator" is not available during server-side rendering. Enable "DEV_SSR" to debug this during "gatsby develop".`

- 정확한 문제 해결이 아닌 방향성을 제시하는 차원에서 PR을 생성했어요. (navigator를 호출하는 시점을 조정했어요)
- 다른 컨텍스트가 없어서 이 방향이 맞는지 다른 문제는 없을지 정확히 검증하지 못했어요.
- 이 부분은 디자인시스템 팀에서 코드를 검토해주시면 좋겠어요🙏