### PR TITLE
docs(seed-docs): fix typo in box button usage

### DIFF
--- a/docs/content/component/box-button/usage.mdx
+++ b/docs/content/component/box-button/usage.mdx
@@ -238,12 +238,14 @@ slug: /component/box-button/usage
 <br />
 
 <DoDontLayout>
-  <DoBox>
-    <DoImage>![box button guideline](./boxbutton-guideline-do-1.png)</DoImage>
-    <DoText>
+  <DontBox>
+    <DontImage>
+      ![box button guideline](./boxbutton-guideline-do-1.png)
+    </DontImage>
+    <DontText>
       Box Button 형태를 임의로 변형하여 Full-Width 타입으로 사용하지 않습니다.
-    </DoText>
-  </DoBox>
+    </DontText>
+  </DontBox>
   <DontBox>
     <DontImage>
       ![box button guideline](./boxbutton-guideline-dont-1.png)


### PR DESCRIPTION
<img width="467" alt="image" src="https://github.com/daangn/seed-design/assets/96626216/4e3e51aa-8b2f-4e59-b501-df2e7c67ccf1">
