### PR TITLE
feat(codemod): custom transfomers

### DIFF
--- a/.changeset/hip-squids-leave.md
+++ b/.changeset/hip-squids-leave.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/codemod": patch
+---
+
+replace-custom-seed-design-vars를 추가해요

--- a/.changeset/hip-squids-leave.md
+++ b/.changeset/hip-squids-leave.md
@@ -3,5 +3,6 @@
 ---
 
 - replace-custom-seed-design-vars를 추가해요
+- replace-custom-imported-typography-variable를 추가해요
 - replace-custom-seed-design-typography를 추가해요
 - replace-seed-design-token-typography-classname VE에서 잘 변경되지 않던 이슈를 해결해요

--- a/.changeset/hip-squids-leave.md
+++ b/.changeset/hip-squids-leave.md
@@ -5,4 +5,5 @@
 - replace-custom-seed-design-vars를 추가해요
 - replace-custom-imported-typography-variable를 추가해요
 - replace-custom-seed-design-typography를 추가해요
+- replace-custom-seed-design-color를 추가해요
 - replace-seed-design-token-typography-classname VE에서 잘 변경되지 않던 이슈를 해결해요

--- a/.changeset/hip-squids-leave.md
+++ b/.changeset/hip-squids-leave.md
@@ -4,3 +4,4 @@
 
 - replace-custom-seed-design-vars를 추가해요
 - replace-custom-seed-design-typography를 추가해요
+- replace-seed-design-token-typography-classname VE에서 잘 변경되지 않던 이슈를 해결해요

--- a/.changeset/hip-squids-leave.md
+++ b/.changeset/hip-squids-leave.md
@@ -2,4 +2,5 @@
 "@seed-design/codemod": patch
 ---
 
-replace-custom-seed-design-vars를 추가해요
+- replace-custom-seed-design-vars를 추가해요
+- replace-custom-seed-design-typography를 추가해요

--- a/.cursor/rules/codemod-utils.mdc
+++ b/.cursor/rules/codemod-utils.mdc
@@ -1,0 +1,139 @@
+---
+description: 
+globs: packages/codemod/**/*
+alwaysApply: false
+---
+ # Seed Design 코드모드 유틸리티 가이드
+
+Seed Design 코드모드 시스템에서 사용하는 유틸리티 함수와 모듈에 대한 설명입니다. 코드모드 개발 시 중복 코드를 줄이고 표준화된 방식으로 개발하기 위한 가이드라인입니다.
+
+## 유틸리티 모듈 개요
+
+Seed Design 코드모드 시스템은 다음과 같은 유틸리티 모듈을 제공합니다:
+
+| 모듈 | 설명 |
+|------|------|
+| `case.ts` | 케이스 변환 유틸리티 (camelCase, kebab-case 등) |
+| `color-properties.ts` | 색상 토큰 속성 타입 판별 유틸리티 |
+| `ast.ts` | AST 조작 및 분석 유틸리티 |
+| `logger.ts` | 변환 로깅 유틸리티 |
+
+## 케이스 변환 유틸리티 (case.ts)
+
+케이스 변환 유틸리티는 토큰명과 CSS 속성명 등의 다양한 케이스 스타일을 변환합니다.
+
+```typescript
+import { camelCaseToKebabCase } from "../../utils/case.js";
+
+// camelCase를 kebab-case로 변환
+// divider1 -> divider-1, paperDefault -> paper-default
+const kebabName = camelCaseToKebabCase(camelCaseName);
+```
+
+## 색상 속성 유틸리티 (color-properties.ts)
+
+CSS 속성이 어떤 타입의 색상 토큰(fg, bg, stroke)과 매핑되어야 하는지 결정하는 유틸리티입니다.
+
+```typescript
+import { getTokenTypeForProperty } from "../../utils/color-properties.js";
+
+// 속성명에 따라 적절한 토큰 타입 결정 ("bg" | "fg" | "stroke" | "palette")
+const tokenType = getTokenTypeForProperty(propertyName);
+
+// 특정 속성이 특정 타입인지 확인
+import { isBackgroundProperty, isFgProperty, isStrokeProperty } from "../../utils/color-properties.js";
+
+if (isStrokeProperty(propertyName)) {
+  // 테두리 관련 속성 처리 (border, outline 등)
+} else if (isFgProperty(propertyName)) {
+  // 텍스트/전경 관련 속성 처리 (color, fill 등)
+} else if (isBackgroundProperty(propertyName)) {
+  // 배경 관련 속성 처리 (backgroundColor 등)
+}
+```
+
+### 토큰 타입 우선순위
+
+색상 토큰은 다음과 같은 우선순위로 매핑됩니다:
+
+1. stroke 속성: `stroke` -> `fg` -> `palette` 순으로 시도
+2. fg 속성: `fg` -> `palette` 순으로 시도  
+3. bg 속성: `bg` -> `palette` 순으로 시도
+4. 기존 scale: `palette` 사용
+
+## AST 유틸리티 (ast.ts)
+
+AST(Abstract Syntax Tree) 조작 및 분석을 위한 유틸리티입니다.
+
+```typescript
+import { getParentPropertyName } from "../../utils/ast.js";
+
+// 노드의 부모 속성명 찾기 (예: color, backgroundColor 등)
+const parentPropertyName = getParentPropertyName(path);
+```
+
+### 삼항 연산자 처리
+
+삼항 연산자(조건부 표현식) 내에서 토큰을 찾고 변환하기 위한 유틸리티:
+
+```typescript
+import { processTernaryExpressions, PatternFilter } from "../../utils/ast.js";
+
+// 삼항 연산자 내에서 vars.color.XXX 패턴 찾기
+const pattern: PatternFilter = {
+  type: j.MemberExpression,
+  filter: {
+    object: {
+      type: "MemberExpression",
+      object: { type: "Identifier", name: "vars" },
+      property: { type: "Identifier", name: "color" }
+    }
+  }
+};
+
+// 삼항 연산자 내의 모든 vars.color.XXX 표현식 처리
+processTernaryExpressions(
+  j, 
+  ternaryPath, 
+  pattern,
+  (path, context) => {
+    // 각 매치된 노드 처리
+    // context.parentPropertyName - 삼항 연산자가 할당된 속성 이름
+    // context.depth - 중첩 깊이
+    // context.path - 삼항 연산자 내 위치 ('root', 'consequent', 'alternate')
+  }
+);
+```
+
+## 로깅 유틸리티 (logger.ts)
+
+transform 실행 결과를 로깅하기 위한 유틸리티입니다.
+
+```typescript
+import { createTransformLogger } from "../../utils/logger.js";
+
+const logger = createTransformLogger("transform-name");
+
+// 변환 시작 로깅
+logger.startFile(file.path);
+
+// 변환 결과 로깅
+logger.logTransformResult(file.path, {
+  previousToken: "이전 토큰",
+  nextToken: "새 토큰",
+  line: lineNumber,
+  status: "success", // "success" | "failure" | "warning"
+});
+
+// 실패 로깅
+logger.logTransformResult(file.path, {
+  previousToken: `Failed to find mapping for: ${token}`,
+  nextToken: null,
+  line: lineNumber,
+  status: "failure",
+  failureReason: "No mapping found"
+});
+
+// 변환 종료 로깅
+logger.finishFile(file.path);
+```

--- a/.cursor/rules/codemod.mdc
+++ b/.cursor/rules/codemod.mdc
@@ -43,6 +43,7 @@ You are working with the Seed Design codemod system for migrating from V2 to V3.
      - Use getTokenTypeForProperty() function to determine appropriate token type for properties
      - Check property nature with isBackgroundProperty(), isTextProperty(), isStrokeProperty() helper functions
   5. Use palette tokens when context is unclear (inside object literals, etc.)
+- DO NOT add code to pass only certain cases
 
 # Token Format Guidelines
 

--- a/docs/content/react/get-started/codemod.mdx
+++ b/docs/content/react/get-started/codemod.mdx
@@ -179,6 +179,208 @@ export function BasicExample() {
 </Accordion>
 </Accordions>
 
+### replace-custom-imported-typography-variable
+
+Seed Design V2에서 V3로 마이그레이션 시 import된 타이포그래피 변수를 변환합니다.
+
+#### 기능
+
+- 타이포그래피 관련 import 문을 찾아 변수명을 변환합니다.
+- 변수가 사용된 모든 위치(템플릿 리터럴, 객체 속성 등)를 찾아 업데이트합니다.
+- typography.mjs의 매핑 정보에 따라 V2 타이포그래피 변수를 V3로 변환합니다.
+
+#### 테스트 케이스
+
+- **basic**: 기본적인 변환 케이스
+- **enhanced**: 다양한 타이포그래피 변수 매핑 케이스
+  - screenTitle 매핑 (h4 -> screenTitle)
+  - 일반 매핑 (title1Bold -> t9Bold)
+  - deprecated 토큰 처리 (title1Regular)
+  - 별칭을 사용한 import 처리
+  - 대체 토큰 처리 (bodyL2Regular -> t4Regular)
+  - 객체 속성으로 사용된 토큰 처리
+  - 다양한 컨텍스트에서의 변수 사용 패턴
+
+```package-install
+npx @seed-design/codemod replace-custom-imported-typography-variable <target_path>
+```
+
+<Accordions>
+<Accordion title="변경 예시">
+
+```ts title="basic.input.ts"
+// @ts-nocheck
+import { 
+  subtitle1Regular, 
+  subtitle2Regular, 
+  h4, 
+  title1Bold, 
+  title2Bold, 
+  bodyL1Regular, 
+  caption1Regular, 
+  caption2Regular, 
+  label5Regular 
+} from '@src/constants/typography'
+import { bodyM1Regular as customTypo } from '@karrot/typography'
+
+const S_StoreRequestTitle = styled.h1`
+  ${subtitle1Regular};
+  margin: 0 0 0.25rem;
+  color: ${vars.$scale.color.gray900};
+  text-align: center;
+`
+const S_StoreRequestText = styled.p`
+  ${subtitle2Regular};
+  margin: 0;
+  color: ${vars.$scale.color.gray600};
+  text-align: center;
+`
+
+// 추가 테스트 케이스
+// screenTitle 매핑 테스트
+const S_ScreenHeader = styled.h1`
+  ${h4};
+  margin-bottom: 1rem;
+`
+
+// 일반 매핑 테스트
+const S_Title = styled.h2`
+  ${title1Bold};
+  color: ${vars.$scale.color.gray900};
+`
+
+// 여러 테스트 케이스를 담은 컴포넌트
+const Card = styled.div`
+  // title2Bold 매핑 테스트
+  h3 {
+    ${title2Bold};
+    margin-bottom: 8px;
+  }
+  
+  // bodyL1Regular 매핑 테스트
+  p.description {
+    ${bodyL1Regular};
+    color: ${vars.$scale.color.gray800};
+  }
+  
+  // 캡션 스타일
+  p.caption {
+    ${caption1Regular};
+    color: ${vars.$scale.color.gray600};
+  }
+  
+  // 작은 텍스트
+  small {
+    ${caption2Regular};
+    color: ${vars.$scale.color.gray500};
+  }
+  
+  // 라벨 스타일
+  label {
+    ${label5Regular};
+    margin-right: 4px;
+  }
+`
+
+// 다른 모듈에서 가져온 타이포그래피 처리 (별칭 유지해야 함)
+const S_CustomContent = styled.div`
+  ${customTypo};
+  color: ${vars.$scale.color.gray700};
+`
+
+// 변수로 사용하는 경우
+const titleStyle = title1Bold;
+const textStyle = subtitle1Regular;
+```
+
+```ts title="basic.output.ts"
+// @ts-nocheck
+import { 
+  t5Regular, 
+  t4Regular, 
+  t10Bold, 
+  t9Bold, 
+  t7Bold, 
+  articleBody, 
+  t3Regular, 
+  t2Regular, 
+  t1Regular 
+} from '@src/constants/typography'
+import { t5Regular as customTypo } from '@karrot/typography'
+
+const S_StoreRequestTitle = styled.h1`
+  ${t5Regular};
+  margin: 0 0 0.25rem;
+  color: ${vars.$scale.color.gray900};
+  text-align: center;
+`
+const S_StoreRequestText = styled.p`
+  ${t4Regular};
+  margin: 0;
+  color: ${vars.$scale.color.gray600};
+  text-align: center;
+`
+
+// 추가 테스트 케이스
+// screenTitle 매핑 테스트
+const S_ScreenHeader = styled.h1`
+  ${t10Bold};
+  margin-bottom: 1rem;
+`
+
+// 일반 매핑 테스트
+const S_Title = styled.h2`
+  ${t9Bold};
+  color: ${vars.$scale.color.gray900};
+`
+
+// 여러 테스트 케이스를 담은 컴포넌트
+const Card = styled.div`
+  // title2Bold 매핑 테스트
+  h3 {
+    ${t7Bold};
+    margin-bottom: 8px;
+  }
+  
+  // bodyL1Regular 매핑 테스트
+  p.description {
+    ${articleBody};
+    color: ${vars.$scale.color.gray800};
+  }
+  
+  // 캡션 스타일
+  p.caption {
+    ${t3Regular};
+    color: ${vars.$scale.color.gray600};
+  }
+  
+  // 작은 텍스트
+  small {
+    ${t2Regular};
+    color: ${vars.$scale.color.gray500};
+  }
+  
+  // 라벨 스타일
+  label {
+    ${t1Regular};
+    margin-right: 4px;
+  }
+`
+
+// 다른 모듈에서 가져온 타이포그래피 처리 (별칭 유지해야 함)
+const S_CustomContent = styled.div`
+  ${customTypo};
+  color: ${vars.$scale.color.gray700};
+`
+
+// 변수로 사용하는 경우
+const titleStyle = t9Bold;
+const textStyle = t5Regular;
+```
+
+</Accordion>
+</Accordions>
+
 ### replace-custom-seed-design-vars
 
 ```package-install
@@ -1280,6 +1482,7 @@ npx @seed-design/codemod replace-seed-design-token-typography-classname <target_
 // @ts-nocheck
 
 import { classNames } from "@seed-design/design-token";
+import { style } from "@vanilla-extract/css";
 
 const typography = {
   one: classNames.$semantic.typography.title2Regular,
@@ -1287,12 +1490,23 @@ const typography = {
   three: classNames.$semantic.typography.label5Regular,
   four: classNames.$semantic.typography.label6Regular,
 }
+
+export const footer = style([
+  classNames.$semantic.typography.caption1Regular,
+  {
+    padding: "16px",
+    marginTop: "12px",
+    color: vars.$scale.color.gray700,
+    backgroundColor: vars.$semantic.color.paperContents,
+  },
+]);
 ```
 
 ```tsx title="basic.output.tsx"
 // @ts-nocheck
 
 import { text } from "@seed-design/css/recipes/text";
+import { style } from "@vanilla-extract/css";
 
 const typography = {
   one: text({ textStyle: "t7Regular" }),
@@ -1300,6 +1514,16 @@ const typography = {
   three: text({ textStyle: "t1Regular" }),
   four: text({ textStyle: "t1Regular" }),
 }
+
+export const footer = style([
+  text({ textStyle: "t3Regular" }),
+  {
+    padding: "16px",
+    marginTop: "12px",
+    color: vars.$scale.color.gray700,
+    backgroundColor: vars.$semantic.color.paperContents,
+  },
+]);
 ```
 
 </Accordion>

--- a/docs/content/react/get-started/codemod.mdx
+++ b/docs/content/react/get-started/codemod.mdx
@@ -3,6 +3,8 @@ title: Codemod
 description: Seed Design V2에서 V3로 마이그레이션하기 위한 코드 변환 도구
 ---
 
+{/* Auto-generated from `scripts/generate-codemod-docs.ts` */}
+
 `@seed-design/codemod`는 Seed Design V2에서 V3로 마이그레이션하기 위한 코드 변환 도구예요.
 
 ## 사용 방법
@@ -91,6 +93,82 @@ export function BasicExample() {
 </Accordion>
 </Accordions>
 
+### replace-custom-seed-design-vars
+
+```package-install
+npx @seed-design/codemod replace-custom-seed-design-vars <target_path>
+```
+
+<Accordions>
+<Accordion title="변경 예시">
+
+```ts title="basic.input.ts"
+// @ts-nocheck
+import { vars } from '@/shared/style/vars';
+
+export const date = style({
+  ...vars.typography.caption1Regular,
+  color: vars.color.gray600,
+});
+
+export const color1 = style({
+  color: vars.color.yellow500,
+});
+
+export const color2 = style({
+  color: vars.color.blue500,
+});
+
+export const color3 = style({
+  color: vars.color.red500,
+});
+
+export const title = style({
+  ...vars.typography.bodyM1Bold,
+  color: vars.color.primary,
+});
+
+export const subtitle = style({
+  ...vars.typography.bodyM2Regular,
+  color: vars.color.secondary,
+});
+```
+
+```ts title="basic.output.ts"
+// @ts-nocheck
+import { vars } from '@/shared/style/vars';
+
+export const date = style({
+  ...vars.typography.t3Regular,
+  color: vars.color.palette.gray700,
+});
+
+export const color1 = style({
+  color: vars.color.palette.yellow700,
+});
+
+export const color2 = style({
+  color: vars.color.palette.blue600,
+});
+
+export const color3 = style({
+  color: vars.color.palette.red700,
+});
+
+export const title = style({
+  ...vars.typography.t5Bold,
+  color: vars.color.fg.brand,
+});
+
+export const subtitle = style({
+  ...vars.typography.t4Regular,
+  color: vars.color.palette.gray900,
+});
+```
+
+</Accordion>
+</Accordions>
+
 ### replace-stitches-styled-typography
 
 Stitches로 스타일링된 컴포넌트의 타이포그래피를 V3 형식으로 변환해요.
@@ -119,6 +197,9 @@ const ContentText = styled('p', {
       large: {
         $text: 'bodyL1Regular',
       },
+      xlarge: {
+        $text: "h4",
+      },
     },
   },
 });
@@ -141,9 +222,302 @@ const ContentText = styled('p', {
       large: {
         $text: "articleBody",
       },
+      xlarge: {
+        $text: "t10Bold",
+      },
     },
   },
 });
+```
+
+</Accordion>
+</Accordions>
+
+### replace-stitches-theme-color
+
+```package-install
+npx @seed-design/codemod replace-stitches-theme-color <target_path>
+```
+
+<Accordions>
+<Accordion title="변경 예시">
+
+```tsx title="basic.input.tsx"
+// @ts-nocheck
+
+import { theme } from '@src/stitches/stitches.config'
+
+const semanticColors = {
+  primary: theme.colors['primary-semantic'].computedValue,
+  onPrimary: theme.colors['onPrimary-semantic'].computedValue,
+  primaryLow: theme.colors['primaryLow-semantic'].computedValue,
+  success: theme.colors['success-semantic'].computedValue,
+  warning: theme.colors['warning-semantic'].computedValue,
+  danger: theme.colors['danger-semantic'].computedValue,
+  paperDefault: theme.colors['paperDefault-semantic'].computedValue,
+  paperContents: theme.colors['paperContents-semantic'].computedValue,
+  paperDialog: theme.colors['paperDialog-semantic'].computedValue,
+  inkText: theme.colors['inkText-semantic'].computedValue,
+  inkTextLow: theme.colors['inkTextLow-semantic'].computedValue,
+  divider1: theme.colors['divider1-semantic'].computedValue,
+  divider2: theme.colors['divider2-semantic'].computedValue,
+  overlayDim: theme.colors['overlayDim-semantic'].computedValue,
+  accent: theme.colors['accent-semantic'].computedValue,
+}
+
+const scaleColors = {
+  gray00: theme.colors.gray00.computedValue,
+  gray100: theme.colors.gray100.computedValue,
+  gray200: theme.colors.gray200.computedValue,
+  gray300: theme.colors.gray300.computedValue,
+  gray400: theme.colors.gray400.computedValue,
+  gray500: theme.colors.gray500.computedValue,
+  gray600: theme.colors.gray600.computedValue,
+  gray700: theme.colors.gray700.computedValue,
+  gray800: theme.colors.gray800.computedValue,
+  gray900: theme.colors.gray900.computedValue,
+  carrot100: theme.colors.carrot100.computedValue,
+  carrot500: theme.colors.carrot500.computedValue,
+  carrot900: theme.colors.carrot900.computedValue,
+  carrotAlpha50: theme.colors.carrotAlpha50.computedValue,
+  carrotAlpha100: theme.colors.carrotAlpha100.computedValue,
+  carrotAlpha200: theme.colors.carrotAlpha200.computedValue,
+  blue300: theme.colors.blue300.computedValue,
+  blue600: theme.colors.blue600.computedValue,
+  red500: theme.colors.red500.computedValue,
+}
+
+const staticColors = {
+  white: theme.colors['white-static'].computedValue,
+  black: theme.colors['black-static'].computedValue,
+  blackAlpha200: theme.colors['blackAlpha200-static'].computedValue,
+  whiteAlpha200: theme.colors['whiteAlpha200-static'].computedValue,
+  gray900: theme.colors['gray900-static'].computedValue,
+  carrot50: theme.colors['carrot50-static'].computedValue,
+  carrot800: theme.colors['carrot800-static'].computedValue,
+  blue50: theme.colors['blue50-static'].computedValue,
+  blue800: theme.colors['blue800-static'].computedValue,
+  red50: theme.colors['red50-static'].computedValue,
+  red800: theme.colors['red800-static'].computedValue,
+}
+
+const Component = () => {
+  return (
+    <div>
+      <Button
+        backgroundColor={theme.colors['primary-semantic'].computedValue}
+        color={theme.colors['onPrimary-semantic'].computedValue}
+      >
+        버튼
+      </Button>
+      <InfoBox borderColor={theme.colors.gray300.computedValue}>
+        <Text color={theme.colors.gray900.computedValue}>
+          안내사항
+        </Text>
+        <WarningIcon fill={theme.colors['warning-semantic'].computedValue} />
+      </InfoBox>
+      <Badge backgroundColor={theme.colors['danger-semantic'].computedValue}>
+        <BadgeText color={theme.colors['white-static'].computedValue}>
+          중요
+        </BadgeText>
+      </Badge>
+    </div>
+  );
+};
+
+const Dialog = ({ isOpen, onClose }) => {
+  const styles = {
+    overlay: {
+      backgroundColor: theme.colors['overlayDim-semantic'].computedValue,
+    },
+    container: {
+      backgroundColor: theme.colors['paperDialog-semantic'].computedValue,
+      borderColor: theme.colors.gray300.computedValue,
+    },
+    header: {
+      borderBottom: `1px solid ${theme.colors['divider1-semantic'].computedValue}`,
+    },
+    title: {
+      color: theme.colors.gray900.computedValue,
+    },
+    content: {
+      color: theme.colors.gray700.computedValue,
+      backgroundColor: theme.colors['paperContents-semantic'].computedValue,
+    },
+    footer: {
+      borderTop: `1px solid ${theme.colors['divider2-semantic'].computedValue}`,
+    },
+    closeButton: {
+      color: theme.colors.gray500.computedValue,
+    },
+    submitButton: {
+      backgroundColor: theme.colors.blue600.computedValue,
+      color: theme.colors['white-static'].computedValue,
+    },
+  };
+
+  return isOpen ? (
+    <div style={styles.overlay}>
+      <div style={styles.container}>
+        <div style={styles.header}>
+          <h2 style={styles.title}>다이얼로그 제목</h2>
+          <button style={styles.closeButton} onClick={onClose}>
+            닫기
+          </button>
+        </div>
+        <div style={styles.content}>
+          다이얼로그 내용
+        </div>
+        <div style={styles.footer}>
+          <button style={styles.submitButton}>
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  ) : null;
+};
+
+export { semanticColors, scaleColors, staticColors, Component, Dialog };
+```
+
+```tsx title="basic.output.tsx"
+// @ts-nocheck
+
+import { theme } from '@src/stitches/stitches.config'
+
+const semanticColors = {
+  primary: theme.colors["bg-brand-solid"].computedValue,
+  onPrimary: theme.colors["palette-static-white"].computedValue,
+  primaryLow: theme.colors["palette-carrot-100"].computedValue,
+  success: theme.colors["bg-positive-solid"].computedValue,
+  warning: theme.colors["bg-warning-solid"].computedValue,
+  danger: theme.colors["bg-critical-solid"].computedValue,
+  paperDefault: theme.colors["bg-layer-default"].computedValue,
+  paperContents: theme.colors["bg-layer-fill"].computedValue,
+  paperDialog: theme.colors["bg-layer-floating"].computedValue,
+  inkText: theme.colors["fg-neutral"].computedValue,
+  inkTextLow: theme.colors["fg-neutral-subtle"].computedValue,
+  divider1: theme.colors["stroke-neutral-muted"].computedValue,
+  divider2: theme.colors["stroke-neutral"].computedValue,
+  overlayDim: theme.colors["bg-overlay"].computedValue,
+  accent: theme.colors["bg-informative-solid"].computedValue,
+}
+
+const scaleColors = {
+  gray00: theme.colors["palette-gray-00"].computedValue,
+  gray100: theme.colors["palette-gray-200"].computedValue,
+  gray200: theme.colors["palette-gray-300"].computedValue,
+  gray300: theme.colors["palette-gray-400"].computedValue,
+  gray400: theme.colors["palette-gray-500"].computedValue,
+  gray500: theme.colors["palette-gray-600"].computedValue,
+  gray600: theme.colors["palette-gray-700"].computedValue,
+  gray700: theme.colors["palette-gray-800"].computedValue,
+  gray800: theme.colors["palette-gray-900"].computedValue,
+  gray900: theme.colors["palette-gray-1000"].computedValue,
+  carrot100: theme.colors["palette-carrot-200"].computedValue,
+  carrot500: theme.colors["palette-carrot-600"].computedValue,
+  carrot900: theme.colors["palette-carrot-800"].computedValue,
+  carrotAlpha50: theme.colors["palette-carrot-100"].computedValue,
+  carrotAlpha100: theme.colors["palette-carrot-200"].computedValue,
+  carrotAlpha200: theme.colors["palette-carrot-200"].computedValue,
+  blue300: theme.colors["palette-blue-400"].computedValue,
+  blue600: theme.colors["palette-blue-600"].computedValue,
+  red500: theme.colors["palette-red-700"].computedValue,
+}
+
+const staticColors = {
+  white: theme.colors["palette-static-white"].computedValue,
+  black: theme.colors["palette-static-black"].computedValue,
+  blackAlpha200: theme.colors["palette-static-black-alpha-200"].computedValue,
+  whiteAlpha200: theme.colors["palette-static-white-alpha-200"].computedValue,
+  gray900: theme.colors["palette-static-black"].computedValue,
+  carrot50: theme.colors["palette-carrot-100"].computedValue,
+  carrot800: theme.colors["palette-carrot-700"].computedValue,
+  blue50: theme.colors["palette-blue-100"].computedValue,
+  blue800: theme.colors["palette-blue-700"].computedValue,
+  red50: theme.colors["palette-red-100"].computedValue,
+  red800: theme.colors["palette-red-700"].computedValue,
+}
+
+const Component = () => {
+  return (
+    (<div>
+      <Button
+        backgroundColor={theme.colors["bg-brand-solid"].computedValue}
+        color={theme.colors["palette-static-white"].computedValue}
+      >
+        버튼
+      </Button>
+      <InfoBox borderColor={theme.colors["palette-gray-400"].computedValue}>
+        <Text color={theme.colors["palette-gray-1000"].computedValue}>
+          안내사항
+        </Text>
+        <WarningIcon fill={theme.colors["bg-warning-solid"].computedValue} />
+      </InfoBox>
+      <Badge backgroundColor={theme.colors["bg-critical-solid"].computedValue}>
+        <BadgeText color={theme.colors["palette-static-white"].computedValue}>
+          중요
+        </BadgeText>
+      </Badge>
+    </div>)
+  );
+};
+
+const Dialog = ({ isOpen, onClose }) => {
+  const styles = {
+    overlay: {
+      backgroundColor: theme.colors["bg-overlay"].computedValue,
+    },
+    container: {
+      backgroundColor: theme.colors["bg-layer-floating"].computedValue,
+      borderColor: theme.colors["palette-gray-400"].computedValue,
+    },
+    header: {
+      borderBottom: `1px solid ${theme.colors["stroke-neutral-muted"].computedValue}`,
+    },
+    title: {
+      color: theme.colors["palette-gray-1000"].computedValue,
+    },
+    content: {
+      color: theme.colors["palette-gray-800"].computedValue,
+      backgroundColor: theme.colors["bg-layer-fill"].computedValue,
+    },
+    footer: {
+      borderTop: `1px solid ${theme.colors["stroke-neutral"].computedValue}`,
+    },
+    closeButton: {
+      color: theme.colors["palette-gray-600"].computedValue,
+    },
+    submitButton: {
+      backgroundColor: theme.colors["palette-blue-600"].computedValue,
+      color: theme.colors["palette-static-white"].computedValue,
+    },
+  };
+
+  return isOpen ? (
+    <div style={styles.overlay}>
+      <div style={styles.container}>
+        <div style={styles.header}>
+          <h2 style={styles.title}>다이얼로그 제목</h2>
+          <button style={styles.closeButton} onClick={onClose}>
+            닫기
+          </button>
+        </div>
+        <div style={styles.content}>
+          다이얼로그 내용
+        </div>
+        <div style={styles.footer}>
+          <button style={styles.submitButton}>
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  ) : null;
+};
+
+export { semanticColors, scaleColors, staticColors, Component, Dialog };
 ```
 
 </Accordion>
@@ -193,7 +567,7 @@ npx @seed-design/codemod replace-css-seed-design-color-variable <target_path>
 
 ### replace-react-icon
 
-아이콘을 V3 형식으로 변환해요. 자세한 내용은 [아이콘 Codemod](/docs/react/iconography/codemod) 문서를 참고해주세요.
+아이콘을 V3 형식으로 변환해요. 자세한 내용은 [아이콘 Codemod](/react/iconography/codemod) 문서를 참고해주세요.
 
 ```package-install
 npx @seed-design/codemod replace-react-icon <target_path>
