### PR TITLE
feat: provide v3-compatible background colors for legacy stylesheet

### DIFF
--- a/packages/stylesheet/global.css
+++ b/packages/stylesheet/global.css
@@ -206,6 +206,8 @@
   --seed-scale-color-gray-700: #4d5159;
   --seed-scale-color-gray-800: #393a40;
   --seed-scale-color-gray-900: #212124;
+  --seed-scale-color-v3-gray-00: #ffffff;
+  --seed-scale-color-v3-gray-100: #f7f8f9;
   --seed-scale-color-carrot-50: #fff5f0;
   --seed-scale-color-carrot-100: #ffe2d2;
   --seed-scale-color-carrot-200: #ffd2b9;
@@ -358,6 +360,8 @@
   --seed-scale-color-gray-700: #adb1ba;
   --seed-scale-color-gray-800: #ced3de;
   --seed-scale-color-gray-900: #eaebee;
+  --seed-scale-color-v3-gray-00: #000000;
+  --seed-scale-color-v3-gray-100: #16171b;
   --seed-scale-color-carrot-50: #7a3814;
   --seed-scale-color-carrot-100: #974011;
   --seed-scale-color-carrot-200: #bf4c0d;
@@ -464,12 +468,12 @@
   --seed-semantic-color-warning-low: var(--seed-scale-color-yellow-alpha-50);
   --seed-semantic-color-danger: var(--seed-scale-color-red-400);
   --seed-semantic-color-danger-low: var(--seed-scale-color-red-alpha-50);
-  --seed-semantic-color-paper-sheet: var(--seed-scale-color-gray-50);
+  --seed-semantic-color-paper-sheet: var(--seed-scale-color-v3-gray-100);
   --seed-semantic-color-paper-dialog: var(--seed-scale-color-gray-100);
   --seed-semantic-color-paper-floating: var(--seed-scale-color-gray-100);
-  --seed-semantic-color-paper-contents: var(--seed-scale-color-gray-00);
-  --seed-semantic-color-paper-default: var(--seed-scale-color-gray-50);
-  --seed-semantic-color-paper-background: var(--seed-scale-color-gray-00);
+  --seed-semantic-color-paper-contents: var(--seed-scale-color-v3-gray-00);
+  --seed-semantic-color-paper-default: var(--seed-scale-color-v3-gray-100);
+  --seed-semantic-color-paper-background: var(--seed-scale-color-v3-gray-00);
   --seed-semantic-color-paper-accent: var(--seed-scale-color-gray-100);
   --seed-semantic-color-primary-hover: var(--seed-scale-color-carrot-600);
   --seed-semantic-color-primary-pressed: var(--seed-scale-color-carrot-600);


### PR DESCRIPTION
## 배경
V3 color의 주요 변경점 중 하나는 다크모드의 기본 배경 색상 변경입니다. V3 마이그레이션이 점진적으로 진행되더라도, 다크모드 배경색이 페이지마다 다르면 일관되지 않은 사용자 경험을 초래할 수 있습니다.

이러한 문제를 방지하기 위해, 기존 스타일시트에서 사용되는 다크모드 주요 배경 색상에 V3 color와 동일한 다크모드 색상을 적용합니다.

## 변경사항
- global.css에 v3-gray-00, v3-gray-100 scale token을 추가
  - 이는 V3 호환성을 위한 색상이며, 직접 사용하는 것은 권장되지 않음
- 다크모드 주요 배경 색상을 v3-gray-00, v3-gray-100으로 업데이트

## 영향
- V3로 마이그레이션하는 동안 다크모드 배경색이 페이지마다 달라지는 문제 방지
- 기존 스타일과 충돌을 최소화하면서 V3 color와의 호환성을 제공

## 기타
이 변경은 V3 마이그레이션을 원활하게 진행하기 위한 임시 조치이며, codemod를 통한 V3 파운데이션 전환을 권장합니다.