### PR TITLE
refactor(qvism): fork postcss-js parser

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -143,13 +143,11 @@
         "change-case": "^5.4.4",
         "lightningcss": "^1.29.1",
         "outdent": "^0.8.0",
-        "postcss": "^8.4.30",
-        "postcss-js": "^4.0.1",
-        "postcss-nested": "^6.0.1",
+        "postcss": "^8.5.3",
+        "postcss-nested": "^7.0.2",
       },
       "devDependencies": {
-        "@types/postcss-js": "^4.0.2",
-        "csstype": "^3.1.2",
+        "csstype": "^3.1.3",
         "typescript": "^5.4.5",
       },
     },
@@ -1169,7 +1167,7 @@
 
     "@fastify/deepmerge": ["@fastify/deepmerge@1.3.0", "", {}, "sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A=="],
 
-    "@figma/plugin-typings": ["@figma/plugin-typings@1.107.0-beta.2", "", {}, "sha512-EFTasm6l3p4QtmnUgCGb0Neeczizk62CqTSNcVh9vYybpctY65kO1w/Da0yuT/WfrdrxD9QZjO8i/ePcZIrqzw=="],
+    "@figma/plugin-typings": ["@figma/plugin-typings@1.107.0", "", {}, "sha512-wC+Wwnk5H22W71xoq4ZQBHuXJL8Q7eMMBP+ubHZjAVybrJRysj/A9gJTIguVEcV+x2zpRsVunyVyWxg56qZr8g=="],
 
     "@figma/rest-api-spec": ["@figma/rest-api-spec@0.23.0", "", {}, "sha512-x7oWMfg8cYv1yGAxqEzq6m0Eg3mzqa96PvrXBLPWbm3xHiA3Zj9KvhfQau2hVi6BCVBW+ZcJYvllg25JXe6y+w=="],
 
@@ -1926,8 +1924,6 @@
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
 
     "@types/parse-path": ["@types/parse-path@7.0.3", "", {}, "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg=="],
-
-    "@types/postcss-js": ["@types/postcss-js@4.0.4", "", { "dependencies": { "postcss": "^8.3.3" } }, "sha512-j5+GMZVIPCJpRTwI/mO64mCzv7X+zAEq3JP0EV2lo/BrLWHAohEubUJimIAY23rH27+wKce0fXUYjAdBoqlaYw=="],
 
     "@types/progress-stream": ["@types/progress-stream@2.0.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-5YNriuEZkHlFHHepLIaxzq3atGeav1qCTGzB74HKWpo66qjfostF+rHc785YYYHeBytve8ZG3ejg42jEIfXNiQ=="],
 
@@ -3591,7 +3587,7 @@
 
     "postcss-modules-values": ["postcss-modules-values@4.0.0", "", { "dependencies": { "icss-utils": "^5.0.0" }, "peerDependencies": { "postcss": "^8.1.0" } }, "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ=="],
 
-    "postcss-nested": ["postcss-nested@6.2.0", "", { "dependencies": { "postcss-selector-parser": "^6.1.1" }, "peerDependencies": { "postcss": "^8.2.14" } }, "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ=="],
+    "postcss-nested": ["postcss-nested@7.0.2", "", { "dependencies": { "postcss-selector-parser": "^7.0.0" }, "peerDependencies": { "postcss": "^8.2.14" } }, "sha512-5osppouFc0VR9/VYzYxO03VaDa3e8F23Kfd6/9qcZTUI8P58GIYlArOET2Wq0ywSl2o2PjELhYOFI4W7l5QHKw=="],
 
     "postcss-normalize-charset": ["postcss-normalize-charset@7.0.0", "", { "peerDependencies": { "postcss": "^8.4.31" } }, "sha512-ABisNUXMeZeDNzCQxPxBCkXexvBrUHV+p7/BXOY+ulxkcjUZO0cp8ekGBwvIh2LbCwnWbyMPNJVtBSdyhM2zYQ=="],
 