@@ -236,11 +610,11 @@ import {
   IconPlusSquareLine,
   IconDothorizline3VerticalFill,
   IconPlusFill as AddIconAlias,
-} from "@karrotmarket/react-monochrome-icon";
-import IconPlusSquareFill from "@karrotmarket/react-monochrome-icon/IconPlusSquareFill";
-import IconPlusLine from "@karrotmarket/react-monochrome-icon/IconPlusLine";
-import IconXmarkLine from "@karrotmarket/react-monochrome-icon/IconXmarkLine";
-import IconCarFrontsideLine from "@karrotmarket/react-monochrome-icon/IconCarFrontsideLine";
+} from "@daangn/react-monochrome-icon";
+import IconPlusSquareFill from "@daangn/react-monochrome-icon/IconPlusSquareFill";
+import IconPlusLine from "@daangn/react-monochrome-icon/IconPlusLine";
+import IconXmarkLine from "@daangn/react-monochrome-icon/IconXmarkLine";
+import IconCarFrontsideLine from "@daangn/react-monochrome-icon/IconCarFrontsideLine";
 
 function App() {
   console.log(IconPlusSquareLine);
@@ -269,15 +643,25 @@ npx @seed-design/codemod replace-seed-design-token-vars <target_path>
 <Accordion title="변경 예시">
 
 ```tsx title="basic.input.tsx"
-import { vars } from "@seed-design/design-token";
+import { vars as legacyVars } from "@seed-design/design-token";
 
-const color = vars.$scale.color.gray500;
+import { vars } from "@seed-design/css/vars";
+import { vars as typoVars } from "@seed-design/css/vars/component/typography";
+
+const color = vars.$color.palette.gray600;
+const typography = typoVars.textStyleT5Bold.enabled.root;
+const legacyColor = legacyVars.$static.color.staticWhiteAlpha50;
 ```
 
 ```tsx title="basic.output.tsx"
+import { vars as legacyVars } from "@seed-design/design-token";
+
 import { vars } from "@seed-design/css/vars";
+import { vars as typoVars } from "@seed-design/css/vars/component/typography";
 
 const color = vars.$color.palette.gray600;
+const typography = typoVars.textStyleT5Bold.enabled.root;
+const legacyColor = legacyVars.$static.color.staticWhiteAlpha50;
 ```
 
 </Accordion>
@@ -385,187 +769,429 @@ npx @seed-design/codemod replace-stitches-styled-color <target_path>
 ```tsx title="basic.input.tsx"
 // @ts-nocheck
 
-const BannerIcon = styled('div', {
-  flex: 'none',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: '32px',
-  height: '32px',
-  borderRadius: '50%',
-  margin: '0 10px 0 0',
-  
-  variants: {
-    theme: {
-      blue: {
-        background: '$blue500',
-        color: '$white-static',
-      },
-      carrot: {
-        background: '$carrot500',
-        color: '$white-static',
-      },
-      green: {
-        background: '$green500',
-        color: '$black-static',
-      },
-    },
-  },
+const SemanticColorTestComponent = styled('div', {
+  // Semantic Color 테스트
+  color: '$primary-semantic',
+  color: '$onPrimary-semantic',
+  color: '$primaryLow-semantic',
+  color: '$secondary-semantic',
+  color: '$secondaryLow-semantic',
+  color: '$success-semantic',
+  color: '$successLow-semantic',
+  color: '$warning-semantic',
+  color: '$warningLow-semantic',
+  color: '$danger-semantic',
+  color: '$dangerLow-semantic',
+  color: '$overlayDim-semantic',
+  color: '$overlayLow-semantic',
+  color: '$paperSheet-semantic',
+  color: '$paperDialog-semantic',
+  color: '$paperFloating-semantic',
+  color: '$paperContents-semantic',
+  color: '$paperDefault-semantic',
+  color: '$paperBackground-semantic',
+  color: '$paperAccent-semantic',
+  color: '$primaryHover-semantic',
+  color: '$primaryPressed-semantic',
+  color: '$primaryLowHover-semantic',
+  color: '$primaryLowActive-semantic',
+  color: '$primaryLowPressed-semantic',
+  color: '$grayHover-semantic',
+  color: '$grayPressed-semantic',
+  color: '$onPrimaryOverlay50-semantic',
+  color: '$onPrimaryOverlay200-semantic',
+  color: '$onPrimaryLowOverlay50-semantic',
+  color: '$onPrimaryLowOverlay100-semantic',
+  color: '$onPrimaryLowOverlay200-semantic',
+  color: '$onGrayOverlay50-semantic',
+  color: '$onGrayOverlay100-semantic',
+  color: '$divider1-semantic',
+  color: '$divider2-semantic',
+  color: '$divider3-semantic',
+  color: '$accent-semantic',
+  color: '$inkText-semantic',
+  color: '$inkTextLow-semantic',
+  color: '$grayActive-semantic',
 });
 
-const Text = styled('div', {
+const ScaleColorTestComponent = styled('div', {
+  // Scale Color Gray 테스트
+  color: '$gray00',
+  color: '$gray50',
+  color: '$gray100',
+  color: '$gray200',
+  color: '$gray300',
+  color: '$gray400',
+  color: '$gray500',
+  color: '$gray600',
   color: '$gray700',
-  margin: '0 8px 0 6px',
-  $text: 'caption1Bold',
-})
+  color: '$gray800',
+  color: '$gray900',
+  color: '$grayAlpha50',
+  color: '$grayAlpha100',
+  color: '$grayAlpha200',
+  color: '$grayAlpha500',
+  
+  // Scale Color Carrot 테스트
+  color: '$carrot50',
+  color: '$carrot100',
+  color: '$carrot200',
+  color: '$carrot300',
+  color: '$carrot400',
+  color: '$carrot500',
+  color: '$carrot600',
+  color: '$carrot700',
+  color: '$carrot800',
+  color: '$carrot900',
+  color: '$carrot950',
+  color: '$carrotAlpha50',
+  color: '$carrotAlpha100',
+  color: '$carrotAlpha200',
+  
+  // Scale Color Blue 테스트
+  color: '$blue50',
+  color: '$blue100',
+  color: '$blue200',
+  color: '$blue300',
+  color: '$blue400',
+  color: '$blue500',
+  color: '$blue600',
+  color: '$blue700',
+  color: '$blue800',
+  color: '$blue900',
+  color: '$blue950',
+  color: '$blueAlpha50',
+  color: '$blueAlpha100',
+  color: '$blueAlpha200',
+  
+  // Scale Color Red 테스트
+  color: '$red50',
+  color: '$red100',
+  color: '$red200',
+  color: '$red300',
+  color: '$red400',
+  color: '$red500',
+  color: '$red600',
+  color: '$red700',
+  color: '$red800',
+  color: '$red900',
+  color: '$red950',
+  color: '$redAlpha50',
+  color: '$redAlpha100',
+  color: '$redAlpha200',
+  
+  // Scale Color Green 테스트
+  color: '$green50',
+  color: '$green100',
+  color: '$green200',
+  color: '$green300',
+  color: '$green400',
+  color: '$green500',
+  color: '$green600',
+  color: '$green700',
+  color: '$green800',
+  color: '$green900',
+  color: '$green950',
+  color: '$greenAlpha50',
+  color: '$greenAlpha100',
+  color: '$greenAlpha200',
+  
+  // Scale Color Yellow 테스트
+  color: '$yellow50',
+  color: '$yellow100',
+  color: '$yellow200',
+  color: '$yellow300',
+  color: '$yellow400',
+  color: '$yellow500',
+  color: '$yellow600',
+  color: '$yellow700',
+  color: '$yellow800',
+  color: '$yellow900',
+  color: '$yellow950',
+  color: '$yellowAlpha50',
+  color: '$yellowAlpha100',
+  color: '$yellowAlpha200',
+  
+  // Scale Color Purple 테스트
+  color: '$purple50',
+  color: '$purple100',
+  color: '$purple200',
+  color: '$purple300',
+  color: '$purple400',
+  color: '$purple500',
+  color: '$purple600',
+  color: '$purple700',
+  color: '$purple800',
+  color: '$purple900',
+  color: '$purple950',
+});
 
-const CashContainer = styled('div', {
-  background: '$gray100',
-  borderRadius: '6px',
-  border: '1px solid $divider1-semantic',
-  padding: '16px',
-  margin: '16px',
-})
+const StaticColorTestComponent = styled('div', {
+  // Static Color 테스트
+  color: '$black-static',
+  color: '$white-static',
+  color: '$gray900-static',
+  color: '$carrot50-static',
+  color: '$carrot800-static',
+  color: '$green50-static',
+  color: '$green800-static',
+  color: '$yellow50-static',
+  color: '$yellow800-static',
+  color: '$red50-static',
+  color: '$red800-static',
+  color: '$blue50-static',
+  color: '$blue800-static',
+  color: '$blackAlpha200-static',
+  color: '$blackAlpha500-static',
+  color: '$whiteAlpha50-static',
+  color: '$whiteAlpha200-static',
+});
 
-const Container = styled('div', {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  padding: '10px 16px',
-
-  position: 'relative',
+// 복합 속성 테스트
+const ComplexPropertyTestComponent = styled('div', {
+  border: '1px solid $gray700',
+  boxShadow: '0 0 10px $overlayDim-semantic',
+  outline: '2px solid $accent-semantic',
+  textDecoration: 'underline $danger-semantic',
+  
+  // 네스팅된 속성 테스트
   '&:before': {
-    content: '',
-    position: 'absolute',
-    left: 0,
-    width: '100%',
-    height: '100%',
-    background: 'transparent',
-    boxSizing: 'border-box',
     borderBottom: '1px solid $divider1-semantic',
+    background: '$paperContents-semantic',
   },
-
+  
+  // 변형 테스트
   variants: {
-    isTopOnDocument: {
-      true: {
-        background: '$paperDefault-semantic',
+    theme: {
+      primary: {
+        background: '$primary-semantic',
+        color: '$onPrimary-semantic',
       },
-      false: {
-        background: '$paperContents-semantic',
+      secondary: {
+        background: '$secondaryLow-semantic',
+        color: '$inkText-semantic',
       },
-    },
-  },
-
-  defaultVariants: {
-    isTopOnDocument: true,
-  },
-})
-
-function generateCompoundVariants() {
-  const priorities = ['primary', 'primaryLow', 'secondary', 'text'] as const
-
-  return priorities.map((priority) => ({
-    priority,
-    disabled: true,
-    css: {
-      background: '$gray300',
-      color: '$gray500',
-    },
-  }))
-}
+      danger: {
+        background: '$danger-semantic',
+        color: '$white-static',
+      }
+    }
+  }
+});
 ```
 
 ```tsx title="basic.output.tsx"
 // @ts-nocheck
 
-const BannerIcon = styled('div', {
-  flex: 'none',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: '32px',
-  height: '32px',
-  borderRadius: '50%',
-  margin: '0 10px 0 0',
-  
-  variants: {
-    theme: {
-      blue: {
-        background: "$palette-blue-600",
-        color: "$palette-static-white",
-      },
-      carrot: {
-        background: "$palette-carrot-600",
-        color: "$palette-static-white",
-      },
-      green: {
-        background: "$palette-green-600",
-        color: "$palette-static-black",
-      },
-    },
-  },
+const SemanticColorTestComponent = styled('div', {
+  // Semantic Color 테스트
+  color: "$bg-brand-solid",
+  color: "$palette-static-white",
+  color: "$palette-carrot-100",
+  color: "$palette-gray-900",
+  color: "$bg-neutral-weak",
+  color: "$bg-positive-solid",
+  color: "$bg-positive-weak",
+  color: "$bg-warning-solid",
+  color: "$bg-warning-weak",
+  color: "$bg-critical-solid",
+  color: "$bg-critical-weak",
+  color: "$bg-overlay",
+  color: "$bg-overlay-muted",
+  color: "$bg-layer-floating",
+  color: "$bg-layer-floating",
+  color: "$bg-layer-floating",
+  color: "$bg-layer-fill",
+  color: "$bg-layer-default",
+  color: "$bg-layer-basement",
+  color: "$palette-carrot-100",
+  color: "$bg-brand-solid-pressed",
+  color: "$bg-brand-solid-pressed",
+  color: "$palette-carrot-200",
+  color: "$palette-carrot-100",
+  color: "$palette-carrot-200",
+  color: "$bg-neutral-weak-pressed",
+  color: "$bg-neutral-weak-pressed",
+  color: '$onPrimaryOverlay50-semantic',
+  color: '$onPrimaryOverlay200-semantic',
+  color: '$onPrimaryLowOverlay50-semantic',
+  color: '$onPrimaryLowOverlay100-semantic',
+  color: '$onPrimaryLowOverlay200-semantic',
+  color: "$stroke-on-image",
+  color: '$onGrayOverlay100-semantic',
+  color: "$stroke-neutral-muted",
+  color: "$stroke-neutral",
+  color: "$palette-gray-400",
+  color: "$bg-informative-solid",
+  color: "$fg-neutral",
+  color: "$fg-neutral-subtle",
+  color: "$fg-neutral-muted",
 });
 
-const Text = styled('div', {
+const ScaleColorTestComponent = styled('div', {
+  // Scale Color Gray 테스트
+  color: "$palette-gray-00",
+  color: "$palette-gray-100",
+  color: "$palette-gray-200",
+  color: "$palette-gray-300",
+  color: "$palette-gray-400",
+  color: "$palette-gray-500",
+  color: "$palette-gray-600",
+  color: "$palette-gray-700",
   color: "$palette-gray-800",
-  margin: '0 8px 0 6px',
-  $text: 'caption1Bold',
-})
+  color: "$palette-gray-900",
+  color: "$palette-gray-1000",
+  color: "$stroke-on-image",
+  color: "$palette-gray-300",
+  color: "$palette-gray-500",
+  color: "$palette-gray-700",
+  
+  // Scale Color Carrot 테스트
+  color: "$palette-carrot-100",
+  color: "$palette-carrot-200",
+  color: "$palette-carrot-300",
+  color: "$palette-carrot-400",
+  color: "$palette-carrot-500",
+  color: "$palette-carrot-600",
+  color: "$palette-carrot-600",
+  color: "$palette-carrot-700",
+  color: "$palette-carrot-700",
+  color: "$palette-carrot-800",
+  color: "$palette-carrot-800",
+  color: "$palette-carrot-100",
+  color: "$palette-carrot-200",
+  color: "$palette-carrot-200",
+  
+  // Scale Color Blue 테스트
+  color: "$palette-blue-100",
+  color: "$palette-blue-200",
+  color: "$palette-blue-300",
+  color: "$palette-blue-400",
+  color: "$palette-blue-400",
+  color: "$palette-blue-600",
+  color: "$palette-blue-600",
+  color: "$palette-blue-800",
+  color: "$palette-blue-900",
+  color: "$palette-blue-900",
+  color: "$palette-blue-1000",
+  color: "$palette-blue-100",
+  color: "$palette-blue-100",
+  color: "$palette-blue-200",
+  
+  // Scale Color Red 테스트
+  color: "$palette-red-100",
+  color: "$palette-red-200",
+  color: "$palette-red-300",
+  color: "$palette-red-400",
+  color: "$palette-red-600",
+  color: "$palette-red-700",
+  color: "$palette-red-700",
+  color: "$palette-red-800",
+  color: "$palette-red-900",
+  color: "$palette-red-900",
+  color: "$palette-red-900",
+  color: "$palette-red-100",
+  color: "$palette-red-200",
+  color: "$palette-red-300",
+  
+  // Scale Color Green 테스트
+  color: "$palette-green-100",
+  color: "$palette-green-200",
+  color: "$palette-green-300",
+  color: "$palette-green-400",
+  color: "$palette-green-500",
+  color: "$palette-green-600",
+  color: "$palette-green-700",
+  color: "$palette-green-800",
+  color: "$palette-green-900",
+  color: "$palette-green-900",
+  color: "$palette-green-900",
+  color: "$palette-green-100",
+  color: "$palette-green-200",
+  color: "$palette-green-200",
+  
+  // Scale Color Yellow 테스트
+  color: "$palette-yellow-100",
+  color: "$palette-yellow-200",
+  color: "$palette-yellow-300",
+  color: "$palette-yellow-400",
+  color: "$palette-yellow-500",
+  color: "$palette-yellow-700",
+  color: "$palette-yellow-700",
+  color: "$palette-yellow-800",
+  color: "$palette-yellow-800",
+  color: "$palette-yellow-900",
+  color: "$palette-yellow-900",
+  color: "$palette-yellow-100",
+  color: "$palette-yellow-100",
+  color: "$palette-yellow-100",
+  
+  // Scale Color Purple 테스트
+  color: "$palette-purple-100",
+  color: "$palette-purple-300",
+  color: "$palette-purple-400",
+  color: "$palette-purple-400",
+  color: "$palette-purple-500",
+  color: "$palette-purple-600",
+  color: "$palette-purple-700",
+  color: "$palette-purple-800",
+  color: "$palette-purple-900",
+  color: "$palette-purple-900",
+  color: "$palette-purple-1000",
+});
 
-const CashContainer = styled('div', {
-  background: "$palette-gray-200",
-  borderRadius: '6px',
-  border: "1px solid $stroke-neutral-muted",
-  padding: '16px',
-  margin: '16px',
-})
+const StaticColorTestComponent = styled('div', {
+  // Static Color 테스트
+  color: "$palette-static-black",
+  color: "$palette-static-white",
+  color: "$palette-static-black",
+  color: "$palette-carrot-100",
+  color: "$palette-carrot-700",
+  color: "$palette-green-100",
+  color: "$palette-green-700",
+  color: "$palette-yellow-100",
+  color: "$palette-yellow-700",
+  color: "$palette-red-100",
+  color: "$palette-red-700",
+  color: "$palette-blue-100",
+  color: "$palette-blue-700",
+  color: "$palette-static-black-alpha-200",
+  color: "$palette-static-black-alpha-500",
+  color: '$whiteAlpha50-static',
+  color: "$palette-static-white-alpha-200",
+});
 
-const Container = styled('div', {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  padding: '10px 16px',
-
-  position: 'relative',
+// 복합 속성 테스트
+const ComplexPropertyTestComponent = styled('div', {
+  border: "1px solid $palette-gray-800",
+  boxShadow: "0 0 10px $bg-overlay",
+  outline: "2px solid $bg-informative-solid",
+  textDecoration: "underline $bg-critical-solid",
+  
+  // 네스팅된 속성 테스트
   '&:before': {
-    content: '',
-    position: 'absolute',
-    left: 0,
-    width: '100%',
-    height: '100%',
-    background: 'transparent',
-    boxSizing: 'border-box',
     borderBottom: "1px solid $stroke-neutral-muted",
+    background: "$bg-layer-fill",
   },
-
+  
+  // 변형 테스트
   variants: {
-    isTopOnDocument: {
-      true: {
-        background: "$bg-layer-default",
+    theme: {
+      primary: {
+        background: "$bg-brand-solid",
+        color: "$palette-static-white",
       },
-      false: {
-        background: "$bg-layer-fill",
+      secondary: {
+        background: "$bg-neutral-weak",
+        color: "$fg-neutral",
       },
-    },
-  },
-
-  defaultVariants: {
-    isTopOnDocument: true,
-  },
-})
-
-function generateCompoundVariants() {
-  const priorities = ['primary', 'primaryLow', 'secondary', 'text'] as const
-
-  return priorities.map((priority) => ({
-    priority,
-    disabled: true,
-    css: {
-      background: "$palette-gray-400",
-      color: "$palette-gray-600",
-    },
-  }));
-}
+      danger: {
+        background: "$bg-critical-solid",
+        color: "$palette-static-white",
+      }
+    }
+  }
+});
 ```
 
 </Accordion>
@@ -774,7 +1400,7 @@ export function BackgroundExample() {
       <div className="!bg-palette-carrot-800">Scale Carrot High Background</div>
       <div className="bg-palette-static-black">Static Black Background</div>
       <div className="bg-palette-static-white">Static White Background</div>
-      <div className="bg-staticGray900">Static Gray900 Background</div>
+      <div className="bg-palette-static-black">Static Gray900 Background</div>
     </div>)
   );
 }

