### PR TITLE
fix(docs): sidebar size issue

### DIFF
--- a/docs/src/components/sidebar/Sidebar.css.ts
+++ b/docs/src/components/sidebar/Sidebar.css.ts
@@ -86,6 +86,7 @@ export const desktopSidebarContainer = style([
     background: vars.$semantic.color.paperDefault,
 
     width: COMMON_STYLES.SIDEBAR_WIDTH,
+    minWidth: COMMON_STYLES.SIDEBAR_WIDTH,
     height: "100vh",
     transition: "background-color 0.2s ease, color 0.2s ease",
   },


### PR DESCRIPTION
as-is:
<img width="1699" alt="스크린샷 2023-10-10 오후 4 09 35" src="https://github.com/daangn/seed-design/assets/20325202/be32b009-e849-4bd9-9d58-fc5f7826e297">

to-be:
<img width="1699" alt="스크린샷 2023-10-10 오후 4 09 39" src="https://github.com/daangn/seed-design/assets/20325202/10b3cd7c-deca-40b2-80ca-1031243c6350">
