### PR TITLE
fix(pull-to-refresh): keep separate store per each ptr instance

### DIFF
--- a/.changeset/odd-berries-flow.md
+++ b/.changeset/odd-berries-flow.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react-pull-to-refresh": patch
+---
+
+여러 PTR 인스턴스가 동일한 상태를 공유하는 문제를 수정합니다.

--- a/packages/react-headless/pull-to-refresh/src/usePullToRefresh.ts
+++ b/packages/react-headless/pull-to-refresh/src/usePullToRefresh.ts
@@ -55,25 +55,19 @@ interface PullToRefreshContext {
 
 export type PullToRefreshState = "idle" | "pulling" | "ready" | "loading";
 
-// We use useSyncExternalStore to only re-render indicator area on drag
-const contextStore = new Store<PullToRefreshContext>({
-  y0: 0,
-  y: -1,
-  displacement: 0,
-  displacementRatio: 0,
-});
-
-const useContextStore = () => {
-  return useSyncExternalStore(
-    (listener) => contextStore.subscribe(listener),
-    () => contextStore.getState(),
-    () => contextStore.getState(),
-  );
-};
-
 function usePullToRefreshState(props: UsePullToRefreshStateProps) {
   const threshold = props.threshold ?? 44;
   const displacementMultiplier = props.displacementMultiplier ?? 0.5;
+
+  // We use useSyncExternalStore to only re-render indicator area on drag
+  const [contextStore] = useState(
+    new Store<PullToRefreshContext>({
+      y0: 0,
+      y: -1,
+      displacement: 0,
+      displacementRatio: 0,
+    }),
+  );
 
   const [state, setState] = useState<PullToRefreshState>("idle");
   const rootRef = useRef<HTMLDivElement | null>(null);
@@ -137,6 +131,7 @@ function usePullToRefreshState(props: UsePullToRefreshStateProps) {
     threshold,
     refs: { root: rootRef },
     events,
+    contextStore,
   };
 }
 
@@ -151,7 +146,7 @@ export interface PullToRefreshIndicatorRenderProps {
 export type UsePullToRefreshReturn = ReturnType<typeof usePullToRefresh>;
 
 export function usePullToRefresh(props: UsePullToRefreshProps) {
-  const { state, threshold, refs, events } = usePullToRefreshState(props);
+  const { state, threshold, refs, events, contextStore } = usePullToRefreshState(props);
 
   const isDragging = state === "pulling" || state === "ready";
   const stateProps = elementProps({
@@ -193,7 +188,11 @@ export function usePullToRefresh(props: UsePullToRefreshProps) {
       },
     }),
     getIndicatorRenderProps: () => {
-      const ctx = useContextStore();
+      const ctx = useSyncExternalStore(
+        (listener) => contextStore.subscribe(listener),
+        () => contextStore.getState(),
+        () => contextStore.getState(),
+      );
       return {
         minValue: 0,
         maxValue: 100,


### PR DESCRIPTION
여러 PTR 인스턴스가 동일한 상태를 공유하는 문제를 수정합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 여러 Pull-To-Refresh 인스턴스가 동일한 상태를 공유하던 문제를 해결하여, 각 인스턴스가 독립적으로 동작하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->