### PR TITLE
feat(figma): ignore hidden nodes, support BOOLEAN_OPERATION type

### DIFF
--- a/.changeset/nasty-ligers-doubt.md
+++ b/.changeset/nasty-ligers-doubt.md
@@ -1,0 +1,6 @@
+---
+"@seed-design/figma": patch
+---
+
+- 숨겨진 노드 및 Fill을 무시하도록 수정합니다.
+- BOOLEAN_OPERATION 노드를 지원합니다.

--- a/packages/figma/src/normalizer/from-plugin.ts
+++ b/packages/figma/src/normalizer/from-plugin.ts
@@ -7,9 +7,14 @@ import type {
   NormalizedComponentNode,
   NormalizedInstanceNode,
   NormalizedVectorNode,
+  NormalizedBooleanOperationNode,
 } from "./types";
 
 export function createPluginNormalizer() {
+  async function normalizeNodes(nodes: readonly SceneNode[]): Promise<NormalizedSceneNode[]> {
+    return Promise.all(nodes.filter((node) => node.visible).map(normalizeNode));
+  }
+
   async function normalizeNode(node: SceneNode): Promise<NormalizedSceneNode> {
     if (node.type === "FRAME") {
       return normalizeFrameNode(node);
@@ -22,6 +27,9 @@ export function createPluginNormalizer() {
     }
     if (node.type === "VECTOR") {
       return normalizeVectorNode(node);
+    }
+    if (node.type === "BOOLEAN_OPERATION") {
+      return normalizeBooleanOperationNode(node);
     }
     if (node.type === "TEXT") {
       return normalizeTextNode(node);
@@ -44,7 +52,7 @@ export function createPluginNormalizer() {
       boundVariables: await normalizeBoundVariables(node),
       ...normalizeRadiusProps(node),
       ...normalizeAutolayoutProps(node),
-      children: await Promise.all(node.children.map(normalizeNode)),
+      children: await normalizeNodes(node.children),
     };
   }
 
@@ -75,7 +83,7 @@ export function createPluginNormalizer() {
       counterAxisSpacing: node.inferredAutoLayout?.counterAxisSpacing ?? undefined,
       fills: [],
       strokes: [],
-      children: await Promise.all(node.children.map(normalizeNode)),
+      children: await normalizeNodes(node.children),
     };
   }
 
@@ -100,6 +108,18 @@ export function createPluginNormalizer() {
     };
   }
 
+  async function normalizeBooleanOperationNode(
+    node: BooleanOperationNode,
+  ): Promise<NormalizedBooleanOperationNode> {
+    return {
+      type: node.type,
+      id: node.id,
+      name: node.name,
+      boundVariables: await normalizeBoundVariables(node),
+      children: await normalizeNodes(node.children),
+      fills: normalizePaints(node.fills),
+    };
+  }
   async function normalizeTextNode(node: TextNode): Promise<NormalizedTextNode> {
     const segments = node.getStyledTextSegments([
       "fontSize",
@@ -173,7 +193,7 @@ export function createPluginNormalizer() {
       boundVariables: await normalizeBoundVariables(node),
       ...normalizeRadiusProps(node),
       ...normalizeAutolayoutProps(node),
-      children: await Promise.all(node.children.map(normalizeNode)),
+      children: await normalizeNodes(node.children),
     };
   }
 
@@ -203,7 +223,7 @@ export function createPluginNormalizer() {
       boundVariables: await normalizeBoundVariables(node),
       ...normalizeRadiusProps(node),
       ...normalizeAutolayoutProps(node),
-      children: await Promise.all(node.children.map(normalizeNode)),
+      children: await normalizeNodes(node.children),
       componentKey: mainComponent.key,
       componentSetKey:
         mainComponent.parent?.type === "COMPONENT_SET" ? mainComponent.parent.key : undefined,

--- a/packages/figma/src/normalizer/from-rest.ts
+++ b/packages/figma/src/normalizer/from-rest.ts
@@ -8,6 +8,7 @@ import type {
   NormalizedInstanceNode,
   NormalizedTextSegment,
   NormalizedVectorNode,
+  NormalizedBooleanOperationNode,
 } from "./types";
 
 export interface RestNormalizerContext {
@@ -17,6 +18,11 @@ export interface RestNormalizerContext {
 }
 
 export function createRestNormalizer(ctx: RestNormalizerContext) {
+  function normalizeNodes(nodes: readonly FigmaRestSpec.Node[]): NormalizedSceneNode[] {
+    // Figma REST API omits default values for some fields, "visible" is one of them
+    return nodes.filter((node) => !("visible" in node) || node.visible).map(normalizeNode);
+  }
+
   function normalizeNode(node: FigmaRestSpec.Node): NormalizedSceneNode {
     if (node.type === "FRAME") {
       return normalizeFrameNode(node);
@@ -29,6 +35,9 @@ export function createRestNormalizer(ctx: RestNormalizerContext) {
     }
     if (node.type === "VECTOR") {
       return normalizeVectorNode(node);
+    }
+    if (node.type === "BOOLEAN_OPERATION") {
+      return normalizeBooleanOperationNode(node);
     }
     if (node.type === "TEXT") {
       return normalizeTextNode(node);
@@ -46,7 +55,7 @@ export function createRestNormalizer(ctx: RestNormalizerContext) {
   function normalizeFrameNode(node: FigmaRestSpec.FrameNode): NormalizedFrameNode {
     return {
       ...node,
-      children: node.children.map(normalizeNode),
+      children: normalizeNodes(node.children),
     };
   }
 
@@ -54,7 +63,7 @@ export function createRestNormalizer(ctx: RestNormalizerContext) {
     return {
       ...node,
       type: "FRAME",
-      children: node.children.map(normalizeNode),
+      children: normalizeNodes(node.children),
     };
   }
 
@@ -64,6 +73,15 @@ export function createRestNormalizer(ctx: RestNormalizerContext) {
 
   function normalizeVectorNode(node: FigmaRestSpec.VectorNode): NormalizedVectorNode {
     return node;
+  }
+
+  function normalizeBooleanOperationNode(
+    node: FigmaRestSpec.BooleanOperationNode,
+  ): NormalizedBooleanOperationNode {
+    return {
+      ...node,
+      children: normalizeNodes(node.children),
+    };
   }
 
   function normalizeTextNode(node: FigmaRestSpec.TextNode): NormalizedTextNode {
@@ -141,7 +159,7 @@ export function createRestNormalizer(ctx: RestNormalizerContext) {
   function normalizeComponentNode(node: FigmaRestSpec.ComponentNode): NormalizedComponentNode {
     return {
       ...node,
-      children: node.children.map(normalizeNode),
+      children: normalizeNodes(node.children),
     };
   }
 
@@ -167,7 +185,7 @@ export function createRestNormalizer(ctx: RestNormalizerContext) {
 
     return {
       ...node,
-      children: node.children.map(normalizeNode),
+      children: normalizeNodes(node.children),
       componentKey: mainComponent.key,
       componentSetKey: componentSet?.key,
       componentProperties,

--- a/packages/figma/src/normalizer/types.ts
+++ b/packages/figma/src/normalizer/types.ts
@@ -82,7 +82,9 @@ export interface NormalizedVectorNode
   extends Pick<FigmaRestSpec.VectorNode, CommonProps | ShapeProps> {}
 
 export interface NormalizedBooleanOperationNode
-  extends Pick<FigmaRestSpec.BooleanOperationNode, CommonProps | "fills"> {}
+  extends Pick<FigmaRestSpec.BooleanOperationNode, CommonProps | "fills"> {
+  children: NormalizedSceneNode[];
+}
 
 export type NormalizedSceneNode =
   | NormalizedFrameNode


### PR DESCRIPTION
- 숨겨진 노드 및 Fill을 무시하도록 수정합니다.
- BOOLEAN_OPERATION 노드를 지원합니다.