### PR TITLE
contrast check 위젯

### DIFF
--- a/tools/figma-contrast-checker/manifest.json
+++ b/tools/figma-contrast-checker/manifest.json
@@ -1,9 +1,11 @@
 {
   "name": "APCA Contrast Widget",
-  "id": "apca-contrast-widget",
+  "id": "1410286424832252877",
   "api": "1.0.0",
   "editorType": ["figma"],
   "permissions": [],
+  "networkAccess": { "allowedDomains": ["none"] },
+  "documentAccess": "dynamic-page",
   "containsWidget": true,
   "main": "dist/code.js",
   "widgetApi": "1.0.0"

--- a/tools/figma-contrast-checker/widget-src/code.tsx
+++ b/tools/figma-contrast-checker/widget-src/code.tsx
@@ -1,7 +1,18 @@
 import { APCAcontrast, displayP3toY, sRGBtoY, fontLookupAPCA } from "apca-w3";
 
 const { widget } = figma;
-const { AutoLayout, Fragment, Text, usePropertyMenu, useSyncedState, useEffect } = widget;
+const {
+  AutoLayout,
+  Fragment,
+  Text,
+  Ellipse,
+  Rectangle,
+  usePropertyMenu,
+  useSyncedState,
+  useEffect,
+} = widget;
+
+const FRAME_PREFIX = "Input";
 
 export const calculateApcaScore = (
   fg: RGB,
@@ -13,7 +24,7 @@ export const calculateApcaScore = (
     const bgY = displayP3toY([bg.r, bg.g, bg.b]);
     const contrast = APCAcontrast(fgY, bgY);
 
-    return Math.round(Number(contrast));
+    return Math.abs(Math.round(Number(contrast)));
   }
 
   const fgDecimal = {
@@ -27,32 +38,70 @@ export const calculateApcaScore = (
     b: bg.b * 255,
   };
 
-  return Math.round(
-    Number(
-      APCAcontrast(
-        sRGBtoY([fgDecimal.r, fgDecimal.g, fgDecimal.b]),
-        sRGBtoY([bgDecimal.r, bgDecimal.g, bgDecimal.b]),
+  return Math.abs(
+    Math.round(
+      Number(
+        APCAcontrast(
+          sRGBtoY([fgDecimal.r, fgDecimal.g, fgDecimal.b]),
+          sRGBtoY([bgDecimal.r, bgDecimal.g, bgDecimal.b]),
+        ),
       ),
     ),
   );
 };
 
-function Widget() {
-  const [result, setResult] = useSyncedState<
-    {
-      bg: { r: number; g: number; b: number };
-      fg: { r: number; g: number; b: number };
-      contrast: number;
-      fontSizes: {
-        regular: number;
-        medium: number;
-        bold: number;
-      };
-    }[]
-  >("result", []);
+const rgbtoHex = (rgb: RGB): string => {
+  const { r, g, b } = rgb;
+  return `#${Math.round(r * 255).toString(16)}${Math.round(g * 255).toString(16)}${Math.round(b * 255).toString(16)}`;
+};
 
-  function update() {
-    const inputFrame = figma.currentPage.findChild((x) => x.name === "Input") as FrameNode | null;
+type Pair = {
+  bg: { r: number; g: number; b: number; name: string };
+  fg: { r: number; g: number; b: number; name: string };
+  contrast: number;
+  fontSizes: {
+    regular: number;
+    medium: number;
+    bold: number;
+  };
+};
+
+function Widget() {
+  const [result, setResult] = useSyncedState<Pair[]>("result", []);
+  const [inputFrames, setInputFrames] = useSyncedState<string[]>("inputFrames", []);
+  const [selectedFrame, setSelectedFrame] = useSyncedState<string>("selectedFrame", "");
+
+  usePropertyMenu(
+    [{ itemType: "action", tooltip: "refresh", propertyName: "refresh" }],
+    ({ propertyName, propertyValue }) => {
+      if (propertyName === "refresh") {
+        loadInputFrames();
+      }
+    },
+  );
+
+  function loadInputFrames() {
+    const inputFrames = figma.currentPage.children
+      .filter((x) => x.name.startsWith(FRAME_PREFIX))
+      .map((frame) => frame.name);
+    console.log(inputFrames);
+    inputFrames.length === 1
+      ? updateResult(inputFrames[0])
+      : inputFrames.length === 0
+        ? setInputFrames([])
+        : setInputFrames(inputFrames);
+  }
+
+  async function updateResult(frameName: string) {
+    console.log("updateResult", frameName);
+    setSelectedFrame(frameName);
+    const inputFrame = figma.currentPage.findChild((x) => x.name === frameName) as FrameNode | null;
+    const variableMap = new Map(
+      (await figma.variables.getLocalVariablesAsync())
+        .filter((x) => x.resolvedType === "COLOR")
+        .map((x) => [x.id, x]),
+    );
+    // const inputFrame = figma.currentPage.findChild((x) => x.name === "Input") as FrameNode | null;
     const colorSpace = figma.root.documentColorProfile;
 
     if (!inputFrame) {
@@ -64,6 +113,9 @@ function Widget() {
       .map((frame) => {
         const bgFills = frame.fills as SolidPaint[];
         const bg = bgFills[0].color;
+        const bgVariableId = frame.boundVariables?.fills?.[0].id;
+        const bgVariable = bgVariableId ? variableMap.get(bgVariableId) : undefined;
+        const bgName = bgVariable?.name ?? "";
 
         const text = frame.children.find((x): x is TextNode => x.type === "TEXT");
         if (!text) {
@@ -72,6 +124,9 @@ function Widget() {
 
         const fgFills = text.fills as SolidPaint[];
         const fg = fgFills[0].color;
+        const fgVariableId = text.boundVariables?.fills?.[0].id;
+        const fgVariable = fgVariableId ? variableMap.get(fgVariableId) : undefined;
+        const fgName = fgVariable?.name ?? "";
 
         const contrast = calculateApcaScore(fg, bg, colorSpace);
 
@@ -82,11 +137,13 @@ function Widget() {
             r: bg.r,
             g: bg.g,
             b: bg.b,
+            name: bgName,
           },
           fg: {
             r: fg.r,
             g: fg.g,
             b: fg.b,
+            name: fgName,
           },
           contrast,
           fontSizes: {
@@ -97,53 +154,497 @@ function Widget() {
         };
       })
       .filter((x): x is NonNullable<typeof x> => x !== null);
+    pairs.sort((a, b) => b.contrast - a.contrast);
 
     setResult(pairs);
   }
 
+  const chunkResult = (pairs: Pair[]) => {
+    const initial: Pair[][] = [[], [], [], [], [], []];
+
+    return pairs.reduce((acc, current) => {
+      if (current.contrast >= 90) {
+        acc[0].push(current);
+      } else if (current.contrast >= 75) {
+        acc[1].push(current);
+      } else if (current.contrast >= 60) {
+        acc[2].push(current);
+      } else if (current.contrast >= 45) {
+        acc[3].push(current);
+      } else if (current.contrast >= 30) {
+        acc[4].push(current);
+      } else {
+        acc[5].push(current);
+      }
+      return acc;
+    }, initial);
+  };
+
   return (
     <AutoLayout
-      onClick={update}
       fill="#FFFFFF"
-      cornerRadius={4}
       direction="vertical"
       height="hug-contents"
-      spacing={12}
-      padding={12}
-      width={720}
+      spacing={16}
+      padding={24}
+      width="hug-contents"
+      cornerRadius={16}
     >
-      {result.map((pair, i) => (
-        <AutoLayout key={i} verticalAlignItems="center" spacing={4} width="fill-parent">
-          <AutoLayout
-            width={48}
-            height={48}
-            verticalAlignItems="center"
-            horizontalAlignItems="center"
-            fill={{
-              r: pair.bg.r,
-              g: pair.bg.g,
-              b: pair.bg.b,
-              a: 1,
-            }}
-          >
-            <Text
-              fill={{
-                r: pair.fg.r,
-                g: pair.fg.g,
-                b: pair.fg.b,
-                a: 1,
-              }}
+      <Text fontSize={32} fontWeight={700} onClick={loadInputFrames}>
+        APCA Contrast Check
+      </Text>
+
+      {inputFrames.length > 1 && (
+        <AutoLayout spacing={8}>
+          {inputFrames.map((frame, i) => (
+            <AutoLayout
+              key={i}
+              onClick={() => updateResult(frame)}
+              fill={selectedFrame === frame ? "#ECEDEF" : "#FFFFFF"}
             >
-              Aa
-            </Text>
-          </AutoLayout>
-          <Text>{Math.abs(pair.contrast).toFixed(2)}</Text>
-          <Text>Regular: {pair.fontSizes.regular}px</Text>
-          <Text>Medium: {pair.fontSizes.medium}px</Text>
-          <Text>Bold: {pair.fontSizes.bold}px</Text>
+              <Text fontSize={16} fontWeight={400}>
+                {frame}
+              </Text>
+            </AutoLayout>
+          ))}
         </AutoLayout>
-      ))}
+      )}
+
+      {chunkResult(result)[0].length > 0 && (
+        <AutoLayout width="hug-contents" direction="vertical" spacing={16}>
+          <SectionTitle title="≥ 90" description="min for very thin text" />
+          <AutoLayout spacing={24} wrap={true} maxWidth={1800} width="hug-contents">
+            {chunkResult(result)[0].map((pair, i) => (
+              <AutoLayout
+                key={i}
+                direction="vertical"
+                width={280}
+                spacing={32}
+                padding={{ bottom: 24 }}
+              >
+                <ContrastScore pair={pair} />
+                <AutoLayout spacing={10} direction="vertical" width="fill-parent">
+                  <AutoLayout direction="vertical" spacing={4} width="fill-parent">
+                    <AutoLayout
+                      fill={{ r: pair.bg.r, g: pair.bg.g, b: pair.bg.b, a: 1 }}
+                      height={60}
+                      width="fill-parent"
+                      padding={{ top: 8, bottom: 8, left: 12, right: 12 }}
+                      cornerRadius={6}
+                    >
+                      <Text
+                        width="fill-parent"
+                        fill={{ r: pair.fg.r, g: pair.fg.g, b: pair.fg.b, a: 1 }}
+                        fontSize={pair.fontSizes.regular}
+                        fontWeight={400}
+                      >
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut et massa mi.
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut et massa mi.
+                      </Text>
+                    </AutoLayout>
+                    <Text fontSize={12} fill="#4D5159">
+                      {" "}
+                      Regular: 최소 {pair.fontSizes.regular}px
+                    </Text>
+                  </AutoLayout>
+
+                  <AutoLayout direction="vertical" spacing={4} width="fill-parent">
+                    <AutoLayout
+                      fill={{ r: pair.bg.r, g: pair.bg.g, b: pair.bg.b, a: 1 }}
+                      height={60}
+                      width="fill-parent"
+                      padding={{ top: 8, bottom: 8, left: 12, right: 12 }}
+                      cornerRadius={6}
+                    >
+                      <Text
+                        width="fill-parent"
+                        fill={{ r: pair.fg.r, g: pair.fg.g, b: pair.fg.b, a: 1 }}
+                        fontSize={pair.fontSizes.medium}
+                        fontWeight={500}
+                      >
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut et massa mi.
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut et massa mi.
+                      </Text>
+                    </AutoLayout>
+                    <Text fontSize={12} fill="#4D5159">
+                      {" "}
+                      Medium: 최소 {pair.fontSizes.medium}px
+                    </Text>
+                  </AutoLayout>
+
+                  <AutoLayout direction="vertical" spacing={4} width="fill-parent">
+                    <AutoLayout
+                      fill={{ r: pair.bg.r, g: pair.bg.g, b: pair.bg.b, a: 1 }}
+                      height={60}
+                      width="fill-parent"
+                      padding={{ top: 8, bottom: 8, left: 12, right: 12 }}
+                      cornerRadius={6}
+                    >
+                      <Text
+                        width="fill-parent"
+                        fill={{ r: pair.fg.r, g: pair.fg.g, b: pair.fg.b, a: 1 }}
+                        fontSize={pair.fontSizes.bold}
+                        fontWeight={700}
+                      >
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut et massa mi.
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut et massa mi.
+                      </Text>
+                    </AutoLayout>
+                    <Text fontSize={12} fill="#4D5159">
+                      {" "}
+                      Bold: 최소 {pair.fontSizes.bold}px
+                    </Text>
+                  </AutoLayout>
+                </AutoLayout>
+              </AutoLayout>
+            ))}
+          </AutoLayout>
+        </AutoLayout>
+      )}
+
+      {chunkResult(result)[1].length > 0 && (
+        <AutoLayout width="hug-contents" direction="vertical" spacing={16}>
+          <AutoLayout direction="vertical" width="fill-parent">
+            <Rectangle height={1} width="fill-parent" fill="#ECEDEF" />
+            <SectionTitle title="≥ 75" description="min for readability-first text" />
+          </AutoLayout>
+          <AutoLayout spacing={24} wrap={true} maxWidth={1800} width="hug-contents">
+            {chunkResult(result)[1].map((pair, i) => (
+              <AutoLayout
+                key={i}
+                direction="vertical"
+                width={280}
+                spacing={32}
+                padding={{ bottom: 24 }}
+              >
+                <ContrastScore pair={pair} />
+                <AutoLayout spacing={10} direction="vertical" width="fill-parent">
+                  <AutoLayout direction="vertical" spacing={4} width="fill-parent">
+                    <AutoLayout
+                      fill={{ r: pair.bg.r, g: pair.bg.g, b: pair.bg.b, a: 1 }}
+                      height={60}
+                      width="fill-parent"
+                      padding={{ top: 8, bottom: 8, left: 12, right: 12 }}
+                      cornerRadius={6}
+                    >
+                      <Text
+                        width="fill-parent"
+                        fill={{ r: pair.fg.r, g: pair.fg.g, b: pair.fg.b, a: 1 }}
+                        fontSize={pair.fontSizes.regular}
+                        fontWeight={400}
+                      >
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut et massa mi.
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut et massa mi.
+                      </Text>
+                    </AutoLayout>
+                    <Text fontSize={12} fill="#4D5159">
+                      {" "}
+                      Regular: 최소 {pair.fontSizes.regular}px
+                    </Text>
+                  </AutoLayout>
+
+                  <AutoLayout direction="vertical" spacing={4} width="fill-parent">
+                    <AutoLayout
+                      fill={{ r: pair.bg.r, g: pair.bg.g, b: pair.bg.b, a: 1 }}
+                      height={60}
+                      width="fill-parent"
+                      padding={{ top: 8, bottom: 8, left: 12, right: 12 }}
+                      cornerRadius={6}
+                    >
+                      <Text
+                        width="fill-parent"
+                        fill={{ r: pair.fg.r, g: pair.fg.g, b: pair.fg.b, a: 1 }}
+                        fontSize={pair.fontSizes.medium}
+                        fontWeight={500}
+                      >
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut et massa mi.
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut et massa mi.
+                      </Text>
+                    </AutoLayout>
+                    <Text fontSize={12} fill="#4D5159">
+                      {" "}
+                      Medium: 최소 {pair.fontSizes.medium}px
+                    </Text>
+                  </AutoLayout>
+
+                  <AutoLayout direction="vertical" spacing={4} width="fill-parent">
+                    <AutoLayout
+                      fill={{ r: pair.bg.r, g: pair.bg.g, b: pair.bg.b, a: 1 }}
+                      height={60}
+                      width="fill-parent"
+                      padding={{ top: 8, bottom: 8, left: 12, right: 12 }}
+                      cornerRadius={6}
+                    >
+                      <Text
+                        width="fill-parent"
+                        fill={{ r: pair.fg.r, g: pair.fg.g, b: pair.fg.b, a: 1 }}
+                        fontSize={pair.fontSizes.bold}
+                        fontWeight={700}
+                      >
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut et massa mi.
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut et massa mi.
+                      </Text>
+                    </AutoLayout>
+                    <Text fontSize={12} fill="#4D5159">
+                      {" "}
+                      Bold: 최소 {pair.fontSizes.bold}px
+                    </Text>
+                  </AutoLayout>
+                </AutoLayout>
+              </AutoLayout>
+            ))}
+          </AutoLayout>
+        </AutoLayout>
+      )}
+
+      {chunkResult(result)[2].length > 0 && (
+        <AutoLayout width="hug-contents" direction="vertical" spacing={16}>
+          <AutoLayout direction="vertical" width="fill-parent">
+            <Rectangle height={1} width="fill-parent" fill="#ECEDEF" />
+            <SectionTitle title="≥ 60" description="min for body text" />
+          </AutoLayout>
+
+          <AutoLayout spacing={24} wrap={true} maxWidth={1800} width="hug-contents">
+            {chunkResult(result)[2].map((pair, i) => (
+              <AutoLayout
+                key={i}
+                direction="vertical"
+                width={280}
+                spacing={32}
+                padding={{ bottom: 24 }}
+              >
+                <ContrastScore pair={pair} />
+                <Examples pair={pair} />
+              </AutoLayout>
+            ))}
+          </AutoLayout>
+        </AutoLayout>
+      )}
+
+      {chunkResult(result)[3].length > 0 && (
+        <AutoLayout width="hug-contents" direction="vertical" spacing={16}>
+          <AutoLayout direction="vertical" width="fill-parent">
+            <Rectangle height={1} width="fill-parent" fill="#ECEDEF" />
+            <SectionTitle title="≥ 45" description="min for large text / icon" />
+          </AutoLayout>
+          <AutoLayout spacing={24} wrap={true} maxWidth={1800} width="hug-contents">
+            {chunkResult(result)[3].map((pair, i) => (
+              <AutoLayout
+                key={i}
+                direction="vertical"
+                width={280}
+                spacing={32}
+                padding={{ bottom: 24 }}
+              >
+                <ContrastScore pair={pair} />
+                <Examples pair={pair} />
+              </AutoLayout>
+            ))}
+          </AutoLayout>
+        </AutoLayout>
+      )}
+
+      {chunkResult(result)[4].length > 0 && (
+        <AutoLayout width="hug-contents" direction="vertical" spacing={16}>
+          <AutoLayout direction="vertical" width="fill-parent">
+            <Rectangle height={1} width="fill-parent" fill="#ECEDEF" />
+            <SectionTitle
+              title="≥ 30"
+              description="min placeholder, disabled text / understandable non-text element"
+            />
+          </AutoLayout>
+
+          <AutoLayout spacing={24} wrap={true} maxWidth={1800} width="hug-contents">
+            {chunkResult(result)[4].map((pair, i) => (
+              <AutoLayout
+                key={i}
+                direction="vertical"
+                width={280}
+                spacing={32}
+                padding={{ bottom: 24 }}
+              >
+                <ContrastScore pair={pair} />
+                <Examples pair={pair} />
+              </AutoLayout>
+            ))}
+          </AutoLayout>
+        </AutoLayout>
+      )}
+
+      {chunkResult(result)[5].length > 0 && (
+        <AutoLayout width="hug-contents" direction="vertical" spacing={16}>
+          <AutoLayout direction="vertical" width="fill-parent">
+            <Rectangle height={1} width="fill-parent" fill="#ECEDEF" />
+            <SectionTitle title="30 >" description="" />
+          </AutoLayout>
+
+          <AutoLayout spacing={24} wrap={true} maxWidth={1800} width="hug-contents">
+            {chunkResult(result)[5].map((pair, i) => (
+              <AutoLayout
+                key={i}
+                direction="vertical"
+                width={280}
+                spacing={32}
+                padding={{ bottom: 24 }}
+              >
+                <ContrastScore pair={pair} />
+                <Examples pair={pair} />
+              </AutoLayout>
+            ))}
+          </AutoLayout>
+        </AutoLayout>
+      )}
     </AutoLayout>
   );
 }
+
+const ContrastScore = ({ pair }: { pair: Pair }) => (
+  <AutoLayout spacing={12} verticalAlignItems="center" width="hug-contents">
+    <AutoLayout
+      minWidth={40}
+      padding={4}
+      height={40}
+      verticalAlignItems="center"
+      horizontalAlignItems="center"
+      fill={{
+        r: pair.bg.r,
+        g: pair.bg.g,
+        b: pair.bg.b,
+        a: 1,
+      }}
+      cornerRadius={6}
+    >
+      <Text
+        fill={{
+          r: pair.fg.r,
+          g: pair.fg.g,
+          b: pair.fg.b,
+          a: 1,
+        }}
+        fontSize={18}
+        fontWeight={700}
+      >
+        {pair.contrast.toFixed()}
+      </Text>
+    </AutoLayout>
+    <AutoLayout spacing={4} direction="vertical">
+      <AutoLayout spacing={4} verticalAlignItems="center">
+        <Ellipse
+          fill={{
+            r: pair.fg.r,
+            g: pair.fg.g,
+            b: pair.fg.b,
+            a: 1,
+          }}
+          height={12}
+          width={12}
+        />
+        <Text fontSize={14} fontWeight={400}>
+          {pair.fg.name} ({rgbtoHex(pair.fg)})
+        </Text>
+      </AutoLayout>
+
+      <AutoLayout spacing={4} verticalAlignItems="center">
+        <Ellipse
+          fill={{
+            r: pair.bg.r,
+            g: pair.bg.g,
+            b: pair.bg.b,
+            a: 1,
+          }}
+          height={12}
+          width={12}
+        />
+        <Text fontSize={14} fontWeight={400}>
+          {pair.bg.name}({rgbtoHex(pair.bg)})
+        </Text>
+      </AutoLayout>
+    </AutoLayout>
+  </AutoLayout>
+);
+
+const SectionTitle = ({ title, description }: { title: string; description: string }) => (
+  <AutoLayout spacing={8} verticalAlignItems="baseline" width="hug-contents" padding={{ top: 24 }}>
+    <Text fontSize={24} fontWeight={700}>
+      {title}
+    </Text>
+    <Text fontSize={16} fontWeight={700}>
+      {description}
+    </Text>
+  </AutoLayout>
+);
+
+const Examples = ({ pair }: { pair: Pair }) => (
+  <AutoLayout spacing={10} direction="vertical" width="fill-parent">
+    <AutoLayout direction="vertical" spacing={4} width="fill-parent">
+      <AutoLayout
+        fill={{ r: pair.bg.r, g: pair.bg.g, b: pair.bg.b, a: 1 }}
+        height={42}
+        width="fill-parent"
+        padding={{ top: 8, bottom: 8, left: 12, right: 12 }}
+        verticalAlignItems="center"
+        cornerRadius={6}
+      >
+        <Text
+          width="fill-parent"
+          fill={{ r: pair.fg.r, g: pair.fg.g, b: pair.fg.b, a: 1 }}
+          fontSize={pair.fontSizes.regular}
+          fontWeight={400}
+        >
+          Label
+        </Text>
+      </AutoLayout>
+      <Text fontSize={12} fill="#4D5159">
+        Regular: 최소 {pair.fontSizes.regular}px
+      </Text>
+    </AutoLayout>
+
+    <AutoLayout direction="vertical" spacing={4} width="fill-parent">
+      <AutoLayout
+        fill={{ r: pair.bg.r, g: pair.bg.g, b: pair.bg.b, a: 1 }}
+        height={42}
+        width="fill-parent"
+        padding={{ top: 8, bottom: 8, left: 12, right: 12 }}
+        verticalAlignItems="center"
+        cornerRadius={6}
+      >
+        <Text
+          width="fill-parent"
+          fill={{ r: pair.fg.r, g: pair.fg.g, b: pair.fg.b, a: 1 }}
+          fontSize={pair.fontSizes.medium}
+          fontWeight={500}
+        >
+          Label
+        </Text>
+      </AutoLayout>
+      <Text fontSize={12} fill="#4D5159">
+        Medium: 최소 {pair.fontSizes.medium}px
+      </Text>
+    </AutoLayout>
+
+    <AutoLayout direction="vertical" spacing={4} width="fill-parent">
+      <AutoLayout
+        fill={{ r: pair.bg.r, g: pair.bg.g, b: pair.bg.b, a: 1 }}
+        height={42}
+        width="fill-parent"
+        padding={{ top: 8, bottom: 8, left: 12, right: 12 }}
+        verticalAlignItems="center"
+        cornerRadius={6}
+      >
+        <Text
+          width="fill-parent"
+          fill={{ r: pair.fg.r, g: pair.fg.g, b: pair.fg.b, a: 1 }}
+          fontSize={pair.fontSizes.bold}
+          fontWeight={700}
+        >
+          Label
+        </Text>
+      </AutoLayout>
+      <Text fontSize={12} fill="#4D5159">
+        Bold: 최소 {pair.fontSizes.bold}px
+      </Text>
+    </AutoLayout>
+  </AutoLayout>
+);
+
 widget.register(Widget);

--- a/tools/figma-contrast-checker/widget-src/logic.ts
+++ b/tools/figma-contrast-checker/widget-src/logic.ts
@@ -1,0 +1,115 @@
+import { APCAcontrast, displayP3toY, sRGBtoY, fontLookupAPCA } from "apca-w3";
+
+export type Pair = {
+  key: string;
+  bg: { r: number; g: number; b: number; name: string };
+  fg: { r: number; g: number; b: number; name: string };
+  contrast: number;
+  fontSizes: {
+    regular: number;
+    medium: number;
+    bold: number;
+  };
+};
+
+export const calculateApcaScore = (
+  fg: RGB,
+  bg: RGB,
+  colorSpace: "LEGACY" | "SRGB" | "DISPLAY_P3",
+): number => {
+  if (colorSpace === "DISPLAY_P3") {
+    const fgY = displayP3toY([fg.r, fg.g, fg.b]);
+    const bgY = displayP3toY([bg.r, bg.g, bg.b]);
+    const contrast = APCAcontrast(fgY, bgY);
+
+    return Math.abs(Math.round(Number(contrast)));
+  }
+
+  const fgDecimal = {
+    r: fg.r * 255,
+    g: fg.g * 255,
+    b: fg.b * 255,
+  };
+  const bgDecimal = {
+    r: bg.r * 255,
+    g: bg.g * 255,
+    b: bg.b * 255,
+  };
+
+  return Math.abs(
+    Math.round(
+      Number(
+        APCAcontrast(
+          sRGBtoY([fgDecimal.r, fgDecimal.g, fgDecimal.b]),
+          sRGBtoY([bgDecimal.r, bgDecimal.g, bgDecimal.b]),
+        ),
+      ),
+    ),
+  );
+};
+
+export const getPairs = (props: {
+  inputFrame: FrameNode;
+  variableMap: Map<string, Variable>;
+  colorSpace: "LEGACY" | "SRGB" | "DISPLAY_P3";
+}): Pair[] => {
+  const { inputFrame, variableMap, colorSpace } = props;
+
+  const createPairData = (bgFrame: FrameNode, fgText: TextNode) => {
+    const bgFills = bgFrame.fills as SolidPaint[];
+    const bg = bgFills[0].color;
+    const bgVariableId = bgFrame.boundVariables?.fills?.[0].id;
+    const bgVariable = bgVariableId ? variableMap.get(bgVariableId) : undefined;
+    const bgName = bgVariable?.name ?? "";
+
+    const fgFills = fgText.fills as SolidPaint[];
+    const fg = fgFills[0].color;
+    const fgVariableId = fgText.boundVariables?.fills?.[0].id;
+    const fgVariable = fgVariableId ? variableMap.get(fgVariableId) : undefined;
+    const fgName = fgVariable?.name ?? "";
+
+    const contrast = calculateApcaScore(fg, bg, colorSpace);
+
+    const [, , , , regular, medium, , bold] = fontLookupAPCA(contrast);
+
+    return {
+      key: `${bgName} - ${fgName}`,
+      bg: {
+        r: bg.r,
+        g: bg.g,
+        b: bg.b,
+        name: bgName,
+      },
+      fg: {
+        r: fg.r,
+        g: fg.g,
+        b: fg.b,
+        name: fgName,
+      },
+      contrast,
+      fontSizes: {
+        regular,
+        medium,
+        bold,
+      },
+    };
+  };
+
+  return inputFrame.children
+    .map((child) => {
+      if (child.type !== "FRAME") {
+        return null;
+      }
+
+      const bgFrame = child as FrameNode;
+      const fgText = child.children.find((x) => x.type === "TEXT");
+
+      if (!bgFrame || !fgText) {
+        return null;
+      }
+
+      return [bgFrame, fgText];
+    })
+    .filter((x): x is [FrameNode, TextNode] => x !== null)
+    .map(([bgFrame, fgText]) => createPairData(bgFrame, fgText));
+};


### PR DESCRIPTION
## Summary

의도한 색상 조합에 대한 APCA Contrast를 Figma에서 추적할 수 있는 위젯을 추가합니다.

## Motivation

![image](https://github.com/user-attachments/assets/1f70d2d1-32c9-499d-bf20-e2e8eadb44b7)
> image from https://ruitina.com/apca-accessible-colour-contrast/

- WCAG 2.x의 색상 대비 공식은 배경색이 밝은 경우가 아닐 때 실제로 사용자가 [인지하는 대비와 차이가 크다는 문제](https://www.cedc.tools/article.html)가 알려져 있습니다.
  - 특히, 당근 브랜드 색상을 사용하는 방식에서 문제가 더 자주 드러나게 됩니다.
- 따라서, [APCA](https://github.com/Myndex/SAPC-APCA) 를 사용해 더 인지적으로 균일한 색상 대비를 계산하고자 합니다.
- 한편, 디자인 시스템 팔레트를 개선하는 과정에서 접근성 충족을 추적하는 것은 쉽지 않았습니다.
- 결론적으로, **APCA 대비 점수**를 사용하며 **Figma에 지속적으로 동기화**되는 Figma Widget을 작성합니다.


## Approach

- 의도한 background / foreground 조합을 Figma의 FrameNode, TextNode로 만들어서 등록합니다.
![Preview](https://github.com/user-attachments/assets/0a05fdcc-3613-42d7-982b-950472d8ffb8)
- 특정 프레임 안에 있는 모든 FrameNode / TextNode 쌍에 대해 APCA 점수를 계산해 위젯에 시각화합니다.
- APCA는 점수에 따라 적합한 {폰트 굵기, 폰트 크기}의 범위를 계산할 수 있는 [테이블](https://github.com/Myndex/apca-w3/?tab=readme-ov-file#font-lookup-table)을 제공하고 있습니다.
- 이를 활용해 각 색상 조합마다 폰트 굵기별로 적합한 최소 폰트 크기를 함께 제시합니다.

## Preview
<img width="711" alt="Screenshot 2024-09-04 at 6 34 50 PM" src="https://github.com/user-attachments/assets/3a9fc9ea-dbdc-42e9-b0ab-435dbc6b3457">

