### PR TITLE
fix(pull-to-refresh): ssr behavior, pointer event fallback

### DIFF
--- a/packages/react-headless/pull-to-refresh/src/normalize-event.ts
+++ b/packages/react-headless/pull-to-refresh/src/normalize-event.ts
@@ -1,0 +1,21 @@
+import type * as React from "react";
+
+const isTouchSupported = typeof window !== "undefined" && "ontouchstart" in window;
+
+export const touchStart = isTouchSupported ? "onTouchStart" : "onPointerDown";
+
+export const touchMove = isTouchSupported ? "onTouchMove" : "onPointerMove";
+
+export const touchEnd = isTouchSupported ? "onTouchEnd" : "onPointerUp";
+
+function isTouchEvent(e: React.TouchEvent | React.PointerEvent): e is React.TouchEvent {
+  return e.type === "touchstart" || e.type === "touchmove" || e.type === "touchend";
+}
+
+export function isLeftPress(e: React.TouchEvent | React.PointerEvent) {
+  return isTouchEvent(e) ? e.touches.length === 1 : e.buttons === 1;
+}
+
+export function getClientY(e: React.TouchEvent | React.PointerEvent) {
+  return isTouchEvent(e) ? e.touches[0].clientY : e.clientY;
+}

--- a/packages/react-headless/pull-to-refresh/src/usePullToRefresh.ts
+++ b/packages/react-headless/pull-to-refresh/src/usePullToRefresh.ts
@@ -1,5 +1,6 @@
 import { dataAttr, elementProps } from "@seed-design/dom-utils";
 import { useRef, useState, useSyncExternalStore } from "react";
+import { getClientY, isLeftPress, touchEnd, touchMove } from "./normalize-event";
 import { Store } from "./store";
 
 interface UsePullToRefreshStateProps {
@@ -65,6 +66,7 @@ const contextStore = new Store<PullToRefreshContext>({
 const useContextStore = () => {
   return useSyncExternalStore(
     (listener) => contextStore.subscribe(listener),
+    () => contextStore.getState(),
     () => contextStore.getState(),
   );
 };
@@ -164,11 +166,12 @@ export function usePullToRefresh(props: UsePullToRefreshProps) {
     stateProps,
     rootProps: elementProps({
       ...stateProps,
-      onTouchMove: (e: React.TouchEvent) => {
+      [touchMove]: (e: React.TouchEvent | React.PointerEvent) => {
         if (e.defaultPrevented) return;
-        events.move({ y: e.touches[0].clientY, scrollTop: e.currentTarget.scrollTop });
+        if (!isLeftPress(e)) return;
+        events.move({ y: getClientY(e), scrollTop: e.currentTarget.scrollTop });
       },
-      onTouchEnd: () => {
+      [touchEnd]: () => {
         events.end();
       },
       style: {

--- a/packages/react/src/components/PullToRefresh/PullToRefresh.tsx
+++ b/packages/react/src/components/PullToRefresh/PullToRefresh.tsx
@@ -15,7 +15,7 @@ export const PullToRefreshRoot = withProvider<SVGSVGElement, PullToRefreshRootPr
 
 export interface PullToRefreshIndicatorProps extends PullToRefreshPrimitive.IndicatorProps {}
 
-export const PullToRefreshIndicator = withContext<SVGCircleElement, PullToRefreshIndicatorProps>(
+export const PullToRefreshIndicator = withContext<HTMLDivElement, PullToRefreshIndicatorProps>(
   PullToRefreshPrimitive.Indicator,
   "indicator",
 );


### PR DESCRIPTION
- getServerSnapshot()이 누락된 것을 수정합니다.
- 데스크톱 환경에서도 테스트하기 쉽도록 pointer events fallback을 추가합니다.
  - 터치 환경에서 pointer event를 사용할 시 scroll 동작에 관련된 pointer cancel을 제어하는 것이 까다로우므로, 터치 환경에서는 touch event를 우선시합니다.
  - 참고: https://github.com/framework7io/framework7/blob/b06c88686a20dac0fab815bc8c1fa60b935a7dd6/src/core/modules/touch/touch.js#L532
- PullToRefreshIndicator의 ref type이 잘못 선언된 것을 수정합니다.