### PR TITLE
feat: implement remark-react-type-table for documentation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -68,6 +68,7 @@
         "react-dom": "^18.3.1",
         "react-error-boundary": "^4.1.2",
         "react-hook-form": "^7.53.2",
+        "recast": "^0.23.9",
         "remark": "^15.0.1",
         "remark-gfm": "^4.0.1",
         "remark-mdx": "^3.1.0",

--- a/docs/app/react/llms.txt/route.ts
+++ b/docs/app/react/llms.txt/route.ts
@@ -1,3 +1,4 @@
+import { typeTableProject } from "@/components/type-table/project";
 import { remarkReactTypeTable } from "@/components/type-table/remark-react-type-table";
 import { fileGenerator, remarkDocGen, remarkInstall } from "fumadocs-docgen";
 import { remarkInclude } from "fumadocs-mdx/config";
@@ -47,7 +48,7 @@ async function processContent(path: string, content: string): Promise<string> {
     .use(remarkMdx)
     .use(remarkInclude)
     .use(remarkGfm)
-    .use(remarkReactTypeTable)
+    .use(remarkReactTypeTable, { options: { project: typeTableProject } })
     .use(remarkDocGen, { generators: [fileGenerator()] })
     .use(remarkInstall, { persist: { id: "package-manager" } })
     .use(remarkStringify)

--- a/docs/app/react/llms.txt/route.ts
+++ b/docs/app/react/llms.txt/route.ts
@@ -14,22 +14,32 @@ export const revalidate = false;
 export async function GET() {
   const files = await globby(["./content/react/**/*.mdx", "!./content/react/index.mdx"]);
 
-  const scan = files.map(async (file) => {
-    const fileContent = await fs.readFile(file);
-    const { content, data } = matter(fileContent.toString());
+  // Process files in chunks to prevent OOM
+  const CHUNK_SIZE = 10;
+  const results: string[] = [];
 
-    const processed = await processContent(file, content);
-    return `file: ${file}
+  for (let i = 0; i < files.length; i += CHUNK_SIZE) {
+    const chunk = files.slice(i, i + CHUNK_SIZE);
+
+    const chunkPromises = chunk.map(async (file) => {
+      const fileContent = await fs.readFile(file);
+      const { content, data } = matter(fileContent.toString());
+
+      const processed = await processContent(file, content);
+      return `file: ${file}
 # ${data.title}
 
 ${data.description ?? ""}
         
 ${processed}`;
-  });
+    });
 
-  const scanned = await Promise.all(scan);
+    // Process this chunk and wait for completion before moving to next chunk
+    const chunkResults = await Promise.all(chunkPromises);
+    results.push(...chunkResults);
+  }
 
-  return new Response(scanned.join("\n\n"));
+  return new Response(results.join("\n\n"));
 }
 
 async function processContent(path: string, content: string): Promise<string> {

--- a/docs/app/react/llms.txt/route.ts
+++ b/docs/app/react/llms.txt/route.ts
@@ -1,6 +1,6 @@
+import { remarkReactTypeTable } from "@/components/type-table/remark-react-type-table";
 import { fileGenerator, remarkDocGen, remarkInstall } from "fumadocs-docgen";
 import { remarkInclude } from "fumadocs-mdx/config";
-import { remarkAutoTypeTable } from "fumadocs-typescript";
 import { globby } from "globby";
 import matter from "gray-matter";
 import * as fs from "node:fs/promises";
@@ -37,7 +37,7 @@ async function processContent(path: string, content: string): Promise<string> {
     .use(remarkMdx)
     .use(remarkInclude)
     .use(remarkGfm)
-    .use(remarkAutoTypeTable)
+    .use(remarkReactTypeTable)
     .use(remarkDocGen, { generators: [fileGenerator()] })
     .use(remarkInstall, { persist: { id: "package-manager" } })
     .use(remarkStringify)

--- a/docs/components/mdx-components.ts
+++ b/docs/components/mdx-components.ts
@@ -2,19 +2,20 @@ import { ColorGrid } from "@/components/color-grid";
 import { ComponentExample } from "@/components/component-example";
 import { ComponentSpecBlock } from "@/components/component-spec-block";
 import { Installation } from "@/components/installation";
-import { createReactTypeTable } from "@/components/react-type-table";
 import { StackflowExample } from "@/components/stackflow-example";
 import { TokenReference } from "@/components/token-reference";
+import { createReactTypeTable } from "@/components/type-table/react-type-table";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 import { File, Files, Folder } from "fumadocs-ui/components/files";
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
+import { TypeTable } from "fumadocs-ui/components/type-table";
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import { AtomIcon } from "lucide-react";
 import { IconLibrary } from "./iconography/icons";
 import { ColorMigrationIndex } from "./migration/color-migration-index";
-import { IconographyMigrationIndex } from "./migration/iconography-migration-index";
 import { V2Icon, V2IconColor, V3Icon } from "./migration/icon";
+import { IconographyMigrationIndex } from "./migration/iconography-migration-index";
 import { TypographyMigrationIndex } from "./migration/typography-migration-index";
 import { ViteIcon, WebpackIcon } from "./tool-icon";
 
@@ -39,6 +40,7 @@ export const mdxComponents = {
   WebpackIcon,
   ViteIcon,
   StackflowExample,
+  TypeTable,
   ReactTypeTable,
   ColorGrid,
   V3Icon,

--- a/docs/components/mdx-components.ts
+++ b/docs/components/mdx-components.ts
@@ -18,8 +18,9 @@ import { V2Icon, V2IconColor, V3Icon } from "./migration/icon";
 import { IconographyMigrationIndex } from "./migration/iconography-migration-index";
 import { TypographyMigrationIndex } from "./migration/typography-migration-index";
 import { ViteIcon, WebpackIcon } from "./tool-icon";
+import { typeTableProject } from "./type-table/project";
 
-const { ReactTypeTable } = createReactTypeTable();
+const { ReactTypeTable } = createReactTypeTable({ project: typeTableProject });
 
 export const mdxComponents = {
   ...defaultMdxComponents,

--- a/docs/components/type-table/get-react-type-table.ts
+++ b/docs/components/type-table/get-react-type-table.ts
@@ -4,14 +4,6 @@
 import { generateDocumentation, type GenerateDocumentationOptions } from "fumadocs-typescript";
 import fs from "node:fs/promises";
 
-// Memoization cache for generateDocumentation
-const documentationCache = new Map<string, ReturnType<typeof generateDocumentation>>();
-
-// Create cache key from path, typeName, and content
-const createCacheKey = (path: string, typeName: string | undefined, content: string): string => {
-  return `${path}:${typeName || ""}:${content}`;
-};
-
 export interface ReactTypeTableProps {
   /**
    * The path to source TypeScript file.
@@ -69,20 +61,7 @@ export async function getReactTypeTableOutput({
     content += `\nexport type ${typeName} = ${type}`;
   }
 
-  const filePath = path ?? "temp.ts";
-  const cacheKey = createCacheKey(filePath, typeName, content);
-
-  // Check if we have a cached result
-  if (documentationCache.has(cacheKey)) {
-    return documentationCache.get(cacheKey)!.map((item) => {
-      return {
-        ...item,
-        entries: item.entries.filter((entry) => !entry.tags.external),
-      };
-    });
-  }
-
-  const output = generateDocumentation(filePath, typeName, content, {
+  const output = generateDocumentation(path ?? "temp.ts", typeName, content, {
     ...options,
     // get source file from ts symbol, and check if it's from node_modules
     transform: (entry, _type, symbol) => {
@@ -93,9 +72,6 @@ export async function getReactTypeTableOutput({
       }
     },
   });
-
-  // Store result in cache
-  documentationCache.set(cacheKey, output);
 
   if (name && output.length === 0)
     throw new Error(`${name} in ${path ?? "empty file"} doesn't exist`);

--- a/docs/components/type-table/get-react-type-table.ts
+++ b/docs/components/type-table/get-react-type-table.ts
@@ -1,19 +1,8 @@
 // This code includes portions derived from fuma-nama/fumadocs (https://github.com/fuma-nama/fumadocs)
 // Used under the MIT License: https://opensource.org/licenses/MIT
 
-import "server-only";
-
-import {
-  type GenerateDocumentationOptions,
-  generateDocumentation,
-  getProject,
-  renderMarkdownToHast,
-} from "fumadocs-typescript";
-import { TypeTable } from "fumadocs-ui/components/type-table";
-import defaultMdxComponents from "fumadocs-ui/mdx";
-import { type Jsx, toJsxRuntime } from "hast-util-to-jsx-runtime";
+import { generateDocumentation, type GenerateDocumentationOptions } from "fumadocs-typescript";
 import fs from "node:fs/promises";
-import * as runtime from "react/jsx-runtime";
 
 export interface ReactTypeTableProps {
   /**
@@ -52,29 +41,12 @@ export interface ReactTypeTableProps {
   options?: GenerateDocumentationOptions;
 }
 
-export function createReactTypeTable(options: GenerateDocumentationOptions = {}): {
-  ReactTypeTable: (props: Omit<ReactTypeTableProps, "options">) => React.ReactNode;
-} {
-  const project = options.project ?? getProject(options.config);
-
-  return {
-    ReactTypeTable(props) {
-      return <ReactTypeTable {...props} options={{ ...options, project }} />;
-    },
-  };
-}
-
-/**
- * **Server Component Only**
- *
- * Display properties in an exported interface via Type Table
- */
-export async function ReactTypeTable({
+export async function getReactTypeTableOutput({
   path,
-  name,
   type,
+  name,
   options = {},
-}: ReactTypeTableProps): Promise<React.ReactElement> {
+}: ReactTypeTableProps) {
   let typeName = name;
   let content = "";
 
@@ -104,35 +76,10 @@ export async function ReactTypeTable({
   if (name && output.length === 0)
     throw new Error(`${name} in ${path ?? "empty file"} doesn't exist`);
 
-  return (
-    <>
-      {output.map(async (item) => {
-        const entries = item.entries
-          .filter((entry) => !entry.tags.external)
-          .map(
-            async (entry) =>
-              [
-                entry.name,
-                {
-                  type: entry.type,
-                  description: await renderMarkdown(entry.description),
-                  default: entry.tags.default || entry.tags.defaultValue,
-                },
-              ] as const,
-          );
-
-        return <TypeTable key={item.name} type={Object.fromEntries(await Promise.all(entries))} />;
-      })}
-    </>
-  );
-}
-
-async function renderMarkdown(md: string): Promise<React.ReactElement> {
-  return toJsxRuntime(await renderMarkdownToHast(md), {
-    Fragment: runtime.Fragment,
-    jsx: runtime.jsx as Jsx,
-    jsxs: runtime.jsxs as Jsx,
-    // @ts-ignore
-    components: { ...defaultMdxComponents, img: undefined },
-  }) as React.ReactElement;
+  return output.map((item) => {
+    return {
+      ...item,
+      entries: item.entries.filter((entry) => !entry.tags.external),
+    };
+  });
 }

--- a/docs/components/type-table/get-react-type-table.ts
+++ b/docs/components/type-table/get-react-type-table.ts
@@ -4,6 +4,14 @@
 import { generateDocumentation, type GenerateDocumentationOptions } from "fumadocs-typescript";
 import fs from "node:fs/promises";
 
+// Memoization cache for generateDocumentation
+const documentationCache = new Map<string, ReturnType<typeof generateDocumentation>>();
+
+// Create cache key from path, typeName, and content
+const createCacheKey = (path: string, typeName: string | undefined, content: string): string => {
+  return `${path}:${typeName || ""}:${content}`;
+};
+
 export interface ReactTypeTableProps {
   /**
    * The path to source TypeScript file.
@@ -61,7 +69,20 @@ export async function getReactTypeTableOutput({
     content += `\nexport type ${typeName} = ${type}`;
   }
 
-  const output = generateDocumentation(path ?? "temp.ts", typeName, content, {
+  const filePath = path ?? "temp.ts";
+  const cacheKey = createCacheKey(filePath, typeName, content);
+
+  // Check if we have a cached result
+  if (documentationCache.has(cacheKey)) {
+    return documentationCache.get(cacheKey)!.map((item) => {
+      return {
+        ...item,
+        entries: item.entries.filter((entry) => !entry.tags.external),
+      };
+    });
+  }
+
+  const output = generateDocumentation(filePath, typeName, content, {
     ...options,
     // get source file from ts symbol, and check if it's from node_modules
     transform: (entry, _type, symbol) => {
@@ -72,6 +93,9 @@ export async function getReactTypeTableOutput({
       }
     },
   });
+
+  // Store result in cache
+  documentationCache.set(cacheKey, output);
 
   if (name && output.length === 0)
     throw new Error(`${name} in ${path ?? "empty file"} doesn't exist`);

--- a/docs/components/type-table/project.ts
+++ b/docs/components/type-table/project.ts
@@ -1,0 +1,3 @@
+import { getProject } from "fumadocs-typescript";
+
+export const typeTableProject = getProject();

--- a/docs/components/type-table/react-type-table.tsx
+++ b/docs/components/type-table/react-type-table.tsx
@@ -1,0 +1,67 @@
+// This code includes portions derived from fuma-nama/fumadocs (https://github.com/fuma-nama/fumadocs)
+// Used under the MIT License: https://opensource.org/licenses/MIT
+
+import "server-only";
+
+import {
+  type GenerateDocumentationOptions,
+  getProject,
+  renderMarkdownToHast,
+} from "fumadocs-typescript";
+import { TypeTable } from "fumadocs-ui/components/type-table";
+import defaultMdxComponents from "fumadocs-ui/mdx";
+import { type Jsx, toJsxRuntime } from "hast-util-to-jsx-runtime";
+import * as runtime from "react/jsx-runtime";
+import { getReactTypeTableOutput, ReactTypeTableProps } from "./get-react-type-table";
+
+export function createReactTypeTable(options: GenerateDocumentationOptions = {}): {
+  ReactTypeTable: (props: Omit<ReactTypeTableProps, "options">) => React.ReactNode;
+} {
+  const project = options.project ?? getProject(options.config);
+
+  return {
+    ReactTypeTable(props) {
+      return <ReactTypeTable {...props} options={{ ...options, project }} />;
+    },
+  };
+}
+
+/**
+ * **Server Component Only**
+ *
+ * Display properties in an exported interface via Type Table
+ */
+export async function ReactTypeTable(props: ReactTypeTableProps): Promise<React.ReactElement> {
+  const output = await getReactTypeTableOutput(props);
+
+  return (
+    <>
+      {output.map(async (item) => {
+        const entries = item.entries.map(
+          async (entry) =>
+            [
+              entry.name,
+              {
+                type: entry.type,
+                description: await renderMarkdown(entry.description),
+                default: entry.tags.default || entry.tags.defaultValue,
+                required: entry.required,
+              },
+            ] as const,
+        );
+
+        return <TypeTable key={item.name} type={Object.fromEntries(await Promise.all(entries))} />;
+      })}
+    </>
+  );
+}
+
+async function renderMarkdown(md: string): Promise<React.ReactElement> {
+  return toJsxRuntime(await renderMarkdownToHast(md), {
+    Fragment: runtime.Fragment,
+    jsx: runtime.jsx as Jsx,
+    jsxs: runtime.jsxs as Jsx,
+    // @ts-ignore
+    components: { ...defaultMdxComponents, img: undefined },
+  }) as React.ReactElement;
+}

--- a/docs/components/type-table/remark-react-type-table.tsx
+++ b/docs/components/type-table/remark-react-type-table.tsx
@@ -1,0 +1,180 @@
+// This code includes portions derived from fuma-nama/fumadocs (https://github.com/fuma-nama/fumadocs)
+// Used under the MIT License: https://opensource.org/licenses/MIT
+
+import type { Expression, ExpressionStatement, ObjectExpression, Program, Property } from "estree";
+import { valueToEstree } from "estree-util-value-to-estree";
+import type { DocEntry } from "fumadocs-typescript";
+import { getProject, renderMarkdownToHast } from "fumadocs-typescript";
+import { toEstree } from "hast-util-to-estree";
+import type { Root } from "mdast";
+import type { MdxJsxAttribute, MdxJsxFlowElement } from "mdast-util-mdx-jsx";
+import { dirname } from "node:path";
+import { print } from "recast";
+import type { Transformer } from "unified";
+import { visit } from "unist-util-visit";
+import { getReactTypeTableOutput, type ReactTypeTableProps } from "./get-react-type-table";
+
+function expressionToAttribute(key: string, value: Expression): MdxJsxAttribute {
+  return {
+    type: "mdxJsxAttribute",
+    name: key,
+    value: {
+      type: "mdxJsxAttributeValueExpression",
+      data: {
+        estree: {
+          type: "Program",
+          body: [
+            {
+              type: "ExpressionStatement",
+              expression: value,
+            },
+          ],
+        } as Program,
+      },
+      value: print(value).code,
+    },
+  };
+}
+
+async function mapProperty(
+  entry: DocEntry,
+  renderMarkdown: typeof renderMarkdownToHast,
+): Promise<Property> {
+  const value = valueToEstree({
+    type: entry.type,
+    default: entry.tags.default || entry.tags.defaultValue,
+  }) as ObjectExpression;
+
+  if (entry.description) {
+    const hast = toEstree(await renderMarkdown(entry.description), {
+      elementAttributeNameCase: "react",
+    }).body[0] as ExpressionStatement;
+
+    value.properties.push({
+      type: "Property",
+      method: false,
+      shorthand: false,
+      computed: false,
+      key: {
+        type: "Identifier",
+        name: "description",
+      },
+      kind: "init",
+      value: hast.expression,
+    });
+  }
+
+  return {
+    type: "Property",
+    method: false,
+    shorthand: false,
+    computed: false,
+    key: {
+      type: "Identifier",
+      name: entry.name,
+    },
+    kind: "init",
+    value,
+  };
+}
+
+export interface RemarkReactTypeTableOptions {
+  /**
+   * @defaultValue 'react-type-table'
+   */
+  name?: string;
+
+  /**
+   * @defaultValue 'TypeTable'
+   */
+  outputName?: string;
+
+  renderMarkdown?: typeof renderMarkdownToHast;
+
+  /**
+   * Override some type table props
+   */
+  options?: ReactTypeTableProps["options"];
+}
+
+/**
+ * Compile `react-type-table` into Fumadocs UI compatible TypeTable
+ *
+ * MDX is required to use this plugin.
+ */
+export function remarkReactTypeTable({
+  name = "react-type-table",
+  outputName = "TypeTable",
+  renderMarkdown = renderMarkdownToHast,
+  options = {},
+}: RemarkReactTypeTableOptions = {}): Transformer<Root, Root> {
+  const project = options.project ?? getProject(options.config);
+
+  return async (tree, file) => {
+    const queue: Promise<void>[] = [];
+    const basePath = dirname(file.path);
+
+    visit(tree, "mdxJsxFlowElement", (node) => {
+      if (node.name !== name) return;
+      const props: Record<string, string> = {};
+
+      for (const attr of node.attributes) {
+        if (attr.type !== "mdxJsxAttribute" || typeof attr.value !== "string")
+          throw new Error("`react-type-table` does not support non-string attributes");
+
+        props[attr.name] = attr.value;
+      }
+
+      async function run() {
+        const output = await getReactTypeTableOutput({
+          ...props,
+          options: {
+            ...options,
+            project,
+            basePath,
+          },
+        } as ReactTypeTableProps);
+
+        const rendered = output.map(async (doc) => {
+          const properties = await Promise.all(
+            doc.entries.map((entry) => mapProperty(entry, renderMarkdown)),
+          );
+
+          return {
+            type: "mdxJsxFlowElement",
+            name: outputName,
+            attributes: [
+              expressionToAttribute("type", {
+                type: "ObjectExpression",
+                properties,
+              }),
+            ],
+            data: {
+              // for Fumadocs `remarkStructure`
+              _string: [
+                doc.name,
+                doc.description,
+                ...doc.entries.flatMap((entry) => [
+                  `${entry.name}: ${entry.type}`,
+                  entry.description,
+                ]),
+              ],
+            },
+            children: [],
+          } satisfies MdxJsxFlowElement;
+        });
+
+        Object.assign(node, {
+          type: "root",
+          attributes: [],
+          children: await Promise.all(rendered),
+        } as Root);
+      }
+
+      queue.push(run());
+      return "skip";
+    });
+
+    await Promise.all(queue);
+  };
+}

--- a/docs/content/react/components/action-button.mdx
+++ b/docs/content/react/components/action-button.mdx
@@ -18,7 +18,7 @@ description: 사용자가 특정 액션을 실행할 수 있도록 도와주는 
 
 ## Props
 
-<ReactTypeTable path="./registry/ui/action-button.tsx" name="ActionButtonProps" />
+<react-type-table path="./registry/ui/action-button.tsx" name="ActionButtonProps" />
 
 ## Examples
 

--- a/docs/content/react/components/action-chip.mdx
+++ b/docs/content/react/components/action-chip.mdx
@@ -24,7 +24,7 @@ import { ActionChip } from "@seed-design/react";
 
 ## Props
 
-<ReactTypeTable path="../packages/react/src/components/ActionChip/ActionChip.tsx" name="ActionChipProps" />
+<react-type-table path="../packages/react/src/components/ActionChip/ActionChip.tsx" name="ActionChipProps" />
 
 ## Examples
 

--- a/docs/content/react/components/action-sheet.mdx
+++ b/docs/content/react/components/action-sheet.mdx
@@ -20,21 +20,21 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ### `ActionSheetRoot`
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/action-sheet.tsx"
   name="ActionSheetRootProps"
 />
 
 ### `ActionSheetContent`
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/action-sheet.tsx"
   name="ActionSheetContentProps"
 />
 
 ### `ActionSheetItem`
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/action-sheet.tsx"
   name="ActionSheetItemProps"
 />

--- a/docs/content/react/components/alert-dialog.mdx
+++ b/docs/content/react/components/alert-dialog.mdx
@@ -18,7 +18,7 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ## Props
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/alert-dialog.tsx"
   name="AlertDialogRootProps"
 />

--- a/docs/content/react/components/avatar.mdx
+++ b/docs/content/react/components/avatar.mdx
@@ -18,7 +18,7 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ## Props
 
-<ReactTypeTable path="./registry/ui/avatar.tsx" name="AvatarProps" />
+<react-type-table path="./registry/ui/avatar.tsx" name="AvatarProps" />
 
 ## Examples
 

--- a/docs/content/react/components/badge.mdx
+++ b/docs/content/react/components/badge.mdx
@@ -24,7 +24,7 @@ import { Badge } from "@seed-design/react";
 
 ## Props
 
-<ReactTypeTable path="../packages/react/src/components/Badge/Badge.tsx" name="BadgeProps" />
+<react-type-table path="../packages/react/src/components/Badge/Badge.tsx" name="BadgeProps" />
 
 ## Examples
 

--- a/docs/content/react/components/bottom-sheet.mdx
+++ b/docs/content/react/components/bottom-sheet.mdx
@@ -18,7 +18,7 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ## Props
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/bottom-sheet.tsx"
   name="BottomSheetRootProps"
 />

--- a/docs/content/react/components/callout.mdx
+++ b/docs/content/react/components/callout.mdx
@@ -20,18 +20,18 @@ description: 사용자의 주목을 끌어 중요한 정보를 강조하는 컴�
 
 ### `Callout`
 
-<ReactTypeTable path="./registry/ui/callout.tsx" name="CalloutProps" />
+<react-type-table path="./registry/ui/callout.tsx" name="CalloutProps" />
 
 ### `ActionableCallout`
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/callout.tsx"
   name="ActionableCalloutProps"
 />
 
 ### `DismissibleCallout`
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/callout.tsx"
   name="DismissibleCalloutProps"
 />

--- a/docs/content/react/components/checkbox.mdx
+++ b/docs/content/react/components/checkbox.mdx
@@ -18,7 +18,7 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ## Props
 
-<ReactTypeTable path="./registry/ui/checkbox.tsx" name="CheckboxProps" />
+<react-type-table path="./registry/ui/checkbox.tsx" name="CheckboxProps" />
 
 ## Examples
 

--- a/docs/content/react/components/control-chip.mdx
+++ b/docs/content/react/components/control-chip.mdx
@@ -20,28 +20,28 @@ description: Control Chip은 사용자가 선택, 필터링, 전환과 같은 �
 
 ### ControlChip.Button
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/control-chip.tsx"
   name="ButtonControlChipProps"
 />
 
 ### ControlChip.Toggle
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/control-chip.tsx"
   name="ToggleControlChipProps"
 />
 
 ### ControlChip.RadioRoot
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/control-chip.tsx"
   name="RadioControlChipRootProps"
 />
 
 ### ControlChip.RadioItem
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/control-chip.tsx"
   name="RadioControlChipItemProps"
 />

--- a/docs/content/react/components/error-state.mdx
+++ b/docs/content/react/components/error-state.mdx
@@ -18,7 +18,7 @@ description: 사용자에게 오류 혹은 조회 결과가 없음을 알리는 
 
 ## Props
 
-<ReactTypeTable path="./registry/ui/error-state.tsx" name="ErrorStateProps" />
+<react-type-table path="./registry/ui/error-state.tsx" name="ErrorStateProps" />
 
 ## Examples
 

--- a/docs/content/react/components/extended-action-sheet.mdx
+++ b/docs/content/react/components/extended-action-sheet.mdx
@@ -20,21 +20,21 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ### `ExtendedActionSheetRoot`
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/extended-action-sheet.tsx"
   name="ExtendedActionSheetRootProps"
 />
 
 ### `ExtendedActionSheetContent`
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/extended-action-sheet.tsx"
   name="ExtendedActionSheetContentProps"
 />
 
 ### `ExtendedActionSheetItem`
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/extended-action-sheet.tsx"
   name="ExtendedActionSheetItemProps"
 />

--- a/docs/content/react/components/extended-fab.mdx
+++ b/docs/content/react/components/extended-fab.mdx
@@ -27,7 +27,7 @@ import { ExtendedFab, PrefixIcon } from "@seed-design/react";
 
 ## Props
 
-<ReactTypeTable path="../packages/react/src/components/ExtendedFab/ExtendedFab.tsx" name="ExtendedFabProps" />
+<react-type-table path="../packages/react/src/components/ExtendedFab/ExtendedFab.tsx" name="ExtendedFabProps" />
 
 ## Examples
 

--- a/docs/content/react/components/fab.mdx
+++ b/docs/content/react/components/fab.mdx
@@ -27,4 +27,4 @@ import { IconPlusLine } from "@daangn/react-monochrome-icon";
 
 ## Props
 
-<ReactTypeTable path="../packages/react/src/components/Fab/Fab.tsx" name="FabProps" />
+<react-type-table path="../packages/react/src/components/Fab/Fab.tsx" name="FabProps" />

--- a/docs/content/react/components/help-bubble.mdx
+++ b/docs/content/react/components/help-bubble.mdx
@@ -18,7 +18,7 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ## Props
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/help-bubble.tsx"
   name="HelpBubbleTriggerProps"
 />

--- a/docs/content/react/components/identity-placeholder.mdx
+++ b/docs/content/react/components/identity-placeholder.mdx
@@ -18,7 +18,7 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ## Props
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/identity-placeholder.tsx"
   name="IdentityPlaceholderProps"
 />

--- a/docs/content/react/components/inline-banner.mdx
+++ b/docs/content/react/components/inline-banner.mdx
@@ -20,21 +20,21 @@ description: 사용자가 꼭 알아야 하는 경고 메시지나 현재 상태
 
 ### `InlineBanner`
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/inline-banner.tsx"
   name="InlineBannerProps"
 />
 
 ### `ActionableInlineBanner`
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/inline-banner.tsx"
   name="ActionableInlineBannerProps"
 />
 
 ### `DismissibleInlineBanner`
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/inline-banner.tsx"
   name="DismissibleInlineBannerProps"
 />

--- a/docs/content/react/components/link-content.mdx
+++ b/docs/content/react/components/link-content.mdx
@@ -28,7 +28,7 @@ import { IconChevronRightLine } from "@daangn/react-monochrome-icon";
 
 ## Props
 
-<ReactTypeTable path="../packages/react/src/components/LinkContent/LinkContent.tsx" name="LinkContentProps" />
+<react-type-table path="../packages/react/src/components/LinkContent/LinkContent.tsx" name="LinkContentProps" />
 
 ## Examples
 

--- a/docs/content/react/components/manner-temp-badge.mdx
+++ b/docs/content/react/components/manner-temp-badge.mdx
@@ -18,4 +18,4 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ## Props
 
-<ReactTypeTable path="./registry/ui/manner-temp-badge.tsx" name="MannerTempBadgeProps" />
+<react-type-table path="./registry/ui/manner-temp-badge.tsx" name="MannerTempBadgeProps" />

--- a/docs/content/react/components/manner-temp.mdx
+++ b/docs/content/react/components/manner-temp.mdx
@@ -18,4 +18,4 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ## Props
 
-<ReactTypeTable path="./registry/ui/manner-temp.tsx" name="MannerTempProps" />
+<react-type-table path="./registry/ui/manner-temp.tsx" name="MannerTempProps" />

--- a/docs/content/react/components/progress-circle.mdx
+++ b/docs/content/react/components/progress-circle.mdx
@@ -18,7 +18,7 @@ description: 작업이 진행 중임을 알리거나 작업 시간을 시각적�
 
 ## Props
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/progress-circle.tsx"
   name="ProgressCircleProps"
 />

--- a/docs/content/react/components/pull-to-refresh.mdx
+++ b/docs/content/react/components/pull-to-refresh.mdx
@@ -20,15 +20,15 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ### PullToRefreshRoot
 
-<ReactTypeTable path="./registry/ui/pull-to-refresh.tsx" name="PullToRefreshRootProps" />
+<react-type-table path="./registry/ui/pull-to-refresh.tsx" name="PullToRefreshRootProps" />
 
 ### PullToRefreshIndicator
 
-<ReactTypeTable path="./registry/ui/pull-to-refresh.tsx" name="PullToRefreshIndicatorProps" />
+<react-type-table path="./registry/ui/pull-to-refresh.tsx" name="PullToRefreshIndicatorProps" />
 
 ### PullToRefreshContent
 
-<ReactTypeTable path="./registry/ui/pull-to-refresh.tsx" name="PullToRefreshContentProps" />
+<react-type-table path="./registry/ui/pull-to-refresh.tsx" name="PullToRefreshContentProps" />
 
 ## Examples
 

--- a/docs/content/react/components/reaction-button.mdx
+++ b/docs/content/react/components/reaction-button.mdx
@@ -18,7 +18,7 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ## Props
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/reaction-button.tsx"
   name="ReactionButtonProps"
 />

--- a/docs/content/react/components/segmented-control.mdx
+++ b/docs/content/react/components/segmented-control.mdx
@@ -24,14 +24,14 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 `value`와 `defaultValue` 중 적어도 하나를 제공해야 해요.
 </Callout>
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/segmented-control.tsx"
   name="SegmentedControlProps"
 />
 
 ### `SegmentedControlItem`
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/segmented-control.tsx"
   name="SegmentedControlItemProps"
 />

--- a/docs/content/react/components/select-box/check-select-box.mdx
+++ b/docs/content/react/components/select-box/check-select-box.mdx
@@ -20,7 +20,7 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ### `CheckSelectBox`
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/select-box.tsx"
   name="CheckSelectBoxProps"
 />

--- a/docs/content/react/components/select-box/radio-select-box.mdx
+++ b/docs/content/react/components/select-box/radio-select-box.mdx
@@ -20,14 +20,14 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ### `RadioSelectBoxRoot`
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/select-box.tsx"
   name="RadioSelectBoxRootProps"
 />
 
 ### `RadioSelectBoxItem`
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/select-box.tsx"
   name="RadioSelectBoxItemProps"
 />

--- a/docs/content/react/components/skeleton.mdx
+++ b/docs/content/react/components/skeleton.mdx
@@ -24,7 +24,7 @@ import { Skeleton } from "@seed-design/react";
 
 ## Props
 
-<ReactTypeTable path="../packages/react/src/components/Skeleton/Skeleton.tsx" name="SkeletonProps" />
+<react-type-table path="../packages/react/src/components/Skeleton/Skeleton.tsx" name="SkeletonProps" />
 
 ## Examples
 

--- a/docs/content/react/components/snackbar.mdx
+++ b/docs/content/react/components/snackbar.mdx
@@ -20,11 +20,11 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ### Snackbar
 
-<ReactTypeTable path="./registry/ui/snackbar.tsx" name="SnackbarProps" />
+<react-type-table path="./registry/ui/snackbar.tsx" name="SnackbarProps" />
 
 ### SnackbarAdapter.create
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/snackbar.tsx"
   name="CreateSnackbarOptions"
 />

--- a/docs/content/react/components/stackflow/app-screen.mdx
+++ b/docs/content/react/components/stackflow/app-screen.mdx
@@ -13,15 +13,15 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ### AppScreen
 
-<ReactTypeTable path="./registry/ui/app-screen.tsx" name="AppScreenProps" />
+<react-type-table path="./registry/ui/app-screen.tsx" name="AppScreenProps" />
 
 ### AppBar
 
-<ReactTypeTable path="./registry/ui/app-bar.tsx" name="AppBarProps" />
+<react-type-table path="./registry/ui/app-bar.tsx" name="AppBarProps" />
 
 ### AppBarMain
 
-<ReactTypeTable path="./registry/ui/app-bar.tsx" name="AppBarMainProps" />
+<react-type-table path="./registry/ui/app-bar.tsx" name="AppBarMainProps" />
 
 ## Examples
 

--- a/docs/content/react/components/switch.mdx
+++ b/docs/content/react/components/switch.mdx
@@ -18,7 +18,7 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ## Props
 
-<ReactTypeTable path="./registry/ui/switch.tsx" name="SwitchProps" />
+<react-type-table path="./registry/ui/switch.tsx" name="SwitchProps" />
 
 ## Examples
 

--- a/docs/content/react/components/tabs/chip-tabs.mdx
+++ b/docs/content/react/components/tabs/chip-tabs.mdx
@@ -20,23 +20,23 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ### `ChipTabsRoot`
 
-<ReactTypeTable path="./registry/ui/chip-tabs.tsx" name="ChipTabsRootProps" />
+<react-type-table path="./registry/ui/chip-tabs.tsx" name="ChipTabsRootProps" />
 
 ### `ChipTabsList`
 
-<ReactTypeTable path="./registry/ui/chip-tabs.tsx" name="ChipTabsListProps" />
+<react-type-table path="./registry/ui/chip-tabs.tsx" name="ChipTabsListProps" />
 
 ### `ChipTabsTrigger`
 
-<ReactTypeTable path="./registry/ui/chip-tabs.tsx" name="ChipTabsTriggerProps" />
+<react-type-table path="./registry/ui/chip-tabs.tsx" name="ChipTabsTriggerProps" />
 
 ### `ChipTabsCarousel`
 
-<ReactTypeTable path="./registry/ui/chip-tabs.tsx" name="ChipTabsCarouselProps" />
+<react-type-table path="./registry/ui/chip-tabs.tsx" name="ChipTabsCarouselProps" />
 
 ### `ChipTabsContent`
 
-<ReactTypeTable path="./registry/ui/chip-tabs.tsx" name="ChipTabsContentProps" />
+<react-type-table path="./registry/ui/chip-tabs.tsx" name="ChipTabsContentProps" />
 
 ## Examples
 

--- a/docs/content/react/components/tabs/tabs.mdx
+++ b/docs/content/react/components/tabs/tabs.mdx
@@ -20,23 +20,23 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ### TabsRoot
 
-<ReactTypeTable path="./registry/ui/tabs.tsx" name="TabsRootProps" />
+<react-type-table path="./registry/ui/tabs.tsx" name="TabsRootProps" />
 
 ### TabsList
 
-<ReactTypeTable path="./registry/ui/tabs.tsx" name="TabsListProps" />
+<react-type-table path="./registry/ui/tabs.tsx" name="TabsListProps" />
 
 ### TabsTrigger
 
-<ReactTypeTable path="./registry/ui/tabs.tsx" name="TabsTriggerProps" />
+<react-type-table path="./registry/ui/tabs.tsx" name="TabsTriggerProps" />
 
 ### TabsCarousel
 
-<ReactTypeTable path="./registry/ui/tabs.tsx" name="TabsCarouselProps" />
+<react-type-table path="./registry/ui/tabs.tsx" name="TabsCarouselProps" />
 
 ### TabsContent
 
-<ReactTypeTable path="./registry/ui/tabs.tsx" name="TabsContentProps" />
+<react-type-table path="./registry/ui/tabs.tsx" name="TabsContentProps" />
 
 ## Examples
 

--- a/docs/content/react/components/text-fields/multiline-text-field.mdx
+++ b/docs/content/react/components/text-fields/multiline-text-field.mdx
@@ -20,11 +20,11 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ### `TextField`
 
-<ReactTypeTable path="./registry/ui/text-field.tsx" name="TextFieldProps" />
+<react-type-table path="./registry/ui/text-field.tsx" name="TextFieldProps" />
 
 ### `TextFieldTextarea`
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/text-field.tsx"
   name="TextFieldTextareaProps"
 />

--- a/docs/content/react/components/text-fields/text-field.mdx
+++ b/docs/content/react/components/text-fields/text-field.mdx
@@ -20,11 +20,11 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ### `TextField`
 
-<ReactTypeTable path="./registry/ui/text-field.tsx" name="TextFieldProps" />
+<react-type-table path="./registry/ui/text-field.tsx" name="TextFieldProps" />
 
 ### `TextFieldInput`
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/text-field.tsx"
   name="TextFieldInputProps"
 />

--- a/docs/content/react/components/toggle-button.mdx
+++ b/docs/content/react/components/toggle-button.mdx
@@ -18,7 +18,7 @@ description: "이 문서는 정리 중이에요. 문의 내용은 #_design_core 
 
 ## Props
 
-<ReactTypeTable
+<react-type-table
   path="./registry/ui/toggle-button.tsx"
   name="ToggleButtonProps"
 />

--- a/docs/content/react/layout/box.mdx
+++ b/docs/content/react/layout/box.mdx
@@ -24,4 +24,4 @@ import { Box } from "@seed-design/react";
 
 ## Props
 
-<ReactTypeTable path="../packages/react/src/components/Box/Box.tsx" name="BoxProps" />
+<react-type-table path="../packages/react/src/components/Box/Box.tsx" name="BoxProps" />

--- a/docs/content/react/layout/columns.mdx
+++ b/docs/content/react/layout/columns.mdx
@@ -26,9 +26,9 @@ import { Columns, Column } from "@seed-design/react";
 
 ### `Columns`
 
-<ReactTypeTable path="../packages/react/src/components/Columns/Columns.tsx" name="ColumnsProps" />
+<react-type-table path="../packages/react/src/components/Columns/Columns.tsx" name="ColumnsProps" />
 
 ### `Column`
 
-<ReactTypeTable path="../packages/react/src/components/Columns/Columns.tsx" name="ColumnProps" />
+<react-type-table path="../packages/react/src/components/Columns/Columns.tsx" name="ColumnProps" />
 

--- a/docs/content/react/layout/flex.mdx
+++ b/docs/content/react/layout/flex.mdx
@@ -24,4 +24,4 @@ import { Flex } from "@seed-design/react";
 
 ## Props
 
-<ReactTypeTable path="../packages/react/src/components/Flex/Flex.tsx" name="FlexProps" />
+<react-type-table path="../packages/react/src/components/Flex/Flex.tsx" name="FlexProps" />

--- a/docs/content/react/layout/inline.mdx
+++ b/docs/content/react/layout/inline.mdx
@@ -24,4 +24,4 @@ import { Inline } from "@seed-design/react";
 
 ## Props
 
-<ReactTypeTable path="../packages/react/src/components/Inline/Inline.tsx" name="InlineProps" />
+<react-type-table path="../packages/react/src/components/Inline/Inline.tsx" name="InlineProps" />

--- a/docs/content/react/layout/stack.mdx
+++ b/docs/content/react/layout/stack.mdx
@@ -24,4 +24,4 @@ import { Stack } from "@seed-design/react";
 
 ## Props
 
-<ReactTypeTable path="../packages/react/src/components/Stack/Stack.tsx" name="StackProps" />
+<react-type-table path="../packages/react/src/components/Stack/Stack.tsx" name="StackProps" />

--- a/docs/content/react/typography/text.mdx
+++ b/docs/content/react/typography/text.mdx
@@ -24,4 +24,4 @@ import { Text } from "@seed-design/react";
 
 ## Props
 
-<ReactTypeTable path="../packages/react/src/components/Text/Text.tsx" name="TextProps" />
+<react-type-table path="../packages/react/src/components/Text/Text.tsx" name="TextProps" />

--- a/docs/package.json
+++ b/docs/package.json
@@ -58,6 +58,7 @@
     "react-dom": "^18.3.1",
     "react-error-boundary": "^4.1.2",
     "react-hook-form": "^7.53.2",
+    "recast": "^0.23.9",
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1",
     "remark-mdx": "^3.1.0",

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -1,5 +1,6 @@
 import { fileGenerator, remarkDocGen, remarkInstall } from "fumadocs-docgen";
 import { defineConfig, defineDocs } from "fumadocs-mdx/config";
+import { remarkReactTypeTable } from "./components/type-table/remark-react-type-table";
 
 export const docs = defineDocs({
   dir: "content/docs",
@@ -28,6 +29,7 @@ export default defineConfig({
         },
       ],
       [remarkDocGen, { generators: [fileGenerator()] }],
+      remarkReactTypeTable,
     ],
     rehypeCodeOptions: {
       lazy: true,


### PR DESCRIPTION
- auto type table의 타입 정보를 llms.txt에 제공하는 remark plugin을 작성합니다.
- `getProject()` 결과를 AutoTypeTable과 `remark-react-type-table` 에서 공유합니다.