### PR TITLE
fix: change `header.paddingBottom` of `dialog.yaml` to `header.paddingTop`

### DIFF
--- a/docs/public/rootage/components/dialog.json
+++ b/docs/public/rootage/components/dialog.json
@@ -82,7 +82,7 @@
             "paddingX": {
               "type": "dimension"
             },
-            "paddingBottom": {
+            "paddingTop": {
               "type": "dimension"
             }
           }

--- a/packages/rootage/components/dialog.yaml
+++ b/packages/rootage/components/dialog.yaml
@@ -54,7 +54,7 @@ data:
             type: dimension
           paddingX:
             type: dimension
-          paddingBottom:
+          paddingTop:
             type: dimension
       footer:
         properties:


### PR DESCRIPTION
- `dialog.yaml`에 잘못 기재되어 있던 `header.paddingBottom` 슬롯명을 `header.paddingTop`으로 변경합니다.