### PR TITLE
fix(docs): gatsby-plugin-seed-design readme

### DIFF
--- a/packages/gatsby-plugin-seed-design/README.md
+++ b/packages/gatsby-plugin-seed-design/README.md
@@ -11,6 +11,8 @@ $ yarn add gatsby-plugin-seed-design
 
 ## 사용법
 
+1. gatsby-config 파일에 plugin을 추가해요.
+
 ```js
 // gatsby-config 파일에 설정을 넣어줘야해요.
 module.exports = {
@@ -32,4 +34,28 @@ module.exports = {
     },
   ],
 };
+```
+
+2. 직접 stylesheet를 활용하거나, `@seed-design/design-token` 을 활용해 값을 넣어요.
+
+```js
+// css-in-js example
+
+export const wrapper = style({
+  color: var(--seed-scale-color-gray-00)
+})
+```
+
+// 혹은
+```console
+yarn add -D @seed-design/design-token
+```
+
+```js
+// css-in-js example
+import { vars } from "@seed-design/design-token"
+
+export const wrapper = style({
+  color: vars.$scale.color.gray00
+})
 ```


### PR DESCRIPTION
gatsby 에 seed-design plugin 을 사용하다가 readme 를 보충하면 좋겠어서,

1. 그냥 plugin만 사용하는 방식 (stylesheet)
2. `@seed-design/design-token` 을 설치하고 사용하는 방식

을 추가했어요.