### PR TITLE
feat(css): introduce ScopedColor types for improved type safety

### DIFF
--- a/.changeset/healthy-poets-protect.md
+++ b/.changeset/healthy-poets-protect.md
@@ -1,0 +1,6 @@
+---
+"@seed-design/react": patch
+"@seed-design/css": patch
+---
+
+유틸리티 컴포넌트에 사용되는 ScopedColorFg, ScopedColorBg, ScopedColorPalette, ScopedColorStroke 타입을 제공합니다.

--- a/packages/css/vars/index.d.ts
+++ b/packages/css/vars/index.d.ts
@@ -5,11 +5,23 @@ export type TokenObject = typeof vars;
 
 export type ColorFg = keyof TokenObject["$color"]["fg"];
 
+// Workaround for type docgen
+export type ScopedColorFg = Exclude<`fg.${ColorFg}`, "">;
+
 export type ColorBg = keyof TokenObject["$color"]["bg"];
+
+// Workaround for type docgen
+export type ScopedColorBg = Exclude<`bg.${ColorBg}`, "">;
 
 export type ColorStroke = keyof TokenObject["$color"]["stroke"];
 
+// Workaround for type docgen
+export type ScopedColorStroke = Exclude<`stroke.${ColorStroke}`, "">;
+
 export type ColorPalette = keyof TokenObject["$color"]["palette"];
+
+// Workaround for type docgen
+export type ScopedColorPalette = Exclude<`palette.${ColorPalette}`, "">;
 
 export type Duration = keyof TokenObject["$duration"];
 

--- a/packages/qvism-preset/src/vars/index.d.ts
+++ b/packages/qvism-preset/src/vars/index.d.ts
@@ -5,11 +5,23 @@ export type TokenObject = typeof vars;
 
 export type ColorFg = keyof TokenObject["$color"]["fg"];
 
+// Workaround for type docgen
+export type ScopedColorFg = Exclude<`fg.${ColorFg}`, "">;
+
 export type ColorBg = keyof TokenObject["$color"]["bg"];
+
+// Workaround for type docgen
+export type ScopedColorBg = Exclude<`bg.${ColorBg}`, "">;
 
 export type ColorStroke = keyof TokenObject["$color"]["stroke"];
 
+// Workaround for type docgen
+export type ScopedColorStroke = Exclude<`stroke.${ColorStroke}`, "">;
+
 export type ColorPalette = keyof TokenObject["$color"]["palette"];
+
+// Workaround for type docgen
+export type ScopedColorPalette = Exclude<`palette.${ColorPalette}`, "">;
 
 export type Duration = keyof TokenObject["$duration"];
 

--- a/packages/react/src/components/Icon/Icon.tsx
+++ b/packages/react/src/components/Icon/Icon.tsx
@@ -1,6 +1,6 @@
 import { Slot } from "@radix-ui/react-slot";
 import { useLayoutEffect } from "@radix-ui/react-use-layout-effect";
-import type { ColorFg, ColorPalette, Dimension } from "@seed-design/css/vars";
+import type { Dimension, ScopedColorFg, ScopedColorPalette } from "@seed-design/css/vars";
 import { createContext, forwardRef, useCallback, useContext, useMemo, useRef } from "react";
 import { handleColor, handleDimension } from "../../utils/styled";
 
@@ -108,7 +108,7 @@ export interface IconProps {
 
   size?: Dimension | string;
 
-  color?: `fg.${ColorFg}` | `palette.${ColorPalette}`;
+  color?: ScopedColorFg | ScopedColorPalette;
 }
 
 export const Icon = forwardRef<SVGSVGElement, IconProps>(

--- a/packages/react/src/components/Text/Text.tsx
+++ b/packages/react/src/components/Text/Text.tsx
@@ -1,11 +1,11 @@
 import { text, type TextVariantProps } from "@seed-design/css/recipes/text";
 import {
   vars,
-  type ColorFg,
-  type ColorPalette,
   type FontSize,
   type FontWeight,
   type LineHeight,
+  type ScopedColorFg,
+  type ScopedColorPalette,
 } from "@seed-design/css/vars";
 import clsx from "clsx";
 import type * as React from "react";
@@ -56,7 +56,7 @@ export interface TextProps
   /**
    * The color of the text.
    */
-  color?: `fg.${ColorFg}` | `palette.${ColorPalette}`;
+  color?: ScopedColorFg | ScopedColorPalette;
 
   /**
    * The font size of the text. Partially overrides the textStyle.

--- a/packages/react/src/utils/styled.tsx
+++ b/packages/react/src/utils/styled.tsx
@@ -1,8 +1,8 @@
 import type {
-  ColorBg,
-  ColorFg,
-  ColorPalette,
-  ColorStroke,
+  ScopedColorBg,
+  ScopedColorFg,
+  ScopedColorPalette,
+  ScopedColorStroke,
   Dimension,
   Radius,
   SpacingX,
@@ -105,11 +105,11 @@ function handleAlignItems(alignItems: string | undefined) {
 }
 
 export interface StyleProps {
-  background?: `bg.${ColorBg}` | `palette.${ColorPalette}`;
+  background?: ScopedColorBg | ScopedColorPalette;
 
-  color?: `fg.${ColorFg}` | `palette.${ColorPalette}`;
+  color?: ScopedColorFg | ScopedColorPalette;
 
-  borderColor?: `stroke.${ColorStroke}` | `palette.${ColorPalette}`;
+  borderColor?: ScopedColorStroke | ScopedColorPalette;
 
   borderWidth?: 0 | 1 | (number & {});
 


### PR DESCRIPTION
유틸리티 컴포넌트에 사용되는 ScopedColorFg, ScopedColorBg, ScopedColorPalette, ScopedColorStroke 타입을 제공합니다.