### PR TITLE
feat: tabs 헤드리스를 개선해요 (키보드 접근성 등)

### DIFF
--- a/packages/react-headless/tabs/src/useTabs.test.tsx
+++ b/packages/react-headless/tabs/src/useTabs.test.tsx
@@ -8,6 +8,16 @@ import * as React from "react";
 
 import { useTabs, type ContentProps, type TriggerProps, type UseTabsProps } from "./index";
 
+/**
+ * @see https://github.com/ZeeCoder/use-resize-observer/issues/40#issuecomment-644536259
+ * useSize에서 사용하는 ResizeObserver를 mock으로 대체합니다.
+ */
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
 function setUp(jsx: ReactElement) {
   return {
     user: userEvent.setup(),
@@ -113,6 +123,8 @@ function UncontrolledTabs({
 afterEach(cleanup);
 
 describe("useTabs", () => {
+  window.ResizeObserver = ResizeObserver;
+
   const tabItems: Record<string, TabItem> = {
     tab1: {
       value: "Tab 1",
@@ -148,6 +160,8 @@ describe("useTabs", () => {
   });
 
   describe("disabled tab test", () => {
+    window.ResizeObserver = ResizeObserver;
+
     const tabItemsWithDisabled: Record<string, TabItem> = {
       tab1: {
         value: "Tab 1",

--- a/packages/react-headless/tabs/src/useTabs.ts
+++ b/packages/react-headless/tabs/src/useTabs.ts
@@ -242,6 +242,14 @@ export function useTabs(props: UseTabsProps) {
             if (itemState.isDisabled) return;
             events.setActiveValue(null);
           },
+          onFocus(event) {
+            events.setFocusedValue(triggerValue);
+            events.setIsFocusVisible(event.target.matches(":focus-visible"));
+          },
+          onBlur() {
+            events.setFocusedValue(null);
+            events.setIsFocusVisible(false);
+          },
         }),
         labelProps: elementProps({
           id: dom.getTabTriggerLabelId(triggerValue, id),

--- a/packages/react-headless/tabs/src/useTabs.ts
+++ b/packages/react-headless/tabs/src/useTabs.ts
@@ -202,8 +202,6 @@ export function useTabs(props: UseTabsProps) {
         "data-disabled": dataAttr(itemState.isDisabled),
         "aria-disabled": ariaAttr(itemState.isDisabled),
         "aria-selected": ariaAttr(itemState.isSelected),
-        tabIndex: itemState.isSelected ? 0 : -1,
-        disabled: isDisabled,
       };
 
       return {
@@ -211,6 +209,8 @@ export function useTabs(props: UseTabsProps) {
           id: dom.getTabTriggerRootId(triggerValue, id),
           role: "tab",
           type: "button",
+          disabled: isDisabled,
+          tabIndex: itemState.isSelected ? 0 : -1,
           ...itemStateProps,
           "data-value": triggerValue,
           "data-orientation": orientation,

--- a/packages/react-headless/tabs/src/useTabs.ts
+++ b/packages/react-headless/tabs/src/useTabs.ts
@@ -34,20 +34,48 @@ function useTabsState(props: UseTabsStateProps & { id: string }) {
   }, [props.id]);
 
   const events = {
-    moveNext: () => {
-      const isLast = currentTabEnabledIndex === tabEnabledValues.length - 1;
-      if (isLast) return;
-
-      const nextIndex = (tabEnabledValues.indexOf(value) + 1) % tabEnabledValues.length;
-      setValue(tabEnabledValues[nextIndex]);
-    },
     movePrev: () => {
       const isFirst = currentTabEnabledIndex === 0;
-      if (isFirst) return;
 
-      const prevIndex =
-        (tabEnabledValues.indexOf(value) - 1 + tabEnabledValues.length) % tabEnabledValues.length;
+      const prevIndex = isFirst
+        ? tabEnabledValues.length - 1
+        : (tabEnabledValues.indexOf(value) - 1 + tabEnabledValues.length) % tabEnabledValues.length;
+
       setValue(tabEnabledValues[prevIndex]);
+    },
+    moveNext: () => {
+      const isLast = currentTabEnabledIndex === tabEnabledValues.length - 1;
+
+      const nextIndex = isLast
+        ? 0
+        : (tabEnabledValues.indexOf(value) + 1) % tabEnabledValues.length;
+
+      setValue(tabEnabledValues[nextIndex]);
+    },
+    focusPrev: () => {
+      const isFirst = currentTabEnabledIndex === 0;
+
+      const prevIndex = isFirst
+        ? tabEnabledValues.length - 1
+        : (tabEnabledValues.indexOf(value) - 1 + tabEnabledValues.length) % tabEnabledValues.length;
+
+      const prevTriggerEl = dom.getTabTriggerEl(tabEnabledValues[prevIndex], props.id);
+
+      if (prevTriggerEl) prevTriggerEl.focus();
+    },
+    focusCurrent: () => {
+      if (triggerEl) triggerEl.focus();
+    },
+    focusNext: () => {
+      const isLast = currentTabEnabledIndex === tabEnabledValues.length - 1;
+
+      const nextIndex = isLast
+        ? 0
+        : (tabEnabledValues.indexOf(value) + 1) % tabEnabledValues.length;
+
+      const nextTriggerEl = dom.getTabTriggerEl(tabEnabledValues[nextIndex], props.id);
+
+      if (nextTriggerEl) nextTriggerEl.focus();
     },
     setValue,
     setHoveredValue,
@@ -249,6 +277,56 @@ export function useTabs(props: UseTabsProps) {
           onBlur() {
             events.setFocusedValue(null);
             events.setIsFocusVisible(false);
+          },
+          onKeyDown({ key }) {
+            if (itemState.isDisabled) return;
+
+            switch (key) {
+              case "ArrowLeft":
+                if (orientation !== "horizontal") return;
+
+                events.movePrev();
+                events.focusPrev();
+
+                break;
+              case "ArrowRight":
+                if (orientation !== "horizontal") return;
+
+                events.moveNext();
+                events.focusNext();
+
+                break;
+              case "ArrowUp":
+                if (orientation !== "vertical") return;
+
+                events.movePrev();
+                events.focusPrev();
+
+                break;
+              case "ArrowDown":
+                if (orientation !== "vertical") return;
+
+                events.moveNext();
+                events.focusNext();
+
+                break;
+              case "Home":
+                events.setValue(tabEnabledValues[0]);
+
+                break;
+              case "End":
+                events.setValue(tabEnabledValues[tabEnabledValues.length - 1]);
+
+                break;
+              case " ":
+              case "Enter":
+                events.setValue(triggerValue);
+
+                events.focusCurrent();
+                events.setIsFocusVisible(true);
+
+                break;
+            }
           },
         }),
         labelProps: elementProps({

--- a/packages/react-headless/tabs/src/useTabs.ts
+++ b/packages/react-headless/tabs/src/useTabs.ts
@@ -207,6 +207,7 @@ export function useTabs(props: UseTabsProps) {
 
     tabTriggerListProps: elementProps({
       id: dom.getTabTriggerListId(id),
+      role: "tablist",
       "aria-orientation": orientation,
       "data-orientation": orientation,
     }),

--- a/packages/react-headless/tabs/src/useTabs.ts
+++ b/packages/react-headless/tabs/src/useTabs.ts
@@ -29,36 +29,27 @@ function useTabsState(props: UseTabsStateProps & { id: string }) {
   const currentTabIndex = dom.getTabIndex(value, props.id);
   const currentTabEnabledIndex = dom.getTabIndexOnlyEnabled(value, props.id);
 
+  const isFirst = currentTabEnabledIndex === 0;
+  const isLast = currentTabEnabledIndex === tabEnabledValues.length - 1;
+
+  const prevIndex = isFirst
+    ? tabEnabledValues.length - 1
+    : (tabEnabledValues.indexOf(value) - 1 + tabEnabledValues.length) % tabEnabledValues.length;
+
+  const nextIndex = isLast ? 0 : (tabEnabledValues.indexOf(value) + 1) % tabEnabledValues.length;
+
   useLayoutEffect(() => {
     setRootEl(dom.getRootEl(props.id));
   }, [props.id]);
 
   const events = {
     movePrev: () => {
-      const isFirst = currentTabEnabledIndex === 0;
-
-      const prevIndex = isFirst
-        ? tabEnabledValues.length - 1
-        : (tabEnabledValues.indexOf(value) - 1 + tabEnabledValues.length) % tabEnabledValues.length;
-
       setValue(tabEnabledValues[prevIndex]);
     },
     moveNext: () => {
-      const isLast = currentTabEnabledIndex === tabEnabledValues.length - 1;
-
-      const nextIndex = isLast
-        ? 0
-        : (tabEnabledValues.indexOf(value) + 1) % tabEnabledValues.length;
-
       setValue(tabEnabledValues[nextIndex]);
     },
     focusPrev: () => {
-      const isFirst = currentTabEnabledIndex === 0;
-
-      const prevIndex = isFirst
-        ? tabEnabledValues.length - 1
-        : (tabEnabledValues.indexOf(value) - 1 + tabEnabledValues.length) % tabEnabledValues.length;
-
       const prevTriggerEl = dom.getTabTriggerEl(tabEnabledValues[prevIndex], props.id);
 
       if (prevTriggerEl) prevTriggerEl.focus();
@@ -67,12 +58,6 @@ function useTabsState(props: UseTabsStateProps & { id: string }) {
       if (triggerEl) triggerEl.focus();
     },
     focusNext: () => {
-      const isLast = currentTabEnabledIndex === tabEnabledValues.length - 1;
-
-      const nextIndex = isLast
-        ? 0
-        : (tabEnabledValues.indexOf(value) + 1) % tabEnabledValues.length;
-
       const nextTriggerEl = dom.getTabTriggerEl(tabEnabledValues[nextIndex], props.id);
 
       if (nextTriggerEl) nextTriggerEl.focus();


### PR DESCRIPTION
- label과 알림 인디케이터에 disabled와 tabIndex prop을 주지 않아요
- 키보드로 조작할 수 있도록 해요
- `tabTriggerListProps`에 role=tablist를 줘요
- focus/blur에 따라 data-focus와 data-focus-visible prop을 줘요