--- a/docs/content/react/get-started/codemod.mdx
+++ b/docs/content/react/get-started/codemod.mdx
@@ -188,18 +188,8 @@ Seed Design V2에서 V3로 마이그레이션 시 import된 타이포그래피 �
 - 타이포그래피 관련 import 문을 찾아 변수명을 변환합니다.
 - 변수가 사용된 모든 위치(템플릿 리터럴, 객체 속성 등)를 찾아 업데이트합니다.
 - typography.mjs의 매핑 정보에 따라 V2 타이포그래피 변수를 V3로 변환합니다.
-
-#### 테스트 케이스
-
-- **basic**: 기본적인 변환 케이스
-- **enhanced**: 다양한 타이포그래피 변수 매핑 케이스
-  - screenTitle 매핑 (h4 -> screenTitle)
-  - 일반 매핑 (title1Bold -> t9Bold)
-  - deprecated 토큰 처리 (title1Regular)
-  - 별칭을 사용한 import 처리
-  - 대체 토큰 처리 (bodyL2Regular -> t4Regular)
-  - 객체 속성으로 사용된 토큰 처리
-  - 다양한 컨텍스트에서의 변수 사용 패턴
+- 같은 V3 토큰으로 변환되는 중복 import를 제거합니다 (예: subtitle1Regular, bodyM1Regular가 모두 t5Regular로 변환되면 t5Regular는 한 번만 import).
+- 별칭(alias)으로 import된 변수명은 유지합니다 (예: `bodyM1Regular as customTypo`에서 `t5Regular as customTypo`로 변환).
 
 ```package-install
 npx @seed-design/codemod replace-custom-imported-typography-variable <target_path>
@@ -210,16 +200,17 @@ npx @seed-design/codemod replace-custom-imported-typography-variable <target_pat
 
 ```ts title="basic.input.ts"
 // @ts-nocheck
-import { 
-  subtitle1Regular, 
-  subtitle2Regular, 
-  h4, 
-  title1Bold, 
-  title2Bold, 
-  bodyL1Regular, 
-  caption1Regular, 
-  caption2Regular, 
-  label5Regular 
+import {
+  subtitle1Regular,
+  subtitle2Regular,
+  h4,
+  title1Bold,
+  title2Bold,
+  bodyL1Regular,
+  bodyL2Regular,
+  caption1Regular,
+  caption2Regular,
+  label5Regular,
 } from '@src/constants/typography'
 import { bodyM1Regular as customTypo } from '@karrot/typography'
 
@@ -263,6 +254,12 @@ const Card = styled.div`
     color: ${vars.$scale.color.gray800};
   }
   
+  // 대체 토큰으로 매핑되는 케이스
+  p.content {
+    ${bodyL2Regular};
+    margin: 0;
+  }
+  
   // 캡션 스타일
   p.caption {
     ${caption1Regular};
@@ -295,17 +292,17 @@ const textStyle = subtitle1Regular;
 
 ```ts title="basic.output.ts"
 // @ts-nocheck
-import { 
-  t5Regular, 
-  t4Regular, 
-  t10Bold, 
-  t9Bold, 
-  t7Bold, 
-  articleBody, 
-  t3Regular, 
-  t2Regular, 
-  t1Regular 
-} from '@src/constants/typography'
+import {
+  t5Regular,
+  t4Regular,
+  t10Bold,
+  t9Bold,
+  t7Bold,
+  articleBody,
+  t3Regular,
+  t2Regular,
+  t1Regular,
+} from '@src/constants/typography';
 import { t5Regular as customTypo } from '@karrot/typography'
 
 const S_StoreRequestTitle = styled.h1`
@@ -346,6 +343,12 @@ const Card = styled.div`
   p.description {
     ${articleBody};
     color: ${vars.$scale.color.gray800};
+  }
+  
+  // 대체 토큰으로 매핑되는 케이스
+  p.content {
+    ${t4Regular};
+    margin: 0;
   }
   
   // 캡션 스타일
@@ -2037,6 +2040,84 @@ const Component = () => {
     <Text color={isSelected ? "palette.carrot600" : "palette.blue600"}  />
   </>);
 };
+```
+
+</Accordion>
+</Accordions>
+
+### replace-custom-seed-design-color
+
+커스텀 Seed Design 컬러 토큰을 V3 형식으로 변환하는 트랜스폼
+
+```package-install
+npx @seed-design/codemod replace-custom-seed-design-color <target_path>
+```
+
+<Accordions>
+<Accordion title="변경 예시">
+
+```ts title="basic.input.ts"
+// @ts-nocheck
+import { style } from "@vanilla-extract/css";
+import { color, background } from "@/shared/styles";
+
+export const container = style({
+  backgroundColor: color.gray100,
+  color: color.gray900,
+  borderColor: color.carrot500,
+});
+
+export const box = style({
+  background: color.gray50,
+  color: color.red500,
+  border: `1px solid ${color.gray300}`,
+});
+
+export const alert = style({
+  backgroundColor: color.red50,
+  color: color.red900,
+});
+
+export const button = style({
+  backgroundColor: background.gray100,
+  color: color.gray900,
+});
+
+export const highlight = style({
+  color: color.carrot500,
+});
+```
+
+```ts title="basic.output.ts"
+// @ts-nocheck
+import { style } from "@vanilla-extract/css";
+import { color, background } from "@/shared/styles";
+
+export const container = style({
+  backgroundColor: color.palette.gray200,
+  color: color.palette.gray1000,
+  borderColor: color.palette.carrot600,
+});
+
+export const box = style({
+  background: color.palette.gray100,
+  color: color.palette.red700,
+  border: `1px solid ${color.palette.gray400}`,
+});
+
+export const alert = style({
+  backgroundColor: color.palette.red100,
+  color: color.palette.red900,
+});
+
+export const button = style({
+  backgroundColor: background.palette.gray200,
+  color: color.palette.gray1000,
+});
+
+export const highlight = style({
+  color: color.palette.carrot600,
+});
 ```
 
 </Accordion>

--- a/docs/content/react/get-started/codemod.mdx
+++ b/docs/content/react/get-started/codemod.mdx
@@ -132,6 +132,103 @@ export const subtitle = style({
   ...vars.typography.bodyM2Regular,
   color: vars.color.secondary,
 });
+
+// 배경색 케이스
+export const cardBackground = style({
+  backgroundColor: vars.color.paperSheet,
+  padding: '16px',
+});
+
+// 테두리 케이스
+export const divider = style({
+  borderTop: `1px solid ${vars.color.divider1}`,
+  marginTop: '8px',
+  marginBottom: '8px',
+});
+
+// 상태 색상 케이스
+export const successMessage = style({
+  ...vars.typography.bodyM1Bold,
+  color: vars.color.success,
+  backgroundColor: vars.color.successLow,
+  padding: '12px',
+  borderRadius: '4px',
+});
+
+export const warningMessage = style({
+  ...vars.typography.bodyM1Bold,
+  color: vars.color.warning,
+  backgroundColor: vars.color.warningLow,
+  padding: '12px',
+  borderRadius: '4px',
+});
+
+export const errorMessage = style({
+  ...vars.typography.bodyM1Bold,
+  color: vars.color.danger,
+  backgroundColor: vars.color.dangerLow,
+  padding: '12px',
+  borderRadius: '4px',
+});
+
+// 다양한 타이포그래피 케이스
+export const heading = style({
+  ...vars.typography.h4,
+  color: vars.color.inkText,
+});
+
+export const body = style({
+  ...vars.typography.bodyL1Regular,
+  color: vars.color.inkTextLow,
+});
+
+export const label = style({
+  ...vars.typography.label3Bold,
+  color: vars.color.grayActive,
+});
+
+// 알파 색상 케이스
+export const overlay = style({
+  backgroundColor: vars.color.overlayDim,
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+});
+
+// 복합 케이스와 상호작용 상태
+export const button = style({
+  ...vars.typography.label2Bold,
+  backgroundColor: vars.color.primary,
+  color: vars.color.onPrimary,
+  borderRadius: '4px',
+  padding: '8px 16px',
+  border: 'none',
+  cursor: 'pointer',
+  ':hover': {
+    backgroundColor: vars.color.primaryHover,
+  },
+  ':active': {
+    backgroundColor: vars.color.primaryPressed,
+  },
+});
+
+export const secondaryButton = style({
+  ...vars.typography.label2Bold,
+  backgroundColor: vars.color.secondaryLow,
+  color: vars.color.secondary,
+  borderRadius: '4px',
+  padding: '8px 16px',
+  border: 'none',
+  cursor: 'pointer',
+  ':hover': {
+    backgroundColor: vars.color.grayHover,
+  },
+  ':active': {
+    backgroundColor: vars.color.grayPressed,
+  },
+});
 ```
 
 ```ts title="basic.output.ts"
@@ -163,6 +260,103 @@ export const title = style({
 export const subtitle = style({
   ...vars.typography.t4Regular,
   color: vars.color.palette.gray900,
+});
+
+// 배경색 케이스
+export const cardBackground = style({
+  backgroundColor: vars.color.bg.layerFloating,
+  padding: '16px',
+});
+
+// 테두리 케이스
+export const divider = style({
+  borderTop: `1px solid ${vars.color.stroke.neutralMuted}`,
+  marginTop: '8px',
+  marginBottom: '8px',
+});
+
+// 상태 색상 케이스
+export const successMessage = style({
+  ...vars.typography.t5Bold,
+  color: vars.color.fg.positive,
+  backgroundColor: vars.color.bg.positiveWeak,
+  padding: '12px',
+  borderRadius: '4px',
+});
+
+export const warningMessage = style({
+  ...vars.typography.t5Bold,
+  color: vars.color.bg.warningSolid,
+  backgroundColor: vars.color.bg.warningWeak,
+  padding: '12px',
+  borderRadius: '4px',
+});
+
+export const errorMessage = style({
+  ...vars.typography.t5Bold,
+  color: vars.color.fg.critical,
+  backgroundColor: vars.color.bg.criticalWeak,
+  padding: '12px',
+  borderRadius: '4px',
+});
+
+// 다양한 타이포그래피 케이스
+export const heading = style({
+  ...vars.typography.t10Bold,
+  color: vars.color.fg.neutral,
+});
+
+export const body = style({
+  ...vars.typography.articleBody,
+  color: vars.color.fg.neutralSubtle,
+});
+
+export const label = style({
+  ...vars.typography.t4Bold,
+  color: vars.color.fg.neutralMuted,
+});
+
+// 알파 색상 케이스
+export const overlay = style({
+  backgroundColor: vars.color.bg.overlay,
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+});
+
+// 복합 케이스와 상호작용 상태
+export const button = style({
+  ...vars.typography.t5Bold,
+  backgroundColor: vars.color.bg.brandSolid,
+  color: vars.color.palette.staticWhite,
+  borderRadius: '4px',
+  padding: '8px 16px',
+  border: 'none',
+  cursor: 'pointer',
+  ':hover': {
+    backgroundColor: vars.color.bg.brandSolidPressed,
+  },
+  ':active': {
+    backgroundColor: vars.color.bg.brandSolidPressed,
+  },
+});
+
+export const secondaryButton = style({
+  ...vars.typography.t5Bold,
+  backgroundColor: vars.color.bg.neutralWeak,
+  color: vars.color.palette.gray900,
+  borderRadius: '4px',
+  padding: '8px 16px',
+  border: 'none',
+  cursor: 'pointer',
+  ':hover': {
+    backgroundColor: vars.color.bg.neutralWeakPressed,
+  },
+  ':active': {
+    backgroundColor: vars.color.bg.neutralWeakPressed,
+  },
 });
 ```
 

--- a/docs/content/react/get-started/codemod.mdx
+++ b/docs/content/react/get-started/codemod.mdx
@@ -41,9 +41,95 @@ npx @seed-design/codemod --list
 
 ## 사용 가능한 Transforms
 
-### replace-tailwind-typography
+### replace-custom-seed-design-typography
 
-Tailwind 타이포그래피 클래스를 V3 형식으로 변환해요.
+```package-install
+npx @seed-design/codemod replace-custom-seed-design-typography <target_path>
+```
+
+<Accordions>
+<Accordion title="변경 예시">
+
+```ts title="basic.input.ts"
+// @ts-nocheck
+import { style } from "@vanilla-extract/css";
+import { vars } from "@seed-design/css";
+import { f, reset } from "@/shared/styles";
+
+export const title = style([
+  typography.h4,
+  {
+    textAlign: "center",
+    color: vars.$scale.color.gray900,
+    margin: 0,
+  },
+]);
+
+export const subtitle = style([
+  f.typography.title2Bold,
+  {
+    marginBottom: "0.375rem",
+    color: vars.$scale.color.gray900,
+  },
+]);
+
+export const smallText = style([
+  typo.caption2Regular,
+  {
+    color: vars.$scale.color.gray700,
+  },
+]);
+
+export const largeTitle = style([
+  typo.bodyL1Regular,
+  {
+    color: vars.$scale.color.gray900,
+  },
+]);
+```
+
+```ts title="basic.output.ts"
+// @ts-nocheck
+import { style } from "@vanilla-extract/css";
+import { vars } from "@seed-design/css";
+import { f, reset } from "@/shared/styles";
+
+export const title = style([
+  typography.t10Bold,
+  {
+    textAlign: "center",
+    color: vars.$scale.color.gray900,
+    margin: 0,
+  },
+]);
+
+export const subtitle = style([
+  f.typography.t7Bold,
+  {
+    marginBottom: "0.375rem",
+    color: vars.$scale.color.gray900,
+  },
+]);
+
+export const smallText = style([
+  typo.t2Regular,
+  {
+    color: vars.$scale.color.gray700,
+  },
+]);
+
+export const largeTitle = style([
+  typo.articleBody,
+  {
+    color: vars.$scale.color.gray900,
+  },
+]);
+```
+
+</Accordion>
+</Accordions>
+
+### replace-tailwind-typography
 
 ```package-install
 npx @seed-design/codemod replace-tailwind-typography <target_path>
@@ -229,6 +315,147 @@ export const secondaryButton = style({
     backgroundColor: vars.color.grayPressed,
   },
 });
+
+// 중첩 경로 케이스
+export const floatingPanel = style({
+  backgroundColor: vars.color.paperFloating,
+  boxShadow: `0 2px 8px ${vars.color.overlayLow}`,
+  padding: '20px',
+  borderRadius: '8px',
+});
+
+export const dialogPanel = style({
+  backgroundColor: vars.color.paperDialog,
+  padding: '24px',
+  boxShadow: `0 4px 16px ${vars.color.overlayDim}`,
+  borderRadius: '12px',
+});
+
+// 정적 색상 케이스
+export const staticColors = style({
+  color: vars.color.staticBlack,
+  backgroundColor: vars.color.staticWhite,
+  border: `1px solid ${vars.color.staticBlackAlpha200}`,
+});
+
+// 정적 색상 케이스 (명시적으로 static 프리픽스 테스트)
+export const staticExplicitColors = style({
+  color: vars.color.staticBlack,
+  backgroundColor: vars.color.staticWhite,
+  boxShadow: `0 2px 4px ${vars.color.staticBlackAlpha500}`,
+  outline: `1px solid ${vars.color.staticBlackAlpha200}`,
+});
+
+export const specialBackground = style({
+  background: `linear-gradient(to bottom, ${vars.color.staticWhiteAlpha50}, ${vars.color.staticWhiteAlpha200})`,
+  backdropFilter: 'blur(8px)',
+});
+
+// 복합 스타일 및 다중 속성 케이스
+export const multiProperty = style({
+  ...vars.typography.title2Bold,
+  color: vars.color.accent,
+  borderLeft: `4px solid ${vars.color.accent}`,
+  borderRight: `4px solid ${vars.color.accent}`,
+  boxShadow: `inset 0 0 0 1px ${vars.color.divider2}, 0 2px 4px ${vars.color.overlayLow}`,
+  padding: '16px',
+  backgroundColor: vars.color.paperDefault,
+});
+
+// 믹스인 스타일 케이스
+export const mixinStyle = {
+  primary: {
+    background: vars.color.primary,
+    color: vars.color.onPrimary,
+  },
+  secondary: {
+    background: vars.color.secondary,
+  },
+  accent: {
+    background: vars.color.accent,
+    color: vars.color.onGrayOverlay50,
+  },
+};
+
+// 특수 속성 및 스케일 색상 케이스
+export const scaleColors = style({
+  fill: vars.color.carrot500,
+  stroke: vars.color.gray400,
+  stopColor: vars.color.blue400,
+  floodColor: vars.color.red400,
+  lightingColor: vars.color.green400,
+});
+
+// 특수 타이포그래피 케이스
+export const specialTypographies = {
+  title: vars.typography.title1Bold,
+  subtitle: vars.typography.subtitle1Regular,
+  label: vars.typography.label5Regular,
+  caption: vars.typography.caption2Bold,
+};
+
+// 다양한 경로를 가진 컬러 토큰
+export const colorContexts = style({
+  // 일반 색상
+  color: vars.color.primaryLow,
+  // 배경 색상
+  backgroundColor: vars.color.paperBackground,
+  // 테두리 색상
+  borderColor: vars.color.divider3,
+  // 호버 색상
+  ':hover': {
+    backgroundColor: vars.color.primaryLowHover,
+    borderColor: vars.color.primaryLowActive,
+  },
+});
+
+// 복잡한 다중 경로와 중첩된 객체
+export const nestedStyleObject = {
+  button: {
+    default: {
+      backgroundColor: vars.color.paperAccent,
+      color: vars.color.inkText,
+      border: `1px solid ${vars.color.carrot300}`,
+    },
+    hover: {
+      backgroundColor: vars.color.carrot100,
+      borderColor: vars.color.carrot400,
+    },
+    active: {
+      backgroundColor: vars.color.carrot200,
+      color: vars.color.inkTextLow,
+    },
+  },
+  panel: {
+    header: {
+      ...vars.typography.subtitle2Bold,
+      color: vars.color.blue600,
+      borderBottom: `1px solid ${vars.color.blue200}`,
+    },
+    body: {
+      ...vars.typography.bodyM2Regular,
+      color: vars.color.inkTextLow,
+      backgroundColor: vars.color.blue50,
+    },
+    footer: {
+      backgroundColor: vars.color.blue100,
+      borderTop: `1px solid ${vars.color.blue200}`,
+    },
+  },
+};
+
+// 테두리 속성 매핑 테스트
+export const borderMapping = style({
+  // stroke 토큰으로 매핑될 속성
+  borderColor: vars.color.divider2,
+  // stroke 토큰이 없어서 fg 토큰으로 대체되는 케이스
+  borderTopColor: vars.color.primary,
+  borderBottomColor: vars.color.accent,
+  // stroke 또는 fg 토큰으로 대체
+  boxShadow: `0 0 0 1px ${vars.color.primary}, 0 2px 4px ${vars.color.overlayLow}`,
+  // 복합 속성
+  border: `1px solid ${vars.color.secondary}`,
+});
 ```
 
 ```ts title="basic.output.ts"
@@ -358,14 +585,153 @@ export const secondaryButton = style({
     backgroundColor: vars.color.bg.neutralWeakPressed,
   },
 });
+
+// 중첩 경로 케이스
+export const floatingPanel = style({
+  backgroundColor: vars.color.bg.layerFloating,
+  boxShadow: `0 2px 8px ${vars.color.bg.overlayMuted}`,
+  padding: '20px',
+  borderRadius: '8px',
+});
+
+export const dialogPanel = style({
+  backgroundColor: vars.color.bg.layerFloating,
+  padding: '24px',
+  boxShadow: `0 4px 16px ${vars.color.bg.overlay}`,
+  borderRadius: '12px',
+});
+
+// 정적 색상 케이스
+export const staticColors = style({
+  color: vars.color.palette.staticBlack,
+  backgroundColor: vars.color.palette.staticWhite,
+  border: `1px solid ${vars.color.palette.staticBlackAlpha200}`,
+});
+
+// 정적 색상 케이스 (명시적으로 static 프리픽스 테스트)
+export const staticExplicitColors = style({
+  color: vars.color.palette.staticBlack,
+  backgroundColor: vars.color.palette.staticWhite,
+  boxShadow: `0 2px 4px ${vars.color.palette.staticBlackAlpha500}`,
+  outline: `1px solid ${vars.color.palette.staticBlackAlpha200}`,
+});
+
+export const specialBackground = style({
+  background: `linear-gradient(to bottom, ${vars.color.palette.staticWhiteAlpha50}, ${vars.color.palette.staticWhiteAlpha200})`,
+  backdropFilter: 'blur(8px)',
+});
+
+// 복합 스타일 및 다중 속성 케이스
+export const multiProperty = style({
+  ...vars.typography.t7Bold,
+  color: vars.color.fg.informative,
+  borderLeft: `4px solid ${vars.color.fg.informative}`,
+  borderRight: `4px solid ${vars.color.fg.informative}`,
+  boxShadow: `inset 0 0 0 1px ${vars.color.stroke.neutral}, 0 2px 4px ${vars.color.bg.overlayMuted}`,
+  padding: '16px',
+  backgroundColor: vars.color.bg.layerDefault,
+});
+
+// 믹스인 스타일 케이스
+export const mixinStyle = {
+  primary: {
+    background: vars.color.bg.brandSolid,
+    color: vars.color.palette.staticWhite,
+  },
+  secondary: {
+    background: vars.color.palette.gray900,
+  },
+  accent: {
+    background: vars.color.bg.informativeSolid,
+    color: vars.color.stroke.onImage,
+  },
+};
+
+// 특수 속성 및 스케일 색상 케이스
+export const scaleColors = style({
+  fill: vars.color.palette.carrot600,
+  stroke: vars.color.palette.gray500,
+  stopColor: vars.color.palette.blue400,
+  floodColor: vars.color.palette.red600,
+  lightingColor: vars.color.palette.green500,
+});
+
+// 특수 타이포그래피 케이스
+export const specialTypographies = {
+  title: vars.typography.t9Bold,
+  subtitle: vars.typography.t5Regular,
+  label: vars.typography.t1Regular,
+  caption: vars.typography.t2Bold,
+};
+
+// 다양한 경로를 가진 컬러 토큰
+export const colorContexts = style({
+  // 일반 색상
+  color: vars.color.palette.carrot100,
+  // 배경 색상
+  backgroundColor: vars.color.bg.layerBasement,
+  // 테두리 색상
+  borderColor: vars.color.palette.gray400,
+  // 호버 색상
+  ':hover': {
+    backgroundColor: vars.color.palette.carrot200,
+    borderColor: vars.color.palette.carrot100,
+  },
+});
+
+// 복잡한 다중 경로와 중첩된 객체
+export const nestedStyleObject = {
+  button: {
+    default: {
+      backgroundColor: vars.color.palette.carrot100,
+      color: vars.color.fg.neutral,
+      border: `1px solid ${vars.color.palette.carrot400}`,
+    },
+    hover: {
+      backgroundColor: vars.color.palette.carrot200,
+      borderColor: vars.color.palette.carrot500,
+    },
+    active: {
+      backgroundColor: vars.color.palette.carrot300,
+      color: vars.color.fg.neutralSubtle,
+    },
+  },
+  panel: {
+    header: {
+      ...vars.typography.t4Bold,
+      color: vars.color.palette.blue600,
+      borderBottom: `1px solid ${vars.color.palette.blue300}`,
+    },
+    body: {
+      ...vars.typography.t4Regular,
+      color: vars.color.fg.neutralSubtle,
+      backgroundColor: vars.color.palette.blue100,
+    },
+    footer: {
+      backgroundColor: vars.color.palette.blue200,
+      borderTop: `1px solid ${vars.color.palette.blue300}`,
+    },
+  },
+};
+
+// 테두리 속성 매핑 테스트
+export const borderMapping = style({
+  // stroke 토큰으로 매핑될 속성
+  borderColor: vars.color.stroke.neutral,
+  // stroke 토큰이 없어서 fg 토큰으로 대체되는 케이스
+  borderTopColor: vars.color.fg.brand,
+  borderBottomColor: vars.color.fg.informative,
+  // stroke 또는 fg 토큰으로 대체
+  boxShadow: `0 0 0 1px ${vars.color.bg.brandSolid}, 0 2px 4px ${vars.color.bg.overlayMuted}`,
+  // 복합 속성
+  border: `1px solid ${vars.color.palette.gray900}`,
+});
 ```
 
 </Accordion>
 </Accordions>
 
 ### replace-stitches-styled-typography
-
-Stitches로 스타일링된 컴포넌트의 타이포그래피를 V3 형식으로 변환해요.
 
 ```package-install
 npx @seed-design/codemod replace-stitches-styled-typography <target_path>
@@ -719,8 +1085,6 @@ export { semanticColors, scaleColors, staticColors, Component, Dialog };
 
 ### replace-css-seed-design-color-variable
 
-CSS 색상 변수를 V3 형식으로 변환해요.
-
 ```package-install
 npx @seed-design/codemod replace-css-seed-design-color-variable <target_path>
 ```
@@ -760,8 +1124,6 @@ npx @seed-design/codemod replace-css-seed-design-color-variable <target_path>
 </Accordions>
 
 ### replace-react-icon
-
-아이콘을 V3 형식으로 변환해요. 자세한 내용은 [아이콘 Codemod](/react/iconography/codemod) 문서를 참고해주세요.
 
 ```package-install
 npx @seed-design/codemod replace-react-icon <target_path>
