### PR TITLE
refactor: createRecipeContext

### DIFF
--- a/packages/react/src/components/ActionButton/ActionButton.tsx
+++ b/packages/react/src/components/ActionButton/ActionButton.tsx
@@ -5,15 +5,12 @@ import {
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";
 import clsx from "clsx";
 import * as React from "react";
-import { createRecipeContext } from "../../utils/createRecipeContext";
 import { IconRequired } from "../Icon/Icon";
 import {
   PendingButtonProvider,
   usePendingButton,
   type UsePendingButtonProps,
 } from "../LoadingIndicator/usePendingButton";
-
-const { ClassNameProvider } = createRecipeContext(actionButton);
 
 export interface ActionButtonProps
   extends ActionButtonVariantProps,
@@ -36,20 +33,18 @@ export const ActionButton = React.forwardRef<HTMLButtonElement, ActionButtonProp
     }
 
     return (
-      <ClassNameProvider value={recipeClassName}>
-        <PendingButtonProvider value={api}>
-          <IconRequired enabled={layout === "iconOnly"}>
-            <Primitive.button
-              ref={ref}
-              className={clsx(recipeClassName, className)}
-              {...api.stateProps}
-              {...otherProps}
-            >
-              {children}
-            </Primitive.button>
-          </IconRequired>
-        </PendingButtonProvider>
-      </ClassNameProvider>
+      <PendingButtonProvider value={api}>
+        <IconRequired enabled={layout === "iconOnly"}>
+          <Primitive.button
+            ref={ref}
+            className={clsx(recipeClassName, className)}
+            {...api.stateProps}
+            {...otherProps}
+          >
+            {children}
+          </Primitive.button>
+        </IconRequired>
+      </PendingButtonProvider>
     );
   },
 );

--- a/packages/react/src/components/ActionChip/ActionChip.tsx
+++ b/packages/react/src/components/ActionChip/ActionChip.tsx
@@ -4,7 +4,7 @@ import type * as React from "react";
 import { createRecipeContext } from "../../utils/createRecipeContext";
 import { withIconRequired } from "../Icon/Icon";
 
-const { withProvider } = createRecipeContext(actionChip);
+const { withContext } = createRecipeContext(actionChip);
 
 export interface ActionChipProps
   extends ActionChipVariantProps,
@@ -12,7 +12,7 @@ export interface ActionChipProps
     React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 export const ActionChip = withIconRequired(
-  withProvider<HTMLButtonElement, ActionChipProps>(Primitive.button),
+  withContext<HTMLButtonElement, ActionChipProps>(Primitive.button),
   (props: ActionChipProps) => props.layout === "iconOnly",
 );
 ActionChip.displayName = "ActionChip";

--- a/packages/react/src/components/ActionSheet/ActionSheet.tsx
+++ b/packages/react/src/components/ActionSheet/ActionSheet.tsx
@@ -11,7 +11,7 @@ import { createSlotRecipeContext } from "../../utils/createSlotRecipeContext";
 import { createWithStateProps } from "../../utils/createWithStateProps";
 
 const { withRootProvider, withContext } = createSlotRecipeContext(actionSheet);
-const { withProvider: withItemProvider } = createRecipeContext(actionSheetItem);
+const { withContext: withItemContext } = createRecipeContext(actionSheetItem);
 const withStateProps = createWithStateProps([useDialogContext]);
 
 ////////////////////////////////////////////////////////////////////////////////////
@@ -103,7 +103,7 @@ export interface ActionSheetItemProps
     ActionSheetItemVariantProps,
     React.HTMLAttributes<HTMLButtonElement> {}
 
