### PR TITLE
fix: add missing slot properties to `bottom-sheet.yaml`

### DIFF
--- a/docs/public/rootage/components/bottom-sheet.json
+++ b/docs/public/rootage/components/bottom-sheet.json
@@ -61,7 +61,10 @@
             "gap": {
               "type": "dimension"
             },
-            "paddingX": {
+            "paddingLeft": {
+              "type": "dimension"
+            },
+            "paddingRight": {
               "type": "dimension"
             },
             "paddingTop": {

--- a/packages/rootage/components/bottom-sheet.yaml
+++ b/packages/rootage/components/bottom-sheet.yaml
@@ -40,7 +40,9 @@ data:
         properties:
           gap:
             type: dimension
-          paddingX:
+          paddingLeft:
+            type: dimension
+          paddingRight:
             type: dimension
           paddingTop:
             type: dimension


### PR DESCRIPTION
- `bottom-sheet.yaml`의 `header.paddingX` 속성을 `header.paddingLeft` / `header.paddingRight`로 분리합니다.