@@ -4591,8 +4587,6 @@
 
     "@seed-design/figma-v3-migration/tailwindcss": ["tailwindcss@3.4.14", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.5.3", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.0", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.0", "lilconfig": "^2.1.0", "micromatch": "^4.0.5", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.0.0", "postcss": "^8.4.23", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.1", "postcss-nested": "^6.0.1", "postcss-selector-parser": "^6.0.11", "resolve": "^1.22.2", "sucrase": "^3.32.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-IcSvOcTRcUtQQ7ILQL5quRDg7Xs93PdJEk1ZLbhhvJc7uj/OAhYOnruEiwnGgBvUtaUAJ8/mhSw1o8L2jCiENA=="],
 
-    "@seed-design/qvism-core/postcss": ["postcss@8.5.1", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ=="],
-
     "@seed-design/stackflow-spa/@daangn/react-monochrome-icon": ["@daangn/react-monochrome-icon@0.0.14", "https://npm.pkg.github.com/download/@daangn/react-monochrome-icon/0.0.14/3f3426bb4125879dfd5bb1c7863dcd0bf0770784", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-P12RUaGmcBXKd43P4BtL4cDG1knQ8hwCdFyS0JEtm/VDUWrfJU/WV+jARXiLj64YTQg3CrhMZWYQFyvojd2waQ=="],
 
     "@shikijs/rehype/@shikijs/types": ["@shikijs/types@2.5.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw=="],
@@ -4650,8 +4644,6 @@
     "@types/jscodeshift/ast-types": ["ast-types@0.14.2", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA=="],
 
     "@types/jscodeshift/recast": ["recast@0.20.5", "", { "dependencies": { "ast-types": "0.14.2", "esprima": "~4.0.0", "source-map": "~0.6.1", "tslib": "^2.0.1" } }, "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ=="],
-
-    "@types/postcss-js/postcss": ["postcss@8.5.1", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ=="],
 
     "@vanilla-extract/compiler/vite": ["vite@6.1.0", "", { "dependencies": { "esbuild": "^0.24.2", "postcss": "^8.5.1", "rollup": "^4.30.1" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ=="],
 
@@ -4956,8 +4948,6 @@
     "postcss-modules-local-by-default/postcss-selector-parser": ["postcss-selector-parser@7.1.0", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA=="],
 
     "postcss-modules-scope/postcss-selector-parser": ["postcss-selector-parser@7.1.0", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA=="],
-
-    "postcss-nested/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
     "postcss-unique-selectors/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
@@ -5481,8 +5471,6 @@
 
     "@seed-design/figma-v3-migration/@create-figma-plugin/build/find-up": ["find-up@7.0.0", "", { "dependencies": { "locate-path": "^7.2.0", "path-exists": "^5.0.0", "unicorn-magic": "^0.1.0" } }, "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g=="],
 
-    "@seed-design/figma-v3-migration/@create-figma-plugin/build/postcss": ["postcss@8.5.1", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ=="],
-
     "@seed-design/figma-v3-migration/concurrently/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@seed-design/figma-v3-migration/concurrently/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
@@ -5492,6 +5480,8 @@
     "@seed-design/figma-v3-migration/tailwindcss/jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
 
     "@seed-design/figma-v3-migration/tailwindcss/postcss": ["postcss@8.5.1", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ=="],
+
+    "@seed-design/figma-v3-migration/tailwindcss/postcss-nested": ["postcss-nested@6.2.0", "", { "dependencies": { "postcss-selector-parser": "^6.1.1" }, "peerDependencies": { "postcss": "^8.2.14" } }, "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ=="],
 
     "@seed-design/figma-v3-migration/tailwindcss/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
@@ -6194,6 +6184,8 @@
     "@seed-design/figma-v3-migration/tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "@seed-design/figma-v3-migration/tailwindcss/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "@seed-design/figma-v3-migration/tailwindcss/postcss-nested/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
     "@shikijs/rehype/shiki/@shikijs/engine-javascript/oniguruma-to-es": ["oniguruma-to-es@3.1.0", "", { "dependencies": { "emoji-regex-xs": "^1.0.0", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-BJ3Jy22YlgejHSO7Fvmz1kKazlaPmRSUH+4adTDUS/dKQ4wLxI+gALZ8updbaux7/m7fIlpgOZ5fp/Inq5jUAw=="],
 

--- a/ecosystem/qvism/core/package.json
+++ b/ecosystem/qvism/core/package.json
@@ -31,13 +31,11 @@
     "change-case": "^5.4.4",
     "lightningcss": "^1.29.1",
     "outdent": "^0.8.0",
-    "postcss": "^8.4.30",
-    "postcss-js": "^4.0.1",
-    "postcss-nested": "^6.0.1"
+    "postcss": "^8.5.3",
+    "postcss-nested": "^7.0.2"
   },
   "devDependencies": {
-    "@types/postcss-js": "^4.0.2",
-    "csstype": "^3.1.2",
+    "csstype": "^3.1.3",
     "typescript": "^5.4.5"
   },
   "publishConfig": {

--- a/ecosystem/qvism/core/src/css.ts
+++ b/ecosystem/qvism/core/src/css.ts
@@ -1,9 +1,9 @@
 import postcss from "postcss";
-import postcssJs from "postcss-js";
 import postcssNested from "postcss-nested";
 
 import { transform } from "lightningcss";
 import { compact } from "./compact";
+import parseCssJs from "./parser";
 import type {
   Config,
   CssKeyframes,
@@ -24,7 +24,7 @@ export function generateBaseRules(definition: RecipeDefinition, options: { prefi
       if (!style) {
         return undefined;
       }
-      const parsed = postcssJs.parse(style);
+      const parsed = parseCssJs(style);
       return postcss.rule({
         selector: `.${name}__${slot}`,
         nodes: parsed.nodes,
@@ -45,7 +45,7 @@ export function generateVariantRules(
           if (!style) {
             return undefined;
           }
-          const parsed = postcssJs.parse(style);
+          const parsed = parseCssJs(style);
           return postcss.rule({
             selector: `.${name}__${slot}--${variantName}_${variantValue}`,
             nodes: parsed.nodes,
@@ -71,7 +71,7 @@ export function generateCompoundVariantRules(
         const selector = `.${name}__${slot}--${Object.entries(selection)
           .map(([variantName, variantValue]) => `${variantName}_${variantValue}`)
           .join("-")}`;
-        const parsed = postcssJs.parse(style);
+        const parsed = parseCssJs(style);
 
         return postcss.rule({
           selector: selector,
@@ -84,7 +84,7 @@ export function generateCompoundVariantRules(
 
 export function generateKeyframeRules(definitions: CssKeyframes) {
   return Object.entries(definitions ?? {}).flatMap(([name, keyframe]) => {
-    const parsed = postcssJs.parse(keyframe);
+    const parsed = parseCssJs(keyframe);
     return postcss.atRule({
       name: "keyframes",
       params: name,
@@ -100,7 +100,7 @@ export async function transpileRulesToCss(rules: postcss.ChildNode[]): Promise<s
 
   const css = await postcss([postcssNested()])
     // @ts-expect-error
-    .process(root, { from: undefined, parser: postcssJs })
+    .process(root, { from: undefined, parser: parseCssJs })
     .then((result) => {
       return result.css;
     });
@@ -148,7 +148,7 @@ export async function generateCssEach(config: Config): Promise<{ name: string; c
 export async function generateCssBundle(config: Config): Promise<string> {
   const { minify = false, prefix, theme } = config;
   const options = { prefix };
-  const globalRules = postcssJs.parse(config.theme.globalCss ?? {}).nodes;
+  const globalRules = parseCssJs(config.theme.globalCss ?? {}).nodes;
   const tokenRules = generateTokenRules(theme.tokens);
   const recipeRules = Object.values(theme.recipes).flatMap((recipe) =>
     generateRecipeRules(recipe, options),

--- a/ecosystem/qvism/core/src/parser.ts
+++ b/ecosystem/qvism/core/src/parser.ts
@@ -1,0 +1,132 @@
+// Forked from https://github.com/postcss/postcss-js/blob/91d72b586410d1711089b14473b14bb59cfd8976/parser.js
+
+import postcss, { Root, Container } from 'postcss';
+
+const IMPORTANT: RegExp = /\s*!important\s*$/i;
+
+const UNITLESS: Record<string, boolean> = {
+  'box-flex': true,
+  'box-flex-group': true,
+  'column-count': true,
+  'flex': true,
+  'flex-grow': true,
+  'flex-positive': true,
+  'flex-shrink': true,
+  'flex-negative': true,
+  'font-weight': true,
+  'line-clamp': true,
+  'line-height': true,
+  'opacity': true,
+  'order': true,
+  'orphans': true,
+  'tab-size': true,
+  'widows': true,
+  'z-index': true,
+  'zoom': true,
+  'fill-opacity': true,
+  'stroke-dashoffset': true,
+  'stroke-opacity': true,
+  'stroke-width': true,
+};
+
+function dashify(str: string): string {
+  return str
+    .replace(/([A-Z])/g, '-$1')
+    .replace(/^ms-/, '-ms-')
+    .toLowerCase();
+}
+
+// Define types for the CSS object structure.
+type CSSValue = string | number | boolean | null | undefined;
+type CSSObject = Record<string, any>;
+
+// A type guard to determine if a value is a primitive (CSSValue)
+function isPrimitive(value: unknown): value is CSSValue {
+  return (
+    value === null ||
+    value === undefined ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  );
+}
+
+function decl(parent: Container, name: string, value: CSSValue): void {
+  if (value === false || value === null || value === undefined) return;
+
+  if (!name.startsWith('--')) {
+    name = dashify(name);
+  }
+
+  let valueStr: string;
+  if (typeof value === 'number') {
+    // Append 'px' if needed
+    valueStr = (value === 0 || UNITLESS[name])
+      ? value.toString()
+      : value + 'px';
+  } else {
+    valueStr = String(value);
+  }
+
+  if (name === 'css-float') name = 'float';
+
+  if (IMPORTANT.test(valueStr)) {
+    valueStr = valueStr.replace(IMPORTANT, '');
+    parent.push(postcss.decl({ prop: name, value: valueStr, important: true }));
+  } else {
+    parent.push(postcss.decl({ prop: name, value: valueStr }));
+  }
+}
+
+function atRule(parent: Container, parts: RegExpMatchArray | null, value: any): void {
+  if (!parts) {
+    throw new Error("Invalid at-rule format");
+  }
+  const atRuleName = parts[1]!;
+  const params = parts[3] ? parts[3].trim() : '';
+  const node = postcss.atRule({ name: atRuleName, params });
+  // If the value is an object (and not an array), parse its content as child nodes.
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    node.nodes = [];
+    parse(value as CSSObject, node);
+  }
+  parent.push(node);
+}
+
+function parse(obj: CSSObject, parent: Container): void {
+  for (const name of Object.keys(obj)) {
+    const value = obj[name];
+    if (value === null || typeof value === 'undefined') {
+      continue;
+    } else if (name[0] === '@') {
+      // Match at-rule format like "@media screen and (min-width: 900px)"
+      const parts = name.match(/@(\S+)(\s+([\W\w]*)\s*)?/);
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          atRule(parent, parts, item);
+        }
+      } else {
+        atRule(parent, parts, value);
+      }
+    } else if (Array.isArray(value)) {
+      for (const item of value) {
+        if (!isPrimitive(item)) {
+          throw new Error("Unexpected CSSObject in array; expected CSSValue");
+        }
+        decl(parent, name, item);
+      }
+    } else if (typeof value === 'object') {
+      const node = postcss.rule({ selector: name });
+      parse(value as CSSObject, node);
+      parent.push(node);
+    } else {
+      decl(parent, name, value);
+    }
+  }
+}
+
+export default function parseCssJs(obj: CSSObject): Root {
+  const root = postcss.root();
+  parse(obj, root);
+  return root;
+}


### PR DESCRIPTION
Since [postcss-js](https://github.com/postcss/postcss-js) is not actively maintained, we fork and migrate postcss-js parser to TypeScript. This change ensures compatibility with the latest PostCSS type definitions, while preparing future enhancements.