### PR TITLE
feat(codemod): replace-custom-seed-design-color `@seed-design/css/vars` import 하도록 수정

### DIFF
--- a/.changeset/salty-spoons-sit.md
+++ b/.changeset/salty-spoons-sit.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/codemod": patch
+---
+
+feat: replace-custom-seed-design-color 직접 seed-design/css 패키지 import 하도록 변경

--- a/docs/content/react/get-started/codemod.mdx
+++ b/docs/content/react/get-started/codemod.mdx
@@ -162,7 +162,7 @@ export function BasicExample() {
 
 export function BasicExample() {
   return (
-    (<div>
+    <div>
       <div className="t3-bold whitespace-pre-wrap text-center text-[--tick-color]">Primary Background</div>
       <p className="t4-regular text-palette-gray-800">{formState.content}</p>
       <div className="t6-bold">Hover Primary Low Background</div>
@@ -171,7 +171,7 @@ export function BasicExample() {
       <h3 className={cn("t5-bold", className)} {...props} />
       <h3 className={isDisabled ? "t5-regular" : "t5-bold"} {...props} />
       <p className="t2-regular text-palette-gray-800">{description}</p>
-    </div>)
+    </div>
   );
 }
 ```
@@ -1207,7 +1207,7 @@ const staticColors = {
 
 const Component = () => {
   return (
-    (<div>
+    <div>
       <Button
         backgroundColor={theme.colors["bg-brand-solid"].computedValue}
         color={theme.colors["palette-static-white"].computedValue}
@@ -1225,7 +1225,7 @@ const Component = () => {
           중요
         </BadgeText>
       </Badge>
-    </div>)
+    </div>
   );
 };
 
@@ -1371,21 +1371,23 @@ import {
   IconPlusSquareLine,
   IconDothorizline3VerticalFill,
   IconPlusFill as AddIconAlias,
-} from "@daangn/react-monochrome-icon";
-import IconPlusSquareFill from "@daangn/react-monochrome-icon/IconPlusSquareFill";
-import IconPlusLine from "@daangn/react-monochrome-icon/IconPlusLine";
-import IconXmarkLine from "@daangn/react-monochrome-icon/IconXmarkLine";
-import IconCarFrontsideLine from "@daangn/react-monochrome-icon/IconCarFrontsideLine";
+} from "@karrotmarket/react-monochrome-icon";
+import IconPlusSquareFill from "@karrotmarket/react-monochrome-icon/IconPlusSquareFill";
+import IconPlusLine from "@karrotmarket/react-monochrome-icon/IconPlusLine";
+import IconXmarkLine from "@karrotmarket/react-monochrome-icon/IconXmarkLine";
+import IconCarFrontsideLine from "@karrotmarket/react-monochrome-icon/IconCarFrontsideLine";
 
 function App() {
   console.log(IconPlusSquareLine);
 
-  return (<>
-    <IconDothorizline3VerticalFill />
-    <IconXmarkLine />
-    <IconCarFrontsideLine />
-    <AddIconAlias />
-  </>);
+  return (
+    <>
+      <IconDothorizline3VerticalFill />
+      <IconXmarkLine />
+      <IconCarFrontsideLine />
+      <AddIconAlias />
+    </>
+  );
 }
 ```
 
@@ -1459,12 +1461,12 @@ import { Text } from "@seed-design/react";
 
 const Component = () => {
   return (
-    (<div>
+    <div>
       <Text textStyle="t7Bold">광고 노출 기준</Text>
       <Text textStyle="t5Regular">
         앱 내 최근 활동 이력을 분석하여 이용자의 관심사와 관련성이 높은 게시글을 노출해요.
       </Text>
-    </div>)
+    </div>
   );
 };
 ```
@@ -2025,20 +2027,22 @@ const Component = () => {
 // @ts-nocheck
 
 const Component = () => {
-  return (<>
-    <Text color="palette.gray200" variant="subtitle2Regular" className="text-ellipsis-2" />
-    <Text color="palette.gray800" variant="subtitle2Regular" className="text-ellipsis-2" />
-    <Text color="palette.carrot200" variant="subtitle2Regular" className="text-ellipsis-2" />
-    <Text color="palette.carrot600" variant="subtitle2Regular" className="text-ellipsis-2" />
-    <Text color="palette.carrot700" variant="subtitle2Regular" className="text-ellipsis-2" />
-    <Text color="palette.carrot800" variant="subtitle2Regular" className="text-ellipsis-2" />
-    <Text color="palette.staticBlack" variant="subtitle2Regular" className="text-ellipsis-2" />
-    <Text color="palette.staticWhite" variant="subtitle2Regular" className="text-ellipsis-2" />
-    <Text color="palette.staticWhite" variant="subtitle2Regular" className="text-ellipsis-2" />
-    <Text color={isSelected ? "palette.staticWhite" : "fg.brand"} />
-    <Text color={isSelected ? "fg.brand" : "palette.gray1000"}  />
-    <Text color={isSelected ? "palette.carrot600" : "palette.blue600"}  />
-  </>);
+  return (
+    <>
+      <Text color="palette.gray200" variant="subtitle2Regular" className="text-ellipsis-2" />
+      <Text color="palette.gray800" variant="subtitle2Regular" className="text-ellipsis-2" />
+      <Text color="palette.carrot200" variant="subtitle2Regular" className="text-ellipsis-2" />
+      <Text color="palette.carrot600" variant="subtitle2Regular" className="text-ellipsis-2" />
+      <Text color="palette.carrot700" variant="subtitle2Regular" className="text-ellipsis-2" />
+      <Text color="palette.carrot800" variant="subtitle2Regular" className="text-ellipsis-2" />
+      <Text color="palette.staticBlack" variant="subtitle2Regular" className="text-ellipsis-2" />
+      <Text color="palette.staticWhite" variant="subtitle2Regular" className="text-ellipsis-2" />
+      <Text color="palette.staticWhite" variant="subtitle2Regular" className="text-ellipsis-2" />
+      <Text color={isSelected ? "palette.staticWhite" : "fg.brand"} />
+      <Text color={isSelected ? "fg.brand" : "palette.gray1000"}  />
+      <Text color={isSelected ? "palette.carrot600" : "palette.blue600"}  />
+    </>
+  );
 };
 ```
 
@@ -2089,34 +2093,34 @@ export const highlight = style({
 ```
 
 ```ts title="basic.output.ts"
+import { vars } from "@seed-design/css/vars";
 // @ts-nocheck
 import { style } from "@vanilla-extract/css";
-import { color, background } from "@/shared/styles";
 
 export const container = style({
-  backgroundColor: color.palette.gray200,
-  color: color.palette.gray1000,
-  borderColor: color.palette.carrot600,
+  backgroundColor: vars.$color.palette.gray200,
+  color: vars.$color.palette.gray1000,
+  borderColor: vars.$color.palette.carrot600,
 });
 
 export const box = style({
-  background: color.palette.gray100,
-  color: color.palette.red700,
-  border: `1px solid ${color.palette.gray400}`,
+  background: vars.$color.palette.gray100,
+  color: vars.$color.palette.red700,
+  border: `1px solid ${vars.$color.palette.gray400}`,
 });
 
 export const alert = style({
-  backgroundColor: color.palette.red100,
-  color: color.palette.red900,
+  backgroundColor: vars.$color.palette.red100,
+  color: vars.$color.palette.red900,
 });
 
 export const button = style({
-  backgroundColor: background.palette.gray200,
-  color: color.palette.gray1000,
+  backgroundColor: vars.$color.palette.gray200,
+  color: vars.$color.palette.gray1000,
 });
 
 export const highlight = style({
-  color: color.palette.carrot600,
+  color: vars.$color.palette.carrot600,
 });
 ```
 
@@ -2268,7 +2272,7 @@ export function BackgroundExample() {
 
 export function BackgroundExample() {
   return (
-    (<div>
+    <div>
       <div className="bg-bg-brand-solid">Primary Background</div>
       <div className="bg-palette-carrot-100">Primary Low Background</div>
       <div className="hover:bg-palette-carrot-100">Hover Primary Low Background</div>
@@ -2288,7 +2292,7 @@ export function BackgroundExample() {
       <div className="bg-palette-static-black">Static Black Background</div>
       <div className="bg-palette-static-white">Static White Background</div>
       <div className="bg-palette-static-black">Static Gray900 Background</div>
-    </div>)
+    </div>
   );
 }
 ```

--- a/docs/content/react/get-started/codemod.mdx
+++ b/docs/content/react/get-started/codemod.mdx
@@ -2063,7 +2063,7 @@ npx @seed-design/codemod replace-custom-seed-design-color <target_path>
 ```ts title="basic.input.ts"
 // @ts-nocheck
 import { style } from "@vanilla-extract/css";
-import { color, background } from "@/shared/styles";
+import { color, backgroundColor, background } from "@/shared/styles";
 
 export const container = style({
   backgroundColor: color.gray100,
@@ -2089,13 +2089,18 @@ export const button = style({
 
 export const highlight = style({
   color: color.carrot500,
+  backgroundColor: backgroundColor.primary,
+}); 
+
+export const primary = style({
+  color: color.primary,
 });
 ```
 
 ```ts title="basic.output.ts"
 // @ts-nocheck
 import { style } from "@vanilla-extract/css";
-import { color, background } from "@/shared/styles";
+import { color, backgroundColor, background } from "@/shared/styles";
 
 export const container = style({
   backgroundColor: color.palette.gray200,
@@ -2121,6 +2126,11 @@ export const button = style({
 
 export const highlight = style({
   color: color.palette.carrot600,
+  backgroundColor: backgroundColor.bg.brandSolid,
+}); 
+
+export const primary = style({
+  color: color.fg.brand,
 });
 ```
 

--- a/docs/content/react/get-started/codemod.mdx
+++ b/docs/content/react/get-started/codemod.mdx
@@ -2093,34 +2093,34 @@ export const highlight = style({
 ```
 
 ```ts title="basic.output.ts"
-import { vars } from "@seed-design/css/vars";
 // @ts-nocheck
 import { style } from "@vanilla-extract/css";
+import { color, background } from "@/shared/styles";
 
 export const container = style({
-  backgroundColor: vars.$color.palette.gray200,
-  color: vars.$color.palette.gray1000,
-  borderColor: vars.$color.palette.carrot600,
+  backgroundColor: color.palette.gray200,
+  color: color.palette.gray1000,
+  borderColor: color.palette.carrot600,
 });
 
 export const box = style({
-  background: vars.$color.palette.gray100,
-  color: vars.$color.palette.red700,
-  border: `1px solid ${vars.$color.palette.gray400}`,
+  background: color.palette.gray100,
+  color: color.palette.red700,
+  border: `1px solid ${color.palette.gray400}`,
 });
 
 export const alert = style({
-  backgroundColor: vars.$color.palette.red100,
-  color: vars.$color.palette.red900,
+  backgroundColor: color.palette.red100,
+  color: color.palette.red900,
 });
 
 export const button = style({
-  backgroundColor: vars.$color.palette.gray200,
-  color: vars.$color.palette.gray1000,
+  backgroundColor: background.palette.gray200,
+  color: color.palette.gray1000,
 });
 
 export const highlight = style({
-  color: vars.$color.palette.carrot600,
+  color: color.palette.carrot600,
 });
 ```
 

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/advanced.output.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/advanced.output.ts
@@ -1,32 +1,32 @@
+import { vars } from "@seed-design/css/vars";
 // @ts-nocheck
 import { style, styleVariants } from "@vanilla-extract/css";
-import { color, background } from "@/shared/styles";
 
 export const buttonVariants = styleVariants({
   primary: {
-    backgroundColor: color.palette.carrot600,
-    color: color.palette.gray00,
-    borderColor: color.palette.carrot600,
+    backgroundColor: vars.$color.palette.carrot600,
+    color: vars.$color.palette.gray00,
+    borderColor: vars.$color.palette.carrot600,
   },
   secondary: {
-    backgroundColor: color.palette.gray300,
-    color: color.palette.gray1000,
-    borderColor: color.palette.gray400,
+    backgroundColor: vars.$color.palette.gray300,
+    color: vars.$color.palette.gray1000,
+    borderColor: vars.$color.palette.gray400,
   },
   danger: {
-    backgroundColor: color.palette.red700,
-    color: color.palette.gray00,
-    outline: `1px solid ${color.palette.red700}`,
+    backgroundColor: vars.$color.palette.red700,
+    color: vars.$color.palette.gray00,
+    outline: `1px solid ${vars.$color.palette.red700}`,
   },
 });
 
 export const iconButton = style({
-  fill: color.palette.gray1000,
-  stroke: color.palette.gray900,
-  backgroundColor: background.palette.gray100,
+  fill: vars.$color.palette.gray1000,
+  stroke: vars.$color.palette.gray900,
+  backgroundColor: vars.$color.palette.gray100,
 });
 
 export const specialItem = style({
-  color: color.palette.gray500,
-  border: `1px solid ${color.palette.gray300}`,
+  color: vars.$color.palette.gray500,
+  border: `1px solid ${vars.$color.palette.gray300}`,
 }); 

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/advanced.output.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/advanced.output.ts
@@ -1,32 +1,32 @@
-import { vars } from "@seed-design/css/vars";
 // @ts-nocheck
 import { style, styleVariants } from "@vanilla-extract/css";
+import { color, background } from "@/shared/styles";
 
 export const buttonVariants = styleVariants({
   primary: {
-    backgroundColor: vars.$color.palette.carrot600,
-    color: vars.$color.palette.gray00,
-    borderColor: vars.$color.palette.carrot600,
+    backgroundColor: color.palette.carrot600,
+    color: color.palette.gray00,
+    borderColor: color.palette.carrot600,
   },
   secondary: {
-    backgroundColor: vars.$color.palette.gray300,
-    color: vars.$color.palette.gray1000,
-    borderColor: vars.$color.palette.gray400,
+    backgroundColor: color.palette.gray300,
+    color: color.palette.gray1000,
+    borderColor: color.palette.gray400,
   },
   danger: {
-    backgroundColor: vars.$color.palette.red700,
-    color: vars.$color.palette.gray00,
-    outline: `1px solid ${vars.$color.palette.red700}`,
+    backgroundColor: color.palette.red700,
+    color: color.palette.gray00,
+    outline: `1px solid ${color.palette.red700}`,
   },
 });
 
 export const iconButton = style({
-  fill: vars.$color.palette.gray1000,
-  stroke: vars.$color.palette.gray900,
-  backgroundColor: vars.$color.palette.gray100,
+  fill: color.palette.gray1000,
+  stroke: color.palette.gray900,
+  backgroundColor: background.palette.gray100,
 });
 
 export const specialItem = style({
-  color: vars.$color.palette.gray500,
-  border: `1px solid ${vars.$color.palette.gray300}`,
+  color: color.palette.gray500,
+  border: `1px solid ${color.palette.gray300}`,
 }); 

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/basic.input.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/basic.input.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { style } from "@vanilla-extract/css";
-import { color, background } from "@/shared/styles";
+import { color, backgroundColor, background } from "@/shared/styles";
 
 export const container = style({
   backgroundColor: color.gray100,
@@ -26,4 +26,9 @@ export const button = style({
 
 export const highlight = style({
   color: color.carrot500,
+  backgroundColor: backgroundColor.primary,
 }); 
+
+export const primary = style({
+  color: color.primary,
+});

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/basic.output.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/basic.output.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { style } from "@vanilla-extract/css";
-import { color, background } from "@/shared/styles";
+import { color, backgroundColor, background } from "@/shared/styles";
 
 export const container = style({
   backgroundColor: color.palette.gray200,
@@ -26,4 +26,9 @@ export const button = style({
 
 export const highlight = style({
   color: color.palette.carrot600,
+  backgroundColor: backgroundColor.bg.brandSolid,
 }); 
+
+export const primary = style({
+  color: color.fg.brand,
+});

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/basic.output.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/basic.output.ts
@@ -1,29 +1,29 @@
-import { vars } from "@seed-design/css/vars";
 // @ts-nocheck
 import { style } from "@vanilla-extract/css";
+import { color, background } from "@/shared/styles";
 
 export const container = style({
-  backgroundColor: vars.$color.palette.gray200,
-  color: vars.$color.palette.gray1000,
-  borderColor: vars.$color.palette.carrot600,
+  backgroundColor: color.palette.gray200,
+  color: color.palette.gray1000,
+  borderColor: color.palette.carrot600,
 });
 
 export const box = style({
-  background: vars.$color.palette.gray100,
-  color: vars.$color.palette.red700,
-  border: `1px solid ${vars.$color.palette.gray400}`,
+  background: color.palette.gray100,
+  color: color.palette.red700,
+  border: `1px solid ${color.palette.gray400}`,
 });
 
 export const alert = style({
-  backgroundColor: vars.$color.palette.red100,
-  color: vars.$color.palette.red900,
+  backgroundColor: color.palette.red100,
+  color: color.palette.red900,
 });
 
 export const button = style({
-  backgroundColor: vars.$color.palette.gray200,
-  color: vars.$color.palette.gray1000,
+  backgroundColor: background.palette.gray200,
+  color: color.palette.gray1000,
 });
 
 export const highlight = style({
-  color: vars.$color.palette.carrot600,
+  color: color.palette.carrot600,
 }); 

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/basic.output.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/basic.output.ts
@@ -1,29 +1,29 @@
+import { vars } from "@seed-design/css/vars";
 // @ts-nocheck
 import { style } from "@vanilla-extract/css";
-import { color, background } from "@/shared/styles";
 
 export const container = style({
-  backgroundColor: color.palette.gray200,
-  color: color.palette.gray1000,
-  borderColor: color.palette.carrot600,
+  backgroundColor: vars.$color.palette.gray200,
+  color: vars.$color.palette.gray1000,
+  borderColor: vars.$color.palette.carrot600,
 });
 
 export const box = style({
-  background: color.palette.gray100,
-  color: color.palette.red700,
-  border: `1px solid ${color.palette.gray400}`,
+  background: vars.$color.palette.gray100,
+  color: vars.$color.palette.red700,
+  border: `1px solid ${vars.$color.palette.gray400}`,
 });
 
 export const alert = style({
-  backgroundColor: color.palette.red100,
-  color: color.palette.red900,
+  backgroundColor: vars.$color.palette.red100,
+  color: vars.$color.palette.red900,
 });
 
 export const button = style({
-  backgroundColor: background.palette.gray200,
-  color: color.palette.gray1000,
+  backgroundColor: vars.$color.palette.gray200,
+  color: vars.$color.palette.gray1000,
 });
 
 export const highlight = style({
-  color: color.palette.carrot600,
+  color: vars.$color.palette.carrot600,
 }); 

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/segmented.input.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/segmented.input.ts
@@ -1,0 +1,30 @@
+// @ts-nocheck
+import { style } from "@vanilla-extract/css";
+import { color } from "@/shared/styles";
+
+export const container = style({
+  backgroundColor: color.scale.gray100,
+  color: color.scale.gray900,
+  borderColor: color.scale.carrot500,
+});
+
+export const box = style({
+  background: color.static.white,
+  color: color.static.black,
+  border: `1px solid ${color.scale.gray300}`,
+});
+
+export const alert = style({
+  backgroundColor: color.semantic.dangerLow,
+  color: color.semantic.danger,
+});
+
+export const button = style({
+  backgroundColor: color.semantic.secondaryLow,
+  color: color.semantic.secondary,
+});
+
+export const highlight = style({
+  color: color.semantic.primary,
+  backgroundColor: color.semantic.primaryLow,
+}); 

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/segmented.input.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/segmented.input.ts
@@ -1,30 +1,30 @@
 // @ts-nocheck
 import { style } from "@vanilla-extract/css";
-import { color } from "@/shared/styles";
+import { f } from "@/shared/styles";
 
 export const container = style({
-  backgroundColor: color.scale.gray100,
-  color: color.scale.gray900,
-  borderColor: color.scale.carrot500,
+  backgroundColor: f.color.scale.gray100,
+  color: f.color.scale.gray900,
+  borderColor: f.color.scale.carrot500,
 });
 
 export const box = style({
-  background: color.static.white,
-  color: color.static.black,
-  border: `1px solid ${color.scale.gray300}`,
+  background: f.color.static.white,
+  color: f.color.static.black,
+  border: `1px solid ${f.color.scale.gray300}`,
 });
 
 export const alert = style({
-  backgroundColor: color.semantic.dangerLow,
-  color: color.semantic.danger,
+  backgroundColor: f.color.semantic.dangerLow,
+  color: f.color.semantic.danger,
 });
 
 export const button = style({
-  backgroundColor: color.semantic.secondaryLow,
-  color: color.semantic.secondary,
+  backgroundColor: f.color.semantic.secondaryLow,
+  color: f.color.semantic.secondary,
 });
 
 export const highlight = style({
-  color: color.semantic.primary,
-  backgroundColor: color.semantic.primaryLow,
+  color: f.color.semantic.primary,
+  backgroundColor: f.color.semantic.primaryLow,
 }); 

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/segmented.output.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/segmented.output.ts
@@ -1,30 +1,30 @@
 // @ts-nocheck
 import { style } from "@vanilla-extract/css";
-import { color } from "@/shared/styles";
+import { f } from "@/shared/styles";
 
 export const container = style({
-  backgroundColor: color.palette.gray200,
-  color: color.palette.gray1000,
-  borderColor: color.palette.carrot600,
+  backgroundColor: f.color.palette.gray200,
+  color: f.color.palette.gray1000,
+  borderColor: f.color.palette.carrot600,
 });
 
 export const box = style({
-  background: color.palette.staticWhite,
-  color: color.palette.staticBlack,
-  border: `1px solid ${color.palette.gray400}`,
+  background: f.color.palette.staticWhite,
+  color: f.color.palette.staticBlack,
+  border: `1px solid ${f.color.palette.gray400}`,
 });
 
 export const alert = style({
-  backgroundColor: color.bg.criticalWeak,
-  color: color.fg.critical,
+  backgroundColor: f.color.bg.criticalWeak,
+  color: f.color.fg.critical,
 });
 
 export const button = style({
-  backgroundColor: color.bg.neutralWeak,
-  color: color.palette.gray900,
+  backgroundColor: f.color.bg.neutralWeak,
+  color: f.color.palette.gray900,
 });
 
 export const highlight = style({
-  color: color.fg.brand,
-  backgroundColor: color.palette.carrot100,
+  color: f.color.fg.brand,
+  backgroundColor: f.color.palette.carrot100,
 }); 

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/segmented.output.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/__testfixtures__/segmented.output.ts
@@ -1,0 +1,30 @@
+// @ts-nocheck
+import { style } from "@vanilla-extract/css";
+import { color } from "@/shared/styles";
+
+export const container = style({
+  backgroundColor: color.palette.gray200,
+  color: color.palette.gray1000,
+  borderColor: color.palette.carrot600,
+});
+
+export const box = style({
+  background: color.palette.staticWhite,
+  color: color.palette.staticBlack,
+  border: `1px solid ${color.palette.gray400}`,
+});
+
+export const alert = style({
+  backgroundColor: color.bg.criticalWeak,
+  color: color.fg.critical,
+});
+
+export const button = style({
+  backgroundColor: color.bg.neutralWeak,
+  color: color.palette.gray900,
+});
+
+export const highlight = style({
+  color: color.fg.brand,
+  backgroundColor: color.palette.carrot100,
+}); 

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/__tests__/transform.test.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/__tests__/transform.test.ts
@@ -1,45 +1,8 @@
-import { readFileSync } from "node:fs";
-import { basename, join } from "node:path";
-import { describe, test, expect } from "vitest";
-import { applyTransform } from "jscodeshift/src/testUtils.js";
-import transformer from "../index.js";
+import { runFixtureTests } from "../../../utils/test.js";
+import { join } from "node:path";
+import transform from "../index.js";
 
-describe("replace-custom-seed-design-color", () => {
-  // 기본 테스트
-  test("basic transform", () => {
-    const fixtureDir = join(__dirname, "..", "__testfixtures__");
-    const inputPath = join(fixtureDir, "basic.input.ts");
-    const inputContent = readFileSync(inputPath, "utf8");
-    const expected = readFileSync(join(fixtureDir, "basic.output.ts"), "utf8").trim();
-
-    // 변환 실행
-    const actual = applyTransform(
-      transformer,
-      {},
-      { source: inputContent, path: inputPath },
-      { parser: "ts" },
-    ).trim();
-
-    // 결과 비교
-    expect(actual).toBe(expected);
-  });
-
-  // 좀 더 복잡한 경우 테스트
-  test("advanced transform", () => {
-    const fixtureDir = join(__dirname, "..", "__testfixtures__");
-    const inputPath = join(fixtureDir, "advanced.input.ts");
-    const inputContent = readFileSync(inputPath, "utf8");
-    const expected = readFileSync(join(fixtureDir, "advanced.output.ts"), "utf8").trim();
-
-    // 변환 실행
-    const actual = applyTransform(
-      transformer,
-      {},
-      { source: inputContent, path: inputPath },
-      { parser: "ts" },
-    ).trim();
-
-    // 결과 비교
-    expect(actual).toBe(expected);
-  });
+runFixtureTests({
+  transform,
+  fixturesDir: join(__dirname, "..", "__testfixtures__"),
 });

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/index.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/index.ts
@@ -9,7 +9,7 @@ import { camelCaseToKebabCase } from "../../utils/case.js";
 const logger = createTransformLogger("replace-custom-seed-design-color");
 
 // 프로젝트별로 다양한 색상 속성 접두사를 허용
-const TARGET_PREFIXES = ["color", "background"];
+const TARGET_PREFIXES = ["color", "background", "backgroundColor"];
 
 // 매핑 접두사 목록
 const TOKEN_PREFIXES = ["$semantic.color.", "$scale.color.", "$static.color."];
@@ -40,7 +40,7 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
       })
       .forEach((path) => {
         const parentPropertyName = getParentPropertyName(path);
-        processColorNode(j, path, file, colorMap, parentPropertyName);
+        processColorNode(j, path, file, colorMap, prefix, parentPropertyName);
         hasChanges = true;
       });
   });
@@ -58,6 +58,7 @@ function processColorNode(
   path: any,
   file: FileInfo,
   colorMap: FoundationTokenMapping[],
+  prefix: string,
   parentPropertyName?: string,
 ) {
   // 속성명 가져오기
@@ -75,7 +76,15 @@ function processColorNode(
   }
 
   // 토큰 타입 결정 (background, color 등에 따라 다른 토큰 타입 사용)
-  const tokenType = getTokenTypeForProperty(parentPropertyName);
+  let tokenType: "bg" | "fg" | "stroke" | "palette";
+
+  if (prefix === "backgroundColor") {
+    // backgroundColor 속성은 항상 bg 토큰 사용
+    tokenType = "bg";
+  } else {
+    // 다른 속성은 parentPropertyName에 따라 결정
+    tokenType = parentPropertyName ? getTokenTypeForProperty(parentPropertyName) : "fg";
+  }
 
   // 입력된 propertyName을 정규화하여 매핑에서 찾을 수 있도록 변환
   const normalizedPropertyName = camelCaseToKebabCase(propertyName);
@@ -83,7 +92,7 @@ function processColorNode(
   // 매핑 후보 토큰 목록 생성
   const potentialTokens = [
     normalizedPropertyName,
-    ...TOKEN_PREFIXES.map((prefix) => `${prefix}${normalizedPropertyName}`),
+    ...TOKEN_PREFIXES.map((tokenPrefix) => `${tokenPrefix}${normalizedPropertyName}`),
   ];
 
   // 매핑에서 해당 토큰 찾기
@@ -96,7 +105,15 @@ function processColorNode(
 
       if (selectedToken) {
         // 토큰을 적용
-        applySelectedToken(j, path, file, propertyName, selectedToken, mapping.needsVerification);
+        applySelectedToken(
+          j,
+          path,
+          file,
+          propertyName,
+          selectedToken,
+          prefix,
+          mapping.needsVerification,
+        );
       } else if (mapping.alternative && mapping.alternative.length > 0) {
         // 대체 토큰이 있는 경우
         const alternativeToken = selectAppropriateToken(mapping.alternative, tokenType);
@@ -109,6 +126,7 @@ function processColorNode(
             file,
             propertyName,
             alternativeToken,
+            prefix,
             true,
             "Using alternative token as primary is deprecated",
           );
@@ -148,7 +166,12 @@ function processColorNode(
     ) {
       // Gray-Alpha-200 처리
       if (propertyName.includes("Alpha") || propertyName.toLowerCase().includes("alpha")) {
-        applySelectedToken(j, path, file, propertyName, "$color.palette.gray-300", false);
+        // prefix에 따라 적절한 토큰 선택
+        if (prefix === "backgroundColor") {
+          applySelectedToken(j, path, file, propertyName, "$color.bg.default", prefix, false);
+        } else {
+          applySelectedToken(j, path, file, propertyName, "$color.fg.default", prefix, false);
+        }
         return;
       }
 
@@ -159,14 +182,40 @@ function processColorNode(
       for (const mapping of colorMap) {
         // static-black-alpha 등의 패턴 찾기
         if (mapping.previous.includes("static") && specialToken.includes("static")) {
-          applySelectedToken(
-            j,
-            path,
-            file,
-            propertyName,
-            mapping.next[0] || "$color.palette.gray-300",
-            true,
-          );
+          // prefix에 따라 적절한 토큰 타입 선택
+          if (prefix === "backgroundColor") {
+            // bg 토큰 찾기
+            const bgToken = mapping.next.find((token) => token.includes("$color.bg"));
+            if (bgToken) {
+              applySelectedToken(j, path, file, propertyName, bgToken, prefix, true);
+            } else {
+              applySelectedToken(
+                j,
+                path,
+                file,
+                propertyName,
+                mapping.next[0] || "$color.bg.default",
+                prefix,
+                true,
+              );
+            }
+          } else {
+            // fg 토큰 찾기
+            const fgToken = mapping.next.find((token) => token.includes("$color.fg"));
+            if (fgToken) {
+              applySelectedToken(j, path, file, propertyName, fgToken, prefix, true);
+            } else {
+              applySelectedToken(
+                j,
+                path,
+                file,
+                propertyName,
+                mapping.next[0] || "$color.fg.default",
+                prefix,
+                true,
+              );
+            }
+          }
           return;
         }
       }
@@ -212,6 +261,13 @@ function findColorMapping(
 }
 
 /**
+ * kebab-case를 camelCase로 변환하는 함수
+ */
+function kebabToCamelCase(kebabString: string): string {
+  return kebabString.replace(/-([a-z0-9])/g, (_, group) => group.toUpperCase());
+}
+
+/**
  * 선택된 토큰을 적용하는 함수
  */
 function applySelectedToken(
@@ -220,6 +276,7 @@ function applySelectedToken(
   file: FileInfo,
   propertyName: string,
   selectedToken: string,
+  prefix: string,
   needsVerification = false,
   warningReason = "Needs manual verification",
 ): void {
@@ -229,22 +286,25 @@ function applySelectedToken(
   // $color.palette.gray-200 => palette.gray200
   if (parts.length >= 3) {
     const category = parts[1]; // palette, bg, fg, stroke
-    const value = parts[2].replace(/-/g, ""); // gray-200 => gray200
 
-    // 기존 object 대신 새로운 MemberExpression 생성
-    const newObject = j.memberExpression(
-      j.identifier(path.node.object.name), // color 또는 background
-      j.identifier(category),
-    );
+    // kebab-case를 camelCase로 변환 (gray-200 => gray200)
+    const value = kebabToCamelCase(parts[2]);
 
-    // 새로운 property로 교체
-    path.node.object = newObject;
+    // 객체 접근 방식 변경: color.palette, color.fg, backgroundColor.bg, backgroundColor.palette
+    // 객체 이름 (color 또는 background)은 유지
+    const objectName = prefix; // color 또는 background/backgroundColor
+
+    // 새로운 멤버 표현식 생성 (color.palette 또는 color.fg 등)
+    const categoryAccess = j.memberExpression(j.identifier(objectName), j.identifier(category));
+
+    // 새로운 property 적용
+    path.node.object = categoryAccess;
     path.node.property = j.identifier(value);
 
     // 성공 로깅
     logger.logTransformResult(file.path, {
       previousToken: propertyName,
-      nextToken: `${category}.${value}`,
+      nextToken: `${objectName}.${category}.${value}`,
       line: path.node.loc?.start.line || 0,
       status: "success",
     });
@@ -253,7 +313,7 @@ function applySelectedToken(
     if (needsVerification) {
       logger.logTransformResult(file.path, {
         previousToken: propertyName,
-        nextToken: `${category}.${value}`,
+        nextToken: `${objectName}.${category}.${value}`,
         line: path.node.loc?.start.line || 0,
         status: "warning",
         failureReason: warningReason,
@@ -291,32 +351,42 @@ function selectAppropriateToken(
   tokens: string[],
   tokenType: "bg" | "fg" | "stroke" | "palette",
 ): string | null {
-  // 1. 해당 타입과 같은 접두사를 가진 토큰을 먼저 찾음
-  const typeToken = tokens.find((token) => token.includes(`$color.${tokenType}`));
-  if (typeToken) return typeToken;
+  // 1. 속성 타입에 맞는 토큰을 우선적으로 사용
+  if (tokenType === "bg") {
+    // bg 속성에는 bg 토큰 우선 사용
+    const bgToken = tokens.find((token) => token.includes("$color.bg"));
+    if (bgToken) return bgToken;
+  } else {
+    // bg가 아닌 다른 속성에는 fg 토큰 우선 사용
+    const fgToken = tokens.find((token) => token.includes("$color.fg"));
+    if (fgToken) return fgToken;
+  }
 
   // 2. 각 타입별 우선순위에 따라 토큰 찾기
   if (tokenType === "stroke") {
-    // stroke -> fg -> palette 순으로 시도
+    // stroke 토큰 사용
     const strokeToken = tokens.find((token) => token.includes("$color.stroke"));
     if (strokeToken) return strokeToken;
+  }
 
+  // 3. fg 토큰 시도 (모든 타입에 대한 대체)
+  if (tokenType !== "bg") {
+    // bg 타입이 아닌 경우에만 fg 토큰 시도
     const fgToken = tokens.find((token) => token.includes("$color.fg"));
     if (fgToken) return fgToken;
-  } else if (tokenType === "fg") {
-    // fg -> palette 순으로 시도
-    const fgToken = tokens.find((token) => token.includes("$color.fg"));
-    if (fgToken) return fgToken;
-  } else if (tokenType === "bg") {
-    // bg -> palette 순으로 시도
+  }
+
+  // 4. bg 토큰 시도 (모든 타입에 대한 대체)
+  if (tokenType === "bg") {
+    // bg 타입인 경우에만 bg 토큰 시도
     const bgToken = tokens.find((token) => token.includes("$color.bg"));
     if (bgToken) return bgToken;
   }
 
-  // 3. palette 토큰 시도 (모든 타입의 기본 대체)
+  // 5. palette 토큰 시도 (모든 타입의 기본 대체)
   const paletteToken = tokens.find((token) => token.includes("$color.palette"));
   if (paletteToken) return paletteToken;
 
-  // 4. 어떤 것도 찾지 못했으면 첫 번째 토큰 반환 (or null)
+  // 6. 어떤 것도 찾지 못했으면 첫 번째 토큰 반환 (or null)
   return tokens[0] || null;
 }

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/index.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/index.ts
@@ -14,6 +14,12 @@ const TARGET_PREFIXES = ["color", "background"];
 // 매핑 접두사 목록
 const TOKEN_PREFIXES = ["$semantic.color.", "$scale.color.", "$static.color."];
 
+// 새 import 경로
+const TARGET_IMPORT_PATH = "@seed-design/css/vars";
+
+// 원본 import 경로
+const SOURCE_IMPORT_PATH = "@/shared/styles";
+
 ///////////////////////////////////////////////////////////////////
 
 export default function transformer(file: FileInfo, api: API, options: Options) {
@@ -29,6 +35,9 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
   // 색상 매핑 정보를 가져옴
   const colorMap = colorMappings as FoundationTokenMapping[];
 
+  // vars import 추가 필요 여부 확인
+  let needsVarsImport = false;
+
   // 단일 접두사 (color, background와 같은) 처리
   TARGET_PREFIXES.filter((prefix) => !prefix.includes(".")).forEach((prefix) => {
     root
@@ -40,10 +49,72 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
       })
       .forEach((path) => {
         const parentPropertyName = getParentPropertyName(path);
-        processColorNode(j, path, file, colorMap, parentPropertyName);
+        processColorNode(j, path, file, colorMap, prefix, parentPropertyName);
         hasChanges = true;
+        needsVarsImport = true;
       });
   });
+
+  // vars import 추가
+  if (needsVarsImport) {
+    // 이미 존재하는 vars import 확인
+    let varsImportExists = false;
+
+    root
+      .find(j.ImportDeclaration, {
+        source: {
+          value: TARGET_IMPORT_PATH,
+        },
+      })
+      .forEach((path) => {
+        const specifiers = path.node.specifiers || [];
+        specifiers.forEach((spec: any) => {
+          if (spec.type === "ImportSpecifier" && spec.imported && spec.imported.name === "vars") {
+            varsImportExists = true;
+          }
+        });
+      });
+
+    // import가 없으면 추가
+    if (!varsImportExists) {
+      const varsImport = j.importDeclaration(
+        [j.importSpecifier(j.identifier("vars"))],
+        j.literal(TARGET_IMPORT_PATH),
+      );
+
+      // 파일 최상단에 import 추가
+      const body = root.get().node.program.body;
+      body.unshift(varsImport);
+    }
+
+    // 기존 import 구문에서 color, background 가 더 이상 사용되지 않는지 확인
+    root
+      .find(j.ImportDeclaration, {
+        source: {
+          value: SOURCE_IMPORT_PATH,
+        },
+      })
+      .forEach((path) => {
+        // color, background import 추출
+        const colorBackgroundImports = (path.node.specifiers || []).filter(
+          (spec: any) =>
+            spec.type === "ImportSpecifier" && TARGET_PREFIXES.includes(spec.imported.name),
+        );
+
+        if (colorBackgroundImports.length > 0) {
+          // color, background만 import하는 경우 import 문 제거
+          if (colorBackgroundImports.length === path.node.specifiers.length) {
+            j(path).remove();
+          } else {
+            // 다른 import도 있는 경우 color, background만 제거
+            path.node.specifiers = path.node.specifiers.filter(
+              (spec: any) =>
+                !(spec.type === "ImportSpecifier" && TARGET_PREFIXES.includes(spec.imported.name)),
+            );
+          }
+        }
+      });
+  }
 
   // 파일 변환 완료 로깅
   logger.finishFile(file.path);
@@ -58,6 +129,7 @@ function processColorNode(
   path: any,
   file: FileInfo,
   colorMap: FoundationTokenMapping[],
+  _prefix: string,
   parentPropertyName?: string,
 ) {
   // 속성명 가져오기
@@ -83,7 +155,7 @@ function processColorNode(
   // 매핑 후보 토큰 목록 생성
   const potentialTokens = [
     normalizedPropertyName,
-    ...TOKEN_PREFIXES.map((prefix) => `${prefix}${normalizedPropertyName}`),
+    ...TOKEN_PREFIXES.map((tokenPrefix) => `${tokenPrefix}${normalizedPropertyName}`),
   ];
 
   // 매핑에서 해당 토큰 찾기
@@ -96,14 +168,21 @@ function processColorNode(
 
       if (selectedToken) {
         // 토큰을 적용
-        applySelectedToken(j, path, file, propertyName, selectedToken, mapping.needsVerification);
+        applySelectedTokenWithVars(
+          j,
+          path,
+          file,
+          propertyName,
+          selectedToken,
+          mapping.needsVerification,
+        );
       } else if (mapping.alternative && mapping.alternative.length > 0) {
         // 대체 토큰이 있는 경우
         const alternativeToken = selectAppropriateToken(mapping.alternative, tokenType);
 
         if (alternativeToken) {
           // 대체 토큰을 적용
-          applySelectedToken(
+          applySelectedTokenWithVars(
             j,
             path,
             file,
@@ -148,7 +227,7 @@ function processColorNode(
     ) {
       // Gray-Alpha-200 처리
       if (propertyName.includes("Alpha") || propertyName.toLowerCase().includes("alpha")) {
-        applySelectedToken(j, path, file, propertyName, "$color.palette.gray-300", false);
+        applySelectedTokenWithVars(j, path, file, propertyName, "$color.palette.gray-300", false);
         return;
       }
 
@@ -159,7 +238,7 @@ function processColorNode(
       for (const mapping of colorMap) {
         // static-black-alpha 등의 패턴 찾기
         if (mapping.previous.includes("static") && specialToken.includes("static")) {
-          applySelectedToken(
+          applySelectedTokenWithVars(
             j,
             path,
             file,
@@ -212,16 +291,16 @@ function findColorMapping(
 }
 
 /**
- * 선택된 토큰을 적용하는 함수
+ * vars를 사용하여 선택된 토큰을 적용하는 함수
  */
-function applySelectedToken(
+function applySelectedTokenWithVars(
   j: API["jscodeshift"],
   path: any,
   file: FileInfo,
   propertyName: string,
   selectedToken: string,
-  needsVerification: boolean = false,
-  warningReason: string = "Needs manual verification",
+  needsVerification = false,
+  warningReason = "Needs manual verification",
 ): void {
   // property를 직접 수정하지 않고, 객체 구조로 변경
   const parts = selectedToken.split(".");
@@ -231,20 +310,22 @@ function applySelectedToken(
     const category = parts[1]; // palette, bg, fg, stroke
     const value = parts[2].replace(/-/g, ""); // gray-200 => gray200
 
-    // 기존 object 대신 새로운 MemberExpression 생성
-    const newObject = j.memberExpression(
-      j.identifier(path.node.object.name), // color 또는 background
-      j.identifier(category),
-    );
+    // vars.$color.palette.gray200 형식으로 변경
+    const varsNode = j.identifier("vars");
+    const dollarColorNode = j.memberExpression(varsNode, j.identifier("$color"));
+    const categoryNode = j.memberExpression(dollarColorNode, j.identifier(category));
+    const valueNode = j.identifier(value);
 
-    // 새로운 property로 교체
-    path.node.object = newObject;
-    path.node.property = j.identifier(value);
+    // 전체 멤버 표현식 작성: vars.$color.palette.gray100
+    const newNode = j.memberExpression(categoryNode, valueNode);
+
+    // 노드 교체
+    j(path).replaceWith(newNode);
 
     // 성공 로깅
     logger.logTransformResult(file.path, {
       previousToken: propertyName,
-      nextToken: `${category}.${value}`,
+      nextToken: `vars.$color.${category}.${value}`,
       line: path.node.loc?.start.line || 0,
       status: "success",
     });
@@ -253,7 +334,7 @@ function applySelectedToken(
     if (needsVerification) {
       logger.logTransformResult(file.path, {
         previousToken: propertyName,
-        nextToken: `${category}.${value}`,
+        nextToken: `vars.$color.${category}.${value}`,
         line: path.node.loc?.start.line || 0,
         status: "warning",
         failureReason: warningReason,

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/index.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/index.ts
@@ -14,6 +14,9 @@ const TARGET_PREFIXES = ["color", "background", "backgroundColor"];
 // 매핑 접두사 목록
 const TOKEN_PREFIXES = ["$semantic.color.", "$scale.color.", "$static.color."];
 
+// 세분화된 네임스페이스 객체 이름들
+const NAMESPACE_OBJECTS = ["semantic", "scale", "static"];
+
 ///////////////////////////////////////////////////////////////////
 
 export default function transformer(file: FileInfo, api: API, options: Options) {
@@ -31,6 +34,7 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
 
   // 단일 접두사 (color, background와 같은) 처리
   TARGET_PREFIXES.filter((prefix) => !prefix.includes(".")).forEach((prefix) => {
+    // 일반 접근 처리 (color.carrot500)
     root
       .find(j.MemberExpression, {
         object: {
@@ -39,10 +43,46 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
         },
       })
       .forEach((path) => {
+        // 네임스페이스 객체인 경우 처리하지 않음 (color.scale, color.semantic 등)
+        if (NAMESPACE_OBJECTS.includes(path.node.property.name)) {
+          return;
+        }
+
         const parentPropertyName = getParentPropertyName(path);
         processColorNode(j, path, file, colorMap, prefix, parentPropertyName);
         hasChanges = true;
       });
+
+    // 세분화된 네임스페이스 접근 처리 (color.scale.gray100, color.static.white 등)
+    NAMESPACE_OBJECTS.forEach((namespace) => {
+      root
+        .find(j.MemberExpression, {
+          object: {
+            type: "MemberExpression",
+            object: {
+              type: "Identifier",
+              name: prefix,
+            },
+            property: {
+              type: "Identifier",
+              name: namespace,
+            },
+          },
+        })
+        .forEach((path) => {
+          const parentPropertyName = getParentPropertyName(path);
+          processNamespacedColorNode(
+            j,
+            path,
+            file,
+            colorMap,
+            prefix,
+            namespace,
+            parentPropertyName,
+          );
+          hasChanges = true;
+        });
+    });
   });
 
   // 파일 변환 완료 로깅
@@ -50,6 +90,200 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
 
   // 변경사항이 있는 경우에만 소스 반환
   return hasChanges ? root.toSource(options) : file.source;
+}
+
+// 세분화된 네임스페이스 색상 노드 처리 함수
+function processNamespacedColorNode(
+  j: API["jscodeshift"],
+  path: any,
+  file: FileInfo,
+  colorMap: FoundationTokenMapping[],
+  prefix: string,
+  namespace: string,
+  parentPropertyName?: string,
+) {
+  // 속성명 가져오기
+  const propertyName = path.node.property.name || path.node.property.value;
+
+  if (!propertyName) {
+    logger.logTransformResult(file.path, {
+      previousToken: "Cannot determine property name",
+      nextToken: null,
+      line: path.node.loc?.start.line || 0,
+      status: "failure",
+      failureReason: "Property name not found",
+    });
+    return;
+  }
+
+  // 토큰 타입 결정 (background, color 등에 따라 다른 토큰 타입 사용)
+  let tokenType: "bg" | "fg" | "stroke" | "palette";
+
+  if (prefix === "backgroundColor") {
+    // backgroundColor 속성은 항상 bg 토큰 사용
+    tokenType = "bg";
+  } else {
+    // 다른 속성은 parentPropertyName에 따라 결정
+    tokenType = parentPropertyName ? getTokenTypeForProperty(parentPropertyName) : "fg";
+  }
+
+  // 정규화된 토큰 이름 생성 (scale.gray100 -> scale-gray-100)
+  const namespacePrefix = `$${namespace}.color.`;
+  const normalizedPropertyName = camelCaseToKebabCase(propertyName);
+  const fullTokenName = `${namespacePrefix}${normalizedPropertyName}`;
+
+  // 매핑 후보 토큰 목록 생성
+  const potentialTokens = [fullTokenName];
+
+  // 매핑에서 해당 토큰 찾기
+  const mapping = findColorMapping(colorMap, potentialTokens, normalizedPropertyName);
+
+  if (mapping) {
+    if (mapping.next && mapping.next.length > 0) {
+      // 적절한 토큰 선택 (bg, fg, stroke, palette 중)
+      const selectedToken = selectAppropriateToken(mapping.next, tokenType);
+
+      if (selectedToken) {
+        // 토큰을 적용
+        applySelectedToken(
+          j,
+          path,
+          file,
+          `${namespace}.${propertyName}`,
+          selectedToken,
+          prefix,
+          mapping.needsVerification,
+        );
+      } else if (mapping.alternative && mapping.alternative.length > 0) {
+        // 대체 토큰이 있는 경우
+        const alternativeToken = selectAppropriateToken(mapping.alternative, tokenType);
+
+        if (alternativeToken) {
+          // 대체 토큰을 적용
+          applySelectedToken(
+            j,
+            path,
+            file,
+            `${namespace}.${propertyName}`,
+            alternativeToken,
+            prefix,
+            true,
+            "Using alternative token as primary is deprecated",
+          );
+        } else {
+          // 적절한 대체 토큰이 없는 경우
+          logFailure(
+            file.path,
+            `${namespace}.${propertyName}`,
+            path.node.loc?.start.line || 0,
+            "No suitable alternative token found",
+          );
+        }
+      } else {
+        // 매핑이 있지만 다음 토큰이 없는 경우 (deprecated)
+        logFailure(
+          file.path,
+          `${namespace}.${propertyName}`,
+          path.node.loc?.start.line || 0,
+          "Token is deprecated with no direct replacement",
+        );
+      }
+    } else {
+      // next 배열이 비어있는 경우 (deprecated)
+      logFailure(
+        file.path,
+        `${namespace}.${propertyName}`,
+        path.node.loc?.start.line || 0,
+        "Token is deprecated with no direct replacement",
+      );
+    }
+  } else {
+    // Alpha와 같은 특수 토큰을 위한 처리
+    if (
+      propertyName.includes("Alpha") ||
+      propertyName.toLowerCase().includes("alpha") ||
+      namespace === "static"
+    ) {
+      // static.blackAlpha500, static.whiteAlpha200 등의 처리
+      if (propertyName.includes("Alpha") || propertyName.toLowerCase().includes("alpha")) {
+        // static.blackAlpha500 -> palette.staticBlackAlpha500
+        const staticTokenName = `static-${propertyName.replace(/([A-Z])/g, "-$1").toLowerCase()}`;
+        const potentialStaticTokens = [`$static.color.${staticTokenName}`];
+
+        const staticMapping = findColorMapping(colorMap, potentialStaticTokens, staticTokenName);
+
+        if (staticMapping?.next && staticMapping.next.length > 0) {
+          const selectedToken = selectAppropriateToken(staticMapping.next, tokenType);
+          if (selectedToken) {
+            applySelectedToken(
+              j,
+              path,
+              file,
+              `${namespace}.${propertyName}`,
+              selectedToken,
+              prefix,
+              staticMapping.needsVerification,
+            );
+            return;
+          }
+        }
+
+        // prefix에 따라 적절한 토큰 선택
+        if (prefix === "backgroundColor") {
+          applySelectedToken(
+            j,
+            path,
+            file,
+            `${namespace}.${propertyName}`,
+            "$color.bg.default",
+            prefix,
+            false,
+          );
+        } else {
+          applySelectedToken(
+            j,
+            path,
+            file,
+            `${namespace}.${propertyName}`,
+            "$color.fg.default",
+            prefix,
+            false,
+          );
+        }
+        return;
+      }
+
+      // static.white, static.black 등의 처리
+      const staticTokenName = `static-${camelCaseToKebabCase(propertyName)}`;
+      const potentialStaticTokens = [`$static.color.${staticTokenName}`];
+
+      const staticMapping = findColorMapping(colorMap, potentialStaticTokens, staticTokenName);
+
+      if (staticMapping?.next && staticMapping.next.length > 0) {
+        const selectedToken = selectAppropriateToken(staticMapping.next, tokenType);
+        if (selectedToken) {
+          applySelectedToken(
+            j,
+            path,
+            file,
+            `${namespace}.${propertyName}`,
+            selectedToken,
+            prefix,
+            staticMapping.needsVerification,
+          );
+          return;
+        }
+      }
+    }
+
+    // 매핑이 없는 경우
+    logFailure(
+      file.path,
+      `${namespace}.${propertyName}`,
+      path.node.loc?.start.line || 0,
+      "No mapping found in the color tokens",
+    );
+  }
 }
 
 // 색상 노드 처리 함수

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/index.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/index.ts
@@ -14,12 +14,6 @@ const TARGET_PREFIXES = ["color", "background"];
 // 매핑 접두사 목록
 const TOKEN_PREFIXES = ["$semantic.color.", "$scale.color.", "$static.color."];
 
-// 새 import 경로
-const TARGET_IMPORT_PATH = "@seed-design/css/vars";
-
-// 원본 import 경로
-const SOURCE_IMPORT_PATH = "@/shared/styles";
-
 ///////////////////////////////////////////////////////////////////
 
 export default function transformer(file: FileInfo, api: API, options: Options) {
@@ -35,9 +29,6 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
   // 색상 매핑 정보를 가져옴
   const colorMap = colorMappings as FoundationTokenMapping[];
 
-  // vars import 추가 필요 여부 확인
-  let needsVarsImport = false;
-
   // 단일 접두사 (color, background와 같은) 처리
   TARGET_PREFIXES.filter((prefix) => !prefix.includes(".")).forEach((prefix) => {
     root
@@ -49,72 +40,10 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
       })
       .forEach((path) => {
         const parentPropertyName = getParentPropertyName(path);
-        processColorNode(j, path, file, colorMap, prefix, parentPropertyName);
+        processColorNode(j, path, file, colorMap, parentPropertyName);
         hasChanges = true;
-        needsVarsImport = true;
       });
   });
-
-  // vars import 추가
-  if (needsVarsImport) {
-    // 이미 존재하는 vars import 확인
-    let varsImportExists = false;
-
-    root
-      .find(j.ImportDeclaration, {
-        source: {
-          value: TARGET_IMPORT_PATH,
-        },
-      })
-      .forEach((path) => {
-        const specifiers = path.node.specifiers || [];
-        specifiers.forEach((spec: any) => {
-          if (spec.type === "ImportSpecifier" && spec.imported && spec.imported.name === "vars") {
-            varsImportExists = true;
-          }
-        });
-      });
-
-    // import가 없으면 추가
-    if (!varsImportExists) {
-      const varsImport = j.importDeclaration(
-        [j.importSpecifier(j.identifier("vars"))],
-        j.literal(TARGET_IMPORT_PATH),
-      );
-
-      // 파일 최상단에 import 추가
-      const body = root.get().node.program.body;
-      body.unshift(varsImport);
-    }
-
-    // 기존 import 구문에서 color, background 가 더 이상 사용되지 않는지 확인
-    root
-      .find(j.ImportDeclaration, {
-        source: {
-          value: SOURCE_IMPORT_PATH,
-        },
-      })
-      .forEach((path) => {
-        // color, background import 추출
-        const colorBackgroundImports = (path.node.specifiers || []).filter(
-          (spec: any) =>
-            spec.type === "ImportSpecifier" && TARGET_PREFIXES.includes(spec.imported.name),
-        );
-
-        if (colorBackgroundImports.length > 0) {
-          // color, background만 import하는 경우 import 문 제거
-          if (colorBackgroundImports.length === path.node.specifiers.length) {
-            j(path).remove();
-          } else {
-            // 다른 import도 있는 경우 color, background만 제거
-            path.node.specifiers = path.node.specifiers.filter(
-              (spec: any) =>
-                !(spec.type === "ImportSpecifier" && TARGET_PREFIXES.includes(spec.imported.name)),
-            );
-          }
-        }
-      });
-  }
 
   // 파일 변환 완료 로깅
   logger.finishFile(file.path);
@@ -129,7 +58,6 @@ function processColorNode(
   path: any,
   file: FileInfo,
   colorMap: FoundationTokenMapping[],
-  _prefix: string,
   parentPropertyName?: string,
 ) {
   // 속성명 가져오기
@@ -155,7 +83,7 @@ function processColorNode(
   // 매핑 후보 토큰 목록 생성
   const potentialTokens = [
     normalizedPropertyName,
-    ...TOKEN_PREFIXES.map((tokenPrefix) => `${tokenPrefix}${normalizedPropertyName}`),
+    ...TOKEN_PREFIXES.map((prefix) => `${prefix}${normalizedPropertyName}`),
   ];
 
   // 매핑에서 해당 토큰 찾기
@@ -168,21 +96,14 @@ function processColorNode(
 
       if (selectedToken) {
         // 토큰을 적용
-        applySelectedTokenWithVars(
-          j,
-          path,
-          file,
-          propertyName,
-          selectedToken,
-          mapping.needsVerification,
-        );
+        applySelectedToken(j, path, file, propertyName, selectedToken, mapping.needsVerification);
       } else if (mapping.alternative && mapping.alternative.length > 0) {
         // 대체 토큰이 있는 경우
         const alternativeToken = selectAppropriateToken(mapping.alternative, tokenType);
 
         if (alternativeToken) {
           // 대체 토큰을 적용
-          applySelectedTokenWithVars(
+          applySelectedToken(
             j,
             path,
             file,
@@ -227,7 +148,7 @@ function processColorNode(
     ) {
       // Gray-Alpha-200 처리
       if (propertyName.includes("Alpha") || propertyName.toLowerCase().includes("alpha")) {
-        applySelectedTokenWithVars(j, path, file, propertyName, "$color.palette.gray-300", false);
+        applySelectedToken(j, path, file, propertyName, "$color.palette.gray-300", false);
         return;
       }
 
@@ -238,7 +159,7 @@ function processColorNode(
       for (const mapping of colorMap) {
         // static-black-alpha 등의 패턴 찾기
         if (mapping.previous.includes("static") && specialToken.includes("static")) {
-          applySelectedTokenWithVars(
+          applySelectedToken(
             j,
             path,
             file,
@@ -291,16 +212,16 @@ function findColorMapping(
 }
 
 /**
- * vars를 사용하여 선택된 토큰을 적용하는 함수
+ * 선택된 토큰을 적용하는 함수
  */
-function applySelectedTokenWithVars(
+function applySelectedToken(
   j: API["jscodeshift"],
   path: any,
   file: FileInfo,
   propertyName: string,
   selectedToken: string,
-  needsVerification = false,
-  warningReason = "Needs manual verification",
+  needsVerification: boolean = false,
+  warningReason: string = "Needs manual verification",
 ): void {
   // property를 직접 수정하지 않고, 객체 구조로 변경
   const parts = selectedToken.split(".");
@@ -310,22 +231,20 @@ function applySelectedTokenWithVars(
     const category = parts[1]; // palette, bg, fg, stroke
     const value = parts[2].replace(/-/g, ""); // gray-200 => gray200
 
-    // vars.$color.palette.gray200 형식으로 변경
-    const varsNode = j.identifier("vars");
-    const dollarColorNode = j.memberExpression(varsNode, j.identifier("$color"));
-    const categoryNode = j.memberExpression(dollarColorNode, j.identifier(category));
-    const valueNode = j.identifier(value);
+    // 기존 object 대신 새로운 MemberExpression 생성
+    const newObject = j.memberExpression(
+      j.identifier(path.node.object.name), // color 또는 background
+      j.identifier(category),
+    );
 
-    // 전체 멤버 표현식 작성: vars.$color.palette.gray100
-    const newNode = j.memberExpression(categoryNode, valueNode);
-
-    // 노드 교체
-    j(path).replaceWith(newNode);
+    // 새로운 property로 교체
+    path.node.object = newObject;
+    path.node.property = j.identifier(value);
 
     // 성공 로깅
     logger.logTransformResult(file.path, {
       previousToken: propertyName,
-      nextToken: `vars.$color.${category}.${value}`,
+      nextToken: `${category}.${value}`,
       line: path.node.loc?.start.line || 0,
       status: "success",
     });
@@ -334,7 +253,7 @@ function applySelectedTokenWithVars(
     if (needsVerification) {
       logger.logTransformResult(file.path, {
         previousToken: propertyName,
-        nextToken: `vars.$color.${category}.${value}`,
+        nextToken: `${category}.${value}`,
         line: path.node.loc?.start.line || 0,
         status: "warning",
         failureReason: warningReason,

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/index.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/index.ts
@@ -9,7 +9,7 @@ import { camelCaseToKebabCase } from "../../utils/case.js";
 const logger = createTransformLogger("replace-custom-seed-design-color");
 
 // 프로젝트별로 다양한 색상 속성 접두사를 허용
-const TARGET_PREFIXES = ["color", "background", "backgroundColor"];
+const TARGET_PREFIXES = ["color", "background", "backgroundColor", "f"];
 
 // 매핑 접두사 목록
 const TOKEN_PREFIXES = ["$semantic.color.", "$scale.color.", "$static.color."];
@@ -44,7 +44,19 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
       })
       .forEach((path) => {
         // 네임스페이스 객체인 경우 처리하지 않음 (color.scale, color.semantic 등)
-        if (NAMESPACE_OBJECTS.includes(path.node.property.name)) {
+        if (
+          path.node.property.type === "Identifier" &&
+          NAMESPACE_OBJECTS.includes(path.node.property.name)
+        ) {
+          return;
+        }
+
+        // color 네임스페이스 객체인 경우 처리하지 않음 (f.color)
+        if (
+          prefix === "f" &&
+          path.node.property.type === "Identifier" &&
+          path.node.property.name === "color"
+        ) {
           return;
         }
 
@@ -83,6 +95,46 @@ export default function transformer(file: FileInfo, api: API, options: Options) 
           hasChanges = true;
         });
     });
+
+    // f.color.scale.gray100와 같은 중첩된 네임스페이스 접근 처리
+    if (prefix === "f") {
+      NAMESPACE_OBJECTS.forEach((namespace) => {
+        root
+          .find(j.MemberExpression, {
+            object: {
+              type: "MemberExpression",
+              object: {
+                type: "MemberExpression",
+                object: {
+                  type: "Identifier",
+                  name: prefix,
+                },
+                property: {
+                  type: "Identifier",
+                  name: "color",
+                },
+              },
+              property: {
+                type: "Identifier",
+                name: namespace,
+              },
+            },
+          })
+          .forEach((path) => {
+            const parentPropertyName = getParentPropertyName(path);
+            processNamespacedColorNode(
+              j,
+              path,
+              file,
+              colorMap,
+              "f.color",
+              namespace,
+              parentPropertyName,
+            );
+            hasChanges = true;
+          });
+      });
+    }
   });
 
   // 파일 변환 완료 로깅
@@ -119,7 +171,7 @@ function processNamespacedColorNode(
   // 토큰 타입 결정 (background, color 등에 따라 다른 토큰 타입 사용)
   let tokenType: "bg" | "fg" | "stroke" | "palette";
 
-  if (prefix === "backgroundColor") {
+  if (prefix === "backgroundColor" || parentPropertyName === "backgroundColor") {
     // backgroundColor 속성은 항상 bg 토큰 사용
     tokenType = "bg";
   } else {
@@ -229,7 +281,7 @@ function processNamespacedColorNode(
         }
 
         // prefix에 따라 적절한 토큰 선택
-        if (prefix === "backgroundColor") {
+        if (prefix === "backgroundColor" || parentPropertyName === "backgroundColor") {
           applySelectedToken(
             j,
             path,
@@ -275,14 +327,6 @@ function processNamespacedColorNode(
         }
       }
     }
-
-    // 매핑이 없는 경우
-    logFailure(
-      file.path,
-      `${namespace}.${propertyName}`,
-      path.node.loc?.start.line || 0,
-      "No mapping found in the color tokens",
-    );
   }
 }
 
@@ -312,7 +356,7 @@ function processColorNode(
   // 토큰 타입 결정 (background, color 등에 따라 다른 토큰 타입 사용)
   let tokenType: "bg" | "fg" | "stroke" | "palette";
 
-  if (prefix === "backgroundColor") {
+  if (prefix === "backgroundColor" || parentPropertyName === "backgroundColor") {
     // backgroundColor 속성은 항상 bg 토큰 사용
     tokenType = "bg";
   } else {
@@ -401,7 +445,7 @@ function processColorNode(
       // Gray-Alpha-200 처리
       if (propertyName.includes("Alpha") || propertyName.toLowerCase().includes("alpha")) {
         // prefix에 따라 적절한 토큰 선택
-        if (prefix === "backgroundColor") {
+        if (prefix === "backgroundColor" || parentPropertyName === "backgroundColor") {
           applySelectedToken(j, path, file, propertyName, "$color.bg.default", prefix, false);
         } else {
           applySelectedToken(j, path, file, propertyName, "$color.fg.default", prefix, false);
@@ -417,7 +461,7 @@ function processColorNode(
         // static-black-alpha 등의 패턴 찾기
         if (mapping.previous.includes("static") && specialToken.includes("static")) {
           // prefix에 따라 적절한 토큰 타입 선택
-          if (prefix === "backgroundColor") {
+          if (prefix === "backgroundColor" || parentPropertyName === "backgroundColor") {
             // bg 토큰 찾기
             const bgToken = mapping.next.find((token) => token.includes("$color.bg"));
             if (bgToken) {
@@ -454,14 +498,6 @@ function processColorNode(
         }
       }
     }
-
-    // 매핑이 없는 경우
-    logFailure(
-      file.path,
-      propertyName,
-      path.node.loc?.start.line || 0,
-      "No mapping found in the color tokens",
-    );
   }
 }
 
@@ -524,21 +560,23 @@ function applySelectedToken(
     // kebab-case를 camelCase로 변환 (gray-200 => gray200)
     const value = kebabToCamelCase(parts[2]);
 
-    // 객체 접근 방식 변경: color.palette, color.fg, backgroundColor.bg, backgroundColor.palette
-    // 객체 이름 (color 또는 background)은 유지
-    const objectName = prefix; // color 또는 background/backgroundColor
+    // 색상 객체 접근 계층 구조 가져오기
+    const colorObject = getColorObjectAccess(j, prefix);
 
-    // 새로운 멤버 표현식 생성 (color.palette 또는 color.fg 등)
-    const categoryAccess = j.memberExpression(j.identifier(objectName), j.identifier(category));
+    // 새로운 카테고리 접근식 생성 (palette, bg, fg 등)
+    const categoryAccess = j.memberExpression(colorObject, j.identifier(category));
 
     // 새로운 property 적용
     path.node.object = categoryAccess;
     path.node.property = j.identifier(value);
 
+    // prefix에 따른 로그 메시지 생성
+    const logPrefix = prefix.includes("f.") ? prefix : prefix;
+
     // 성공 로깅
     logger.logTransformResult(file.path, {
       previousToken: propertyName,
-      nextToken: `${objectName}.${category}.${value}`,
+      nextToken: `${logPrefix}.${category}.${value}`,
       line: path.node.loc?.start.line || 0,
       status: "success",
     });
@@ -547,7 +585,7 @@ function applySelectedToken(
     if (needsVerification) {
       logger.logTransformResult(file.path, {
         previousToken: propertyName,
-        nextToken: `${objectName}.${category}.${value}`,
+        nextToken: `${logPrefix}.${category}.${value}`,
         line: path.node.loc?.start.line || 0,
         status: "warning",
         failureReason: warningReason,
@@ -563,6 +601,20 @@ function applySelectedToken(
       failureReason: "Invalid token format",
     });
   }
+}
+
+/**
+ * 색상 객체 접근식을 생성하는 함수
+ */
+function getColorObjectAccess(j: API["jscodeshift"], prefix: string) {
+  // f.color 형태인 경우
+  if (prefix === "f.color") {
+    // f.color 접근식 생성
+    return j.memberExpression(j.identifier("f"), j.identifier("color"));
+  }
+
+  // 일반적인 경우 (color, background 등)
+  return j.identifier(prefix);
 }
 
 /**

--- a/packages/codemod/src/transforms/replace-custom-seed-design-color/index.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-color/index.ts
@@ -220,8 +220,8 @@ function applySelectedToken(
   file: FileInfo,
   propertyName: string,
   selectedToken: string,
-  needsVerification: boolean = false,
-  warningReason: string = "Needs manual verification",
+  needsVerification = false,
+  warningReason = "Needs manual verification",
 ): void {
   // property를 직접 수정하지 않고, 객체 구조로 변경
   const parts = selectedToken.split(".");

--- a/packages/codemod/src/transforms/replace-custom-seed-design-text-component/__testfixtures__/basic.output.tsx
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-text-component/__testfixtures__/basic.output.tsx
@@ -4,11 +4,11 @@ import { Text } from "@seed-design/react";
 
 const Component = () => {
   return (
-    (<div>
+    <div>
       <Text textStyle="t7Bold">광고 노출 기준</Text>
       <Text textStyle="t5Regular">
         앱 내 최근 활동 이력을 분석하여 이용자의 관심사와 관련성이 높은 게시글을 노출해요.
       </Text>
-    </div>)
+    </div>
   );
 };

--- a/packages/codemod/src/transforms/replace-custom-seed-design-text-component/__testfixtures__/conditional.output.tsx
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-text-component/__testfixtures__/conditional.output.tsx
@@ -4,11 +4,11 @@ import { Text } from "@seed-design/react";
 
 const Component = () => {
   return (
-    (<div>
+    <div>
       <Text color="palette.gray700" textStyle={isPrimary ? "t5Bold" : "t6Bold"}>광고 노출 기준</Text>
       <Text color="palette.gray700" textStyle={isDetail ? "t5Bold" : "t6Bold"}>
         앱 내 최근 활동 이력을 분석하여 이용자의 관심사와 관련성이 높은 게시글을 노출해요.
       </Text>
-    </div>)
+    </div>
   );
 };

--- a/packages/codemod/src/transforms/replace-custom-seed-design-text-component/__tests__/transform.test.ts
+++ b/packages/codemod/src/transforms/replace-custom-seed-design-text-component/__tests__/transform.test.ts
@@ -5,4 +5,5 @@ import transform from "../index.js";
 runFixtureTests({
   transform,
   fixturesDir: join(__dirname, "..", "__testfixtures__"),
+  extension: ["tsx", "ts"],
 });

--- a/packages/codemod/src/transforms/replace-custom-text-component-color-prop/__testfixtures__/basic.output.tsx
+++ b/packages/codemod/src/transforms/replace-custom-text-component-color-prop/__testfixtures__/basic.output.tsx
@@ -1,18 +1,20 @@
 // @ts-nocheck
 
 const Component = () => {
-  return (<>
-    <Text color="palette.gray200" variant="subtitle2Regular" className="text-ellipsis-2" />
-    <Text color="palette.gray800" variant="subtitle2Regular" className="text-ellipsis-2" />
-    <Text color="palette.carrot200" variant="subtitle2Regular" className="text-ellipsis-2" />
-    <Text color="palette.carrot600" variant="subtitle2Regular" className="text-ellipsis-2" />
-    <Text color="palette.carrot700" variant="subtitle2Regular" className="text-ellipsis-2" />
-    <Text color="palette.carrot800" variant="subtitle2Regular" className="text-ellipsis-2" />
-    <Text color="palette.staticBlack" variant="subtitle2Regular" className="text-ellipsis-2" />
-    <Text color="palette.staticWhite" variant="subtitle2Regular" className="text-ellipsis-2" />
-    <Text color="palette.staticWhite" variant="subtitle2Regular" className="text-ellipsis-2" />
-    <Text color={isSelected ? "palette.staticWhite" : "fg.brand"} />
-    <Text color={isSelected ? "fg.brand" : "palette.gray1000"}  />
-    <Text color={isSelected ? "palette.carrot600" : "palette.blue600"}  />
-  </>);
+  return (
+    <>
+      <Text color="palette.gray200" variant="subtitle2Regular" className="text-ellipsis-2" />
+      <Text color="palette.gray800" variant="subtitle2Regular" className="text-ellipsis-2" />
+      <Text color="palette.carrot200" variant="subtitle2Regular" className="text-ellipsis-2" />
+      <Text color="palette.carrot600" variant="subtitle2Regular" className="text-ellipsis-2" />
+      <Text color="palette.carrot700" variant="subtitle2Regular" className="text-ellipsis-2" />
+      <Text color="palette.carrot800" variant="subtitle2Regular" className="text-ellipsis-2" />
+      <Text color="palette.staticBlack" variant="subtitle2Regular" className="text-ellipsis-2" />
+      <Text color="palette.staticWhite" variant="subtitle2Regular" className="text-ellipsis-2" />
+      <Text color="palette.staticWhite" variant="subtitle2Regular" className="text-ellipsis-2" />
+      <Text color={isSelected ? "palette.staticWhite" : "fg.brand"} />
+      <Text color={isSelected ? "fg.brand" : "palette.gray1000"}  />
+      <Text color={isSelected ? "palette.carrot600" : "palette.blue600"}  />
+    </>
+  );
 };

--- a/packages/codemod/src/transforms/replace-react-icon/__testfixtures__/basic.output.tsx
+++ b/packages/codemod/src/transforms/replace-react-icon/__testfixtures__/basic.output.tsx
@@ -13,10 +13,12 @@ import IconCarFrontsideLine from "@karrotmarket/react-monochrome-icon/IconCarFro
 function App() {
   console.log(IconPlusSquareLine);
 
-  return (<>
-    <IconDothorizline3VerticalFill />
-    <IconXmarkLine />
-    <IconCarFrontsideLine />
-    <AddIconAlias />
-  </>);
+  return (
+    <>
+      <IconDothorizline3VerticalFill />
+      <IconXmarkLine />
+      <IconCarFrontsideLine />
+      <AddIconAlias />
+    </>
+  );
 } 

--- a/packages/codemod/src/transforms/replace-react-icon/__testfixtures__/direct-import.output.tsx
+++ b/packages/codemod/src/transforms/replace-react-icon/__testfixtures__/direct-import.output.tsx
@@ -5,9 +5,9 @@ import IconPlusSquareLine from "@karrotmarket/react-monochrome-icon/dist/lib/tes
 
 function App() {
   return (
-    (<div>
+    <div>
       <IconDothorizline3VerticalLine />
       <IconPlusSquareLine />
-    </div>)
+    </div>
   );
 } 

--- a/packages/codemod/src/transforms/replace-react-icon/__tests__/transform.test.ts
+++ b/packages/codemod/src/transforms/replace-react-icon/__tests__/transform.test.ts
@@ -5,7 +5,7 @@ import transform, { reactMatch } from "../index.js";
 runFixtureTests({
   transform,
   fixturesDir: join(__dirname, "..", "__testfixtures__"),
-  extension: "tsx",
+  extension: ["tsx", "ts"],
   transformOptions: {
     log: true,
     match: reactMatch,

--- a/packages/codemod/src/transforms/replace-stitches-theme-color/__testfixtures__/basic.output.tsx
+++ b/packages/codemod/src/transforms/replace-stitches-theme-color/__testfixtures__/basic.output.tsx
@@ -58,7 +58,7 @@ const staticColors = {
 
 const Component = () => {
   return (
-    (<div>
+    <div>
       <Button
         backgroundColor={theme.colors["bg-brand-solid"].computedValue}
         color={theme.colors["palette-static-white"].computedValue}
@@ -76,7 +76,7 @@ const Component = () => {
           중요
         </BadgeText>
       </Badge>
-    </div>)
+    </div>
   );
 };
 

--- a/packages/codemod/src/transforms/replace-stitches-theme-color/__testfixtures__/jobs.output.tsx
+++ b/packages/codemod/src/transforms/replace-stitches-theme-color/__testfixtures__/jobs.output.tsx
@@ -4,7 +4,7 @@ import { theme } from '@src/stitches/stitches.config'
 
 const Component = () => {
   return (
-    (<div>
+    <div>
       <IconCloseRegular
         width={20}
         height={20}
@@ -18,7 +18,7 @@ const Component = () => {
         <IconArrowUpBracketDownLine width={24} height={24} color={theme.colors["palette-gray-1000"].computedValue} />
       )}
       </IconWrapper>
-    </div>)
+    </div>
   );
 };
 
@@ -26,35 +26,35 @@ const Radio: React.FCC<RadioProps> = ({ isSelected, isDisabled = false }) => {
   switch (true) {
     case isSelected && isDisabled:
       return (
-        (<RadioIcon
+        <RadioIcon
           outerCircleFill={theme.colors["palette-gray-300"].computedValue}
           middleCircleFill={theme.colors["bg-layer-default"].computedValue}
           innerCircleFill={theme.colors["palette-gray-300"].computedValue}
-        />)
+        />
       );
     case isSelected && !isDisabled:
       return (
-        (<RadioIcon
+        <RadioIcon
           outerCircleFill={theme.colors["bg-brand-solid"].computedValue}
           middleCircleFill={theme.colors["bg-brand-solid"].computedValue}
           innerCircleFill={theme.colors["palette-static-white"].computedValue}
-        />)
+        />
       );
     case !isSelected && isDisabled:
       return (
-        (<RadioIcon
+        <RadioIcon
           outerCircleFill={theme.colors["palette-gray-400"].computedValue}
           middleCircleFill={theme.colors["palette-gray-300"].computedValue}
           innerCircleFill={theme.colors["palette-gray-300"].computedValue}
-        />)
+        />
       );
     case !isSelected && !isDisabled:
       return (
-        (<RadioIcon
+        <RadioIcon
           outerCircleFill={theme.colors["palette-gray-600"].computedValue}
           middleCircleFill={theme.colors["bg-layer-default"].computedValue}
           innerCircleFill={theme.colors["bg-layer-default"].computedValue}
-        />)
+        />
       );
     default:
       return null

--- a/packages/codemod/src/transforms/replace-stitches-theme-color/__testfixtures__/ternary.output.tsx
+++ b/packages/codemod/src/transforms/replace-stitches-theme-color/__testfixtures__/ternary.output.tsx
@@ -7,7 +7,7 @@ const Component = () => {
   const isDisabled = false;
   
   return (
-    (<div>
+    <div>
       <Button 
         backgroundColor={isActive ? theme.colors["bg-brand-solid"].computedValue : theme.colors["palette-gray-300"].computedValue}
         color={isActive ? theme.colors["palette-static-white"].computedValue : theme.colors["palette-gray-1000"].computedValue}
@@ -30,7 +30,7 @@ const Component = () => {
         상태 표시
       </Badge>
       <StatusIcon fill={isActive ? isDisabled ? theme.colors["palette-gray-500"].computedValue : theme.colors["bg-informative-solid"].computedValue : theme.colors["bg-critical-solid"].computedValue} />
-    </div>)
+    </div>
   );
 };
 

--- a/packages/codemod/src/transforms/replace-tailwind-color/__testfixtures__/basic.output.tsx
+++ b/packages/codemod/src/transforms/replace-tailwind-color/__testfixtures__/basic.output.tsx
@@ -2,7 +2,7 @@
 
 export function BackgroundExample() {
   return (
-    (<div>
+    <div>
       <div className="bg-bg-brand-solid">Primary Background</div>
       <div className="bg-palette-carrot-100">Primary Low Background</div>
       <div className="hover:bg-palette-carrot-100">Hover Primary Low Background</div>
@@ -22,6 +22,6 @@ export function BackgroundExample() {
       <div className="bg-palette-static-black">Static Black Background</div>
       <div className="bg-palette-static-white">Static White Background</div>
       <div className="bg-palette-static-black">Static Gray900 Background</div>
-    </div>)
+    </div>
   );
 }

--- a/packages/codemod/src/transforms/replace-tailwind-color/__testfixtures__/modifier.output.tsx
+++ b/packages/codemod/src/transforms/replace-tailwind-color/__testfixtures__/modifier.output.tsx
@@ -2,7 +2,7 @@
 
 export function ModifierExample() {
     return (
-      (<div>
+      <div>
         <div className="!bg-bg-brand-solid">Primary Background</div>
         <div className="!bg-palette-carrot-100">Primary Low Background</div>
         <div className="hover:!bg-palette-carrot-100">Hover Primary Low Background</div>
@@ -22,7 +22,7 @@ export function ModifierExample() {
         <div className="first:bg-palette-static-black">Static Black Background</div>
         <div className="last:bg-palette-static-white">Static White Background</div>
         <div className="odd:bg-palette-static-black">Static Gray900 Background</div>
-      </div>)
+      </div>
     );
   }
   

--- a/packages/codemod/src/transforms/replace-tailwind-color/__testfixtures__/text.output.tsx
+++ b/packages/codemod/src/transforms/replace-tailwind-color/__testfixtures__/text.output.tsx
@@ -2,7 +2,7 @@
 
 export function TextExample() {
   return (
-    (<div>
+    <div>
       <p className="text-fg-brand">Primary Text</p>
       <p className="text-palette-gray-900">Secondary Text</p>
       <p className="text-fg-positive">Success Text</p>
@@ -26,6 +26,6 @@ export function TextExample() {
       <div className="text-palette-gray-200 hover:text-palette-gray-900">
         Complex State Text
       </div>
-    </div>)
+    </div>
   );
 }

--- a/packages/codemod/src/transforms/replace-tailwind-color/__testfixtures__/unsafe-class-name.output.tsx
+++ b/packages/codemod/src/transforms/replace-tailwind-color/__testfixtures__/unsafe-class-name.output.tsx
@@ -2,7 +2,7 @@
 
 export function BackgroundExample() {
     return (
-      (<div>
+      <div>
         <div UNSAFE_className="bg-bg-brand-solid">Primary Background</div>
         <div UNSAFE_className="bg-palette-carrot-100">Primary Low Background</div>
         <div UNSAFE_className="hover:bg-palette-carrot-100">Hover Primary Low Background</div>
@@ -23,7 +23,7 @@ export function BackgroundExample() {
         <div UNSAFE_className="bg-palette-static-white">Static White Background</div>
         <div UNSAFE_className="bg-palette-static-black">Static Gray900 Background</div>
         <div UNSAFE_className="[&_[data-part='field']]:!bg-bg-layer-default" />
-      </div>)
+      </div>
     );
   }
   

--- a/packages/codemod/src/transforms/replace-tailwind-typography/__testfixtures__/basic.output.tsx
+++ b/packages/codemod/src/transforms/replace-tailwind-typography/__testfixtures__/basic.output.tsx
@@ -2,7 +2,7 @@
 
 export function BasicExample() {
   return (
-    (<div>
+    <div>
       <div className="t3-bold whitespace-pre-wrap text-center text-[--tick-color]">Primary Background</div>
       <p className="t4-regular text-palette-gray-800">{formState.content}</p>
       <div className="t6-bold">Hover Primary Low Background</div>
@@ -11,6 +11,6 @@ export function BasicExample() {
       <h3 className={cn("t5-bold", className)} {...props} />
       <h3 className={isDisabled ? "t5-regular" : "t5-bold"} {...props} />
       <p className="t2-regular text-palette-gray-800">{description}</p>
-    </div>)
+    </div>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **문서화**
  - JSX 반환문에서 불필요한 괄호를 제거하여 코드 가독성을 개선했습니다.
  - 아이콘 컴포넌트 import 경로를 새로운 패키지 네임스페이스로 통일했습니다.
  - Text 컴포넌트의 color prop을 palette 기반 네이밍으로 일관성 있게 수정했습니다.
  - 스타일 관련 import에 backgroundColor를 추가하고, 관련 스타일 선언에 backgroundColor 속성을 포함시켰습니다.

- **테스트**
  - 테스트 설정을 확장하여 .ts 및 .tsx 파일을 모두 지원하도록 변경했습니다.
  - 테스트 코드를 공통 유틸리티를 활용하는 형태로 리팩터링하여 유지보수성을 향상시켰습니다.

- **스타일**
  - JSX 반환문의 들여쓰기 및 줄바꿈을 개선하여 코드 스타일을 통일했습니다.

- **Chore**
  - 패키지 업데이트 사항을 한국어로 기록한 changeset 파일을 추가했습니다.

- **신규 기능**
  - 색상 토큰 변환 기능에 backgroundColor 접두어 및 네임스페이스를 지원하여 색상 처리의 정확성과 세분화를 강화했습니다.
  - 스타일 선언에 새로운 primary 스타일을 추가하여 색상 활용 범위를 확장했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->