-export const ActionSheetItem = withItemProvider<HTMLButtonElement, ActionSheetItemProps>(
+export const ActionSheetItem = withItemContext<HTMLButtonElement, ActionSheetItemProps>(
   withStateProps(Primitive.button),
 );
 

--- a/packages/react/src/components/Badge/Badge.tsx
+++ b/packages/react/src/components/Badge/Badge.tsx
@@ -3,7 +3,7 @@ import { badge, type BadgeVariantProps } from "@seed-design/css/recipes/badge";
 import type * as React from "react";
 import { createRecipeContext } from "../../utils/createRecipeContext";
 
-const { withProvider } = createRecipeContext(badge);
+const { withContext } = createRecipeContext(badge);
 
 ////////////////////////////////////////////////////////////////////////////////////
 
@@ -12,4 +12,4 @@ export interface BadgeProps
     PrimitiveProps,
     React.HTMLAttributes<HTMLSpanElement> {}
 
-export const Badge = withProvider<HTMLSpanElement, BadgeProps>(Primitive.span);
+export const Badge = withContext<HTMLSpanElement, BadgeProps>(Primitive.span);

--- a/packages/react/src/components/ControlChip/ControlChip.tsx
+++ b/packages/react/src/components/ControlChip/ControlChip.tsx
@@ -4,7 +4,7 @@ import type * as React from "react";
 import { createRecipeContext } from "../../utils/createRecipeContext";
 import { withIconRequired } from "../Icon/Icon";
 
-const { withProvider } = createRecipeContext(controlChip);
+const { withContext } = createRecipeContext(controlChip);
 
 export interface ControlChipBaseProps extends PrimitiveProps, ControlChipVariantProps {}
 
@@ -13,6 +13,6 @@ export interface ControlChipProps
     React.HTMLAttributes<HTMLButtonElement> {}
 
 export const ControlChip = withIconRequired(
-  withProvider<HTMLButtonElement, ControlChipProps>(Primitive.button),
+  withContext<HTMLButtonElement, ControlChipProps>(Primitive.button),
   (props: ControlChipProps) => props.layout === "iconOnly",
 );

--- a/packages/react/src/components/ExtendedActionSheet/ExtendedActionSheet.tsx
+++ b/packages/react/src/components/ExtendedActionSheet/ExtendedActionSheet.tsx
@@ -14,7 +14,7 @@ import { createSlotRecipeContext } from "../../utils/createSlotRecipeContext";
 import { createWithStateProps } from "../../utils/createWithStateProps";
 
 const { withRootProvider, withContext } = createSlotRecipeContext(extendedActionSheet);
-const { withProvider: withItemProvider } = createRecipeContext(extendedActionSheetItem);
+const { withContext: withItemContext } = createRecipeContext(extendedActionSheetItem);
 const withStateProps = createWithStateProps([useDialogContext]);
 
 ////////////////////////////////////////////////////////////////////////////////////
@@ -113,7 +113,7 @@ export interface ExtendedActionSheetItemProps
     ExtendedActionSheetItemVariantProps,
     React.HTMLAttributes<HTMLButtonElement> {}
 
-export const ExtendedActionSheetItem = withItemProvider<
+export const ExtendedActionSheetItem = withItemContext<
   HTMLButtonElement,
   ExtendedActionSheetItemProps
 >(withStateProps(Primitive.button));

--- a/packages/react/src/components/ExtendedFab/ExtendedFab.tsx
+++ b/packages/react/src/components/ExtendedFab/ExtendedFab.tsx
@@ -2,7 +2,7 @@ import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";
 import { extendedFab, type ExtendedFabVariantProps } from "@seed-design/css/recipes/extended-fab";
 import { createRecipeContext } from "../../utils/createRecipeContext";
 
-const { withProvider } = createRecipeContext(extendedFab);
+const { withContext } = createRecipeContext(extendedFab);
 
 ////////////////////////////////////////////////////////////////////////////////////
 
@@ -11,7 +11,7 @@ export interface ExtendedFabProps
     PrimitiveProps,
     React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
-export const ExtendedFab = withProvider<HTMLButtonElement, ExtendedFabProps>(Primitive.button, {
+export const ExtendedFab = withContext<HTMLButtonElement, ExtendedFabProps>(Primitive.button, {
   defaultProps: {
     variant: "neutralSolid",
     size: "medium",

--- a/packages/react/src/components/Fab/Fab.tsx
+++ b/packages/react/src/components/Fab/Fab.tsx
@@ -3,7 +3,7 @@ import { fab, type FabVariantProps } from "@seed-design/css/recipes/fab";
 import type * as React from "react";
 import { createRecipeContext } from "../../utils/createRecipeContext";
 
-const { withProvider } = createRecipeContext(fab);
+const { withContext } = createRecipeContext(fab);
 
 ////////////////////////////////////////////////////////////////////////////////////
 
@@ -12,4 +12,4 @@ export interface FabProps
     PrimitiveProps,
     React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
-export const Fab = withProvider<HTMLButtonElement, FabProps>(Primitive.button);
+export const Fab = withContext<HTMLButtonElement, FabProps>(Primitive.button);

--- a/packages/react/src/components/LinkContent/LinkContent.tsx
+++ b/packages/react/src/components/LinkContent/LinkContent.tsx
@@ -4,7 +4,7 @@ import { createRecipeContext } from "../../utils/createRecipeContext";
 import type * as React from "react";
 import { withStyleProps, type StyleProps } from "../../utils/styled";
 
-const { withProvider } = createRecipeContext(linkContent);
+const { withContext } = createRecipeContext(linkContent);
 
 export interface LinkContentProps
   extends LinkContentVariantProps,
@@ -12,6 +12,6 @@ export interface LinkContentProps
     Pick<StyleProps, "color">,
     Omit<React.HTMLAttributes<HTMLSpanElement>, "color"> {}
 
-export const LinkContent = withProvider<HTMLButtonElement, LinkContentProps>(
+export const LinkContent = withContext<HTMLButtonElement, LinkContentProps>(
   withStyleProps(Primitive.span),
 );

--- a/packages/react/src/components/MannerTempBadge/MannerTempBadge.tsx
+++ b/packages/react/src/components/MannerTempBadge/MannerTempBadge.tsx
@@ -6,7 +6,7 @@ import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";
 import type * as React from "react";
 import { createRecipeContext } from "../../utils/createRecipeContext";
 
-const { withProvider } = createRecipeContext(mannerTempBadge);
+const { withContext } = createRecipeContext(mannerTempBadge);
 
 ////////////////////////////////////////////////////////////////////////////////////
 
@@ -15,4 +15,4 @@ export interface MannerTempBadgeProps
     PrimitiveProps,
     React.HTMLAttributes<HTMLSpanElement> {}
 
-export const MannerTempBadge = withProvider<HTMLSpanElement, MannerTempBadgeProps>(Primitive.span);
+export const MannerTempBadge = withContext<HTMLSpanElement, MannerTempBadgeProps>(Primitive.span);

--- a/packages/react/src/components/NotificationBadge/NotificationBadge.tsx
+++ b/packages/react/src/components/NotificationBadge/NotificationBadge.tsx
@@ -12,7 +12,7 @@ import * as React from "react";
 import { useMemo } from "react";
 import { createRecipeContext } from "../../utils/createRecipeContext";
 
-const { withProvider, PropsProvider } = createRecipeContext(notificationBadge);
+const { withContext, PropsProvider } = createRecipeContext(notificationBadge);
 
 ////////////////////////////////////////////////////////////////////////////////////
 
@@ -21,7 +21,7 @@ export interface NotificationBadgeProps
     PrimitiveProps,
     React.HTMLAttributes<HTMLSpanElement> {}
 
-export const NotificationBadge = withProvider<HTMLSpanElement, NotificationBadgeProps>(
+export const NotificationBadge = withContext<HTMLSpanElement, NotificationBadgeProps>(
   Primitive.span,
 );
 

--- a/packages/react/src/components/ReactionButton/ReactionButton.tsx
+++ b/packages/react/src/components/ReactionButton/ReactionButton.tsx
@@ -5,14 +5,11 @@ import {
 import { Toggle as TogglePrimitive } from "@seed-design/react-toggle";
 import clsx from "clsx";
 import * as React from "react";
-import { createRecipeContext } from "../../utils/createRecipeContext";
 import {
   PendingButtonProvider,
   usePendingButton,
   type UsePendingButtonProps,
 } from "../LoadingIndicator/usePendingButton";
-
-const { ClassNameProvider } = createRecipeContext(reactionButton);
 
 export interface ReactionButtonProps
   extends ReactionButtonVariantProps,
@@ -25,16 +22,14 @@ export const ReactionButton = React.forwardRef<HTMLButtonElement, ReactionButton
     const api = usePendingButton({ loading, disabled: otherProps.disabled });
 
     return (
-      <ClassNameProvider value={recipeClassName}>
-        <PendingButtonProvider value={api}>
-          <TogglePrimitive.Root
-            ref={ref}
-            className={clsx(recipeClassName, className)}
-            {...api.stateProps}
-            {...otherProps}
-          />
-        </PendingButtonProvider>
-      </ClassNameProvider>
+      <PendingButtonProvider value={api}>
+        <TogglePrimitive.Root
+          ref={ref}
+          className={clsx(recipeClassName, className)}
+          {...api.stateProps}
+          {...otherProps}
+        />
+      </PendingButtonProvider>
     );
   },
 );

--- a/packages/react/src/components/SelectBox/CheckSelectBox.tsx
+++ b/packages/react/src/components/SelectBox/CheckSelectBox.tsx
@@ -8,8 +8,8 @@ import { createSlotRecipeContext } from "../../utils/createSlotRecipeContext";
 import { createWithStateProps } from "../../utils/createWithStateProps";
 import { InternalIcon, type InternalIconProps } from "../private/Icon";
 
-const { withProvider: withGroupProvider } = createRecipeContext(selectBoxGroup);
-const { withProvider, withContext } = createSlotRecipeContext(selectBox);
+const { withContext: withGroupContext } = createRecipeContext(selectBoxGroup);
+const { withContext, withProvider } = createSlotRecipeContext(selectBox);
 const withStateProps = createWithStateProps([useCheckboxContext]);
 
 export interface CheckSelectBoxGroupProps
@@ -20,7 +20,7 @@ export interface CheckSelectBoxGroupProps
  * CheckSelectBoxGroup is a simple div wrapper for future extensibility.
  * It does not have spacing by default, nesting <Stack> under it is recommended.
  */
-export const CheckSelectBoxGroup = withGroupProvider<HTMLDivElement, CheckSelectBoxGroupProps>(
+export const CheckSelectBoxGroup = withGroupContext<HTMLDivElement, CheckSelectBoxGroupProps>(
   forwardRef<HTMLDivElement, CheckSelectBoxGroupProps>((props, ref) => (
     <Primitive.div ref={ref} role="group" {...props} />
   )),

--- a/packages/react/src/components/SelectBox/RadioSelectBox.tsx
+++ b/packages/react/src/components/SelectBox/RadioSelectBox.tsx
@@ -10,13 +10,13 @@ import { createSlotRecipeContext } from "../../utils/createSlotRecipeContext";
 import { createWithStateProps } from "../../utils/createWithStateProps";
 import { InternalIcon, type InternalIconProps } from "../private/Icon";
 
-const { withProvider: withGroupProvider } = createRecipeContext(selectBoxGroup);
-const { withProvider, withContext } = createSlotRecipeContext(selectBox);
+const { withContext: withGroupContext } = createRecipeContext(selectBoxGroup);
+const { withContext, withProvider } = createSlotRecipeContext(selectBox);
 const withStateProps = createWithStateProps([useRadioGroupItemContext]);
 
 export interface RadioSelectBoxRootProps extends RadioGroupPrimitive.RootProps {}
 
-export const RadioSelectBoxRoot = withGroupProvider<HTMLDivElement, RadioSelectBoxRootProps>(
+export const RadioSelectBoxRoot = withGroupContext<HTMLDivElement, RadioSelectBoxRootProps>(
   RadioGroupPrimitive.Root,
 );
 

--- a/packages/react/src/components/Skeleton/Skeleton.tsx
+++ b/packages/react/src/components/Skeleton/Skeleton.tsx
@@ -4,7 +4,7 @@ import type * as React from "react";
 import { createRecipeContext } from "../../utils/createRecipeContext";
 import { withStyleProps, type StyleProps } from "../../utils/styled";
 
-const { withProvider } = createRecipeContext(skeleton);
+const { withContext } = createRecipeContext(skeleton);
 
 export interface SkeletonProps
   extends SkeletonVariantProps,
@@ -12,4 +12,4 @@ export interface SkeletonProps
     Pick<StyleProps, "height" | "width">,
     Omit<React.HTMLAttributes<HTMLDivElement>, "color"> {}
 
-export const Skeleton = withProvider<HTMLDivElement, SkeletonProps>(withStyleProps(Primitive.div));
+export const Skeleton = withContext<HTMLDivElement, SkeletonProps>(withStyleProps(Primitive.div));

--- a/packages/react/src/components/Snackbar/Snackbar.tsx
+++ b/packages/react/src/components/Snackbar/Snackbar.tsx
@@ -8,7 +8,7 @@ import { createRecipeContext } from "../../utils/createRecipeContext";
 import { createSlotRecipeContext } from "../../utils/createSlotRecipeContext";
 import { InternalIcon, type InternalIconProps } from "../private/Icon";
 
-const { withProvider: withRegionProvider } = createRecipeContext(snackbarRegion);
+const { withContext: withRegionContext } = createRecipeContext(snackbarRegion);
 const { withProvider, withContext } = createSlotRecipeContext(snackbar);
 
 ////////////////////////////////////////////////////////////////////////////////////
@@ -21,7 +21,7 @@ export const SnackbarRootProvider = SnackbarPrimitive.RootProvider;
 
 export interface SnackbarRegionProps extends SnackbarVariantProps, SnackbarPrimitive.RegionProps {}
 
-export const SnackbarRegion = withRegionProvider<HTMLDivElement, SnackbarRegionProps>(
+export const SnackbarRegion = withRegionContext<HTMLDivElement, SnackbarRegionProps>(
   SnackbarPrimitive.Region,
 );
 

--- a/packages/react/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/react/src/components/ToggleButton/ToggleButton.tsx
@@ -12,8 +12,6 @@ import {
   type UsePendingButtonProps,
 } from "../LoadingIndicator/usePendingButton";
 
-const { ClassNameProvider } = createRecipeContext(toggleButton);
-
 export interface ToggleButtonProps
   extends ToggleButtonVariantProps,
     UsePendingButtonProps,
@@ -25,16 +23,14 @@ export const ToggleButton = React.forwardRef<HTMLButtonElement, ToggleButtonProp
     const api = usePendingButton({ loading, disabled: otherProps.disabled });
 
     return (
-      <ClassNameProvider value={recipeClassName}>
-        <PendingButtonProvider value={api}>
-          <TogglePrimitive.Root
-            ref={ref}
-            className={clsx(recipeClassName, className)}
-            {...api.stateProps}
-            {...otherProps}
-          />
-        </PendingButtonProvider>
-      </ClassNameProvider>
+      <PendingButtonProvider value={api}>
+        <TogglePrimitive.Root
+          ref={ref}
+          className={clsx(recipeClassName, className)}
+          {...api.stateProps}
+          {...otherProps}
+        />
+      </PendingButtonProvider>
     );
   },
 );

--- a/packages/react/src/utils/createRecipeContext.tsx
+++ b/packages/react/src/utils/createRecipeContext.tsx
@@ -1,74 +1,26 @@
 import clsx from "clsx";
 import { createContext, forwardRef, useContext } from "react";
 
-type Recipe<
-  Props extends Record<string, string | boolean | undefined>,
-  ClassName extends string,
-> = ((props?: Props) => ClassName) & {
+type Recipe<Props extends Record<string, string | boolean | undefined>> = ((
+  props?: Props,
+) => string) & {
   splitVariantProps: <T extends Props>(props: T) => [Props, Omit<T, keyof Props>];
 };
 
-export function createRecipeContext<
-  Props extends Record<string, string | boolean | undefined>,
-  ClassName extends string,
->(recipe: Recipe<Props, ClassName>) {
-  const ClassNameContext = createContext<ClassName | null>(null);
+export function createRecipeContext<Props extends Record<string, string | boolean | undefined>>(
+  recipe: Recipe<Props>,
+) {
   const PropsContext = createContext<Props | null>(null);
-
-  const ClassNameProvider = ({
-    children,
-    value,
-  }: {
-    children: React.ReactNode;
-    value: ClassName;
-  }) => {
-    return <ClassNameContext.Provider value={value}>{children}</ClassNameContext.Provider>;
-  };
 
   const PropsProvider = ({ children, value }: { children: React.ReactNode; value: Props }) => {
     return <PropsContext.Provider value={value}>{children}</PropsContext.Provider>;
   };
 
-  function useClassName() {
-    const context = useContext(ClassNameContext);
-    if (context === null) {
-      throw new Error(
-        "useClassName must be used within a ClassNameProvider. Did you forget to wrap your component in a ClassNameProvider?",
-      );
-    }
-    return context;
-  }
-
   function useProps() {
     return useContext(PropsContext);
   }
 
-  const withRootProvider = <P,>(
-    Component: React.ElementType<any>,
-    options?: {
-      defaultProps?: Partial<P>;
-    },
-  ): React.ForwardRefExoticComponent<React.PropsWithoutRef<P>> => {
-    const { defaultProps } = options ?? {};
-
-    const StyledComponent = (innerProps: any) => {
-      const props = { ...(defaultProps ?? {}), ...useProps(), ...innerProps } as Props &
-        React.HTMLAttributes<HTMLElement>;
-      const [variantProps, otherProps] = recipe.splitVariantProps(props);
-      const className = recipe(variantProps);
-
-      return (
-        <ClassNameProvider value={className}>
-          <Component {...otherProps} className={clsx(className, props.className)} />
-        </ClassNameProvider>
-      );
-    };
-
-    StyledComponent.displayName = (Component as any).displayName || (Component as any).name;
-    return StyledComponent as any;
-  };
-
-  const withProvider = <T, P>(
+  const withContext = <T, P>(
     Component: React.ElementType<any>,
     options?: {
       defaultProps?: Partial<P>;
@@ -80,7 +32,7 @@ export function createRecipeContext<
       const props = { ...(defaultProps ?? {}), ...useProps(), ...innerProps } as Props &
         React.HTMLAttributes<HTMLElement>;
       const [variantProps, otherProps] = recipe.splitVariantProps(props);
-      const className = recipe(variantProps);
+      const className = recipe(variantProps); // TODO: should we memoize this?
 
       return <Component ref={ref} {...otherProps} className={clsx(className, props.className)} />;
     });
@@ -89,26 +41,14 @@ export function createRecipeContext<
     return StyledComponent as any;
   };
 
-  const withContext = <T, P>(
-    Component: React.ElementType<any>,
-  ): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>> => {
-    const StyledComponent = forwardRef<any, React.HTMLAttributes<HTMLElement>>((props, ref) => {
-      const className = useClassName();
-
-      return <Component ref={ref} {...props} className={clsx(className, props.className)} />;
-    });
-
-    StyledComponent.displayName = (Component as any).displayName || (Component as any).name;
-    return StyledComponent as any;
-  };
+  function withPropsProvider<P>(): React.Provider<Partial<P>> {
+    return PropsProvider as any;
+  }
 
   return {
-    ClassNameProvider,
     PropsProvider,
-    useClassName,
     useProps,
-    withRootProvider,
-    withProvider,
     withContext,
+    withPropsProvider,
   };
 }


### PR DESCRIPTION
- 사용되지 않는 ClassNameProvider를 제거합니다.
- Provider 제거에 따라, withProvider를 withContext로 이름을 변경합니다.