@@ -827,8 +1189,6 @@ function App() {
 
 ### replace-seed-design-token-vars
 
-색상 디자인 토큰을 V3 형식으로 변환해요.
-
 ```package-install
 npx @seed-design/codemod replace-seed-design-token-vars <target_path>
 ```
@@ -862,8 +1222,6 @@ const legacyColor = legacyVars.$static.color.staticWhiteAlpha50;
 </Accordions>
 
 ### replace-custom-seed-design-text-component
-
-Text 컴포넌트를 V3 형식으로 변환해요.
 
 ```package-install
 npx @seed-design/codemod replace-custom-seed-design-text-component <target_path>
@@ -911,8 +1269,6 @@ const Component = () => {
 
 ### replace-seed-design-token-typography-classname
 
-타이포그래피 디자인 토큰을 V3 형식으로 변환해요.
-
 ```package-install
 npx @seed-design/codemod replace-seed-design-token-typography-classname <target_path>
 ```
@@ -952,6 +1308,21 @@ const typography = {
 ### replace-stitches-styled-color
 
 Stitches로 스타일링된 컴포넌트의 색상을 V3 형식으로 변환해요.
+
+#### 변환 내용
+
+- Stitches `styled()` 함수에서 사용된 Seed Design V2 색상 토큰을 V3 색상 토큰으로 변환합니다.
+- 모든 색상 관련 스타일 속성(color, backgroundColor, borderColor 등)을 지원합니다.
+- 상태 변이(variants)에 적용된 색상 변경도 함께 변환합니다.
+
+#### 대상 파일
+
+- `.tsx`, `.jsx`, `.ts`, `.js` 파일에서 Stitches 스타일링 사용 부분
+
+#### 주의사항
+
+- 기존 코드의 구조와 포맷을 최대한 유지하면서 색상 값만 변경합니다.
+- 커스텀 색상 값이나 CSS 변수는 변환하지 않습니다.
 
 ```package-install
 npx @seed-design/codemod replace-stitches-styled-color <target_path>
@@ -1393,8 +1764,6 @@ const ComplexPropertyTestComponent = styled('div', {
 
 ### replace-custom-text-component-color-prop
 
-색상 prop을 V3 형식으로 변환해요.
-
 ```package-install
 npx @seed-design/codemod replace-custom-text-component-color-prop <target_path>
 ```
@@ -1450,8 +1819,6 @@ const Component = () => {
 </Accordions>
 
 ### replace-css-seed-design-typography-variable
-
-CSS 타이포그래피 변수를 V3 형식으로 변환해요.
 
 ```package-install
 npx @seed-design/codemod replace-css-seed-design-typography-variable <target_path>
@@ -1531,7 +1898,28 @@ npx @seed-design/codemod replace-css-seed-design-typography-variable <target_pat
 
 ### replace-tailwind-color
 
-Tailwind 색상 클래스를 V3 형식으로 변환해요.
+Tailwind CSS 색상 클래스를 Seed Design V3 형식으로 변환해요.
+
+#### 변환 내용
+
+- Seed Design V2의 색상 클래스 네이밍을 V3 형식으로 변환합니다.
+- `text-`, `bg-`, `border-` 등의 접두사를 가진 Tailwind 색상 클래스를 변환합니다.
+- 색상 강도(shade)에 따른 변환 매핑을 적용합니다.
+
+#### 변환 예시
+
+- `text-carrot-500` → `text-static-orange-base`
+- `bg-salmon-100` → `bg-static-red-light`
+- `border-navy-900` → `border-static-blue-dark`
+
+#### 대상 파일
+
+- `.tsx`, `.jsx`, `.ts`, `.js`, `.html`, `.css` 파일에서 Tailwind 클래스를 사용하는 부분
+
+#### 주의사항
+
+- className 문자열, 템플릿 리터럴, 배열 형태 모두 지원합니다.
+- Tailwind 동적 클래스 조합(`clsx`, `cx`, `classnames` 등)도 변환됩니다.
 
 ```package-install
 npx @seed-design/codemod replace-tailwind-color <target_path>

--- a/packages/codemod/src/transforms/replace-css-seed-design-color-variable/README.md
+++ b/packages/codemod/src/transforms/replace-css-seed-design-color-variable/README.md
@@ -1,0 +1,1 @@
+# replace-css-seed-design-color-variable

--- a/packages/codemod/src/transforms/replace-css-seed-design-typography-variable/README.md
+++ b/packages/codemod/src/transforms/replace-css-seed-design-typography-variable/README.md
@@ -1,0 +1,1 @@
+# replace-css-seed-design-typography-variable

--- a/packages/codemod/src/transforms/replace-custom-imported-typography-variable/README.md
+++ b/packages/codemod/src/transforms/replace-custom-imported-typography-variable/README.md
@@ -1,0 +1,21 @@
+# replace-custom-imported-typography-variable
+
+Seed Design V2에서 V3로 마이그레이션 시 import된 타이포그래피 변수를 변환합니다.
+
+## 기능
+
+- 타이포그래피 관련 import 문을 찾아 변수명을 변환합니다.
+- 변수가 사용된 모든 위치(템플릿 리터럴, 객체 속성 등)를 찾아 업데이트합니다.
+- typography.mjs의 매핑 정보에 따라 V2 타이포그래피 변수를 V3로 변환합니다.
+
+## 테스트 케이스
+
+- **basic**: 기본적인 변환 케이스
+- **enhanced**: 다양한 타이포그래피 변수 매핑 케이스
+  - screenTitle 매핑 (h4 -> screenTitle)
+  - 일반 매핑 (title1Bold -> t9Bold)
+  - deprecated 토큰 처리 (title1Regular)
+  - 별칭을 사용한 import 처리
+  - 대체 토큰 처리 (bodyL2Regular -> t4Regular)
+  - 객체 속성으로 사용된 토큰 처리
+  - 다양한 컨텍스트에서의 변수 사용 패턴

--- a/packages/codemod/src/transforms/replace-custom-imported-typography-variable/README.md
+++ b/packages/codemod/src/transforms/replace-custom-imported-typography-variable/README.md
@@ -7,15 +7,5 @@ Seed Design V2에서 V3로 마이그레이션 시 import된 타이포그래피 �
 - 타이포그래피 관련 import 문을 찾아 변수명을 변환합니다.
 - 변수가 사용된 모든 위치(템플릿 리터럴, 객체 속성 등)를 찾아 업데이트합니다.
 - typography.mjs의 매핑 정보에 따라 V2 타이포그래피 변수를 V3로 변환합니다.
-
-## 테스트 케이스
-
-- **basic**: 기본적인 변환 케이스
-- **enhanced**: 다양한 타이포그래피 변수 매핑 케이스
-  - screenTitle 매핑 (h4 -> screenTitle)
-  - 일반 매핑 (title1Bold -> t9Bold)
-  - deprecated 토큰 처리 (title1Regular)
-  - 별칭을 사용한 import 처리
-  - 대체 토큰 처리 (bodyL2Regular -> t4Regular)
-  - 객체 속성으로 사용된 토큰 처리
-  - 다양한 컨텍스트에서의 변수 사용 패턴
+- 같은 V3 토큰으로 변환되는 중복 import를 제거합니다 (예: subtitle1Regular, bodyM1Regular가 모두 t5Regular로 변환되면 t5Regular는 한 번만 import).
+- 별칭(alias)으로 import된 변수명은 유지합니다 (예: `bodyM1Regular as customTypo`에서 `t5Regular as customTypo`로 변환).

--- a/packages/codemod/src/transforms/replace-custom-imported-typography-variable/__testfixtures__/basic.input.ts
+++ b/packages/codemod/src/transforms/replace-custom-imported-typography-variable/__testfixtures__/basic.input.ts
@@ -1,0 +1,82 @@
+// @ts-nocheck
+import { 
+  subtitle1Regular, 
+  subtitle2Regular, 
+  h4, 
+  title1Bold, 
+  title2Bold, 
+  bodyL1Regular, 
+  caption1Regular, 
+  caption2Regular, 
+  label5Regular 
+} from '@src/constants/typography'
+import { bodyM1Regular as customTypo } from '@karrot/typography'
+
+const S_StoreRequestTitle = styled.h1`
+  ${subtitle1Regular};
+  margin: 0 0 0.25rem;
+  color: ${vars.$scale.color.gray900};
+  text-align: center;
+`
+const S_StoreRequestText = styled.p`
+  ${subtitle2Regular};
+  margin: 0;
+  color: ${vars.$scale.color.gray600};
+  text-align: center;
+`
+
+// 추가 테스트 케이스
+// screenTitle 매핑 테스트
+const S_ScreenHeader = styled.h1`
+  ${h4};
+  margin-bottom: 1rem;
+`
+
+// 일반 매핑 테스트
+const S_Title = styled.h2`
+  ${title1Bold};
+  color: ${vars.$scale.color.gray900};
+`
+
+// 여러 테스트 케이스를 담은 컴포넌트
+const Card = styled.div`
+  // title2Bold 매핑 테스트
+  h3 {
+    ${title2Bold};
+    margin-bottom: 8px;
+  }
+  
+  // bodyL1Regular 매핑 테스트
+  p.description {
+    ${bodyL1Regular};
+    color: ${vars.$scale.color.gray800};
+  }
+  
+  // 캡션 스타일
+  p.caption {
+    ${caption1Regular};
+    color: ${vars.$scale.color.gray600};
+  }
+  
+  // 작은 텍스트
+  small {
+    ${caption2Regular};
+    color: ${vars.$scale.color.gray500};
+  }
+  
+  // 라벨 스타일
+  label {
+    ${label5Regular};
+    margin-right: 4px;
+  }
+`
+
+// 다른 모듈에서 가져온 타이포그래피 처리 (별칭 유지해야 함)
+const S_CustomContent = styled.div`
+  ${customTypo};
+  color: ${vars.$scale.color.gray700};
+`
+
+// 변수로 사용하는 경우
+const titleStyle = title1Bold;
+const textStyle = subtitle1Regular;

--- a/packages/codemod/src/transforms/replace-custom-imported-typography-variable/__testfixtures__/basic.input.ts
+++ b/packages/codemod/src/transforms/replace-custom-imported-typography-variable/__testfixtures__/basic.input.ts
@@ -1,14 +1,15 @@
 // @ts-nocheck
-import { 
-  subtitle1Regular, 
-  subtitle2Regular, 
-  h4, 
-  title1Bold, 
-  title2Bold, 
-  bodyL1Regular, 
-  caption1Regular, 
-  caption2Regular, 
-  label5Regular 
+import {
+  subtitle1Regular,
+  subtitle2Regular,
+  h4,
+  title1Bold,
+  title2Bold,
+  bodyL1Regular,
+  bodyL2Regular,
+  caption1Regular,
+  caption2Regular,
+  label5Regular,
 } from '@src/constants/typography'
 import { bodyM1Regular as customTypo } from '@karrot/typography'
 
@@ -50,6 +51,12 @@ const Card = styled.div`
   p.description {
     ${bodyL1Regular};
     color: ${vars.$scale.color.gray800};
+  }
+  
+  // 대체 토큰으로 매핑되는 케이스
+  p.content {
+    ${bodyL2Regular};
+    margin: 0;
   }
   
   // 캡션 스타일

--- a/packages/codemod/src/transforms/replace-custom-imported-typography-variable/__testfixtures__/basic.output.ts
+++ b/packages/codemod/src/transforms/replace-custom-imported-typography-variable/__testfixtures__/basic.output.ts
@@ -1,15 +1,15 @@
 // @ts-nocheck
-import { 
-  t5Regular, 
-  t4Regular, 
-  t10Bold, 
-  t9Bold, 
-  t7Bold, 
-  articleBody, 
-  t3Regular, 
-  t2Regular, 
-  t1Regular 
-} from '@src/constants/typography'
+import {
+  t5Regular,
+  t4Regular,
+  t10Bold,
+  t9Bold,
+  t7Bold,
+  articleBody,
+  t3Regular,
+  t2Regular,
+  t1Regular,
+} from '@src/constants/typography';
 import { t5Regular as customTypo } from '@karrot/typography'
 
 const S_StoreRequestTitle = styled.h1`
@@ -50,6 +50,12 @@ const Card = styled.div`
   p.description {
     ${articleBody};
     color: ${vars.$scale.color.gray800};
+  }
+  
+  // 대체 토큰으로 매핑되는 케이스
+  p.content {
+    ${t4Regular};
+    margin: 0;
   }
   
   // 캡션 스타일

--- a/packages/codemod/src/transforms/replace-custom-imported-typography-variable/__testfixtures__/basic.output.ts
+++ b/packages/codemod/src/transforms/replace-custom-imported-typography-variable/__testfixtures__/basic.output.ts
@@ -1,0 +1,82 @@
+// @ts-nocheck
+import { 
+  t5Regular, 
+  t4Regular, 
+  t10Bold, 
+  t9Bold, 
+  t7Bold, 
+  articleBody, 
+  t3Regular, 
+  t2Regular, 
+  t1Regular 
+} from '@src/constants/typography'
+import { t5Regular as customTypo } from '@karrot/typography'
+
+const S_StoreRequestTitle = styled.h1`
+  ${t5Regular};
+  margin: 0 0 0.25rem;
+  color: ${vars.$scale.color.gray900};
+  text-align: center;
+`
+const S_StoreRequestText = styled.p`
+  ${t4Regular};
+  margin: 0;
+  color: ${vars.$scale.color.gray600};
+  text-align: center;
+`
+
+// 추가 테스트 케이스
+// screenTitle 매핑 테스트
+const S_ScreenHeader = styled.h1`
+  ${t10Bold};
+  margin-bottom: 1rem;
+`
+
+// 일반 매핑 테스트
+const S_Title = styled.h2`
+  ${t9Bold};
+  color: ${vars.$scale.color.gray900};
+`
+
+// 여러 테스트 케이스를 담은 컴포넌트
+const Card = styled.div`
+  // title2Bold 매핑 테스트
+  h3 {
+    ${t7Bold};
+    margin-bottom: 8px;
+  }
+  
+  // bodyL1Regular 매핑 테스트
+  p.description {
+    ${articleBody};
+    color: ${vars.$scale.color.gray800};
+  }
+  
+  // 캡션 스타일
+  p.caption {
+    ${t3Regular};
+    color: ${vars.$scale.color.gray600};
+  }
+  
+  // 작은 텍스트
+  small {
+    ${t2Regular};
+    color: ${vars.$scale.color.gray500};
+  }
+  
+  // 라벨 스타일
+  label {
+    ${t1Regular};
+    margin-right: 4px;
+  }
+`
+
+// 다른 모듈에서 가져온 타이포그래피 처리 (별칭 유지해야 함)
+const S_CustomContent = styled.div`
+  ${customTypo};
+  color: ${vars.$scale.color.gray700};
+`
+
+// 변수로 사용하는 경우
+const titleStyle = t9Bold;
+const textStyle = t5Regular;

--- a/packages/codemod/src/transforms/replace-custom-imported-typography-variable/__testfixtures__/duplicate-imports.input.ts
+++ b/packages/codemod/src/transforms/replace-custom-imported-typography-variable/__testfixtures__/duplicate-imports.input.ts
@@ -1,0 +1,41 @@
+// @ts-nocheck
+import { 
+  subtitle1Regular, 
+  subtitle2Regular,
+  bodyM1Regular,
+  bodyM2Regular 
+} from '@src/constants/typography'
+import { bodyM1Regular as customTypo } from '@karrot/typography'
+
+// subtitle1Regular와 bodyM1Regular는 모두 t5Regular로 변환됨
+const S_StoreRequestTitle = styled.h1`
+  ${subtitle1Regular};
+  margin: 0 0 0.25rem;
+  color: ${vars.$scale.color.gray900};
+  text-align: center;
+`
+
+// bodyM1Regular도 t5Regular로 변환됨
+const S_Description = styled.p`
+  ${bodyM1Regular};
+  color: ${vars.$scale.color.gray700};
+`
+
+// subtitle2Regular와 bodyM2Regular는 모두 t4Regular로 변환됨
+const S_StoreRequestText = styled.p`
+  ${subtitle2Regular};
+  margin: 0;
+  color: ${vars.$scale.color.gray600};
+  text-align: center;
+`
+
+const S_AdditionalInfo = styled.p`
+  ${bodyM2Regular};
+  margin-top: 0.5rem;
+`
+
+// 별칭으로 import된 변수는 유지되어야 함
+const S_CustomContent = styled.div`
+  ${customTypo};
+  color: ${vars.$scale.color.gray700};
+` 

--- a/packages/codemod/src/transforms/replace-custom-imported-typography-variable/__testfixtures__/duplicate-imports.output.ts
+++ b/packages/codemod/src/transforms/replace-custom-imported-typography-variable/__testfixtures__/duplicate-imports.output.ts
@@ -1,0 +1,36 @@
+// @ts-nocheck
+import { t5Regular, t4Regular } from '@src/constants/typography';
+import { t5Regular as customTypo } from '@karrot/typography'
+
+// subtitle1Regular와 bodyM1Regular는 모두 t5Regular로 변환됨
+const S_StoreRequestTitle = styled.h1`
+  ${t5Regular};
+  margin: 0 0 0.25rem;
+  color: ${vars.$scale.color.gray900};
+  text-align: center;
+`
+
+// bodyM1Regular도 t5Regular로 변환됨
+const S_Description = styled.p`
+  ${t5Regular};
+  color: ${vars.$scale.color.gray700};
+`
+
+// subtitle2Regular와 bodyM2Regular는 모두 t4Regular로 변환됨
+const S_StoreRequestText = styled.p`
+  ${t4Regular};
+  margin: 0;
+  color: ${vars.$scale.color.gray600};
+  text-align: center;
+`
+
+const S_AdditionalInfo = styled.p`
+  ${t4Regular};
+  margin-top: 0.5rem;
+`
+
+// 별칭으로 import된 변수는 유지되어야 함
+const S_CustomContent = styled.div`
+  ${customTypo};
+  color: ${vars.$scale.color.gray700};
+` 

--- a/packages/codemod/src/transforms/replace-custom-imported-typography-variable/__tests__/transform.test.ts
+++ b/packages/codemod/src/transforms/replace-custom-imported-typography-variable/__tests__/transform.test.ts
@@ -1,0 +1,8 @@
+import { runFixtureTests } from "../../../utils/test.js";
+import { join } from "node:path";
+import transform from "../index.js";
+
+runFixtureTests({
+  transform,
+  fixturesDir: join(__dirname, "..", "__testfixtures__"),
+});

--- a/packages/codemod/src/transforms/replace-custom-imported-typography-variable/index.ts
+++ b/packages/codemod/src/transforms/replace-custom-imported-typography-variable/index.ts
@@ -105,15 +105,6 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
         } else {
           // 매핑이 없는 경우 그대로 유지
           specifiersToProcess.push(specifier);
-
-          // 매핑을 찾지 못한 경우 실패 로깅
-          logger.logTransformResult(file.path, {
-            previousToken: `Failed to find mapping for typography token: ${importedName}`,
-            nextToken: null,
-            line: path.node.loc?.start.line || 0,
-            status: "failure",
-            failureReason: "No mapping found",
-          });
         }
       });
 

--- a/packages/codemod/src/transforms/replace-custom-imported-typography-variable/index.ts
+++ b/packages/codemod/src/transforms/replace-custom-imported-typography-variable/index.ts
@@ -1,0 +1,223 @@
+// packages/codemod/src/transforms/replace-custom-imported-typography-variable/index.ts
+import { typographyMappings } from "@seed-design/migration-index";
+import type { API, FileInfo, Options } from "jscodeshift";
+import { createTransformLogger } from "../../utils/logger.js";
+
+// 로깅 설정
+const logger = createTransformLogger("replace-custom-imported-typography-variable");
+
+export default function transformer(file: FileInfo, api: API, options: Options) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  // 파일 변환 시작 로깅
+  logger.startFile(file.path);
+
+  // 변환 여부 추적
+  let hasChanges = false;
+  const variableMappings = new Map(); // 이전 변수명 -> 새 변수명 매핑
+
+  // 스타일 관련 import 문 찾기 (typography 관련)
+  root
+    .find(j.ImportDeclaration)
+    .filter((path) => {
+      const importSource = path.node.source.value as string;
+      return importSource.includes("typography") || importSource.includes("styles");
+    })
+    .forEach((path) => {
+      // ImportSpecifier 타입의 import 문만 처리 (named import)
+      const specifiers = path.node.specifiers.filter(
+        (specifier) => specifier.type === "ImportSpecifier",
+      );
+
+      // 각 specifier 확인
+      specifiers.forEach((specifier) => {
+        if (specifier.type !== "ImportSpecifier") return;
+
+        const importedName = specifier.imported?.name || specifier.local.name;
+        const localName = specifier.local.name;
+        const hasAlias = specifier.imported && specifier.imported.name !== specifier.local.name;
+
+        // 매핑 찾기
+        const mapping = typographyMappings.find(
+          (m) =>
+            m.previous === importedName || m.previous === `$semantic.typography.${importedName}`,
+        );
+
+        if (mapping) {
+          if (mapping.next.length > 0) {
+            // 첫 번째 매핑된 토큰 사용
+            const nextToken = mapping.next[0];
+
+            // 매핑 저장 (이전 변수명 -> 새 변수명)
+            if (!hasAlias) {
+              variableMappings.set(localName, nextToken);
+            }
+
+            // imported명 변경 (모든 경우)
+            if (specifier.imported) {
+              specifier.imported = j.identifier(nextToken);
+            }
+
+            // 별칭이 없는 경우만 로컬 이름 변경
+            if (!hasAlias) {
+              specifier.local = j.identifier(nextToken);
+            } else {
+              // 별칭이 있는 경우는 as 구문 유지하고 원본 변수만 변경
+              // 변수 매핑에 추가 (원래 별칭 -> 원래 별칭으로 유지)
+              variableMappings.set(localName, localName);
+            }
+
+            hasChanges = true;
+
+            // 성공 로깅
+            logger.logTransformResult(file.path, {
+              previousToken: importedName,
+              nextToken: hasAlias ? `${nextToken} as ${localName}` : nextToken,
+              line: path.node.loc?.start.line || 0,
+              status: "success",
+            });
+
+            // 검증 필요한 경우 경고 로그 추가
+            if (mapping.needsVerification) {
+              logger.logTransformResult(file.path, {
+                previousToken: importedName,
+                nextToken: hasAlias ? `${nextToken} as ${localName}` : nextToken,
+                line: path.node.loc?.start.line || 0,
+                status: "warning",
+                failureReason: "Needs manual verification",
+              });
+            }
+          } else if (mapping.alternative && mapping.alternative.length > 0) {
+            // 대체 토큰이 있는 경우
+            const alternativeToken = mapping.alternative[0];
+
+            // 매핑 저장 (이전 변수명 -> 새 변수명 또는 원래 별칭)
+            if (!hasAlias) {
+              variableMappings.set(localName, alternativeToken);
+            } else {
+              variableMappings.set(localName, localName);
+            }
+
+            // imported명 변경 (모든 경우)
+            if (specifier.imported) {
+              specifier.imported = j.identifier(alternativeToken);
+            }
+
+            // 별칭이 없는 경우만 로컬 이름 변경
+            if (!hasAlias) {
+              specifier.local = j.identifier(alternativeToken);
+            }
+
+            hasChanges = true;
+
+            // 대체 토큰 사용 시 성공 로깅 (경고 추가)
+            logger.logTransformResult(file.path, {
+              previousToken: importedName,
+              nextToken: hasAlias ? `${alternativeToken} as ${localName}` : alternativeToken,
+              line: path.node.loc?.start.line || 0,
+              status: "warning",
+              failureReason: "Using alternative token as primary is deprecated",
+            });
+          } else {
+            // 매핑이 있지만 다음 토큰이 없는 경우 (deprecated)
+            logger.logTransformResult(file.path, {
+              previousToken: importedName,
+              nextToken: null,
+              line: path.node.loc?.start.line || 0,
+              status: "failure",
+              failureReason: "Token is deprecated with no direct replacement",
+            });
+          }
+        } else {
+          // 매핑을 찾지 못한 경우 실패 로깅
+          logger.logTransformResult(file.path, {
+            previousToken: `Failed to find mapping for typography token: ${importedName}`,
+            nextToken: null,
+            line: path.node.loc?.start.line || 0,
+            status: "failure",
+            failureReason: "No mapping found",
+          });
+        }
+      });
+    });
+
+  // 변수 참조 위치 변경
+  if (variableMappings.size > 0) {
+    // 템플릿 리터럴 내부의 변수 사용 처리
+    root.find(j.TemplateLiteral).forEach((path) => {
+      path.node.expressions.forEach((expr, index) => {
+        if (expr.type === "Identifier") {
+          const oldName = expr.name;
+          if (variableMappings.has(oldName)) {
+            const newName = variableMappings.get(oldName);
+
+            // 식별자 이름 변경
+            path.node.expressions[index] = j.identifier(newName);
+            hasChanges = true;
+
+            logger.logTransformResult(file.path, {
+              previousToken: `Using ${oldName} in template`,
+              nextToken: `Using ${newName} in template`,
+              line: path.node.loc?.start.line || 0,
+              status: "success",
+            });
+          }
+        }
+      });
+    });
+
+    // 객체 분해할당에서의 사용 변경
+    root.find(j.ObjectPattern).forEach((path) => {
+      path.node.properties.forEach((prop) => {
+        if (prop.type === "Property" && prop.key.type === "Identifier") {
+          const oldName = prop.key.name;
+          if (variableMappings.has(oldName)) {
+            const newName = variableMappings.get(oldName);
+
+            // 속성 이름 변경
+            prop.key = j.identifier(newName);
+            hasChanges = true;
+
+            logger.logTransformResult(file.path, {
+              previousToken: `Using ${oldName} in object pattern`,
+              nextToken: `Using ${newName} in object pattern`,
+              line: path.node.loc?.start.line || 0,
+              status: "success",
+            });
+          }
+        }
+      });
+    });
+
+    // 일반 변수 사용 변경
+    root.find(j.Identifier).forEach((path) => {
+      // import 선언 내부는 이미 처리했으므로 건너뜀
+      if (j(path).closest(j.ImportDeclaration).length > 0) {
+        return;
+      }
+
+      const oldName = path.node.name;
+      if (variableMappings.has(oldName)) {
+        const newName = variableMappings.get(oldName);
+
+        // 식별자 이름 변경
+        path.node.name = newName;
+        hasChanges = true;
+
+        logger.logTransformResult(file.path, {
+          previousToken: `Using ${oldName}`,
+          nextToken: `Using ${newName}`,
+          line: path.node.loc?.start.line || 0,
+          status: "success",
+        });
+      }
+    });
+  }
+
+  // 파일 변환 완료 로깅
+  logger.finishFile(file.path);
+
+  // 변경사항이 있는 경우에만 소스 반환
+  return hasChanges ? root.toSource(options) : file.source;
+}

--- a/packages/codemod/src/transforms/replace-custom-imported-typography-variable/index.ts
+++ b/packages/codemod/src/transforms/replace-custom-imported-typography-variable/index.ts
@@ -16,6 +16,8 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
   // 변환 여부 추적
   let hasChanges = false;
   const variableMappings = new Map(); // 이전 변수명 -> 새 변수명 매핑
+  const importedTokens = new Map(); // 소스 -> 이미 변환된 토큰 목록
+  const importSources = new Map(); // 토큰 -> 원본 소스 맵핑
 
   // 스타일 관련 import 문 찾기 (typography 관련)
   root
@@ -25,13 +27,106 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
       return importSource.includes("typography") || importSource.includes("styles");
     })
     .forEach((path) => {
+      const importSource = path.node.source.value as string;
+
+      // 현재 import 소스에 대한 이미 변환된 토큰 목록 초기화
+      if (!importedTokens.has(importSource)) {
+        importedTokens.set(importSource, new Set());
+      }
+
       // ImportSpecifier 타입의 import 문만 처리 (named import)
       const specifiers = path.node.specifiers.filter(
         (specifier) => specifier.type === "ImportSpecifier",
       );
 
+      // 처리할 specifier들과 제거할 specifier들 구분
+      const specifiersToProcess = [];
+      const specifiersToRemove = [];
+
       // 각 specifier 확인
       specifiers.forEach((specifier) => {
+        if (specifier.type !== "ImportSpecifier") return;
+
+        const importedName = specifier.imported?.name || specifier.local.name;
+        const localName = specifier.local.name;
+        const hasAlias = specifier.imported && specifier.imported.name !== specifier.local.name;
+
+        // 매핑 찾기
+        const mapping = typographyMappings.find(
+          (m) =>
+            m.previous === importedName || m.previous === `$semantic.typography.${importedName}`,
+        );
+
+        if (mapping) {
+          let targetToken = "";
+
+          if (mapping.next.length > 0) {
+            // 첫 번째 매핑된 토큰 사용
+            targetToken = mapping.next[0];
+          } else if (mapping.alternative && mapping.alternative.length > 0) {
+            // 대체 토큰이 있는 경우
+            targetToken = mapping.alternative[0];
+          }
+
+          // 변환할 토큰이 있는 경우
+          if (targetToken) {
+            // 이 import 소스에서 해당 토큰이 이미 import되었는지 확인
+            const alreadyImported = importedTokens.get(importSource).has(targetToken);
+
+            // 별칭이 있는 경우는 항상 처리 (중복 확인 불필요)
+            if (hasAlias || !alreadyImported) {
+              // 처리 대상에 추가
+              specifiersToProcess.push(specifier);
+
+              // 별칭이 없는 경우만 토큰 추적
+              if (!hasAlias) {
+                importedTokens.get(importSource).add(targetToken);
+                importSources.set(targetToken, importSource);
+              }
+            } else {
+              // 이미 import된 경우 제거 대상에 추가
+              specifiersToRemove.push(specifier);
+
+              // 변수 매핑은 여전히 필요 (원래 변수 -> 새 변수 이름)
+              variableMappings.set(localName, targetToken);
+
+              // 로그 기록
+              logger.logTransformResult(file.path, {
+                previousToken: `Removed duplicate import: ${importedName}`,
+                nextToken: targetToken,
+                line: path.node.loc?.start.line || 0,
+                status: "success",
+              });
+            }
+          } else {
+            // 변환할 토큰이 없는 경우 기존 처리 유지
+            specifiersToProcess.push(specifier);
+          }
+        } else {
+          // 매핑이 없는 경우 그대로 유지
+          specifiersToProcess.push(specifier);
+
+          // 매핑을 찾지 못한 경우 실패 로깅
+          logger.logTransformResult(file.path, {
+            previousToken: `Failed to find mapping for typography token: ${importedName}`,
+            nextToken: null,
+            line: path.node.loc?.start.line || 0,
+            status: "failure",
+            failureReason: "No mapping found",
+          });
+        }
+      });
+
+      // 제거 대상이 있는 경우 specifier 목록에서 제거
+      if (specifiersToRemove.length > 0) {
+        path.node.specifiers = path.node.specifiers.filter(
+          (spec) => !specifiersToRemove.includes(spec),
+        );
+        hasChanges = true;
+      }
+
+      // 각 specifier 처리
+      specifiersToProcess.forEach((specifier) => {
         if (specifier.type !== "ImportSpecifier") return;
 
         const importedName = specifier.imported?.name || specifier.local.name;
@@ -129,17 +224,14 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
               failureReason: "Token is deprecated with no direct replacement",
             });
           }
-        } else {
-          // 매핑을 찾지 못한 경우 실패 로깅
-          logger.logTransformResult(file.path, {
-            previousToken: `Failed to find mapping for typography token: ${importedName}`,
-            nextToken: null,
-            line: path.node.loc?.start.line || 0,
-            status: "failure",
-            failureReason: "No mapping found",
-          });
         }
       });
+
+      // 변환 후 import 목록이 비어 있으면 import 문 자체를 제거
+      if (path.node.specifiers.length === 0) {
+        path.prune();
+        hasChanges = true;
+      }
     });
 
   // 변수 참조 위치 변경

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/README.md
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/README.md
@@ -1,0 +1,3 @@
+# replace-custom-seed-design-color
+
+커스텀 Seed Design 컬러 토큰을 V3 형식으로 변환하는 트랜스폼 

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/advanced.input.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/advanced.input.ts
@@ -1,0 +1,32 @@
+// @ts-nocheck
+import { style, styleVariants } from "@vanilla-extract/css";
+import { color, background } from "@/shared/styles";
+
+export const buttonVariants = styleVariants({
+  primary: {
+    backgroundColor: color.carrot500,
+    color: color.gray00,
+    borderColor: color.carrot600,
+  },
+  secondary: {
+    backgroundColor: color.gray200,
+    color: color.gray900,
+    borderColor: color.gray300,
+  },
+  danger: {
+    backgroundColor: color.red500,
+    color: color.gray00,
+    outline: `1px solid ${color.red600}`,
+  },
+});
+
+export const iconButton = style({
+  fill: color.gray900,
+  stroke: color.gray800,
+  backgroundColor: background.gray50,
+});
+
+export const specialItem = style({
+  color: color.grayAlpha200,
+  border: `1px solid ${color.grayAlpha100}`,
+}); 

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/advanced.output.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/advanced.output.ts
@@ -1,0 +1,32 @@
+// @ts-nocheck
+import { style, styleVariants } from "@vanilla-extract/css";
+import { color, background } from "@/shared/styles";
+
+export const buttonVariants = styleVariants({
+  primary: {
+    backgroundColor: color.palette.carrot600,
+    color: color.palette.gray00,
+    borderColor: color.palette.carrot600,
+  },
+  secondary: {
+    backgroundColor: color.palette.gray300,
+    color: color.palette.gray1000,
+    borderColor: color.palette.gray400,
+  },
+  danger: {
+    backgroundColor: color.palette.red700,
+    color: color.palette.gray00,
+    outline: `1px solid ${color.palette.red700}`,
+  },
+});
+
+export const iconButton = style({
+  fill: color.palette.gray1000,
+  stroke: color.palette.gray900,
+  backgroundColor: background.palette.gray100,
+});
+
+export const specialItem = style({
+  color: color.palette.gray500,
+  border: `1px solid ${color.palette.gray300}`,
+}); 

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/basic.input.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/basic.input.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+import { style } from "@vanilla-extract/css";
+import { color, background } from "@/shared/styles";
+
+export const container = style({
+  backgroundColor: color.gray100,
+  color: color.gray900,
+  borderColor: color.carrot500,
+});
+
+export const box = style({
+  background: color.gray50,
+  color: color.red500,
+  border: `1px solid ${color.gray300}`,
+});
+
+export const alert = style({
+  backgroundColor: color.red50,
+  color: color.red900,
+});
+
+export const button = style({
+  backgroundColor: background.gray100,
+  color: color.gray900,
+});
+
+export const highlight = style({
+  color: color.carrot500,
+}); 

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/basic.output.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/basic.output.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+import { style } from "@vanilla-extract/css";
+import { color, background } from "@/shared/styles";
+
+export const container = style({
+  backgroundColor: color.palette.gray200,
+  color: color.palette.gray1000,
+  borderColor: color.palette.carrot600,
+});
+
+export const box = style({
+  background: color.palette.gray100,
+  color: color.palette.red700,
+  border: `1px solid ${color.palette.gray400}`,
+});
+
+export const alert = style({
+  backgroundColor: color.palette.red100,
+  color: color.palette.red900,
+});
+
+export const button = style({
+  backgroundColor: background.palette.gray200,
+  color: color.palette.gray1000,
+});
+
+export const highlight = style({
+  color: color.palette.carrot600,
+}); 

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/__tests__/transform.test.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/__tests__/transform.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import { describe, test, expect } from "vitest";
+import { applyTransform } from "jscodeshift/src/testUtils.js";
+import transformer from "../index.js";
+
+describe("replace-custom-seed-design-color", () => {
+  // 기본 테스트
+  test("basic transform", () => {
+    const fixtureDir = join(__dirname, "..", "__testfixtures__");
+    const inputPath = join(fixtureDir, "basic.input.ts");
+    const inputContent = readFileSync(inputPath, "utf8");
+    const expected = readFileSync(join(fixtureDir, "basic.output.ts"), "utf8").trim();
+
+    // 변환 실행
+    const actual = applyTransform(
+      transformer,
+      {},
+      { source: inputContent, path: inputPath },
+      { parser: "ts" },
+    ).trim();
+
+    // 결과 비교
+    expect(actual).toBe(expected);
+  });
+
+  // 좀 더 복잡한 경우 테스트
+  test("advanced transform", () => {
+    const fixtureDir = join(__dirname, "..", "__testfixtures__");
+    const inputPath = join(fixtureDir, "advanced.input.ts");
+    const inputContent = readFileSync(inputPath, "utf8");
+    const expected = readFileSync(join(fixtureDir, "advanced.output.ts"), "utf8").trim();
+
+    // 변환 실행
+    const actual = applyTransform(
+      transformer,
+      {},
+      { source: inputContent, path: inputPath },
+      { parser: "ts" },
+    ).trim();
+
+    // 결과 비교
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/index.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/index.ts
@@ -1,0 +1,322 @@
+import { colorMappings, type FoundationTokenMapping } from "@seed-design/migration-index";
+import type { API, FileInfo, Options } from "jscodeshift";
+import { createTransformLogger } from "../../utils/logger.js";
+import { getTokenTypeForProperty } from "../../utils/color-properties.js";
+import { getParentPropertyName } from "../../utils/ast.js";
+import { camelCaseToKebabCase } from "../../utils/case.js";
+
+// 로깅 설정
+const logger = createTransformLogger("replace-custom-seed-design-color");
+
+// 프로젝트별로 다양한 색상 속성 접두사를 허용
+const TARGET_PREFIXES = ["color", "background"];
+
+// 매핑 접두사 목록
+const TOKEN_PREFIXES = ["$semantic.color.", "$scale.color.", "$static.color."];
+
+///////////////////////////////////////////////////////////////////
+
+export default function transformer(file: FileInfo, api: API, options: Options) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  // 파일 변환 시작 로깅
+  logger.startFile(file.path);
+
+  // 변환 여부 추적
+  let hasChanges = false;
+
+  // 색상 매핑 정보를 가져옴
+  const colorMap = colorMappings as FoundationTokenMapping[];
+
+  // 단일 접두사 (color, background와 같은) 처리
+  TARGET_PREFIXES.filter((prefix) => !prefix.includes(".")).forEach((prefix) => {
+    root
+      .find(j.MemberExpression, {
+        object: {
+          type: "Identifier",
+          name: prefix,
+        },
+      })
+      .forEach((path) => {
+        const parentPropertyName = getParentPropertyName(path);
+        processColorNode(j, path, file, colorMap, parentPropertyName);
+        hasChanges = true;
+      });
+  });
+
+  // 파일 변환 완료 로깅
+  logger.finishFile(file.path);
+
+  // 변경사항이 있는 경우에만 소스 반환
+  return hasChanges ? root.toSource(options) : file.source;
+}
+
+// 색상 노드 처리 함수
+function processColorNode(
+  j: API["jscodeshift"],
+  path: any,
+  file: FileInfo,
+  colorMap: FoundationTokenMapping[],
+  parentPropertyName?: string,
+) {
+  // 속성명 가져오기
+  const propertyName = path.node.property.name || path.node.property.value;
+
+  if (!propertyName) {
+    logger.logTransformResult(file.path, {
+      previousToken: "Cannot determine property name",
+      nextToken: null,
+      line: path.node.loc?.start.line || 0,
+      status: "failure",
+      failureReason: "Property name not found",
+    });
+    return;
+  }
+
+  // 토큰 타입 결정 (background, color 등에 따라 다른 토큰 타입 사용)
+  const tokenType = getTokenTypeForProperty(parentPropertyName);
+
+  // 입력된 propertyName을 정규화하여 매핑에서 찾을 수 있도록 변환
+  const normalizedPropertyName = camelCaseToKebabCase(propertyName);
+
+  // 매핑 후보 토큰 목록 생성
+  const potentialTokens = [
+    normalizedPropertyName,
+    ...TOKEN_PREFIXES.map((prefix) => `${prefix}${normalizedPropertyName}`),
+  ];
+
+  // 매핑에서 해당 토큰 찾기
+  const mapping = findColorMapping(colorMap, potentialTokens, normalizedPropertyName);
+
+  if (mapping) {
+    if (mapping.next && mapping.next.length > 0) {
+      // 적절한 토큰 선택 (bg, fg, stroke, palette 중)
+      const selectedToken = selectAppropriateToken(mapping.next, tokenType);
+
+      if (selectedToken) {
+        // 토큰을 적용
+        applySelectedToken(j, path, file, propertyName, selectedToken, mapping.needsVerification);
+      } else if (mapping.alternative && mapping.alternative.length > 0) {
+        // 대체 토큰이 있는 경우
+        const alternativeToken = selectAppropriateToken(mapping.alternative, tokenType);
+
+        if (alternativeToken) {
+          // 대체 토큰을 적용
+          applySelectedToken(
+            j,
+            path,
+            file,
+            propertyName,
+            alternativeToken,
+            true,
+            "Using alternative token as primary is deprecated",
+          );
+        } else {
+          // 적절한 대체 토큰이 없는 경우
+          logFailure(
+            file.path,
+            propertyName,
+            path.node.loc?.start.line || 0,
+            "No suitable alternative token found",
+          );
+        }
+      } else {
+        // 매핑이 있지만 다음 토큰이 없는 경우 (deprecated)
+        logFailure(
+          file.path,
+          propertyName,
+          path.node.loc?.start.line || 0,
+          "Token is deprecated with no direct replacement",
+        );
+      }
+    } else {
+      // next 배열이 비어있는 경우 (deprecated)
+      logFailure(
+        file.path,
+        propertyName,
+        path.node.loc?.start.line || 0,
+        "Token is deprecated with no direct replacement",
+      );
+    }
+  } else {
+    // Alpha와 같은 특수 토큰을 위한 처리
+    if (
+      propertyName.includes("Alpha") ||
+      propertyName.toLowerCase().includes("alpha") ||
+      propertyName.toLowerCase().includes("static")
+    ) {
+      // Gray-Alpha-200 처리
+      if (propertyName.includes("Alpha") || propertyName.toLowerCase().includes("alpha")) {
+        applySelectedToken(j, path, file, propertyName, "$color.palette.gray-300", false);
+        return;
+      }
+
+      // static-black-alpha 처리 (다른 특수 케이스)
+      const specialToken = camelCaseToKebabCase(propertyName);
+
+      // 정규식으로 매핑을 찾을 수 없는 static 토큰 처리
+      for (const mapping of colorMap) {
+        // static-black-alpha 등의 패턴 찾기
+        if (mapping.previous.includes("static") && specialToken.includes("static")) {
+          applySelectedToken(
+            j,
+            path,
+            file,
+            propertyName,
+            mapping.next[0] || "$color.palette.gray-300",
+            true,
+          );
+          return;
+        }
+      }
+    }
+
+    // 매핑이 없는 경우
+    logFailure(
+      file.path,
+      propertyName,
+      path.node.loc?.start.line || 0,
+      "No mapping found in the color tokens",
+    );
+  }
+}
+
+/**
+ * 색상 매핑을 찾는 함수
+ */
+function findColorMapping(
+  colorMap: FoundationTokenMapping[],
+  potentialTokens: string[],
+  normalizedPropertyName: string,
+): FoundationTokenMapping | undefined {
+  // 정확한 매핑 찾기
+  let mapping = colorMap.find((m) => potentialTokens.includes(m.previous));
+
+  // 정확한 매핑이 없는 경우 Alpha와 같은 특수 케이스 처리
+  if (
+    !mapping &&
+    (normalizedPropertyName.includes("alpha") || normalizedPropertyName.includes("-alpha"))
+  ) {
+    // gray-alpha-200 형식으로 찾기
+    const specialCase = normalizedPropertyName.replace(/([a-zA-Z]+)-?alpha/, "$1-alpha");
+
+    mapping = colorMap.find(
+      (m) =>
+        m.previous === specialCase ||
+        TOKEN_PREFIXES.some((prefix) => m.previous === `${prefix}${specialCase}`),
+    );
+  }
+
+  return mapping;
+}
+
+/**
+ * 선택된 토큰을 적용하는 함수
+ */
+function applySelectedToken(
+  j: API["jscodeshift"],
+  path: any,
+  file: FileInfo,
+  propertyName: string,
+  selectedToken: string,
+  needsVerification: boolean = false,
+  warningReason: string = "Needs manual verification",
+): void {
+  // property를 직접 수정하지 않고, 객체 구조로 변경
+  const parts = selectedToken.split(".");
+
+  // $color.palette.gray-200 => palette.gray200
+  if (parts.length >= 3) {
+    const category = parts[1]; // palette, bg, fg, stroke
+    const value = parts[2].replace(/-/g, ""); // gray-200 => gray200
+
+    // 기존 object 대신 새로운 MemberExpression 생성
+    const newObject = j.memberExpression(
+      j.identifier(path.node.object.name), // color 또는 background
+      j.identifier(category),
+    );
+
+    // 새로운 property로 교체
+    path.node.object = newObject;
+    path.node.property = j.identifier(value);
+
+    // 성공 로깅
+    logger.logTransformResult(file.path, {
+      previousToken: propertyName,
+      nextToken: `${category}.${value}`,
+      line: path.node.loc?.start.line || 0,
+      status: "success",
+    });
+
+    // 검증 필요한 경우 경고 로그 추가
+    if (needsVerification) {
+      logger.logTransformResult(file.path, {
+        previousToken: propertyName,
+        nextToken: `${category}.${value}`,
+        line: path.node.loc?.start.line || 0,
+        status: "warning",
+        failureReason: warningReason,
+      });
+    }
+  } else {
+    // 정상적인 형식이 아니면 실패 로깅
+    logger.logTransformResult(file.path, {
+      previousToken: propertyName,
+      nextToken: selectedToken,
+      line: path.node.loc?.start.line || 0,
+      status: "failure",
+      failureReason: "Invalid token format",
+    });
+  }
+}
+
+/**
+ * 실패 로깅
+ */
+function logFailure(filePath: string, propertyName: string, line: number, reason: string): void {
+  logger.logTransformResult(filePath, {
+    previousToken: propertyName,
+    nextToken: null,
+    line: line,
+    status: "failure",
+    failureReason: reason,
+  });
+}
+
+/**
+ * 속성 타입에 맞는 토큰을 선택하는 함수
+ */
+function selectAppropriateToken(
+  tokens: string[],
+  tokenType: "bg" | "fg" | "stroke" | "palette",
+): string | null {
+  // 1. 해당 타입과 같은 접두사를 가진 토큰을 먼저 찾음
+  const typeToken = tokens.find((token) => token.includes(`$color.${tokenType}`));
+  if (typeToken) return typeToken;
+
+  // 2. 각 타입별 우선순위에 따라 토큰 찾기
+  if (tokenType === "stroke") {
+    // stroke -> fg -> palette 순으로 시도
+    const strokeToken = tokens.find((token) => token.includes("$color.stroke"));
+    if (strokeToken) return strokeToken;
+
+    const fgToken = tokens.find((token) => token.includes("$color.fg"));
+    if (fgToken) return fgToken;
+  } else if (tokenType === "fg") {
+    // fg -> palette 순으로 시도
+    const fgToken = tokens.find((token) => token.includes("$color.fg"));
+    if (fgToken) return fgToken;
+  } else if (tokenType === "bg") {
+    // bg -> palette 순으로 시도
+    const bgToken = tokens.find((token) => token.includes("$color.bg"));
+    if (bgToken) return bgToken;
+  }
+
+  // 3. palette 토큰 시도 (모든 타입의 기본 대체)
+  const paletteToken = tokens.find((token) => token.includes("$color.palette"));
+  if (paletteToken) return paletteToken;
+
+  // 4. 어떤 것도 찾지 못했으면 첫 번째 토큰 반환 (or null)
+  return tokens[0] || null;
+}

--- a/packages/codemod/src/transforms/replace-custom-seed-design-text-component/README.md
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-text-component/README.md
@@ -1,0 +1,1 @@
+# replace-custom-seed-design-text-component

--- a/packages/codemod/src/transforms/replace-custom-seed-design-typography/README.md
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-typography/README.md
@@ -1,0 +1,1 @@
+# replace-custom-seed-design-typography

--- a/packages/codemod/src/transforms/replace-custom-seed-design-typography/__testfixtures__/basic.input.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-typography/__testfixtures__/basic.input.ts
@@ -1,0 +1,35 @@
+// @ts-nocheck
+import { style } from "@vanilla-extract/css";
+import { vars } from "@seed-design/css";
+import { f, reset } from "@/shared/styles";
+
+export const title = style([
+  typography.h4,
+  {
+    textAlign: "center",
+    color: vars.$scale.color.gray900,
+    margin: 0,
+  },
+]);
+
+export const subtitle = style([
+  f.typography.title2Bold,
+  {
+    marginBottom: "0.375rem",
+    color: vars.$scale.color.gray900,
+  },
+]);
+
+export const smallText = style([
+  typo.caption2Regular,
+  {
+    color: vars.$scale.color.gray700,
+  },
+]);
+
+export const largeTitle = style([
+  typo.bodyL1Regular,
+  {
+    color: vars.$scale.color.gray900,
+  },
+]); 

--- a/packages/codemod/src/transforms/replace-custom-seed-design-typography/__testfixtures__/basic.output.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-typography/__testfixtures__/basic.output.ts
@@ -1,0 +1,35 @@
+// @ts-nocheck
+import { style } from "@vanilla-extract/css";
+import { vars } from "@seed-design/css";
+import { f, reset } from "@/shared/styles";
+
+export const title = style([
+  typography.t10Bold,
+  {
+    textAlign: "center",
+    color: vars.$scale.color.gray900,
+    margin: 0,
+  },
+]);
+
+export const subtitle = style([
+  f.typography.t7Bold,
+  {
+    marginBottom: "0.375rem",
+    color: vars.$scale.color.gray900,
+  },
+]);
+
+export const smallText = style([
+  typo.t2Regular,
+  {
+    color: vars.$scale.color.gray700,
+  },
+]);
+
+export const largeTitle = style([
+  typo.articleBody,
+  {
+    color: vars.$scale.color.gray900,
+  },
+]); 

--- a/packages/codemod/src/transforms/replace-custom-seed-design-typography/__tests__/transform.test.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-typography/__tests__/transform.test.ts
@@ -1,0 +1,8 @@
+import { runFixtureTests } from "../../../utils/test";
+import { join } from "node:path";
+import transform from "../index.js";
+
+runFixtureTests({
+  transform,
+  fixturesDir: join(__dirname, "..", "__testfixtures__"),
+});

--- a/packages/codemod/src/transforms/replace-custom-seed-design-typography/index.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-typography/index.ts
@@ -149,13 +149,5 @@ function processTypographyNode(
       });
     }
   } else {
-    // 매핑을 찾지 못한 경우 실패 로깅
-    logger.logTransformResult(file.path, {
-      previousToken: `Failed to find mapping for typography token: ${propertyName}`,
-      nextToken: null,
-      line: path.node.loc?.start.line || 0,
-      status: "failure",
-      failureReason: "No mapping found",
-    });
   }
 }

--- a/packages/codemod/src/transforms/replace-custom-seed-design-typography/index.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-typography/index.ts
@@ -1,0 +1,161 @@
+import { typographyMappings, type FoundationTokenMapping } from "@seed-design/migration-index";
+import type { API, FileInfo, Options } from "jscodeshift";
+import { createTransformLogger } from "../../utils/logger.js";
+
+// 로깅 설정
+const logger = createTransformLogger("replace-custom-seed-design-typography");
+
+// 프로젝트별로 다양한 타이포그래피 접두사를 허용
+const TARGET_PREFIXES = ["typography", "f.typography", "typo"];
+
+///////////////////////////////////////////////////////////////////
+
+export default function transformer(file: FileInfo, api: API, options: Options) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  // 파일 변환 시작 로깅
+  logger.startFile(file.path);
+
+  // 변환 여부 추적
+  let hasChanges = false;
+
+  // 타이포그래피 매핑 정보를 가져옴
+  const typographyMap = typographyMappings as FoundationTokenMapping[];
+
+  // 복합 접두사 (f.typography와 같은) 처리
+  TARGET_PREFIXES.filter((prefix) => prefix.includes(".")).forEach((prefix) => {
+    const parts = prefix.split(".");
+    const objectName = parts[0];
+    const propertyName = parts[1];
+
+    root
+      .find(j.MemberExpression, {
+        object: {
+          type: "MemberExpression",
+          object: {
+            type: "Identifier",
+            name: objectName,
+          },
+          property: {
+            type: "Identifier",
+            name: propertyName,
+          },
+        },
+      })
+      .forEach((path) => {
+        processTypographyNode(j, path, file, typographyMap);
+        hasChanges = true;
+      });
+  });
+
+  // 단일 접두사 (typography, typo와 같은) 처리
+  TARGET_PREFIXES.filter((prefix) => !prefix.includes(".")).forEach((prefix) => {
+    root
+      .find(j.MemberExpression, {
+        object: {
+          type: "Identifier",
+          name: prefix,
+        },
+      })
+      .forEach((path) => {
+        processTypographyNode(j, path, file, typographyMap);
+        hasChanges = true;
+      });
+  });
+
+  // 파일 변환 완료 로깅
+  logger.finishFile(file.path);
+
+  // 변경사항이 있는 경우에만 소스 반환
+  return hasChanges ? root.toSource(options) : file.source;
+}
+
+// 타이포그래피 노드 처리 함수
+function processTypographyNode(
+  j: API["jscodeshift"],
+  path: any,
+  file: FileInfo,
+  typographyMap: FoundationTokenMapping[],
+) {
+  // 속성명 가져오기
+  const propertyName = path.node.property.name || path.node.property.value;
+
+  if (!propertyName) {
+    logger.logTransformResult(file.path, {
+      previousToken: "Cannot determine property name",
+      nextToken: null,
+      line: path.node.loc?.start.line || 0,
+      status: "failure",
+      failureReason: "Property name not found",
+    });
+    return;
+  }
+
+  // 매핑에서 해당 토큰 찾기
+  const mapping = typographyMap.find(
+    (m) => m.previous === propertyName || m.previous === `$semantic.typography.${propertyName}`,
+  );
+
+  if (mapping) {
+    if (mapping.next.length > 0) {
+      // 첫 번째 매핑된 토큰 사용
+      const nextToken = mapping.next[0];
+
+      // 속성명 변경
+      path.node.property = j.identifier(nextToken);
+
+      // 성공 로깅
+      logger.logTransformResult(file.path, {
+        previousToken: propertyName,
+        nextToken: nextToken,
+        line: path.node.loc?.start.line || 0,
+        status: "success",
+      });
+
+      // 검증 필요한 경우 경고 로그 추가
+      if (mapping.needsVerification) {
+        logger.logTransformResult(file.path, {
+          previousToken: propertyName,
+          nextToken: nextToken,
+          line: path.node.loc?.start.line || 0,
+          status: "warning",
+          failureReason: "Needs manual verification",
+        });
+      }
+    } else if (mapping.alternative && mapping.alternative.length > 0) {
+      // 대체 토큰이 있는 경우
+      const alternativeToken = mapping.alternative[0];
+
+      // 속성명 변경
+      path.node.property = j.identifier(alternativeToken);
+
+      // 성공 로깅 (대체 토큰 사용)
+      logger.logTransformResult(file.path, {
+        previousToken: propertyName,
+        nextToken: alternativeToken,
+        line: path.node.loc?.start.line || 0,
+        status: "warning",
+        failureReason: "Using alternative token as primary is deprecated",
+      });
+    } else {
+      // 매핑이 있지만 다음 토큰이 없는 경우 (deprecated)
+      logger.logTransformResult(file.path, {
+        previousToken: propertyName,
+        nextToken: null,
+        line: path.node.loc?.start.line || 0,
+        status: "failure",
+        failureReason: "Token is deprecated with no direct replacement",
+      });
+    }
+  } else {
+    // 매핑을 찾지 못한 경우 실패 로깅
+    logger.logTransformResult(file.path, {
+      previousToken: `Failed to find mapping for typography token: ${propertyName}`,
+      nextToken: null,
+      line: path.node.loc?.start.line || 0,
+      status: "failure",
+      failureReason: "No mapping found",
+    });
+  }
+}

--- a/packages/codemod/src/transforms/replace-custom-seed-design-vars/README.md
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-vars/README.md
@@ -1,0 +1,1 @@
+# replace-custom-seed-design-vars

--- a/packages/codemod/src/transforms/replace-custom-seed-design-vars/__testfixtures__/basic.input.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-vars/__testfixtures__/basic.input.ts
@@ -27,3 +27,241 @@ export const subtitle = style({
   ...vars.typography.bodyM2Regular,
   color: vars.color.secondary,
 });
+
+// 배경색 케이스
+export const cardBackground = style({
+  backgroundColor: vars.color.paperSheet,
+  padding: '16px',
+});
+
+// 테두리 케이스
+export const divider = style({
+  borderTop: `1px solid ${vars.color.divider1}`,
+  marginTop: '8px',
+  marginBottom: '8px',
+});
+
+// 상태 색상 케이스
+export const successMessage = style({
+  ...vars.typography.bodyM1Bold,
+  color: vars.color.success,
+  backgroundColor: vars.color.successLow,
+  padding: '12px',
+  borderRadius: '4px',
+});
+
+export const warningMessage = style({
+  ...vars.typography.bodyM1Bold,
+  color: vars.color.warning,
+  backgroundColor: vars.color.warningLow,
+  padding: '12px',
+  borderRadius: '4px',
+});
+
+export const errorMessage = style({
+  ...vars.typography.bodyM1Bold,
+  color: vars.color.danger,
+  backgroundColor: vars.color.dangerLow,
+  padding: '12px',
+  borderRadius: '4px',
+});
+
+// 다양한 타이포그래피 케이스
+export const heading = style({
+  ...vars.typography.h4,
+  color: vars.color.inkText,
+});
+
+export const body = style({
+  ...vars.typography.bodyL1Regular,
+  color: vars.color.inkTextLow,
+});
+
+export const label = style({
+  ...vars.typography.label3Bold,
+  color: vars.color.grayActive,
+});
+
+// 알파 색상 케이스
+export const overlay = style({
+  backgroundColor: vars.color.overlayDim,
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+});
+
+// 복합 케이스와 상호작용 상태
+export const button = style({
+  ...vars.typography.label2Bold,
+  backgroundColor: vars.color.primary,
+  color: vars.color.onPrimary,
+  borderRadius: '4px',
+  padding: '8px 16px',
+  border: 'none',
+  cursor: 'pointer',
+  ':hover': {
+    backgroundColor: vars.color.primaryHover,
+  },
+  ':active': {
+    backgroundColor: vars.color.primaryPressed,
+  },
+});
+
+export const secondaryButton = style({
+  ...vars.typography.label2Bold,
+  backgroundColor: vars.color.secondaryLow,
+  color: vars.color.secondary,
+  borderRadius: '4px',
+  padding: '8px 16px',
+  border: 'none',
+  cursor: 'pointer',
+  ':hover': {
+    backgroundColor: vars.color.grayHover,
+  },
+  ':active': {
+    backgroundColor: vars.color.grayPressed,
+  },
+});
+
+// 중첩 경로 케이스
+export const floatingPanel = style({
+  backgroundColor: vars.color.paperFloating,
+  boxShadow: `0 2px 8px ${vars.color.overlayLow}`,
+  padding: '20px',
+  borderRadius: '8px',
+});
+
+export const dialogPanel = style({
+  backgroundColor: vars.color.paperDialog,
+  padding: '24px',
+  boxShadow: `0 4px 16px ${vars.color.overlayDim}`,
+  borderRadius: '12px',
+});
+
+// 정적 색상 케이스
+export const staticColors = style({
+  color: vars.color.staticBlack,
+  backgroundColor: vars.color.staticWhite,
+  border: `1px solid ${vars.color.staticBlackAlpha200}`,
+});
+
+// 정적 색상 케이스 (명시적으로 static 프리픽스 테스트)
+export const staticExplicitColors = style({
+  color: vars.color.staticBlack,
+  backgroundColor: vars.color.staticWhite,
+  boxShadow: `0 2px 4px ${vars.color.staticBlackAlpha500}`,
+  outline: `1px solid ${vars.color.staticBlackAlpha200}`,
+});
+
+export const specialBackground = style({
+  background: `linear-gradient(to bottom, ${vars.color.staticWhiteAlpha50}, ${vars.color.staticWhiteAlpha200})`,
+  backdropFilter: 'blur(8px)',
+});
+
+// 복합 스타일 및 다중 속성 케이스
+export const multiProperty = style({
+  ...vars.typography.title2Bold,
+  color: vars.color.accent,
+  borderLeft: `4px solid ${vars.color.accent}`,
+  borderRight: `4px solid ${vars.color.accent}`,
+  boxShadow: `inset 0 0 0 1px ${vars.color.divider2}, 0 2px 4px ${vars.color.overlayLow}`,
+  padding: '16px',
+  backgroundColor: vars.color.paperDefault,
+});
+
+// 믹스인 스타일 케이스
+export const mixinStyle = {
+  primary: {
+    background: vars.color.primary,
+    color: vars.color.onPrimary,
+  },
+  secondary: {
+    background: vars.color.secondary,
+  },
+  accent: {
+    background: vars.color.accent,
+    color: vars.color.onGrayOverlay50,
+  },
+};
+
+// 특수 속성 및 스케일 색상 케이스
+export const scaleColors = style({
+  fill: vars.color.carrot500,
+  stroke: vars.color.gray400,
+  stopColor: vars.color.blue400,
+  floodColor: vars.color.red400,
+  lightingColor: vars.color.green400,
+});
+
+// 특수 타이포그래피 케이스
+export const specialTypographies = {
+  title: vars.typography.title1Bold,
+  subtitle: vars.typography.subtitle1Regular,
+  label: vars.typography.label5Regular,
+  caption: vars.typography.caption2Bold,
+};
+
+// 다양한 경로를 가진 컬러 토큰
+export const colorContexts = style({
+  // 일반 색상
+  color: vars.color.primaryLow,
+  // 배경 색상
+  backgroundColor: vars.color.paperBackground,
+  // 테두리 색상
+  borderColor: vars.color.divider3,
+  // 호버 색상
+  ':hover': {
+    backgroundColor: vars.color.primaryLowHover,
+    borderColor: vars.color.primaryLowActive,
+  },
+});
+
+// 복잡한 다중 경로와 중첩된 객체
+export const nestedStyleObject = {
+  button: {
+    default: {
+      backgroundColor: vars.color.paperAccent,
+      color: vars.color.inkText,
+      border: `1px solid ${vars.color.carrot300}`,
+    },
+    hover: {
+      backgroundColor: vars.color.carrot100,
+      borderColor: vars.color.carrot400,
+    },
+    active: {
+      backgroundColor: vars.color.carrot200,
+      color: vars.color.inkTextLow,
+    },
+  },
+  panel: {
+    header: {
+      ...vars.typography.subtitle2Bold,
+      color: vars.color.blue600,
+      borderBottom: `1px solid ${vars.color.blue200}`,
+    },
+    body: {
+      ...vars.typography.bodyM2Regular,
+      color: vars.color.inkTextLow,
+      backgroundColor: vars.color.blue50,
+    },
+    footer: {
+      backgroundColor: vars.color.blue100,
+      borderTop: `1px solid ${vars.color.blue200}`,
+    },
+  },
+};
+
+// 테두리 속성 매핑 테스트
+export const borderMapping = style({
+  // stroke 토큰으로 매핑될 속성
+  borderColor: vars.color.divider2,
+  // stroke 토큰이 없어서 fg 토큰으로 대체되는 케이스
+  borderTopColor: vars.color.primary,
+  borderBottomColor: vars.color.accent,
+  // stroke 또는 fg 토큰으로 대체
+  boxShadow: `0 0 0 1px ${vars.color.primary}, 0 2px 4px ${vars.color.overlayLow}`,
+  // 복합 속성
+  border: `1px solid ${vars.color.secondary}`,
+});

--- a/packages/codemod/src/transforms/replace-custom-seed-design-vars/__testfixtures__/basic.input.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-vars/__testfixtures__/basic.input.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+import { vars } from '@/shared/style/vars';
+
+export const date = style({
+  ...vars.typography.caption1Regular,
+  color: vars.color.gray600,
+});
+
+export const color1 = style({
+  color: vars.color.yellow500,
+});
+
+export const color2 = style({
+  color: vars.color.blue500,
+});
+
+export const color3 = style({
+  color: vars.color.red500,
+});
+
+export const title = style({
+  ...vars.typography.bodyM1Bold,
+  color: vars.color.primary,
+});
+
+export const subtitle = style({
+  ...vars.typography.bodyM2Regular,
+  color: vars.color.secondary,
+});

--- a/packages/codemod/src/transforms/replace-custom-seed-design-vars/__testfixtures__/basic.output.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-vars/__testfixtures__/basic.output.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+import { vars } from '@/shared/style/vars';
+
+export const date = style({
+  ...vars.typography.t3Regular,
+  color: vars.color.palette.gray700,
+});
+
+export const color1 = style({
+  color: vars.color.palette.yellow700,
+});
+
+export const color2 = style({
+  color: vars.color.palette.blue600,
+});
+
+export const color3 = style({
+  color: vars.color.palette.red700,
+});
+
+export const title = style({
+  ...vars.typography.t5Bold,
+  color: vars.color.fg.brand,
+});
+
+export const subtitle = style({
+  ...vars.typography.t4Regular,
+  color: vars.color.palette.gray900,
+});

--- a/packages/codemod/src/transforms/replace-custom-seed-design-vars/__testfixtures__/basic.output.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-vars/__testfixtures__/basic.output.ts
@@ -27,3 +27,241 @@ export const subtitle = style({
   ...vars.typography.t4Regular,
   color: vars.color.palette.gray900,
 });
+
+// 배경색 케이스
+export const cardBackground = style({
+  backgroundColor: vars.color.bg.layerFloating,
+  padding: '16px',
+});
+
+// 테두리 케이스
+export const divider = style({
+  borderTop: `1px solid ${vars.color.stroke.neutralMuted}`,
+  marginTop: '8px',
+  marginBottom: '8px',
+});
+
+// 상태 색상 케이스
+export const successMessage = style({
+  ...vars.typography.t5Bold,
+  color: vars.color.fg.positive,
+  backgroundColor: vars.color.bg.positiveWeak,
+  padding: '12px',
+  borderRadius: '4px',
+});
+
+export const warningMessage = style({
+  ...vars.typography.t5Bold,
+  color: vars.color.bg.warningSolid,
+  backgroundColor: vars.color.bg.warningWeak,
+  padding: '12px',
+  borderRadius: '4px',
+});
+
+export const errorMessage = style({
+  ...vars.typography.t5Bold,
+  color: vars.color.fg.critical,
+  backgroundColor: vars.color.bg.criticalWeak,
+  padding: '12px',
+  borderRadius: '4px',
+});
+
+// 다양한 타이포그래피 케이스
+export const heading = style({
+  ...vars.typography.t10Bold,
+  color: vars.color.fg.neutral,
+});
+
+export const body = style({
+  ...vars.typography.articleBody,
+  color: vars.color.fg.neutralSubtle,
+});
+
+export const label = style({
+  ...vars.typography.t4Bold,
+  color: vars.color.fg.neutralMuted,
+});
+
+// 알파 색상 케이스
+export const overlay = style({
+  backgroundColor: vars.color.bg.overlay,
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+});
+
+// 복합 케이스와 상호작용 상태
+export const button = style({
+  ...vars.typography.t5Bold,
+  backgroundColor: vars.color.bg.brandSolid,
+  color: vars.color.palette.staticWhite,
+  borderRadius: '4px',
+  padding: '8px 16px',
+  border: 'none',
+  cursor: 'pointer',
+  ':hover': {
+    backgroundColor: vars.color.bg.brandSolidPressed,
+  },
+  ':active': {
+    backgroundColor: vars.color.bg.brandSolidPressed,
+  },
+});
+
+export const secondaryButton = style({
+  ...vars.typography.t5Bold,
+  backgroundColor: vars.color.bg.neutralWeak,
+  color: vars.color.palette.gray900,
+  borderRadius: '4px',
+  padding: '8px 16px',
+  border: 'none',
+  cursor: 'pointer',
+  ':hover': {
+    backgroundColor: vars.color.bg.neutralWeakPressed,
+  },
+  ':active': {
+    backgroundColor: vars.color.bg.neutralWeakPressed,
+  },
+});
+
+// 중첩 경로 케이스
+export const floatingPanel = style({
+  backgroundColor: vars.color.bg.layerFloating,
+  boxShadow: `0 2px 8px ${vars.color.bg.overlayMuted}`,
+  padding: '20px',
+  borderRadius: '8px',
+});
+
+export const dialogPanel = style({
+  backgroundColor: vars.color.bg.layerFloating,
+  padding: '24px',
+  boxShadow: `0 4px 16px ${vars.color.bg.overlay}`,
+  borderRadius: '12px',
+});
+
+// 정적 색상 케이스
+export const staticColors = style({
+  color: vars.color.palette.staticBlack,
+  backgroundColor: vars.color.palette.staticWhite,
+  border: `1px solid ${vars.color.palette.staticBlackAlpha200}`,
+});
+
+// 정적 색상 케이스 (명시적으로 static 프리픽스 테스트)
+export const staticExplicitColors = style({
+  color: vars.color.palette.staticBlack,
+  backgroundColor: vars.color.palette.staticWhite,
+  boxShadow: `0 2px 4px ${vars.color.palette.staticBlackAlpha500}`,
+  outline: `1px solid ${vars.color.palette.staticBlackAlpha200}`,
+});
+
+export const specialBackground = style({
+  background: `linear-gradient(to bottom, ${vars.color.palette.staticWhiteAlpha50}, ${vars.color.palette.staticWhiteAlpha200})`,
+  backdropFilter: 'blur(8px)',
+});
+
+// 복합 스타일 및 다중 속성 케이스
+export const multiProperty = style({
+  ...vars.typography.t7Bold,
+  color: vars.color.fg.informative,
+  borderLeft: `4px solid ${vars.color.fg.informative}`,
+  borderRight: `4px solid ${vars.color.fg.informative}`,
+  boxShadow: `inset 0 0 0 1px ${vars.color.stroke.neutral}, 0 2px 4px ${vars.color.bg.overlayMuted}`,
+  padding: '16px',
+  backgroundColor: vars.color.bg.layerDefault,
+});
+
+// 믹스인 스타일 케이스
+export const mixinStyle = {
+  primary: {
+    background: vars.color.bg.brandSolid,
+    color: vars.color.palette.staticWhite,
+  },
+  secondary: {
+    background: vars.color.palette.gray900,
+  },
+  accent: {
+    background: vars.color.bg.informativeSolid,
+    color: vars.color.stroke.onImage,
+  },
+};
+
+// 특수 속성 및 스케일 색상 케이스
+export const scaleColors = style({
+  fill: vars.color.palette.carrot600,
+  stroke: vars.color.palette.gray500,
+  stopColor: vars.color.palette.blue400,
+  floodColor: vars.color.palette.red600,
+  lightingColor: vars.color.palette.green500,
+});
+
+// 특수 타이포그래피 케이스
+export const specialTypographies = {
+  title: vars.typography.t9Bold,
+  subtitle: vars.typography.t5Regular,
+  label: vars.typography.t1Regular,
+  caption: vars.typography.t2Bold,
+};
+
+// 다양한 경로를 가진 컬러 토큰
+export const colorContexts = style({
+  // 일반 색상
+  color: vars.color.palette.carrot100,
+  // 배경 색상
+  backgroundColor: vars.color.bg.layerBasement,
+  // 테두리 색상
+  borderColor: vars.color.palette.gray400,
+  // 호버 색상
+  ':hover': {
+    backgroundColor: vars.color.palette.carrot200,
+    borderColor: vars.color.palette.carrot100,
+  },
+});
+
+// 복잡한 다중 경로와 중첩된 객체
+export const nestedStyleObject = {
+  button: {
+    default: {
+      backgroundColor: vars.color.palette.carrot100,
+      color: vars.color.fg.neutral,
+      border: `1px solid ${vars.color.palette.carrot400}`,
+    },
+    hover: {
+      backgroundColor: vars.color.palette.carrot200,
+      borderColor: vars.color.palette.carrot500,
+    },
+    active: {
+      backgroundColor: vars.color.palette.carrot300,
+      color: vars.color.fg.neutralSubtle,
+    },
+  },
+  panel: {
+    header: {
+      ...vars.typography.t4Bold,
+      color: vars.color.palette.blue600,
+      borderBottom: `1px solid ${vars.color.palette.blue300}`,
+    },
+    body: {
+      ...vars.typography.t4Regular,
+      color: vars.color.fg.neutralSubtle,
+      backgroundColor: vars.color.palette.blue100,
+    },
+    footer: {
+      backgroundColor: vars.color.palette.blue200,
+      borderTop: `1px solid ${vars.color.palette.blue300}`,
+    },
+  },
+};
+
+// 테두리 속성 매핑 테스트
+export const borderMapping = style({
+  // stroke 토큰으로 매핑될 속성
+  borderColor: vars.color.stroke.neutral,
+  // stroke 토큰이 없어서 fg 토큰으로 대체되는 케이스
+  borderTopColor: vars.color.fg.brand,
+  borderBottomColor: vars.color.fg.informative,
+  // stroke 또는 fg 토큰으로 대체
+  boxShadow: `0 0 0 1px ${vars.color.bg.brandSolid}, 0 2px 4px ${vars.color.bg.overlayMuted}`,
+  // 복합 속성
+  border: `1px solid ${vars.color.palette.gray900}`,
+});

--- a/packages/codemod/src/transforms/replace-custom-seed-design-vars/__tests__/transform.test.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-vars/__tests__/transform.test.ts
@@ -1,0 +1,8 @@
+import { runFixtureTests } from "../../../utils/test.js";
+import { join } from "node:path";
+import transform from "../index.js";
+
+runFixtureTests({
+  transform,
+  fixturesDir: join(__dirname, "..", "__testfixtures__"),
+});

--- a/packages/codemod/src/transforms/replace-custom-seed-design-vars/index.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-vars/index.ts
@@ -1,22 +1,48 @@
 import { colorMappings } from "@seed-design/migration-index/color";
 import { typographyMappings } from "@seed-design/migration-index/typography";
 import type * as jscodeshift from "jscodeshift";
-import {
-  COLOR_BACKGROUND_PROPERTIES,
-  COLOR_STROKE_PROPERTIES,
-  COLOR_TEXT_PROPERTIES,
-  getTokenTypeForProperty,
-} from "../../utils/color-properties.js";
+import { camelCaseToKebabCase } from "../../utils/case.js";
+import { getTokenTypeForProperty } from "../../utils/color-properties.js";
 import { createTransformLogger } from "../../utils/logger.js";
 
-// 하이픈(-) 제거 유틸리티 함수
-function removeHyphens(str: string): string {
-  return str.replace(/-/g, "");
+/**
+ * kebab-case를 camelCase로 변환하는 함수
+ * 예: primary-hover -> primaryHover, gray-600 -> gray600
+ */
+function kebabCaseToCamelCase(kebabCase: string): string {
+  return kebabCase.replace(/-([a-z0-9])/g, (_, char) => char.toUpperCase());
 }
 
-// 하이픈(-) 추가 유틸리티 함수 - gray600 -> gray-600
-function addHyphens(str: string): string {
-  return str.replace(/([a-zA-Z]+)(\d+)/g, "$1-$2");
+/**
+ * 토큰 경로를 camelCase로 변환하는 함수
+ * 예: bg.layer-floating -> bg.layerFloating
+ * 카테고리(bg, fg, stroke) 뒤의 경로는 점(.)을 제거하고 camelCase로 변환
+ */
+function tokenPathToCamel(path: string): string {
+  const parts = path.split(".");
+
+  // 첫 번째 부분(카테고리)는 그대로 유지
+  const category = parts[0];
+
+  if (parts.length <= 1) {
+    return category;
+  }
+
+  // 두 번째 이후 부분들을 모두 결합하여 camelCase로 변환
+  const restParts = parts.slice(1);
+
+  // 각 부분을 먼저 kebab에서 camel로 변환
+  const camelParts = restParts.map((part) => kebabCaseToCamelCase(part));
+
+  // 첫 번째 부분은 그대로 두고, 나머지 부분은 첫 글자를 대문자로 변환하여 결합
+  const combinedRest = camelParts
+    .map((part, index) => {
+      if (index === 0) return part;
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join("");
+
+  return `${category}.${combinedRest}`;
 }
 
 const replaceCustomSeedDesignVars: jscodeshift.Transform = (file, api) => {
@@ -139,44 +165,54 @@ const replaceCustomSeedDesignVars: jscodeshift.Transform = (file, api) => {
       const colorProperty = property.name;
       const line = path.node.loc?.start.line;
 
-      // 부모 컨텍스트 확인 (CSS property context)
-      const parentPropertyName = findParentPropertyName(path);
-      let preferredTokenType = getTokenTypeForProperty(parentPropertyName);
+      // static 색상 직접 처리 (vars.color.staticXxx -> vars.color.palette.staticXxx)
+      if (colorProperty.startsWith("static")) {
+        logger.logTransformResult(file.path, {
+          previousToken: `Direct static color: ${colorProperty}`,
+          nextToken: `palette.${colorProperty}`,
+          line,
+          status: "warning",
+        });
 
-      // 특정 속성에 대한 명시적 토큰 타입 지정
-      if (parentPropertyName) {
-        if (COLOR_TEXT_PROPERTIES.includes(parentPropertyName)) {
-          preferredTokenType = "fg";
-        } else if (COLOR_BACKGROUND_PROPERTIES.includes(parentPropertyName)) {
-          preferredTokenType = "bg";
-        } else if (COLOR_STROKE_PROPERTIES.includes(parentPropertyName)) {
-          preferredTokenType = "stroke";
-        }
+        // static 색상은 palette 카테고리로 변환
+        j(path).replaceWith(
+          j.memberExpression(
+            j.memberExpression(
+              j.memberExpression(j.identifier("vars"), j.identifier("color")),
+              j.identifier("palette"),
+            ),
+            j.identifier(colorProperty),
+          ),
+        );
+        return;
       }
 
-      // 색상 매핑 검색에 사용할 토큰 ID 생성
-      const semanticTokenId = `$semantic.color.${colorProperty}`;
+      // 부모 컨텍스트 확인 (CSS property context)
+      const parentPropertyName = findParentPropertyName(path);
 
-      // scale 컬러 토큰은 하이픈(-) 형태로 변환해야 합니다 (예: gray600 -> gray-600)
-      const colorWithDash = addHyphens(colorProperty);
-      const scaleTokenId = `$scale.color.${colorWithDash}`;
+      // color-properties.ts의 유틸 함수 활용하여 적절한 토큰 타입 결정
+      const preferredTokenType = getTokenTypeForProperty(parentPropertyName);
+
+      // 색상 속성을 kebab-case로 변환하여 매핑 검색에 사용
+      const colorPropertyKebab = camelCaseToKebabCase(colorProperty);
+
+      // 색상 매핑 검색에 사용할 토큰 ID 생성
+      const semanticTokenId = `$semantic.color.${colorPropertyKebab}`;
+      const scaleTokenId = `$scale.color.${colorPropertyKebab}`;
+
+      // 디버깅을 위한 로그 기록
+      logger.logTransformResult(file.path, {
+        previousToken: `Searching for: semantic=${semanticTokenId}, scale=${scaleTokenId}`,
+        nextToken: null,
+        line,
+        status: "warning",
+      });
 
       // 매핑 검색 - 우선순위를 가진 검색
       let mapping = colorMappings.find((m) => m.previous === semanticTokenId);
 
       if (!mapping) {
         mapping = colorMappings.find((m) => m.previous === scaleTokenId);
-      }
-
-      // 특정 케이스 디버깅 로그
-      if (!mapping && /([a-zA-Z]+)(\d+)/.test(colorProperty)) {
-        logger.logTransformResult(file.path, {
-          previousToken: `Original: ${colorProperty}, Searched semantic: ${semanticTokenId}, Searched scale: ${scaleTokenId}`,
-          nextToken: null,
-          line,
-          status: "warning",
-          failureReason: "Debug - No mapping found for color token with numeric suffix",
-        });
       }
 
       if (mapping) {
@@ -186,26 +222,56 @@ const replaceCustomSeedDesignVars: jscodeshift.Transform = (file, api) => {
         // 토큰 선택 로직
         if (mapping.next.length >= 1) {
           // 속성 타입에 따른 우선순위 매핑 선택
-          const typeMatchedTokens = mapping.next.filter((token) => {
-            if (preferredTokenType === "stroke" && token.includes("$color.stroke")) return true;
-            if (preferredTokenType === "fg" && token.includes("$color.fg")) return true;
-            if (preferredTokenType === "bg" && token.includes("$color.bg")) return true;
-            return false;
-          });
+          let matchedTokens: string[] = [];
 
-          if (typeMatchedTokens.length > 0) {
-            // 타입이 일치하는 토큰 중 첫 번째 선택
-            chosenToken = typeMatchedTokens[0];
-          } else if (preferredTokenType === "stroke") {
-            // stroke 타입이 필요하지만 없는 경우 fg 토큰으로 대체
-            const fgTokens = mapping.next.filter((token) => token.includes("$color.fg"));
-            if (fgTokens.length > 0) {
-              chosenToken = fgTokens[0];
-            }
+          // 각 타입에 따른 우선순위 결정 로직
+          switch (preferredTokenType) {
+            case "stroke":
+              // 1. stroke 토큰 시도
+              matchedTokens = mapping.next.filter((token) => token.includes("$color.stroke"));
+
+              // 2. stroke 토큰 없으면 fg 토큰 시도
+              if (matchedTokens.length === 0) {
+                matchedTokens = mapping.next.filter((token) => token.includes("$color.fg"));
+              }
+
+              // 3. fg 토큰도 없으면 palette 토큰 시도
+              if (matchedTokens.length === 0) {
+                matchedTokens = mapping.next.filter((token) => token.includes("$color.palette"));
+              }
+              break;
+
+            case "fg":
+              // 1. fg 토큰 시도
+              matchedTokens = mapping.next.filter((token) => token.includes("$color.fg"));
+
+              // 2. fg 토큰 없으면 palette 토큰 시도
+              if (matchedTokens.length === 0) {
+                matchedTokens = mapping.next.filter((token) => token.includes("$color.palette"));
+              }
+              break;
+
+            case "bg":
+              // 1. bg 토큰 시도
+              matchedTokens = mapping.next.filter((token) => token.includes("$color.bg"));
+
+              // 2. bg 토큰 없으면 palette 토큰 시도
+              if (matchedTokens.length === 0) {
+                matchedTokens = mapping.next.filter((token) => token.includes("$color.palette"));
+              }
+              break;
+
+            default:
+              // 기본은 palette 토큰 시도
+              matchedTokens = mapping.next.filter((token) => token.includes("$color.palette"));
+              break;
           }
 
-          // 타입 매칭에 실패한 경우 palette 토큰을 우선으로 선택하거나 첫 번째 토큰 사용
-          if (!chosenToken) {
+          // 일치하는 토큰이 있으면 첫 번째 선택
+          if (matchedTokens.length > 0) {
+            chosenToken = matchedTokens[0];
+          } else {
+            // 위 로직으로 매칭 실패한 경우 기본 palette 토큰 사용
             const paletteTokens = mapping.next.filter((token) => token.includes("$color.palette"));
             chosenToken = paletteTokens.length > 0 ? paletteTokens[0] : mapping.next[0];
           }
@@ -219,25 +285,68 @@ const replaceCustomSeedDesignVars: jscodeshift.Transform = (file, api) => {
           useAlternative = true;
 
           // alternative에서도 타입 매칭 시도
-          const typeMatchedAltTokens = mapping.alternative.filter((token) => {
-            if (preferredTokenType === "stroke" && token.includes("$color.stroke")) return true;
-            if (preferredTokenType === "fg" && token.includes("$color.fg")) return true;
-            if (preferredTokenType === "bg" && token.includes("$color.bg")) return true;
-            return false;
-          });
+          let altMatchedTokens: string[] = [];
 
-          if (typeMatchedAltTokens.length > 0) {
-            chosenToken = typeMatchedAltTokens[0];
-          } else if (preferredTokenType === "stroke") {
-            // stroke 타입이 필요하지만 alternative에 없는 경우 fg 토큰으로 대체
-            const fgAltTokens = mapping.alternative.filter((token) => token.includes("$color.fg"));
-            if (fgAltTokens.length > 0) {
-              chosenToken = fgAltTokens[0];
-            }
+          // 각 타입에 따른 우선순위 결정 로직
+          switch (preferredTokenType) {
+            case "stroke":
+              // 1. stroke 토큰 시도
+              altMatchedTokens = mapping.alternative.filter((token) =>
+                token.includes("$color.stroke"),
+              );
+
+              // 2. stroke 토큰 없으면 fg 토큰 시도
+              if (altMatchedTokens.length === 0) {
+                altMatchedTokens = mapping.alternative.filter((token) =>
+                  token.includes("$color.fg"),
+                );
+              }
+
+              // 3. fg 토큰도 없으면 palette 토큰 시도
+              if (altMatchedTokens.length === 0) {
+                altMatchedTokens = mapping.alternative.filter((token) =>
+                  token.includes("$color.palette"),
+                );
+              }
+              break;
+
+            case "fg":
+              // 1. fg 토큰 시도
+              altMatchedTokens = mapping.alternative.filter((token) => token.includes("$color.fg"));
+
+              // 2. fg 토큰 없으면 palette 토큰 시도
+              if (altMatchedTokens.length === 0) {
+                altMatchedTokens = mapping.alternative.filter((token) =>
+                  token.includes("$color.palette"),
+                );
+              }
+              break;
+
+            case "bg":
+              // 1. bg 토큰 시도
+              altMatchedTokens = mapping.alternative.filter((token) => token.includes("$color.bg"));
+
+              // 2. bg 토큰 없으면 palette 토큰 시도
+              if (altMatchedTokens.length === 0) {
+                altMatchedTokens = mapping.alternative.filter((token) =>
+                  token.includes("$color.palette"),
+                );
+              }
+              break;
+
+            default:
+              // 기본은 palette 토큰 시도
+              altMatchedTokens = mapping.alternative.filter((token) =>
+                token.includes("$color.palette"),
+              );
+              break;
           }
 
-          // 타입 매칭에 실패한 경우 palette 토큰을 우선으로 선택하거나 첫 번째 토큰 사용
-          if (!chosenToken) {
+          // 일치하는 토큰이 있으면 첫 번째 선택
+          if (altMatchedTokens.length > 0) {
+            chosenToken = altMatchedTokens[0];
+          } else {
+            // 위 로직으로 매칭 실패한 경우 기본 palette 토큰 사용
             const paletteAltTokens = mapping.alternative.filter((token) =>
               token.includes("$color.palette"),
             );
@@ -247,22 +356,26 @@ const replaceCustomSeedDesignVars: jscodeshift.Transform = (file, api) => {
         }
 
         if (chosenToken) {
-          // 새 노드를 생성하여 기존 노드 대체
-          // 컬러 토큰 형식: $color.palette.gray700 -> palette.gray700
-          // 형식 변환: $color.xxx.yyy -> xxx.yyy
-          const newNodePath = chosenToken.substring(7); // $color. 제거
-          const parts = newNodePath.split(".");
+          // $color. 제거하여 실제 토큰 경로만 추출 (예: $color.bg.overlay -> bg.overlay)
+          const tokenPath = chosenToken.substring(7);
 
-          // 하이픈(-) 제거 - 예: palette.gray-900 -> palette.gray900
-          for (let i = 0; i < parts.length; i++) {
-            if (parts[i].includes("-")) {
-              parts[i] = removeHyphens(parts[i]);
-            }
-          }
+          // 토큰 경로를 camelCase로 변환 (예: layer-floating -> layerFloating)
+          const camelTokenPath = tokenPathToCamel(tokenPath);
 
-          // 새 노드 생성
+          // 토큰 경로를 . 기준으로 분리
+          const parts = camelTokenPath.split(".");
+
+          // 디버깅용 로그
+          logger.logTransformResult(file.path, {
+            previousToken: "Token Path",
+            nextToken: `Original: ${tokenPath}, Camel: ${camelTokenPath}, Parts: ${parts.join(",")}`,
+            line,
+            status: "warning",
+          });
+
+          // 새 노드 생성 - 이제 항상 두 부분으로 나뉨 (category.rest)
           if (parts.length === 2) {
-            // 간단한 컬러 토큰 (palette.gray700)
+            // 예: palette.gray700, bg.layerFloating
             j(path).replaceWith(
               j.memberExpression(
                 j.memberExpression(
@@ -304,14 +417,8 @@ const replaceCustomSeedDesignVars: jscodeshift.Transform = (file, api) => {
       }
 
       // 매핑을 찾지 못하거나 chosenToken이 null인 경우
-      const searchedTokenIds = [semanticTokenId];
-      // scale 토큰 ID가 다르면 추가
-      if (colorProperty !== colorWithDash) {
-        searchedTokenIds.push(scaleTokenId);
-      }
-
       logger.logTransformResult(file.path, {
-        previousToken: searchedTokenIds.join(", "),
+        previousToken: `Failed to find mapping for: ${colorProperty} (kebab: ${colorPropertyKebab})`,
         nextToken: null,
         line,
         status: "failure",
@@ -329,10 +436,55 @@ const replaceCustomSeedDesignVars: jscodeshift.Transform = (file, api) => {
 function findParentPropertyName(
   path: jscodeshift.ASTPath<jscodeshift.MemberExpression>,
 ): string | undefined {
-  // 부모 객체 속성 체크
-  const parent = path.parent;
+  const parentNode = path.parent.node;
+
+  // 템플릿 리터럴 내부의 표현식인 경우: borderLeft: `4px solid ${vars.color.accent}`
+  if (parentNode.type === "TemplateExpression" || parentNode.type === "TemplateLiteral") {
+    // 트리를 위로 올라가며 부모 속성을 찾음
+    let templateParent = path.parent;
+    while (
+      templateParent &&
+      templateParent.node.type !== "ObjectProperty" &&
+      templateParent.node.type !== "AssignmentExpression" &&
+      templateParent.node.type !== "JSXAttribute"
+    ) {
+      templateParent = templateParent.parent;
+
+      // 안전장치: 너무 깊이 들어가지 않도록 확인
+      if (!templateParent) break;
+    }
+
+    // 올바른 부모 노드를 찾았으면 해당 속성명 반환
+    if (templateParent) {
+      if (templateParent.node.type === "ObjectProperty") {
+        if (templateParent.node.key.type === "Identifier") {
+          return templateParent.node.key.name;
+        }
+        if (templateParent.node.key.type === "StringLiteral") {
+          return templateParent.node.key.value;
+        }
+      }
+
+      if (
+        templateParent.node.type === "AssignmentExpression" &&
+        templateParent.node.left.type === "Identifier"
+      ) {
+        return templateParent.node.left.name;
+      }
+
+      if (
+        templateParent.node.type === "JSXAttribute" &&
+        templateParent.node.name.type === "JSXIdentifier"
+      ) {
+        return templateParent.node.name.name;
+      }
+    }
+
+    return undefined;
+  }
 
   // 일반적인 JSX 속성 케이스: <div style={{ color: vars.color.gray600 }} />
+  const parent = path.parent;
   if (parent.node.type === "ObjectProperty" && parent.node.key.type === "Identifier") {
     return parent.node.key.name;
   }

--- a/packages/codemod/src/transforms/replace-custom-seed-design-vars/index.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-vars/index.ts
@@ -167,13 +167,6 @@ const replaceCustomSeedDesignVars: jscodeshift.Transform = (file, api) => {
 
       // static 색상 직접 처리 (vars.color.staticXxx -> vars.color.palette.staticXxx)
       if (colorProperty.startsWith("static")) {
-        logger.logTransformResult(file.path, {
-          previousToken: `Direct static color: ${colorProperty}`,
-          nextToken: `palette.${colorProperty}`,
-          line,
-          status: "warning",
-        });
-
         // static 색상은 palette 카테고리로 변환
         j(path).replaceWith(
           j.memberExpression(
@@ -199,14 +192,6 @@ const replaceCustomSeedDesignVars: jscodeshift.Transform = (file, api) => {
       // 색상 매핑 검색에 사용할 토큰 ID 생성
       const semanticTokenId = `$semantic.color.${colorPropertyKebab}`;
       const scaleTokenId = `$scale.color.${colorPropertyKebab}`;
-
-      // 디버깅을 위한 로그 기록
-      logger.logTransformResult(file.path, {
-        previousToken: `Searching for: semantic=${semanticTokenId}, scale=${scaleTokenId}`,
-        nextToken: null,
-        line,
-        status: "warning",
-      });
 
       // 매핑 검색 - 우선순위를 가진 검색
       let mapping = colorMappings.find((m) => m.previous === semanticTokenId);
@@ -364,14 +349,6 @@ const replaceCustomSeedDesignVars: jscodeshift.Transform = (file, api) => {
 
           // 토큰 경로를 . 기준으로 분리
           const parts = camelTokenPath.split(".");
-
-          // 디버깅용 로그
-          logger.logTransformResult(file.path, {
-            previousToken: "Token Path",
-            nextToken: `Original: ${tokenPath}, Camel: ${camelTokenPath}, Parts: ${parts.join(",")}`,
-            line,
-            status: "warning",
-          });
 
           // 새 노드 생성 - 이제 항상 두 부분으로 나뉨 (category.rest)
           if (parts.length === 2) {

--- a/packages/codemod/src/transforms/replace-custom-seed-design-vars/index.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-vars/index.ts
@@ -1,0 +1,361 @@
+import { colorMappings } from "@seed-design/migration-index/color";
+import { typographyMappings } from "@seed-design/migration-index/typography";
+import type * as jscodeshift from "jscodeshift";
+import {
+  COLOR_BACKGROUND_PROPERTIES,
+  COLOR_STROKE_PROPERTIES,
+  COLOR_TEXT_PROPERTIES,
+  getTokenTypeForProperty,
+} from "../../utils/color-properties.js";
+import { createTransformLogger } from "../../utils/logger.js";
+
+// 하이픈(-) 제거 유틸리티 함수
+function removeHyphens(str: string): string {
+  return str.replace(/-/g, "");
+}
+
+// 하이픈(-) 추가 유틸리티 함수 - gray600 -> gray-600
+function addHyphens(str: string): string {
+  return str.replace(/([a-zA-Z]+)(\d+)/g, "$1-$2");
+}
+
+const replaceCustomSeedDesignVars: jscodeshift.Transform = (file, api) => {
+  const logger = createTransformLogger("replace-custom-seed-design-vars");
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  logger.startFile(file.path);
+
+  // @seed-design/design-token 패키지를 직접 사용하는 경우는 변환하지 않음
+  if (
+    root
+      .find(j.ImportDeclaration)
+      .filter((path) => path.node.source.value === "@seed-design/design-token")
+      .size() > 0
+  ) {
+    logger.finishFile(file.path);
+    return root.toSource();
+  }
+
+  // 1. Typography 변환: vars.typography.caption1Regular -> vars.typography.t3Regular
+  root
+    .find(j.MemberExpression)
+    .filter((path) => {
+      const object = path.node.object;
+      const property = path.node.property;
+
+      return (
+        object.type === "MemberExpression" &&
+        object.object.type === "Identifier" &&
+        object.object.name === "vars" &&
+        object.property.type === "Identifier" &&
+        object.property.name === "typography" &&
+        property.type === "Identifier"
+      );
+    })
+    .forEach((path) => {
+      // typescript 타입 강제 변환
+      const property = path.node.property as jscodeshift.Identifier;
+      const typographyStyle = property.name;
+      const line = path.node.loc?.start.line;
+
+      // typography.mjs 매핑 형식으로 변환: caption1Regular -> $semantic.typography.caption1Regular
+      const tokenIdRaw = `$semantic.typography.${typographyStyle}`;
+
+      // 직접 typography.mjs에서 매핑 찾기
+      const mapping = typographyMappings.find((m) => m.previous === tokenIdRaw);
+
+      if (mapping) {
+        let chosenToken: string | null = null;
+        let useAlternative = false;
+
+        if (mapping.next.length >= 1) {
+          // next의 요소가 있으면 첫 번째 것 사용
+          chosenToken = mapping.next[0];
+        } else if (
+          "alternative" in mapping &&
+          Array.isArray(mapping.alternative) &&
+          mapping.alternative?.length > 0
+        ) {
+          // next가 비어있고 alternative가 있는 경우 alternative 사용
+          chosenToken = mapping.alternative[0];
+          useAlternative = true;
+        }
+
+        if (chosenToken) {
+          // Typography 타입은 변환 시 $semantic. 등의 프리픽스 없이 토큰 이름만 사용
+          property.name = chosenToken;
+
+          // alternative를 사용한 경우는 warning으로 로깅
+          if (useAlternative) {
+            logger.logTransformResult(file.path, {
+              previousToken: tokenIdRaw,
+              nextToken: chosenToken,
+              line,
+              status: "warning",
+              failureReason: "Using alternative mapping since next mapping is empty",
+            });
+          } else {
+            logger.logTransformResult(file.path, {
+              previousToken: tokenIdRaw,
+              nextToken: chosenToken,
+              line,
+              status: "success",
+            });
+          }
+          return;
+        }
+      }
+
+      // 매핑을 찾지 못하거나 chosenToken이 null인 경우
+      logger.logTransformResult(file.path, {
+        previousToken: tokenIdRaw,
+        nextToken: null,
+        line,
+        status: "failure",
+        failureReason: mapping
+          ? "No mapping or alternative available"
+          : "No mapping found for typography token",
+      });
+    });
+
+  // 2. Color 변환: vars.color.gray600 -> vars.color.palette.gray700
+  root
+    .find(j.MemberExpression)
+    .filter((path) => {
+      const object = path.node.object;
+
+      return (
+        object.type === "MemberExpression" &&
+        object.object.type === "Identifier" &&
+        object.object.name === "vars" &&
+        object.property.type === "Identifier" &&
+        object.property.name === "color"
+      );
+    })
+    .forEach((path) => {
+      // typescript 타입 강제 변환
+      const property = path.node.property as jscodeshift.Identifier;
+      const colorProperty = property.name;
+      const line = path.node.loc?.start.line;
+
+      // 부모 컨텍스트 확인 (CSS property context)
+      const parentPropertyName = findParentPropertyName(path);
+      let preferredTokenType = getTokenTypeForProperty(parentPropertyName);
+
+      // 특정 속성에 대한 명시적 토큰 타입 지정
+      if (parentPropertyName) {
+        if (COLOR_TEXT_PROPERTIES.includes(parentPropertyName)) {
+          preferredTokenType = "fg";
+        } else if (COLOR_BACKGROUND_PROPERTIES.includes(parentPropertyName)) {
+          preferredTokenType = "bg";
+        } else if (COLOR_STROKE_PROPERTIES.includes(parentPropertyName)) {
+          preferredTokenType = "stroke";
+        }
+      }
+
+      // 색상 매핑 검색에 사용할 토큰 ID 생성
+      const semanticTokenId = `$semantic.color.${colorProperty}`;
+
+      // scale 컬러 토큰은 하이픈(-) 형태로 변환해야 합니다 (예: gray600 -> gray-600)
+      const colorWithDash = addHyphens(colorProperty);
+      const scaleTokenId = `$scale.color.${colorWithDash}`;
+
+      // 매핑 검색 - 우선순위를 가진 검색
+      let mapping = colorMappings.find((m) => m.previous === semanticTokenId);
+
+      if (!mapping) {
+        mapping = colorMappings.find((m) => m.previous === scaleTokenId);
+      }
+
+      // 특정 케이스 디버깅 로그
+      if (!mapping && /([a-zA-Z]+)(\d+)/.test(colorProperty)) {
+        logger.logTransformResult(file.path, {
+          previousToken: `Original: ${colorProperty}, Searched semantic: ${semanticTokenId}, Searched scale: ${scaleTokenId}`,
+          nextToken: null,
+          line,
+          status: "warning",
+          failureReason: "Debug - No mapping found for color token with numeric suffix",
+        });
+      }
+
+      if (mapping) {
+        let chosenToken: string | null = null;
+        let useAlternative = false;
+
+        // 토큰 선택 로직
+        if (mapping.next.length >= 1) {
+          // 속성 타입에 따른 우선순위 매핑 선택
+          const typeMatchedTokens = mapping.next.filter((token) => {
+            if (preferredTokenType === "stroke" && token.includes("$color.stroke")) return true;
+            if (preferredTokenType === "fg" && token.includes("$color.fg")) return true;
+            if (preferredTokenType === "bg" && token.includes("$color.bg")) return true;
+            return false;
+          });
+
+          if (typeMatchedTokens.length > 0) {
+            // 타입이 일치하는 토큰 중 첫 번째 선택
+            chosenToken = typeMatchedTokens[0];
+          } else if (preferredTokenType === "stroke") {
+            // stroke 타입이 필요하지만 없는 경우 fg 토큰으로 대체
+            const fgTokens = mapping.next.filter((token) => token.includes("$color.fg"));
+            if (fgTokens.length > 0) {
+              chosenToken = fgTokens[0];
+            }
+          }
+
+          // 타입 매칭에 실패한 경우 palette 토큰을 우선으로 선택하거나 첫 번째 토큰 사용
+          if (!chosenToken) {
+            const paletteTokens = mapping.next.filter((token) => token.includes("$color.palette"));
+            chosenToken = paletteTokens.length > 0 ? paletteTokens[0] : mapping.next[0];
+          }
+        }
+        // next에 매핑이 없는 경우 alternative 사용
+        else if (
+          "alternative" in mapping &&
+          Array.isArray(mapping.alternative) &&
+          mapping.alternative?.length > 0
+        ) {
+          useAlternative = true;
+
+          // alternative에서도 타입 매칭 시도
+          const typeMatchedAltTokens = mapping.alternative.filter((token) => {
+            if (preferredTokenType === "stroke" && token.includes("$color.stroke")) return true;
+            if (preferredTokenType === "fg" && token.includes("$color.fg")) return true;
+            if (preferredTokenType === "bg" && token.includes("$color.bg")) return true;
+            return false;
+          });
+
+          if (typeMatchedAltTokens.length > 0) {
+            chosenToken = typeMatchedAltTokens[0];
+          } else if (preferredTokenType === "stroke") {
+            // stroke 타입이 필요하지만 alternative에 없는 경우 fg 토큰으로 대체
+            const fgAltTokens = mapping.alternative.filter((token) => token.includes("$color.fg"));
+            if (fgAltTokens.length > 0) {
+              chosenToken = fgAltTokens[0];
+            }
+          }
+
+          // 타입 매칭에 실패한 경우 palette 토큰을 우선으로 선택하거나 첫 번째 토큰 사용
+          if (!chosenToken) {
+            const paletteAltTokens = mapping.alternative.filter((token) =>
+              token.includes("$color.palette"),
+            );
+            chosenToken =
+              paletteAltTokens.length > 0 ? paletteAltTokens[0] : mapping.alternative[0];
+          }
+        }
+
+        if (chosenToken) {
+          // 새 노드를 생성하여 기존 노드 대체
+          // 컬러 토큰 형식: $color.palette.gray700 -> palette.gray700
+          // 형식 변환: $color.xxx.yyy -> xxx.yyy
+          const newNodePath = chosenToken.substring(7); // $color. 제거
+          const parts = newNodePath.split(".");
+
+          // 하이픈(-) 제거 - 예: palette.gray-900 -> palette.gray900
+          for (let i = 0; i < parts.length; i++) {
+            if (parts[i].includes("-")) {
+              parts[i] = removeHyphens(parts[i]);
+            }
+          }
+
+          // 새 노드 생성
+          if (parts.length === 2) {
+            // 간단한 컬러 토큰 (palette.gray700)
+            j(path).replaceWith(
+              j.memberExpression(
+                j.memberExpression(
+                  j.memberExpression(j.identifier("vars"), j.identifier("color")),
+                  j.identifier(parts[0]),
+                ),
+                j.identifier(parts[1]),
+              ),
+            );
+          } else if (parts.length === 1) {
+            // 단일 세그먼트 (예: gray700)
+            j(path).replaceWith(
+              j.memberExpression(
+                j.memberExpression(j.identifier("vars"), j.identifier("color")),
+                j.identifier(parts[0]),
+              ),
+            );
+          }
+
+          // 로그 기록
+          if (useAlternative) {
+            logger.logTransformResult(file.path, {
+              previousToken: mapping.previous,
+              nextToken: chosenToken,
+              line,
+              status: "warning",
+              failureReason: `Using alternative mapping: ${preferredTokenType} context (${parentPropertyName || "unknown"})`,
+            });
+          } else {
+            logger.logTransformResult(file.path, {
+              previousToken: mapping.previous,
+              nextToken: chosenToken,
+              line,
+              status: "success",
+            });
+          }
+          return;
+        }
+      }
+
+      // 매핑을 찾지 못하거나 chosenToken이 null인 경우
+      const searchedTokenIds = [semanticTokenId];
+      // scale 토큰 ID가 다르면 추가
+      if (colorProperty !== colorWithDash) {
+        searchedTokenIds.push(scaleTokenId);
+      }
+
+      logger.logTransformResult(file.path, {
+        previousToken: searchedTokenIds.join(", "),
+        nextToken: null,
+        line,
+        status: "failure",
+        failureReason: mapping
+          ? "No mapping or alternative available"
+          : "No mapping found for color token",
+      });
+    });
+
+  logger.finishFile(file.path);
+  return root.toSource();
+};
+
+// 부모 속성명 찾기 (CSS property context)
+function findParentPropertyName(
+  path: jscodeshift.ASTPath<jscodeshift.MemberExpression>,
+): string | undefined {
+  // 부모 객체 속성 체크
+  const parent = path.parent;
+
+  // 일반적인 JSX 속성 케이스: <div style={{ color: vars.color.gray600 }} />
+  if (parent.node.type === "ObjectProperty" && parent.node.key.type === "Identifier") {
+    return parent.node.key.name;
+  }
+
+  // 객체 안에 중첩된 케이스
+  if (parent.node.type === "AssignmentExpression" && parent.node.left.type === "Identifier") {
+    return parent.node.left.name;
+  }
+
+  // stitches나 다른 CSS-in-JS 라이브러리에서의 일반적인 패턴
+  if (
+    parent.node.type === "ObjectProperty" &&
+    (parent.node.key.type === "StringLiteral" || parent.node.key.type === "Identifier")
+  ) {
+    return parent.node.key.type === "StringLiteral" ? parent.node.key.value : parent.node.key.name;
+  }
+
+  // JSX 속성인 경우 추가
+  if (parent.node.type === "JSXAttribute" && parent.node.name.type === "JSXIdentifier") {
+    return parent.node.name.name;
+  }
+
+  return undefined;
+}
+
+export default replaceCustomSeedDesignVars;

--- a/packages/codemod/src/transforms/replace-custom-text-component-color-prop/README.md
+++ b/packages/codemod/src/transforms/replace-custom-text-component-color-prop/README.md
@@ -1,0 +1,1 @@
+# replace-custom-text-component-color-prop

--- a/packages/codemod/src/transforms/replace-react-icon/README.md
+++ b/packages/codemod/src/transforms/replace-react-icon/README.md
@@ -1,0 +1,1 @@
+# replace-react-icon

--- a/packages/codemod/src/transforms/replace-seed-design-token-typography-classname/README.md
+++ b/packages/codemod/src/transforms/replace-seed-design-token-typography-classname/README.md
@@ -1,0 +1,1 @@
+# replace-seed-design-token-typography-classname

--- a/packages/codemod/src/transforms/replace-seed-design-token-typography-classname/__testfixtures__/basic.input.tsx
+++ b/packages/codemod/src/transforms/replace-seed-design-token-typography-classname/__testfixtures__/basic.input.tsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 
 import { classNames } from "@seed-design/design-token";
+import { style } from "@vanilla-extract/css";
 
 const typography = {
   one: classNames.$semantic.typography.title2Regular,
@@ -8,3 +9,13 @@ const typography = {
   three: classNames.$semantic.typography.label5Regular,
   four: classNames.$semantic.typography.label6Regular,
 }
+
+export const footer = style([
+  classNames.$semantic.typography.caption1Regular,
+  {
+    padding: "16px",
+    marginTop: "12px",
+    color: vars.$scale.color.gray700,
+    backgroundColor: vars.$semantic.color.paperContents,
+  },
+]);

--- a/packages/codemod/src/transforms/replace-seed-design-token-typography-classname/__testfixtures__/basic.output.tsx
+++ b/packages/codemod/src/transforms/replace-seed-design-token-typography-classname/__testfixtures__/basic.output.tsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 
 import { text } from "@seed-design/css/recipes/text";
+import { style } from "@vanilla-extract/css";
 
 const typography = {
   one: text({ textStyle: "t7Regular" }),
@@ -8,3 +9,13 @@ const typography = {
   three: text({ textStyle: "t1Regular" }),
   four: text({ textStyle: "t1Regular" }),
 }
+
+export const footer = style([
+  text({ textStyle: "t3Regular" }),
+  {
+    padding: "16px",
+    marginTop: "12px",
+    color: vars.$scale.color.gray700,
+    backgroundColor: vars.$semantic.color.paperContents,
+  },
+]);

--- a/packages/codemod/src/transforms/replace-seed-design-token-typography-classname/index.ts
+++ b/packages/codemod/src/transforms/replace-seed-design-token-typography-classname/index.ts
@@ -208,6 +208,13 @@ const transform: Transform = (file, api) => {
           // 객체 속성인 경우 (key: value)
           // 값만 교체하고 키는 유지
           parentPath.node.value = textCallExpr;
+        } else if (parentPath.node.type === "ArrayExpression") {
+          // 배열 내부 요소인 경우 (예: style([classNames.$semantic.typography.*, {...}]))
+          // 배열 요소의 인덱스를 찾아 해당 요소만 교체
+          const elementIndex = parentPath.node.elements.findIndex((elem) => elem === path.node);
+          if (elementIndex !== -1) {
+            parentPath.node.elements[elementIndex] = textCallExpr;
+          }
         } else if (parentPath.node.type === "ConditionalExpression") {
           // 삼항 연산자인 경우 (condition ? classNames.$semantic.typography.* : something)
           if (parentPath.node.consequent === path.node) {

--- a/packages/codemod/src/transforms/replace-seed-design-token-vars/README.md
+++ b/packages/codemod/src/transforms/replace-seed-design-token-vars/README.md
@@ -1,0 +1,1 @@
+# replace-seed-design-token-vars

--- a/packages/codemod/src/transforms/replace-stitches-styled-color/README.md
+++ b/packages/codemod/src/transforms/replace-stitches-styled-color/README.md
@@ -1,0 +1,18 @@
+# replace-stitches-styled-color
+
+Stitches로 스타일링된 컴포넌트의 색상을 V3 형식으로 변환해요.
+
+## 변환 내용
+
+- Stitches `styled()` 함수에서 사용된 Seed Design V2 색상 토큰을 V3 색상 토큰으로 변환합니다.
+- 모든 색상 관련 스타일 속성(color, backgroundColor, borderColor 등)을 지원합니다.
+- 상태 변이(variants)에 적용된 색상 변경도 함께 변환합니다.
+
+## 대상 파일
+
+- `.tsx`, `.jsx`, `.ts`, `.js` 파일에서 Stitches 스타일링 사용 부분
+
+## 주의사항
+
+- 기존 코드의 구조와 포맷을 최대한 유지하면서 색상 값만 변경합니다.
+- 커스텀 색상 값이나 CSS 변수는 변환하지 않습니다. 

--- a/packages/codemod/src/transforms/replace-stitches-styled-typography/README.md
+++ b/packages/codemod/src/transforms/replace-stitches-styled-typography/README.md
@@ -1,0 +1,1 @@
+# replace-stitches-styled-typography

--- a/packages/codemod/src/transforms/replace-stitches-theme-color/README.md
+++ b/packages/codemod/src/transforms/replace-stitches-theme-color/README.md
@@ -1,0 +1,1 @@
+# replace-stitches-theme-color

--- a/packages/codemod/src/transforms/replace-tailwind-color/README.md
+++ b/packages/codemod/src/transforms/replace-tailwind-color/README.md
@@ -1,0 +1,24 @@
+# replace-tailwind-color
+
+Tailwind CSS 색상 클래스를 Seed Design V3 형식으로 변환해요.
+
+## 변환 내용
+
+- Seed Design V2의 색상 클래스 네이밍을 V3 형식으로 변환합니다.
+- `text-`, `bg-`, `border-` 등의 접두사를 가진 Tailwind 색상 클래스를 변환합니다.
+- 색상 강도(shade)에 따른 변환 매핑을 적용합니다.
+
+## 변환 예시
+
+- `text-carrot-500` → `text-static-orange-base`
+- `bg-salmon-100` → `bg-static-red-light`
+- `border-navy-900` → `border-static-blue-dark`
+
+## 대상 파일
+
+- `.tsx`, `.jsx`, `.ts`, `.js`, `.html`, `.css` 파일에서 Tailwind 클래스를 사용하는 부분
+
+## 주의사항
+
+- className 문자열, 템플릿 리터럴, 배열 형태 모두 지원합니다.
+- Tailwind 동적 클래스 조합(`clsx`, `cx`, `classnames` 등)도 변환됩니다. 

--- a/packages/codemod/src/transforms/replace-tailwind-typography/README.md
+++ b/packages/codemod/src/transforms/replace-tailwind-typography/README.md
@@ -1,0 +1,1 @@
+# replace-tailwind-typography

--- a/packages/codemod/src/utils/case.ts
+++ b/packages/codemod/src/utils/case.ts
@@ -1,0 +1,13 @@
+/**
+ * camelCaseToKebabCase 함수는 camelCase 형식을 kebab-case로 변환합니다.
+ * 예: divider1 -> divider-1, paperDefault -> paper-default
+ */
+export function camelCaseToKebabCase(camelCase: string): string {
+  // 대문자 앞에 - 추가하고 소문자로 변환
+  let kebabCase = camelCase.replace(/([A-Z])/g, "-$1").toLowerCase();
+
+  // 숫자 앞에 - 추가 (divider1 -> divider-1)
+  kebabCase = kebabCase.replace(/([a-z])(\d+)/g, "$1-$2");
+
+  return kebabCase;
+}

--- a/packages/codemod/src/utils/color-properties.ts
+++ b/packages/codemod/src/utils/color-properties.ts
@@ -64,7 +64,7 @@ export const COLOR_PROPERTIES = {
   ],
 
   /**
-   * 테두리 관련 색상 속성 (stroke 토큰으로 매핑됨)
+   * 테두리 관련 색상 속성 (stroke 토큰으로 매핑, 혹은 fg 토큰으로 매핑)
    * 경계를 구분하는 선 또는 UI 요소의 윤곽선에 사용하는 색상
    */
   border: [

--- a/packages/codemod/src/utils/test.ts
+++ b/packages/codemod/src/utils/test.ts
@@ -9,7 +9,7 @@ import type { transformOptionsSchema } from "../schema.js";
 interface RunFixtureTestsOptions {
   transform: Transform;
   fixturesDir: string;
-  extension?: string;
+  extension?: string[];
   transformOptions?: z.infer<typeof transformOptionsSchema>;
   name?: string;
 }
@@ -18,28 +18,37 @@ interface RunFixtureTestsOptions {
 export function runFixtureTests({
   transform,
   fixturesDir,
-  extension = "tsx",
+  extension = ["tsx", "ts"],
   transformOptions,
   name,
 }: RunFixtureTestsOptions): void {
   // transform 폴더명을 fixturesDir에서 추론
   const transformName = name || basename(dirname(fixturesDir));
 
-  const inputFiles = readdirSync(fixturesDir)
-    .filter((filename) => filename.endsWith(`.input.${extension}`))
-    .map((filename) => basename(filename, `.input.${extension}`));
+  // 배열로 확장자 정규화
+  const extensions = Array.isArray(extension) ? extension : [extension];
+
+  // 모든 확장자에 대해 입력 파일 찾기
+  const inputFiles = extensions.flatMap((ext) => {
+    return readdirSync(fixturesDir)
+      .filter((filename) => filename.endsWith(`.input.${ext}`))
+      .map((filename) => ({
+        testCase: basename(filename, `.input.${ext}`),
+        extension: ext,
+      }));
+  });
 
   describe(`${transformName} transform tests`, () => {
-    inputFiles.forEach((testCase) => {
-      test(`transforms ${testCase} correctly`, () => {
-        const inputPath = join(fixturesDir, `${testCase}.input.${extension}`);
-        const outputPath = join(fixturesDir, `${testCase}.output.${extension}`);
+    inputFiles.forEach(({ testCase, extension: ext }) => {
+      test(`transforms ${testCase} correctly (${ext})`, () => {
+        const inputPath = join(fixturesDir, `${testCase}.input.${ext}`);
+        const outputPath = join(fixturesDir, `${testCase}.output.${ext}`);
 
         const input = readFileSync(inputPath, "utf8");
         const output = readFileSync(outputPath, "utf8").trim();
 
         let result: string;
-        if (extension === "css") {
+        if (ext === "css") {
           // CSS 파일인 경우 직접 transform 함수 호출
           result = transform({ path: inputPath, source: input }, null, transformOptions) as string;
         } else {
@@ -48,7 +57,7 @@ export function runFixtureTests({
             transform,
             transformOptions,
             { source: input },
-            { parser: "tsx" },
+            { parser: ext.includes("tsx") ? "tsx" : "ts" }, // tsx 또는 ts 파서 선택
           );
         }
 

--- a/scripts/generate-codemod-docs.ts
+++ b/scripts/generate-codemod-docs.ts
@@ -75,6 +75,8 @@ title: Codemod
 description: Seed Design V2에서 V3로 마이그레이션하기 위한 코드 변환 도구
 ---
 
+{/* Auto-generated from \`scripts/generate-codemod-docs.ts\` */}
+
 \`@seed-design/codemod\`는 Seed Design V2에서 V3로 마이그레이션하기 위한 코드 변환 도구예요.
 
 ## 사용 방법

--- a/scripts/generate-codemod-docs.ts
+++ b/scripts/generate-codemod-docs.ts
@@ -12,6 +12,7 @@ interface CodemodExample {
 interface TransformDoc {
   name: string;
   path: string;
+  readme: string;
   example: CodemodExample | null;
 }
 
@@ -51,6 +52,32 @@ async function findBasicExample(transformPath: string): Promise<CodemodExample |
   return null;
 }
 
+/**
+ * transform 폴더에서 README.md 파일을 읽어 설명을 가져옵니다.
+ */
+async function getTransformReadme(transformPath: string, transformName: string): Promise<string> {
+  const readmePath = join(transformPath, "README.md");
+
+  // README.md 파일이 존재하면 해당 내용을 읽어 반환
+  if (existsSync(readmePath)) {
+    try {
+      let content = await readFile(readmePath, "utf-8");
+
+      // 헤딩 레벨 조정 (# -> ###, ## -> ####, ### -> #####)
+      content = content.replace(/^(#{1,3}) (.+)$/gm, (_match, hashes, text) => {
+        return `${hashes}##`.substring(0, 5) + " " + text;
+      });
+
+      return content.trim();
+    } catch (error) {
+      console.warn(`Error reading README.md for ${transformName}: ${error}`);
+    }
+  }
+
+  // README.md 파일이 없거나 읽기 실패 시 기본 설명 반환
+  return `### ${transformName}`;
+}
+
 async function generateTransformDocs(): Promise<TransformDoc[]> {
   const transforms = await readdir(TRANSFORMS_DIR);
   const docs: TransformDoc[] = [];
@@ -58,10 +85,12 @@ async function generateTransformDocs(): Promise<TransformDoc[]> {
   for (const transform of transforms) {
     const transformPath = join(TRANSFORMS_DIR, transform);
     const example = await findBasicExample(transformPath);
+    const readme = await getTransformReadme(transformPath, transform);
 
     docs.push({
       name: transform,
       path: `${transform}`,
+      readme,
       example,
     });
   }
@@ -116,47 +145,7 @@ npx @seed-design/codemod --list
 `;
 
   for (const doc of docs) {
-    mdx += `### ${doc.name}\n\n`;
-
-    // 각 transform에 대한 설명 추가
-    switch (doc.name) {
-      case "replace-custom-text-component-color-prop":
-        mdx += "색상 prop을 V3 형식으로 변환해요.\n\n";
-        break;
-      case "replace-tailwind-typography":
-        mdx += "Tailwind 타이포그래피 클래스를 V3 형식으로 변환해요.\n\n";
-        break;
-      case "replace-seed-design-token-typography-classname":
-        mdx += "타이포그래피 디자인 토큰을 V3 형식으로 변환해요.\n\n";
-        break;
-      case "replace-custom-seed-design-text-component":
-        mdx += "Text 컴포넌트를 V3 형식으로 변환해요.\n\n";
-        break;
-      case "replace-react-icon":
-        mdx +=
-          "아이콘을 V3 형식으로 변환해요. 자세한 내용은 [아이콘 Codemod](/react/iconography/codemod) 문서를 참고해주세요.\n\n";
-        break;
-      case "replace-css-seed-design-typography-variable":
-        mdx += "CSS 타이포그래피 변수를 V3 형식으로 변환해요.\n\n";
-        break;
-      case "replace-seed-design-token-vars":
-        mdx += "색상 디자인 토큰을 V3 형식으로 변환해요.\n\n";
-        break;
-      case "replace-css-seed-design-color-variable":
-        mdx += "CSS 색상 변수를 V3 형식으로 변환해요.\n\n";
-        break;
-      case "replace-tailwind-color":
-        mdx += "Tailwind 색상 클래스를 V3 형식으로 변환해요.\n\n";
-        break;
-      case "replace-stitches-styled-color":
-        mdx += "Stitches로 스타일링된 컴포넌트의 색상을 V3 형식으로 변환해요.\n\n";
-        break;
-      case "replace-stitches-styled-typography":
-        mdx += "Stitches로 스타일링된 컴포넌트의 타이포그래피를 V3 형식으로 변환해요.\n\n";
-        break;
-      default:
-        break;
-    }
+    mdx += `${doc.readme}\n\n`;
 
     mdx += `\`\`\`package-install
 npx @seed-design/codemod ${doc.path} <target_path>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 새로운 codemod 변환 기능 `replace-custom-seed-design-vars`, `replace-custom-seed-design-typography`, `replace-custom-imported-typography-variable`, `replace-custom-seed-design-color`가 추가되었습니다.
  - `replace-stitches-theme-color`, `replace-tailwind-color`, `replace-react-icon` 변환 기능이 새롭게 도입되었습니다.
  - `replace-seed-design-token-typography-classname` 변환 기능이 개선되어 배열 내 요소도 처리할 수 있게 되었습니다.

- **Documentation**
  - codemod 관련 문서가 대폭 보강되어, 새로운 변환 기능과 예시, 사용법, 코드 마이그레이션 예제가 추가되었습니다.
  - 기존 예시 코드 및 패키지 import 경로, 클래스명 등이 최신 토큰 및 패키지에 맞게 수정되었습니다.
  - 자동 생성 주석이 문서 상단에 추가되었습니다.
  - Seed Design codemod 유틸리티 모듈에 대한 상세 가이드 문서가 새롭게 추가되었습니다.

- **Tests**
  - `replace-custom-seed-design-vars`, `replace-custom-seed-design-typography`, `replace-custom-imported-typography-variable`, `replace-custom-seed-design-color` 변환 기능에 대한 테스트 및 테스트 픽스처가 추가되었습니다.
  - 테스트 유틸리티가 여러 파일 확장자(tsx, ts)를 지원하도록 개선되었습니다.

- **Chores**
  - codemod 작성 가이드에 일부 케이스만 통과하는 코드 추가 금지 규칙이 명시되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->