### PR TITLE
fix(seed-docs): minor errors

### DIFF
--- a/docs/src/components/ComponentDocumentCategoryNav.css.ts
+++ b/docs/src/components/ComponentDocumentCategoryNav.css.ts
@@ -44,8 +44,17 @@ export const navLink = recipe({
   variants: {
     active: {
       true: {
+        position: "relative",
         color: vars.$scale.color.gray700,
-        borderBottom: `3px solid ${vars.$scale.color.gray700}`,
+        selectors: {
+          "&::after": {
+            content: "",
+            position: "absolute",
+            width: "100%",
+            borderBottom: `3px solid ${vars.$scale.color.gray700}`,
+            bottom: "-2px",
+          },
+        },
       },
       false: {
         ":hover": {

--- a/docs/src/components/ComponentDocumentCategoryNav.css.ts
+++ b/docs/src/components/ComponentDocumentCategoryNav.css.ts
@@ -52,7 +52,7 @@ export const navLink = recipe({
             position: "absolute",
             width: "100%",
             borderBottom: `3px solid ${vars.$scale.color.gray700}`,
-            bottom: "-2px",
+            bottom: "-1px",
           },
         },
       },

--- a/docs/src/components/ComponentDocumentCategoryNav.tsx
+++ b/docs/src/components/ComponentDocumentCategoryNav.tsx
@@ -17,8 +17,10 @@ const ComponentDocumentCategoryNav = ({
   const isUsage = /usage/g.test(currentPath);
   const isStyle = /style/g.test(currentPath);
 
-  // NOTE: /component/alert-dialog/overview/ -> /component/alert-dialog/
-  const removedCategoryPath = currentPath.split("/").slice(0, -2).join("/");
+  let removedCategoryPath;
+  if (currentCategory)
+    // NOTE: /component/alert-dialog/overview/ -> /component/alert-dialog/
+    removedCategoryPath = currentPath.split("/").slice(0, -2).join("/");
 
   React.useEffect(() => {
     if (isOverview) {

--- a/docs/src/components/ComponentDocumentCategoryNav.tsx
+++ b/docs/src/components/ComponentDocumentCategoryNav.tsx
@@ -42,6 +42,7 @@ const ComponentDocumentCategoryNav = ({
     <>
       <nav className={style.navContainer}>
         <Link
+          activeClassName=""
           className={style.navLink({
             active: currentCategory === "overview",
           })}
@@ -50,13 +51,19 @@ const ComponentDocumentCategoryNav = ({
           <p className={style.navLinkText}>Overview</p>
         </Link>
         <Link
-          className={style.navLink({ active: currentCategory === "usage" })}
+          activeClassName=""
+          className={style.navLink({
+            active: currentCategory === "usage",
+          })}
           to={`${removedCategoryPath}/usage`}
         >
           <p className={style.navLinkText}>Usage</p>
         </Link>
         <Link
-          className={style.navLink({ active: currentCategory === "style" })}
+          activeClassName=""
+          className={style.navLink({
+            active: currentCategory === "style",
+          })}
           to={`${removedCategoryPath}/style`}
         >
           <p className={style.navLinkText}>Style</p>

--- a/docs/src/components/SEO.tsx
+++ b/docs/src/components/SEO.tsx
@@ -34,12 +34,12 @@ const SEO = ({ name, description }: SEOProps) => {
     setMode(isDark ? "dark" : "light");
   }, []);
 
-  const nameWithPrefix = name ? `${name} | ` : "";
+  const nameWithPrefix = (name ? `${name} | ` : "") + "SEED Design";
 
   return (
     <>
-      <title>{nameWithPrefix}SEED Design</title>
-      <meta property="og:title" content={`${nameWithPrefix}SEED Design`} />
+      <title>{nameWithPrefix}</title>
+      <meta property="og:title" content={nameWithPrefix} />
       <meta property="description" content={description} />
       <meta property="og:image" content={getSrc(data.ogImage!)} />
       {mode === "dark" ? (

--- a/docs/src/components/sidebar/Sidebar.tsx
+++ b/docs/src/components/sidebar/Sidebar.tsx
@@ -101,7 +101,10 @@ const SidebarItemContainer = ({ logo }: { logo?: boolean }) => {
         // 그룹
         if (groupItems?.length! >= 2) {
           return (
-            <SidebarCollapse title={groupName}>
+            <SidebarCollapse
+              key={`${groupItems[0].name}-group`}
+              title={groupName}
+            >
               {groupItems?.map((item) => {
                 const convertedName = item?.name
                   ?.replaceAll(" ", "-")


### PR DESCRIPTION
seed-docs 개발 중에 발생하는 에러를 수정하였습니다.

production에서 유의미한 영향을 주지 않는 에러일 수 있지만 추후 원인을 알 수 없는 에러의 시작이 될 수 있다고 생각합니다.

해당 PR을 통해 아래의 에러를 해결한다면 좋을 것 같습니다.

## [fix: add key attribute to SidebarCollapse](https://github.com/daangn/seed-design/commit/8c67a7e743b7aa2d54407c309c4c89285f8b110b)

`SidebarCollapse`에 존재하지 않는 `key`를 부여하였습니다.

<details>
<summary>에러 사진 보기</summary>
<img width="748" alt="Screenshot 2023-12-17 at 14 57 05" src="https://github.com/daangn/seed-design/assets/48273875/7867bc74-634e-47b2-a95b-41ce35f8e1e7">
</details>

## [fix: removedCategoryPath hydration error](https://github.com/daangn/seed-design/commit/7961e891bc1aa10310076702faeeafeada2f0e87)

`removedCategoryPath`가 서버에서는 `undefined`이고 클라이언트에서는 `currentPath`에 의해 유의미한 값이 설정되어 hydration error가 발생하는 것을 확인하였습니다. `currentPath`의 inconsistency로 인해 발생하는 에러로 확인하였고 `removedCategoryPath`가 이에 의존하도록 수정하였습니다.

<details>
<summary>에러 사진 보기</summary>
<img width="754" alt="Screenshot 2023-12-18 at 21 28 22" src="https://github.com/daangn/seed-design/assets/48273875/9c5aa32c-8fe0-43e4-b343-b20fb183a1f1">
</details>

## [fix: disable activeClassName of Link](https://github.com/daangn/seed-design/commit/30cf54f22c9f0389e1cac6216f348f9a9744b29a)

`gatsby`의 `Link` 컴포넌트는 active한 (url이 매칭되는) path에 대해 자동으로 style을 설정합니다. 이 때문에 hydration error가 나는 것을 확인하여 해당 기능을 비활성화 하였습니다.

<details>
<summary>에러 사진 보기</summary>
<img width="747" alt="Screenshot 2023-12-18 at 21 14 41" src="https://github.com/daangn/seed-design/assets/48273875/f9e87f4b-6dfd-47c1-b13d-12f62f1b69d5">
</details>

## [style: change underline of navLink ComponentDocumentCategoryNav t…](https://github.com/daangn/seed-design/commit/a22f74ed9ec3a3d8ce74d23a6607079d0e016a6b)

underline이 공간을 차지하면서 navigation 간 layout shift가 발생하는 것을 발견하였습니다. `::after`를 통해 underline을 `position: absolute`로 주어 layout shift를 제거하였습니다.

<details>
<summary>수정 사항 보기</summary>
<img width="810" alt="Screenshot 2023-12-18 at 21 50 45" src="https://github.com/daangn/seed-design/assets/48273875/116352cb-9f06-4cb2-a70f-0c2558c70eec">
</details>

## [fix: change nameWithPrefix into a string](https://github.com/daangn/seed-design/commit/b89e0c7d380d64f5fd30d3bc47f729932b885ca1)

`SEO`의 `title`에 삽입하는 `{nameWithPrefix}SEED Design`이 하나의 string이 아니라 `"foo bar |" "SEED Design"`으로 삽입되는 것으로 확인하였습니다. 이로 인해 에러가 나는 것도 확인하여 해당 string을 하나로 만들었습니다.

<details>
<summary>에러 사진 보기</summary>
<img width="1664" alt="Screenshot 2023-12-18 at 21 13 59" src="https://github.com/daangn/seed-design/assets/48273875/4a14e836-a52e-4816-a974-3e1a81781dea">
</details>
