### PR TITLE
feat(figma): enhance JSX generation with metadata and import management

### DIFF
--- a/.changeset/six-times-notice.md
+++ b/.changeset/six-times-notice.md
@@ -1,0 +1,6 @@
+---
+"@seed-design/figma": patch
+"@seed-design/mcp": patch
+---
+
+codegen 결과물이 import 문을 함께 반환하는 기능을 추가합니다.

--- a/packages/figma/src/codegen/core/codegen.ts
+++ b/packages/figma/src/codegen/core/codegen.ts
@@ -67,9 +67,12 @@ export function createCodeGenerator({
 
   function generateCode(node: NormalizedSceneNode, options: { shouldPrintSource: boolean }) {
     const jsxTree = generateJsxTree(node);
-    return jsxTree
-      ? stringifyElement(jsxTree, { printSource: options.shouldPrintSource })
-      : undefined;
+
+    if (!jsxTree) {
+      return undefined;
+    }
+
+    return stringifyElement(jsxTree, { printSource: options.shouldPrintSource });
   }
 
   return { generateJsxTree, generateCode };

--- a/packages/figma/src/codegen/core/jsx.ts
+++ b/packages/figma/src/codegen/core/jsx.ts
@@ -5,22 +5,26 @@ export interface ElementNode {
   tag: string;
   props: Record<string, string | number | boolean | ElementNode | object | undefined>;
   children: (ElementNode | string)[];
-  comment?: string;
-  source?: string;
+
+  meta: {
+    comment?: string;
+    source?: string;
+    importPath?: string;
+  };
 }
 
 export function createElement(
   tag: string,
   props: Record<string, string | number | boolean | object | undefined> = {},
   children?: ElementNode | string | undefined | (ElementNode | string | undefined)[],
-  comment?: string,
+  meta?: ElementNode["meta"],
 ): ElementNode {
   return {
     __IS_JSX_ELEMENT_NODE: true,
     tag,
     props,
     children: ensureArray(children).filter(exists),
-    comment,
+    meta: meta ?? {},
   };
 }
 
@@ -53,14 +57,31 @@ export function isElement(node: unknown): node is ElementNode {
 }
 
 export function stringifyElement(element: ElementNode, options: { printSource?: boolean } = {}) {
+  const importMap = new Map<string, Set<string>>();
+
   function recursive(node: ElementNode | string, depth: number): string {
     if (typeof node === "string") {
       return node;
     }
 
-    const { tag, props, children, comment } = node;
+    const {
+      tag,
+      props,
+      children,
+      meta: { comment, source, importPath },
+    } = node;
+
+    if (importPath) {
+      const existing = importMap.get(importPath);
+      if (existing) {
+        existing.add(tag);
+      } else {
+        importMap.set(importPath, new Set([tag]));
+      }
+    }
+
     const propEntries = Object.entries(
-      options.printSource ? { ...props, "data-figma-node-id": node.source } : props,
+      options.printSource ? { ...props, "data-figma-node-id": source } : props,
     );
     const propFragments = propEntries
       .map(([key, value]) => {
@@ -122,5 +143,15 @@ export function stringifyElement(element: ElementNode, options: { printSource?: 
     return result;
   }
 
-  return recursive(element, 0);
+  const jsx = recursive(element, 0);
+
+  const imports = Array.from(importMap.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([importPath, tags]) => `import { ${Array.from(tags).join(", ")} } from "${importPath}";`)
+    .join("\n");
+
+  return {
+    imports,
+    jsx,
+  };
 }

--- a/packages/figma/src/codegen/targets/figma/shape.ts
+++ b/packages/figma/src/codegen/targets/figma/shape.ts
@@ -35,7 +35,9 @@ export function createVectorTransformer({
         ...propsConverters.shapeFill(node),
       },
       [],
-      "Vector Node Placeholder",
+      {
+        comment: "Vector Node Placeholder",
+      },
     );
   });
 }

--- a/packages/figma/src/codegen/targets/figma/text.ts
+++ b/packages/figma/src/codegen/targets/figma/text.ts
@@ -21,13 +21,10 @@ export function createTextTransformer({
       ...fillProps,
     });
 
-    return createElement(
-      "Text",
-      props,
-      node.characters,
-      hasMultipleFills
+    return createElement("Text", props, node.characters, {
+      comment: hasMultipleFills
         ? "Multiple fills in Text node encountered, only the first fill is used."
-        : "",
-    );
+        : undefined,
+    });
   });
 }

--- a/packages/figma/src/codegen/targets/react/component/handlers/action-button.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/action-button.ts
@@ -1,10 +1,13 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import { camelCase } from "change-case";
 import { match } from "ts-pattern";
 import type { ComponentHandlerDeps } from "../deps.interface";
 import type { ActionButtonProperties } from "@/codegen/component-properties";
 import { handleSizeProp } from "../size";
+import { createLocalSnippetHelper } from "../../element-factories";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("action-button");
 
 export const createActionButtonHandler = (ctx: ComponentHandlerDeps) =>
   defineComponentHandler<ActionButtonProperties>(
@@ -16,7 +19,7 @@ export const createActionButtonHandler = (ctx: ComponentHandlerDeps) =>
         .with("Icon Only", () => ({
           layout: "iconOnly",
           children: [
-            createElement("Icon", {
+            createLocalSnippetElement("Icon", {
               svg: ctx.iconHandler.transform(props["Icon#7574:0"]),
             }),
           ],
@@ -24,7 +27,7 @@ export const createActionButtonHandler = (ctx: ComponentHandlerDeps) =>
         .with("Icon First", () => ({
           layout: "withText",
           children: [
-            createElement("PrefixIcon", {
+            createLocalSnippetElement("PrefixIcon", {
               svg: ctx.iconHandler.transform(props["Prefix Icon#5987:305"]),
             }),
             props["Label#5987:61"].value,
@@ -34,7 +37,7 @@ export const createActionButtonHandler = (ctx: ComponentHandlerDeps) =>
           layout: "withText",
           children: [
             props["Label#5987:61"].value,
-            createElement("SuffixIcon", {
+            createLocalSnippetElement("SuffixIcon", {
               svg: ctx.iconHandler.transform(props["Suffix Icon#5987:244"]),
             }),
           ],
@@ -57,6 +60,6 @@ export const createActionButtonHandler = (ctx: ComponentHandlerDeps) =>
         layout,
       };
 
-      return createElement("ActionButton", commonProps, children);
+      return createLocalSnippetElement("ActionButton", commonProps, children);
     },
   );

--- a/packages/figma/src/codegen/targets/react/component/handlers/action-chip.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/action-chip.ts
@@ -1,8 +1,9 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
+import type { ActionChipProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import { match } from "ts-pattern";
+import { createSeedReactElement } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
-import type { ActionChipProperties } from "@/codegen/component-properties";
 import { handleSizeProp } from "../size";
 
 export const createActionChipHandler = (ctx: ComponentHandlerDeps) =>
@@ -15,7 +16,7 @@ export const createActionChipHandler = (ctx: ComponentHandlerDeps) =>
         .with("Icon Only", () => ({
           layout: "iconOnly",
           children: [
-            createElement("Icon", {
+            createSeedReactElement("Icon", {
               svg: ctx.iconHandler.transform(props["Icon#8714:0"]),
             }),
           ],
@@ -23,7 +24,7 @@ export const createActionChipHandler = (ctx: ComponentHandlerDeps) =>
         .with("Icon First", () => ({
           layout: "withText",
           children: [
-            createElement("PrefixIcon", {
+            createSeedReactElement("PrefixIcon", {
               svg: ctx.iconHandler.transform(props["Prefix Icon#8711:0"]),
             }),
             props["Label#7185:0"].value,
@@ -33,7 +34,7 @@ export const createActionChipHandler = (ctx: ComponentHandlerDeps) =>
           layout: "withText",
           children: [
             props["Label#7185:0"].value,
-            createElement("SuffixIcon", {
+            createSeedReactElement("SuffixIcon", {
               svg: ctx.iconHandler.transform(props["Suffix Icon#8711:3"]),
             }),
           ],
@@ -41,13 +42,27 @@ export const createActionChipHandler = (ctx: ComponentHandlerDeps) =>
         .with("Icon Both", () => ({
           layout: "withText",
           children: [
-            createElement("PrefixIcon", {
-              svg: ctx.iconHandler.transform(props["Prefix Icon#8711:0"]),
-            }),
+            createSeedReactElement(
+              "PrefixIcon",
+              {
+                svg: ctx.iconHandler.transform(props["Prefix Icon#8711:0"]),
+              },
+              undefined,
+              {
+                importPath: "@seed-design/react",
+              },
+            ),
             props["Label#7185:0"].value,
-            createElement("SuffixIcon", {
-              svg: ctx.iconHandler.transform(props["Suffix Icon#8711:3"]),
-            }),
+            createSeedReactElement(
+              "SuffixIcon",
+              {
+                svg: ctx.iconHandler.transform(props["Suffix Icon#8711:3"]),
+              },
+              undefined,
+              {
+                importPath: "@seed-design/react",
+              },
+            ),
           ],
         }))
         .with("Text Only", () => ({
@@ -66,6 +81,6 @@ export const createActionChipHandler = (ctx: ComponentHandlerDeps) =>
           count: Number(props["Count#7185:21"].value),
         }),
       };
-      return createElement("ActionChip", commonProps, children);
+      return createSeedReactElement("ActionChip", commonProps, children);
     },
   );

--- a/packages/figma/src/codegen/targets/react/component/handlers/action-chip.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/action-chip.ts
@@ -42,27 +42,13 @@ export const createActionChipHandler = (ctx: ComponentHandlerDeps) =>
         .with("Icon Both", () => ({
           layout: "withText",
           children: [
-            createSeedReactElement(
-              "PrefixIcon",
-              {
-                svg: ctx.iconHandler.transform(props["Prefix Icon#8711:0"]),
-              },
-              undefined,
-              {
-                importPath: "@seed-design/react",
-              },
-            ),
+            createSeedReactElement("PrefixIcon", {
+              svg: ctx.iconHandler.transform(props["Prefix Icon#8711:0"]),
+            }),
             props["Label#7185:0"].value,
-            createSeedReactElement(
-              "SuffixIcon",
-              {
-                svg: ctx.iconHandler.transform(props["Suffix Icon#8711:3"]),
-              },
-              undefined,
-              {
-                importPath: "@seed-design/react",
-              },
-            ),
+            createSeedReactElement("SuffixIcon", {
+              svg: ctx.iconHandler.transform(props["Suffix Icon#8711:3"]),
+            }),
           ],
         }))
         .with("Text Only", () => ({

--- a/packages/figma/src/codegen/targets/react/component/handlers/action-sheet.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/action-sheet.ts
@@ -1,13 +1,16 @@
+import type {
+  ActionSheetItemProperties,
+  ActionSheetProperties,
+} from "@/codegen/component-properties";
 import { createElement, defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import { findAllInstances } from "@/utils/figma-node";
 import { camelCase } from "change-case";
 import { match } from "ts-pattern";
+import { createLocalSnippetHelper } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
-import type {
-  ActionSheetItemProperties,
-  ActionSheetProperties,
-} from "@/codegen/component-properties";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("action-sheet");
 
 const ACTION_SHEET_ITEM_KEY = "c3cafd3a3fdcd45fecb6971019d88eaf39a2e381";
 const createActionSheetItemHandler = (_ctx: ComponentHandlerDeps) =>
@@ -24,7 +27,7 @@ const createActionSheetItemHandler = (_ctx: ComponentHandlerDeps) =>
         }),
       };
 
-      return createElement("ActionSheetItem", commonProps);
+      return createLocalSnippetElement("ActionSheetItem", commonProps);
     },
   );
 
@@ -60,21 +63,20 @@ export const createActionSheetHandler = (ctx: ComponentHandlerDeps) => {
 
     const contentChildren = items.map(actionSheetItemHandler.transform);
 
-    const content = createElement(
-      "ActionSheetContent",
-      contentProps,
-      contentChildren,
-      contentProps.title
-        ? ""
+    const content = createLocalSnippetElement("ActionSheetContent", contentProps, contentChildren, {
+      comment: contentProps.title
+        ? undefined
         : "title을 제공하지 않는 경우 aria-label이나 aria-labelledby 중 하나를 제공해야 합니다.",
-    );
+    });
 
-    const trigger = createElement(
+    const trigger = createLocalSnippetElement(
       "ActionSheetTrigger",
       { asChild: true },
-      createElement("ActionButton", undefined, "열기", "ActionSheet을 여는 요소를 제공해주세요."),
+      createElement("button", undefined, "열기", {
+        comment: "ActionSheet을 여는 요소를 제공해주세요.",
+      }),
     );
 
-    return createElement("ActionSheet", undefined, [trigger, content]);
+    return createLocalSnippetElement("ActionSheet", undefined, [trigger, content]);
   });
 };

--- a/packages/figma/src/codegen/targets/react/component/handlers/app-bar.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/app-bar.ts
@@ -1,15 +1,18 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
-import * as metadata from "@/entities/data/__generated__/component-sets";
-import type { NormalizedInstanceNode, NormalizedTextNode } from "@/normalizer";
-import { findAll, findAllInstances, findOne } from "@/utils/figma-node";
-import { match } from "ts-pattern";
-import type { ComponentHandlerDeps } from "../deps.interface";
 import type {
   AppBarLeftProperties,
   AppBarMainProperties,
   AppBarProperties,
   AppBarRightProperties,
 } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
+import * as metadata from "@/entities/data/__generated__/component-sets";
+import type { NormalizedInstanceNode, NormalizedTextNode } from "@/normalizer";
+import { findAll, findAllInstances, findOne } from "@/utils/figma-node";
+import { match } from "ts-pattern";
+import { createLocalSnippetHelper } from "../../element-factories";
+import type { ComponentHandlerDeps } from "../deps.interface";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("app-bar");
 
 const APP_BAR_MAIN_KEY = "336b49b26c3933485d87cc460b06c390976ea58e";
 const createAppBarMainHandler = (_ctx: ComponentHandlerDeps) =>
@@ -39,12 +42,9 @@ const createAppBarMainHandler = (_ctx: ComponentHandlerDeps) =>
         layout,
       };
 
-      return createElement(
-        "AppBarMain",
-        commonProps,
-        undefined,
-        title === undefined ? "Title을 제공해주세요." : undefined,
-      );
+      return createLocalSnippetElement("AppBarMain", commonProps, undefined, {
+        comment: title === undefined ? "Title을 제공해주세요." : undefined,
+      });
     },
   );
 
@@ -56,9 +56,9 @@ const createAppBarLeftHandler = (ctx: ComponentHandlerDeps) =>
     const children = (() => {
       switch (props.Action.value) {
         case "Back":
-          return createElement("AppBarBackButton", undefined);
+          return createLocalSnippetElement("AppBarBackButton");
         case "Close":
-          return createElement("AppBarCloseButton", undefined);
+          return createLocalSnippetElement("AppBarCloseButton");
         case "Other": {
           const iconNode = findOne(
             node,
@@ -69,17 +69,19 @@ const createAppBarLeftHandler = (ctx: ComponentHandlerDeps) =>
             return undefined;
           }
 
-          return createElement(
+          return createLocalSnippetElement(
             "AppBarIconButton",
             undefined,
             ctx.iconHandler.transform(iconNode),
-            "aria-label 또는 aria-labelledby를 제공해주세요.",
+            {
+              comment: "aria-label 또는 aria-labelledby를 제공해주세요.",
+            },
           );
         }
       }
     })();
 
-    return createElement("AppBarLeft", undefined, children);
+    return createLocalSnippetElement("AppBarLeft", undefined, children);
   });
 
 const APP_BAR_RIGHT_KEY = "9e157fc2d1f89ffee938a5bc62f4a58064fec44e";
@@ -104,18 +106,20 @@ const createAppBarRightHandler = (ctx: ComponentHandlerDeps) =>
           ) as NormalizedInstanceNode[];
 
           return iconNodes.map((iconNode) =>
-            createElement(
+            createLocalSnippetElement(
               "AppBarIconButton",
               undefined,
               ctx.iconHandler.transform(iconNode),
-              "aria-label 또는 aria-labelledby를 제공해주세요.",
+              {
+                comment: "aria-label 또는 aria-labelledby를 제공해주세요.",
+              },
             ),
           );
         }
       }
     })();
 
-    return createElement("AppBarRight", undefined, children);
+    return createLocalSnippetElement("AppBarRight", undefined, children);
   });
 
 export const createAppBarHandler = (ctx: ComponentHandlerDeps) => {
@@ -165,13 +169,16 @@ export const createAppBarHandler = (ctx: ComponentHandlerDeps) => {
     const onlyRightNode = rightNode.length === 1 ? rightNode[0] : undefined;
     const right = onlyRightNode ? appBarRightHandler.transform(onlyRightNode) : undefined;
 
-    return createElement(
+    return createLocalSnippetElement(
       "AppBar",
       { theme, tone },
       [left, main, right].filter(Boolean),
-      tone === "transparent"
-        ? `<AppScreen layerOffsetTop="none">으로 상단 패딩을 제거할 수 있습니다.`
-        : undefined,
+      {
+        comment:
+          tone === "transparent"
+            ? '<AppScreen layerOffsetTop="none">으로 상단 패딩을 제거할 수 있습니다.'
+            : undefined,
+      },
     );
   });
 };

--- a/packages/figma/src/codegen/targets/react/component/handlers/avatar-stack.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/avatar-stack.ts
@@ -1,9 +1,12 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
+import type { AvatarProperties, AvatarStackProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import { findAllInstances } from "@/utils/figma-node";
+import { createLocalSnippetHelper } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
-import type { AvatarProperties, AvatarStackProperties } from "@/codegen/component-properties";
 import { createAvatarHandler } from "./avatar";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("avatar");
 
 export const createAvatarStackHandler = (ctx: ComponentHandlerDeps) => {
   const avatarHandler = createAvatarHandler(ctx);
@@ -18,12 +21,10 @@ export const createAvatarStackHandler = (ctx: ComponentHandlerDeps) => {
 
     const commonProps = {
       size: props.Size.value,
-      // TODO: 구현될 예정
-      // topItem: camelCase(props["Top Item"].value),
     };
 
     const avatarStackChildren = avatarNodes.map(avatarHandler.transform);
 
-    return createElement("AvatarStack", commonProps, avatarStackChildren);
+    return createLocalSnippetElement("AvatarStack", commonProps, avatarStackChildren);
   });
 };

--- a/packages/figma/src/codegen/targets/react/component/handlers/avatar.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/avatar.ts
@@ -1,12 +1,15 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
-import * as metadata from "@/entities/data/__generated__/component-sets";
-import { findAllInstances } from "@/utils/figma-node";
-import type { ComponentHandlerDeps } from "../deps.interface";
 import type {
   AvatarProperties,
   IdentityPlaceholderProperties,
 } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
+import * as metadata from "@/entities/data/__generated__/component-sets";
+import { findAllInstances } from "@/utils/figma-node";
+import { createLocalSnippetHelper } from "../../element-factories";
+import type { ComponentHandlerDeps } from "../deps.interface";
 import { createIdentityPlaceholderHandler } from "./identity-placeholder";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("avatar");
 
 export const createAvatarHandler = (ctx: ComponentHandlerDeps) => {
   const identityPlaceholderHandler = createIdentityPlaceholderHandler(ctx);
@@ -31,11 +34,13 @@ export const createAvatarHandler = (ctx: ComponentHandlerDeps) => {
       size: props.Size.value,
     };
 
-    return createElement(
+    return createLocalSnippetElement(
       "Avatar",
       commonProps,
-      props["Show Badge#1398:26"].value ? createElement("AvatarBadge", {}) : undefined,
-      avatarHasSrc ? "alt 텍스트를 제공해야 합니다." : undefined,
+      props["Show Badge#1398:26"].value ? createLocalSnippetElement("AvatarBadge", {}) : undefined,
+      {
+        comment: avatarHasSrc ? "alt 텍스트를 제공해야 합니다." : undefined,
+      },
     );
   });
 };

--- a/packages/figma/src/codegen/targets/react/component/handlers/badge.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/badge.ts
@@ -1,8 +1,9 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
+import type { BadgeProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import { camelCase } from "change-case";
+import { createSeedReactElement } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
-import type { BadgeProperties } from "@/codegen/component-properties";
 import { handleSizeProp } from "../size";
 
 export const createBadgeHandler = (_ctx: ComponentHandlerDeps) =>
@@ -14,5 +15,5 @@ export const createBadgeHandler = (_ctx: ComponentHandlerDeps) =>
       shape: camelCase(props.Shape.value),
     };
 
-    return createElement("Badge", commonProps, props["Label#1584:0"].value);
+    return createSeedReactElement("Badge", commonProps, props["Label#1584:0"].value);
   });

--- a/packages/figma/src/codegen/targets/react/component/handlers/callout.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/callout.ts
@@ -1,9 +1,12 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
+import type { CalloutProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import type { NormalizedTextNode } from "@/normalizer";
 import { camelCase } from "change-case";
+import { createLocalSnippetHelper } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
-import type { CalloutProperties } from "@/codegen/component-properties";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("callout");
 
 export const createCalloutHandler = (ctx: ComponentHandlerDeps) =>
   defineComponentHandler<CalloutProperties>(
@@ -25,7 +28,9 @@ export const createCalloutHandler = (ctx: ComponentHandlerDeps) =>
       const textNode = children.find((child) => child.type === "TEXT") as NormalizedTextNode | null;
 
       if (!textNode) {
-        return createElement(tag, undefined, undefined, "내용을 제공해주세요.");
+        return createLocalSnippetElement(tag, undefined, undefined, {
+          comment: "내용을 제공해주세요.",
+        });
       }
 
       const slices = textNode.segments;
@@ -82,6 +87,6 @@ export const createCalloutHandler = (ctx: ComponentHandlerDeps) =>
         }),
       };
 
-      return createElement(tag, commonProps);
+      return createLocalSnippetElement(tag, commonProps);
     },
   );

--- a/packages/figma/src/codegen/targets/react/component/handlers/checkbox.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/checkbox.ts
@@ -1,9 +1,12 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
+import type { CheckboxProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import { camelCase } from "change-case";
+import { createLocalSnippetHelper } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
-import type { CheckboxProperties } from "@/codegen/component-properties";
 import { handleSizeProp } from "../size";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("checkbox");
 
 export const createCheckboxHandler = (_ctx: ComponentHandlerDeps) =>
   defineComponentHandler<CheckboxProperties>(
@@ -28,6 +31,6 @@ export const createCheckboxHandler = (_ctx: ComponentHandlerDeps) =>
         }),
       };
 
-      return createElement("Checkbox", commonProps);
+      return createLocalSnippetElement("Checkbox", commonProps);
     },
   );

--- a/packages/figma/src/codegen/targets/react/component/handlers/chip-tabs.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/chip-tabs.ts
@@ -1,9 +1,12 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
+import type { ChipTabsItemProperties, ChipTabsProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import { findAllInstances } from "@/utils/figma-node";
 import { camelCase } from "change-case";
+import { createLocalSnippetHelper } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
-import type { ChipTabsItemProperties, ChipTabsProperties } from "@/codegen/component-properties";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("chip-tabs");
 
 const CHIP_TABS_ITEM_KEY = "fa80168b02051fbb0ba032238bd76d840dbe2e15";
 const createChipTabsItemHandler = (_ctx: ComponentHandlerDeps) =>
@@ -19,7 +22,7 @@ const createChipTabsItemHandler = (_ctx: ComponentHandlerDeps) =>
         }),
       };
 
-      return createElement("ChipTabsTrigger", commonProps, props["Label#8876:0"].value);
+      return createLocalSnippetElement("ChipTabsTrigger", commonProps, props["Label#8876:0"].value);
     },
   );
 
@@ -36,7 +39,7 @@ export const createChipTabsHandler = (ctx: ComponentHandlerDeps) => {
       chipTabsItem.componentProperties.State.value.split("-").includes("Selected"),
     );
 
-    const chipTabsList = createElement(
+    const chipTabsList = createLocalSnippetElement(
       "ChipTabsList",
       undefined,
       chipTabsItems.map(chipTabsItemHandler.transform),
@@ -49,6 +52,6 @@ export const createChipTabsHandler = (ctx: ComponentHandlerDeps) => {
       }),
     };
 
-    return createElement("ChipTabs", commonProps, chipTabsList);
+    return createLocalSnippetElement("ChipTabs", commonProps, chipTabsList);
   });
 };

--- a/packages/figma/src/codegen/targets/react/component/handlers/control-chip.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/control-chip.ts
@@ -1,9 +1,12 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
+import type { ControlChipProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import { match } from "ts-pattern";
+import { createLocalSnippetHelper, createSeedReactElement } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
-import type { ControlChipProperties } from "@/codegen/component-properties";
 import { handleSizeProp } from "../size";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("control-chip");
 
 export const createControlChipHandler = (ctx: ComponentHandlerDeps) =>
   defineComponentHandler<ControlChipProperties>(
@@ -11,11 +14,13 @@ export const createControlChipHandler = (ctx: ComponentHandlerDeps) =>
     ({ componentProperties: props }) => {
       const states = props.State.value.split("-");
 
+      const count = props["Show Count#7185:42"].value ? props["Count#7185:21"].value : undefined;
+
       const { layout, children } = match(props.Layout.value)
         .with("Icon Only", () => ({
           layout: "iconOnly",
           children: [
-            createElement("Icon", {
+            createSeedReactElement("Icon", {
               svg: ctx.iconHandler.transform(props["Icon#8722:41"]),
             }),
           ],
@@ -23,17 +28,18 @@ export const createControlChipHandler = (ctx: ComponentHandlerDeps) =>
         .with("Icon First", () => ({
           layout: "withText",
           children: [
-            createElement("PrefixIcon", {
+            createSeedReactElement("PrefixIcon", {
               svg: ctx.iconHandler.transform(props["Prefix Icon#8722:0"]),
             }),
             props["Label#7185:0"].value,
+            count ? createSeedReactElement("Count", undefined, [count]) : undefined,
           ],
         }))
         .with("Icon Last", () => ({
           layout: "withText",
           children: [
             props["Label#7185:0"].value,
-            createElement("SuffixIcon", {
+            createSeedReactElement("SuffixIcon", {
               svg: ctx.iconHandler.transform(props["Suffix Icon#8722:82"]),
             }),
           ],
@@ -41,11 +47,11 @@ export const createControlChipHandler = (ctx: ComponentHandlerDeps) =>
         .with("Icon Both", () => ({
           layout: "withText",
           children: [
-            createElement("PrefixIcon", {
+            createSeedReactElement("PrefixIcon", {
               svg: ctx.iconHandler.transform(props["Prefix Icon#8722:0"]),
             }),
             props["Label#7185:0"].value,
-            createElement("SuffixIcon", {
+            createSeedReactElement("SuffixIcon", {
               svg: ctx.iconHandler.transform(props["Suffix Icon#8722:82"]),
             }),
           ],
@@ -70,6 +76,6 @@ export const createControlChipHandler = (ctx: ComponentHandlerDeps) =>
         }),
       };
 
-      return createElement("ControlChip.Toggle", commonProps, children);
+      return createLocalSnippetElement("ControlChip.Toggle", commonProps, children);
     },
   );

--- a/packages/figma/src/codegen/targets/react/component/handlers/error-state.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/error-state.ts
@@ -1,10 +1,13 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
+import type { ActionButtonProperties, ErrorStateProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import { findAllInstances } from "@/utils/figma-node";
 import { camelCase } from "change-case";
+import { createLocalSnippetHelper } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
-import type { ActionButtonProperties, ErrorStateProperties } from "@/codegen/component-properties";
 import { createActionButtonHandler } from "./action-button";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("error-state");
 
 export const createErrorStateHandler = (ctx: ComponentHandlerDeps) => {
   const actionButtonHandler = createActionButtonHandler(ctx);
@@ -33,6 +36,6 @@ export const createErrorStateHandler = (ctx: ComponentHandlerDeps) => {
       }),
     };
 
-    return createElement("ErrorState", commonProps);
+    return createLocalSnippetElement("ErrorState", commonProps);
   });
 };

--- a/packages/figma/src/codegen/targets/react/component/handlers/extended-action-sheet.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/extended-action-sheet.ts
@@ -1,13 +1,16 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
-import * as metadata from "@/entities/data/__generated__/component-sets";
-import { findAllInstances } from "@/utils/figma-node";
-import { camelCase } from "change-case";
-import type { ComponentHandlerDeps } from "../deps.interface";
 import type {
   ExtendedActionSheetGroupProperties,
   ExtendedActionSheetItemProperties,
   ExtendedActionSheetProperties,
 } from "@/codegen/component-properties";
+import { createElement, defineComponentHandler } from "@/codegen/core";
+import * as metadata from "@/entities/data/__generated__/component-sets";
+import { findAllInstances } from "@/utils/figma-node";
+import { camelCase } from "change-case";
+import { createLocalSnippetHelper, createSeedReactElement } from "../../element-factories";
+import type { ComponentHandlerDeps } from "../deps.interface";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("extended-action-sheet");
 
 const EXTENDED_ACTION_SHEET_ITEM_KEY = "057083e95466da59051119eec0b41d4ad5a07f8f";
 const createExtendedActionSheetItemHandler = (ctx: ComponentHandlerDeps) =>
@@ -23,9 +26,9 @@ const createExtendedActionSheetItemHandler = (ctx: ComponentHandlerDeps) =>
         }),
       };
 
-      return createElement("ExtendedActionSheetItem", commonProps, [
+      return createLocalSnippetElement("ExtendedActionSheetItem", commonProps, [
         props["Show Prefix Icon#17043:5"].value
-          ? createElement("PrefixIcon", {
+          ? createSeedReactElement("PrefixIcon", {
               svg: ctx.iconHandler.transform(props["Prefix Icon#55948:0"]),
             })
           : undefined,
@@ -48,7 +51,7 @@ const createExtendedActionSheetGroupHandler = (ctx: ComponentHandlerDeps) => {
 
       const contentChildren = items.map(extendedActionSheetItemHandler.transform);
 
-      return createElement("ExtendedActionSheetGroup", undefined, contentChildren);
+      return createLocalSnippetElement("ExtendedActionSheetGroup", undefined, contentChildren);
     },
   );
 };
@@ -70,27 +73,26 @@ export const createExtendedActionSheetHandler = (ctx: ComponentHandlerDeps) => {
 
       const title = props["Show Title#17043:12"].value ? props["Title#14599:0"].value : undefined;
 
-      const content = createElement(
+      const content = createLocalSnippetElement(
         "ExtendedActionSheetContent",
         { title },
         contentChildren,
-        title
-          ? undefined
-          : "title을 제공하지 않는 경우 aria-label이나 aria-labelledby 중 하나를 제공해야 합니다.",
+        {
+          comment: title
+            ? undefined
+            : "title을 제공하지 않는 경우 aria-label이나 aria-labelledby 중 하나를 제공해야 합니다.",
+        },
       );
 
-      const trigger = createElement(
+      const trigger = createLocalSnippetElement(
         "ExtendedActionSheetTrigger",
         { asChild: true },
-        createElement(
-          "ActionButton",
-          undefined,
-          "열기",
-          "ExtendedActionSheet을 여는 요소를 제공해주세요.",
-        ),
+        createElement("button", undefined, "열기", {
+          comment: "ExtendedActionSheet을 여는 요소를 제공해주세요.",
+        }),
       );
 
-      return createElement("ExtendedActionSheet", undefined, [trigger, content]);
+      return createLocalSnippetElement("ExtendedActionSheet", undefined, [trigger, content]);
     },
   );
 };

--- a/packages/figma/src/codegen/targets/react/component/handlers/extended-fab.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/extended-fab.ts
@@ -1,8 +1,9 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
+import type { ExtendedFabProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import { camelCase } from "change-case";
+import { createSeedReactElement } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
-import type { ExtendedFabProperties } from "@/codegen/component-properties";
 import { handleSizeProp } from "../size";
 
 export const createExtendedFabHandler = (ctx: ComponentHandlerDeps) =>
@@ -14,8 +15,8 @@ export const createExtendedFabHandler = (ctx: ComponentHandlerDeps) =>
         variant: camelCase(props.Variant.value),
       };
 
-      return createElement("ExtendedFab", commonProps, [
-        createElement("PrefixIcon", {
+      return createSeedReactElement("ExtendedFab", commonProps, [
+        createSeedReactElement("PrefixIcon", {
           svg: ctx.iconHandler.transform(props["Icon#28796:0"]),
         }),
         props["Label#28936:0"].value,

--- a/packages/figma/src/codegen/targets/react/component/handlers/fab.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/fab.ts
@@ -1,18 +1,22 @@
+import type { FabProperties } from "@/codegen/component-properties";
 import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
-import { createElement } from "@/codegen/core";
-import type { FabProperties } from "@/codegen/component-properties";
+import { createSeedReactElement } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
 
 export const createFabHandler = (ctx: ComponentHandlerDeps) =>
   defineComponentHandler<FabProperties>(
     metadata.floatingActionButton.key,
     ({ componentProperties: props }) => {
-      return createElement(
+      return createSeedReactElement(
         "Fab",
         undefined,
-        ctx.iconHandler.transform(props["Icon#28796:0"]),
-        "aria-label이나 aria-labelledby 중 하나를 제공해야 합니다.",
+        createSeedReactElement("Icon", {
+          svg: ctx.iconHandler.transform(props["Icon#28796:0"]),
+        }),
+        {
+          comment: "aria-label이나 aria-labelledby 중 하나를 제공해야 합니다.",
+        },
       );
     },
   );

--- a/packages/figma/src/codegen/targets/react/component/handlers/help-bubble.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/help-bubble.ts
@@ -1,8 +1,10 @@
-import { defineComponentHandler } from "@/codegen/core";
-import * as metadata from "@/entities/data/__generated__/component-sets";
-import { createElement } from "@/codegen/core";
 import type { HelpBubbleProperties } from "@/codegen/component-properties";
+import { createElement, defineComponentHandler } from "@/codegen/core";
+import * as metadata from "@/entities/data/__generated__/component-sets";
+import { createLocalSnippetHelper } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("help-bubble");
 
 export const createHelpBubbleHandler = (_ctx: ComponentHandlerDeps) =>
   defineComponentHandler<HelpBubbleProperties>(
@@ -59,10 +61,12 @@ export const createHelpBubbleHandler = (_ctx: ComponentHandlerDeps) =>
         placement,
       };
 
-      return createElement(
+      return createLocalSnippetElement(
         "HelpBubbleTrigger",
         commonProps,
-        createElement("ActionButton", undefined, "열기", "HelpBubble을 여는 요소를 제공해주세요."),
+        createElement("button", undefined, "열기", {
+          comment: "HelpBubble을 여는 요소를 제공해주세요.",
+        }),
       );
     },
   );

--- a/packages/figma/src/codegen/targets/react/component/handlers/identity-placeholder.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/identity-placeholder.ts
@@ -1,8 +1,8 @@
-import { defineComponentHandler } from "@/codegen/core";
-import { camelCase } from "change-case";
-import * as metadata from "@/entities/data/__generated__/component-sets";
-import { createElement } from "@/codegen/core";
 import type { IdentityPlaceholderProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
+import * as metadata from "@/entities/data/__generated__/component-sets";
+import { camelCase } from "change-case";
+import { createSeedReactElement } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
 
 export const createIdentityPlaceholderHandler = (_ctx: ComponentHandlerDeps) =>
@@ -13,6 +13,6 @@ export const createIdentityPlaceholderHandler = (_ctx: ComponentHandlerDeps) =>
         identity: camelCase(props.Identity.value),
       };
 
-      return createElement("IdentityPlaceholder", commonProps);
+      return createSeedReactElement("IdentityPlaceholder", commonProps);
     },
   );

--- a/packages/figma/src/codegen/targets/react/component/handlers/inline-banner.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/inline-banner.ts
@@ -1,10 +1,13 @@
 import type { InlineBannerProperties } from "@/codegen/component-properties";
-import { createElement, defineComponentHandler } from "@/codegen/core";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import type { NormalizedInstanceNode, NormalizedTextNode } from "@/normalizer";
 import { findOne } from "@/utils/figma-node";
 import { camelCase } from "change-case";
+import { createLocalSnippetHelper } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("inline-banner");
 
 export const createInlineBannerHandler = (ctx: ComponentHandlerDeps) =>
   defineComponentHandler<InlineBannerProperties>(metadata.inlineBanner.key, (node) => {
@@ -31,7 +34,9 @@ export const createInlineBannerHandler = (ctx: ComponentHandlerDeps) =>
     ) as NormalizedTextNode | null;
 
     if (!textNode) {
-      return createElement(tag, undefined, undefined, "내용을 제공해주세요.");
+      return createLocalSnippetElement(tag, undefined, undefined, {
+        comment: "내용을 제공해주세요.",
+      });
     }
 
     const slices = textNode.segments;
@@ -73,5 +78,5 @@ export const createInlineBannerHandler = (ctx: ComponentHandlerDeps) =>
       prefixIcon,
     };
 
-    return createElement(tag, commonProps);
+    return createLocalSnippetElement(tag, commonProps);
   });

--- a/packages/figma/src/codegen/targets/react/component/handlers/manner-temp-badge.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/manner-temp-badge.ts
@@ -1,7 +1,10 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
-import * as metadata from "@/entities/data/__generated__/component-sets";
-import type { ComponentHandlerDeps } from "../deps.interface";
 import type { MannerTempBadgeProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
+import * as metadata from "@/entities/data/__generated__/component-sets";
+import { createLocalSnippetHelper } from "../../element-factories";
+import type { ComponentHandlerDeps } from "../deps.interface";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("manner-temp-badge");
 
 export const createMannerTempBadgeHandler = (_ctx: ComponentHandlerDeps) =>
   defineComponentHandler<MannerTempBadgeProperties>(
@@ -13,6 +16,6 @@ export const createMannerTempBadgeHandler = (_ctx: ComponentHandlerDeps) =>
         temperature: Number(textNode?.characters.replace(/[^\d.-]/g, "") ?? "-1"),
       };
 
-      return createElement("MannerTempBadge", commonProps);
+      return createLocalSnippetElement("MannerTempBadge", commonProps);
     },
   );

--- a/packages/figma/src/codegen/targets/react/component/handlers/multiline-text-field.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/multiline-text-field.ts
@@ -1,8 +1,11 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
-import * as metadata from "@/entities/data/__generated__/component-sets";
-import type { ComponentHandlerDeps } from "../deps.interface";
 import type { MultilineTextFieldProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
+import * as metadata from "@/entities/data/__generated__/component-sets";
+import { createLocalSnippetHelper } from "../../element-factories";
+import type { ComponentHandlerDeps } from "../deps.interface";
 import { handleSizeProp } from "../size";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("multiline-text-field");
 
 export const createMultilineTextFieldHandler = (_ctx: ComponentHandlerDeps) =>
   defineComponentHandler<MultilineTextFieldProperties>(
@@ -74,8 +77,8 @@ export const createMultilineTextFieldHandler = (_ctx: ComponentHandlerDeps) =>
         placeholder,
       };
 
-      const TextFieldChildren = createElement("TextFieldTextarea", inputProps);
+      const TextFieldChildren = createLocalSnippetElement("TextFieldTextarea", inputProps);
 
-      return createElement("TextField", commonProps, TextFieldChildren);
+      return createLocalSnippetElement("TextField", commonProps, TextFieldChildren);
     },
   );

--- a/packages/figma/src/codegen/targets/react/component/handlers/progress-circle.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/progress-circle.ts
@@ -1,9 +1,12 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
+import type { ProgressCircleProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import { camelCase } from "change-case";
 import { match } from "ts-pattern";
+import { createLocalSnippetHelper } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
-import type { ProgressCircleProperties } from "@/codegen/component-properties";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("progress-circle");
 
 export const createProgressCircleHandler = (_ctx: ComponentHandlerDeps) =>
   defineComponentHandler<ProgressCircleProperties>(
@@ -45,6 +48,6 @@ export const createProgressCircleHandler = (_ctx: ComponentHandlerDeps) =>
         tone: camelCase(props.Tone.value),
       };
 
-      return createElement("ProgressCircle", commonProps);
+      return createLocalSnippetElement("ProgressCircle", commonProps);
     },
   );

--- a/packages/figma/src/codegen/targets/react/component/handlers/reaction-button.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/reaction-button.ts
@@ -1,8 +1,11 @@
 import type { ReactionButtonProperties } from "@/codegen/component-properties";
-import { createElement, defineComponentHandler } from "@/codegen/core";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
+import { createLocalSnippetHelper, createSeedReactElement } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
 import { handleSizeProp } from "../size";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("reaction-button");
 
 export const createReactionButtonHandler = (ctx: ComponentHandlerDeps) =>
   defineComponentHandler<ReactionButtonProperties>(
@@ -23,13 +26,13 @@ export const createReactionButtonHandler = (ctx: ComponentHandlerDeps) =>
         }),
       };
 
-      return createElement("ReactionButton", commonProps, [
-        createElement("PrefixIcon", {
+      return createLocalSnippetElement("ReactionButton", commonProps, [
+        createSeedReactElement("PrefixIcon", {
           svg: ctx.iconHandler.transform(props["Icon#12379:0"]),
         }),
         props["Label#6397:0"].value,
         props["Show Count#6397:33"].value
-          ? createElement("Count", {}, props["Count#15816:0"].value)
+          ? createSeedReactElement("Count", {}, props["Count#15816:0"].value)
           : undefined,
       ]);
     },

--- a/packages/figma/src/codegen/targets/react/component/handlers/segmented-control.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/segmented-control.ts
@@ -1,11 +1,14 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
-import * as metadata from "@/entities/data/__generated__/component-sets";
-import { findAllInstances } from "@/utils/figma-node";
-import type { ComponentHandlerDeps } from "../deps.interface";
 import type {
   SegmentedControlItemProperties,
   SegmentedControlProperties,
 } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
+import * as metadata from "@/entities/data/__generated__/component-sets";
+import { findAllInstances } from "@/utils/figma-node";
+import { createLocalSnippetHelper } from "../../element-factories";
+import type { ComponentHandlerDeps } from "../deps.interface";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("segmented-control");
 
 const SEGMENTED_CONTROL_ITEM_KEY = "9a7ba0d4c041ddbce84ee48881788434fd6bccc8";
 const createSegmentedControlItemHandler = (_ctx: ComponentHandlerDeps) =>
@@ -20,7 +23,11 @@ const createSegmentedControlItemHandler = (_ctx: ComponentHandlerDeps) =>
         }),
       };
 
-      return createElement("SegmentedControlItem", commonProps, props["Label#11366:15"].value);
+      return createLocalSnippetElement(
+        "SegmentedControlItem",
+        commonProps,
+        props["Label#11366:15"].value,
+      );
     },
   );
 
@@ -47,12 +54,9 @@ export const createSegmentedControlHandler = (ctx: ComponentHandlerDeps) => {
         }),
       };
 
-      return createElement(
-        "SegmentedControl",
-        commonProps,
-        segmentedControlChildren,
-        "aria-label이나 aria-labelledby 중 하나를 제공해야 합니다.",
-      );
+      return createLocalSnippetElement("SegmentedControl", commonProps, segmentedControlChildren, {
+        comment: "aria-label이나 aria-labelledby 중 하나를 제공해야 합니다.",
+      });
     },
   );
 };

--- a/packages/figma/src/codegen/targets/react/component/handlers/select-box.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/select-box.ts
@@ -1,21 +1,21 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
+import type { SelectBoxGroupProperties, SelectBoxProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import { findAllInstances } from "@/utils/figma-node";
+import { match } from "ts-pattern";
+import { createLocalSnippetHelper, createSeedReactElement } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
-import type { SelectBoxGroupProperties, SelectBoxProperties } from "@/codegen/component-properties";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("select-box");
 
 export const createSelectBoxHandler = (_ctx: ComponentHandlerDeps) =>
   defineComponentHandler<SelectBoxProperties>(
     metadata.selectBox.key,
     ({ componentProperties: props }) => {
-      const tag = (() => {
-        switch (props.Control.value) {
-          case "Checkbox":
-            return "CheckSelectBox";
-          case "Radio":
-            return "RadioSelectBox";
-        }
-      })();
+      const tag = match(props.Control.value)
+        .with("Checkbox", () => "CheckSelectBox")
+        .with("Radio", () => "RadioSelectBox")
+        .exhaustive();
 
       const states = props.State.value.split("-");
 
@@ -33,7 +33,7 @@ export const createSelectBoxHandler = (_ctx: ComponentHandlerDeps) =>
           }),
       };
 
-      return createElement(tag, commonProps);
+      return createLocalSnippetElement(tag, commonProps);
     },
   );
 
@@ -45,14 +45,10 @@ export const createSelectBoxGroupHandler = (ctx: ComponentHandlerDeps) => {
     (node) => {
       const props = node.componentProperties;
 
-      const tag = (() => {
-        switch (props.Control.value) {
-          case "Checkbox":
-            return "CheckSelectBoxGroup";
-          case "Radio":
-            return "RadioSelectBoxGroup";
-        }
-      })();
+      const tag = match(props.Control.value)
+        .with("Checkbox", () => "CheckSelectBoxGroup")
+        .with("Radio", () => "RadioSelectBoxGroup")
+        .exhaustive();
 
       const selectBoxes = findAllInstances<SelectBoxProperties>({
         node,
@@ -63,7 +59,7 @@ export const createSelectBoxGroupHandler = (ctx: ComponentHandlerDeps) => {
         selectBox.componentProperties.State.value.split("-").includes("Selected"),
       );
 
-      const stack = createElement(
+      const stack = createSeedReactElement(
         "Stack",
         { gap: "spacingY.componentDefault" },
         selectBoxes.map(selectBoxHandler.transform),
@@ -75,7 +71,7 @@ export const createSelectBoxGroupHandler = (ctx: ComponentHandlerDeps) => {
         }),
       };
 
-      return createElement(tag, commonProps, stack);
+      return createLocalSnippetElement(tag, commonProps, stack);
     },
   );
 };

--- a/packages/figma/src/codegen/targets/react/component/handlers/skeleton.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/skeleton.ts
@@ -1,9 +1,10 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
+import type { SkeletonProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import { camelCase } from "change-case";
-import type { ComponentHandlerDeps } from "../deps.interface";
-import type { SkeletonProperties } from "@/codegen/component-properties";
 import { match } from "ts-pattern";
+import { createSeedReactElement } from "../../element-factories";
+import type { ComponentHandlerDeps } from "../deps.interface";
 
 export const createSkeletonHandler = (ctx: ComponentHandlerDeps) =>
   defineComponentHandler<SkeletonProperties>(metadata.skeleton.key, (node) => {
@@ -21,5 +22,5 @@ export const createSkeletonHandler = (ctx: ComponentHandlerDeps) =>
         .otherwise(() => "full"),
     };
 
-    return createElement("Skeleton", commonProps);
+    return createSeedReactElement("Skeleton", commonProps);
   });

--- a/packages/figma/src/codegen/targets/react/component/handlers/snackbar.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/snackbar.ts
@@ -1,8 +1,11 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
+import type { SnackbarProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import { camelCase } from "change-case";
+import { createLocalSnippetHelper } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
-import type { SnackbarProperties } from "@/codegen/component-properties";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("snackbar");
 
 export const createSnackbarHandler = (_ctx: ComponentHandlerDeps) =>
   defineComponentHandler<SnackbarProperties>(
@@ -17,6 +20,6 @@ export const createSnackbarHandler = (_ctx: ComponentHandlerDeps) =>
       };
 
       // TODO: adapter.create({ render })
-      return createElement("Snackbar", commonProps);
+      return createLocalSnippetElement("Snackbar", commonProps);
     },
   );

--- a/packages/figma/src/codegen/targets/react/component/handlers/switch.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/switch.ts
@@ -1,8 +1,11 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
-import * as metadata from "@/entities/data/__generated__/component-sets";
-import type { ComponentHandlerDeps } from "../deps.interface";
 import type { SwitchProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
+import * as metadata from "@/entities/data/__generated__/component-sets";
+import { createLocalSnippetHelper } from "../../element-factories";
+import type { ComponentHandlerDeps } from "../deps.interface";
 import { handleSizeProp } from "../size";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("switch");
 
 export const createSwitchHandler = (_ctx: ComponentHandlerDeps) =>
   defineComponentHandler<SwitchProperties>(
@@ -25,6 +28,6 @@ export const createSwitchHandler = (_ctx: ComponentHandlerDeps) =>
         }),
       };
 
-      return createElement("Switch", commonProps);
+      return createLocalSnippetElement("Switch", commonProps);
     },
   );

--- a/packages/figma/src/codegen/targets/react/component/handlers/tabs.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/tabs.ts
@@ -1,14 +1,17 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
-import * as metadata from "@/entities/data/__generated__/component-sets";
-import type { NormalizedInstanceNode } from "@/normalizer";
-import { camelCase } from "change-case";
-import type { ComponentHandlerDeps } from "../deps.interface";
 import type {
   TabsFillItemProperties,
   TabsHugItemProperties,
   TabsProperties,
 } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
+import * as metadata from "@/entities/data/__generated__/component-sets";
+import type { NormalizedInstanceNode } from "@/normalizer";
+import { camelCase } from "change-case";
+import { createLocalSnippetHelper } from "../../element-factories";
+import type { ComponentHandlerDeps } from "../deps.interface";
 import { handleSizeProp } from "../size";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("tabs");
 
 const TABS_HUG_ITEM_KEY = "c242492543b327ceb84fa9933841512fc62a898c";
 const createTabsHugItemHandler = (_ctx: ComponentHandlerDeps) =>
@@ -27,7 +30,7 @@ const createTabsHugItemHandler = (_ctx: ComponentHandlerDeps) =>
         }),
       };
 
-      return createElement("TabsTrigger", commonProps, props["Label#4478:2"].value);
+      return createLocalSnippetElement("TabsTrigger", commonProps, props["Label#4478:2"].value);
     },
   );
 
@@ -48,7 +51,7 @@ const createTabsFillItemHandler = (_ctx: ComponentHandlerDeps) =>
         }),
       };
 
-      return createElement("TabsTrigger", commonProps, props["Label#4478:2"].value);
+      return createLocalSnippetElement("TabsTrigger", commonProps, props["Label#4478:2"].value);
     },
   );
 
@@ -96,7 +99,7 @@ export const createTabsHandler = (ctx: ComponentHandlerDeps) => {
       componentProperties.State.value.split("-").includes("Selected"),
     )?.node;
 
-    const tabTriggerList = createElement(
+    const tabTriggerList = createLocalSnippetElement(
       "TabsList",
       undefined,
       tabsItems.map(({ triggerLayout, node }) => {
@@ -112,7 +115,7 @@ export const createTabsHandler = (ctx: ComponentHandlerDeps) => {
     const tabContents = tabsItems.map(({ node }) => {
       const value = node.componentProperties["Label#4478:2"].value;
 
-      return createElement("TabsContent", { value }, "{/* TODO: 컨텐츠 추가 */}");
+      return createLocalSnippetElement("TabsContent", { value }, "{/* TODO: 컨텐츠 추가 */}");
     });
 
     const commonProps = {
@@ -123,6 +126,6 @@ export const createTabsHandler = (ctx: ComponentHandlerDeps) => {
       }),
     };
 
-    return createElement("TabsRoot", commonProps, [tabTriggerList, ...tabContents]);
+    return createLocalSnippetElement("TabsRoot", commonProps, [tabTriggerList, ...tabContents]);
   });
 };

--- a/packages/figma/src/codegen/targets/react/component/handlers/text-button.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/text-button.ts
@@ -1,10 +1,11 @@
 import type { TextButtonProperties } from "@/codegen/component-properties";
-import { createElement, defineComponentHandler } from "@/codegen/core";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import type { NormalizedInstanceNode } from "@/normalizer";
 import { findOne } from "@/utils/figma-node";
 import { camelCase } from "change-case";
 import { match } from "ts-pattern";
+import { createSeedReactElement } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
 import { handleSizeProp } from "../size";
 
@@ -44,5 +45,5 @@ export const createTextButtonHandler = (ctx: ComponentHandlerDeps) =>
       }),
     };
 
-    return createElement("TextButton", commonProps, children);
+    return createSeedReactElement("TextButton", commonProps, children);
   });

--- a/packages/figma/src/codegen/targets/react/component/handlers/text-field.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/text-field.ts
@@ -1,8 +1,11 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
-import * as metadata from "@/entities/data/__generated__/component-sets";
-import type { ComponentHandlerDeps } from "../deps.interface";
 import type { TextFieldProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
+import * as metadata from "@/entities/data/__generated__/component-sets";
+import { createLocalSnippetHelper } from "../../element-factories";
+import type { ComponentHandlerDeps } from "../deps.interface";
 import { handleSizeProp } from "../size";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("text-field");
 
 export const createTextFieldHandler = (ctx: ComponentHandlerDeps) =>
   defineComponentHandler<TextFieldProperties>(
@@ -101,8 +104,8 @@ export const createTextFieldHandler = (ctx: ComponentHandlerDeps) =>
         placeholder,
       };
 
-      const TextFieldChildren = createElement("TextFieldInput", inputProps);
+      const TextFieldChildren = createLocalSnippetElement("TextFieldInput", inputProps);
 
-      return createElement("TextField", commonProps, TextFieldChildren);
+      return createLocalSnippetElement("TextField", commonProps, TextFieldChildren);
     },
   );

--- a/packages/figma/src/codegen/targets/react/component/handlers/toggle-button.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/toggle-button.ts
@@ -1,9 +1,12 @@
-import { createElement, defineComponentHandler } from "@/codegen/core";
+import type { ToggleButtonProperties } from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import { camelCase } from "change-case";
+import { createLocalSnippetHelper, createSeedReactElement } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
-import type { ToggleButtonProperties } from "@/codegen/component-properties";
 import { handleSizeProp } from "../size";
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("toggle-button");
 
 export const createToggleButtonHandler = (ctx: ComponentHandlerDeps) =>
   defineComponentHandler<ToggleButtonProperties>(
@@ -25,15 +28,15 @@ export const createToggleButtonHandler = (ctx: ComponentHandlerDeps) =>
         }),
       };
 
-      return createElement("ToggleButton", commonProps, [
+      return createLocalSnippetElement("ToggleButton", commonProps, [
         props["Show Prefix Icon#6122:392"].value
-          ? createElement("PrefixIcon", {
+          ? createSeedReactElement("PrefixIcon", {
               svg: ctx.iconHandler.transform(props["Prefix Icon#6122:98"]),
             })
           : undefined,
         props["Label#6122:49"].value,
         props["Show Suffix Icon#6122:147"].value
-          ? createElement("SuffixIcon", {
+          ? createSeedReactElement("SuffixIcon", {
               svg: ctx.iconHandler.transform(props["Suffix Icon#6122:343"]),
             })
           : undefined,

--- a/packages/figma/src/codegen/targets/react/element-factories.ts
+++ b/packages/figma/src/codegen/targets/react/element-factories.ts
@@ -1,0 +1,59 @@
+import { createElement, type ElementNode } from "@/codegen/core";
+
+const SEED_REACT_IMPORT_PATH = "@seed-design/react";
+const LOCAL_SNIPPET_BASE_PATH = "@/seed-design/ui";
+const MONOCHROME_ICON_IMPORT_PATH = "@karrotmarket/react-monochrome-icon";
+const MULTICOLOR_ICON_IMPORT_PATH = "@karrotmarket/react-multicolor-icon";
+
+type CreateElementArgs = Parameters<typeof createElement>;
+
+export function createSeedReactElement(
+  tag: CreateElementArgs[0],
+  props?: CreateElementArgs[1],
+  children?: CreateElementArgs[2],
+  meta?: CreateElementArgs[3],
+): ElementNode {
+  return createElement(tag, props, children, {
+    importPath: SEED_REACT_IMPORT_PATH,
+    ...meta,
+  });
+}
+
+export function createMonochromeIconElement(
+  tag: CreateElementArgs[0],
+  props?: CreateElementArgs[1],
+  children?: CreateElementArgs[2],
+  meta?: CreateElementArgs[3],
+): ElementNode {
+  return createElement(tag, props, children, {
+    ...meta,
+    importPath: MONOCHROME_ICON_IMPORT_PATH,
+  });
+}
+
+export function createMulticolorIconElement(
+  tag: CreateElementArgs[0],
+  props?: CreateElementArgs[1],
+  children?: CreateElementArgs[2],
+  meta?: CreateElementArgs[3],
+): ElementNode {
+  return createElement(tag, props, children, { ...meta, importPath: MULTICOLOR_ICON_IMPORT_PATH });
+}
+
+export function createLocalSnippetHelper(moduleName: string) {
+  function createLocalSnippetElement(
+    tag: CreateElementArgs[0],
+    props?: CreateElementArgs[1],
+    children?: CreateElementArgs[2],
+    meta?: CreateElementArgs[3],
+  ): ElementNode {
+    return createElement(tag, props, children, {
+      importPath: `${LOCAL_SNIPPET_BASE_PATH}/${moduleName}`,
+      ...meta,
+    });
+  }
+
+  return {
+    createLocalSnippetElement,
+  };
+}

--- a/packages/figma/src/codegen/targets/react/frame.ts
+++ b/packages/figma/src/codegen/targets/react/frame.ts
@@ -3,12 +3,8 @@ import type {
   NormalizedFrameNode,
   NormalizedInstanceNode,
 } from "@/normalizer";
-import {
-  cloneElement,
-  createElement,
-  defineElementTransformer,
-  type ElementTransformer,
-} from "../../core";
+import { cloneElement, defineElementTransformer, type ElementTransformer } from "../../core";
+import { createSeedReactElement } from "./element-factories";
 import type { ContainerLayoutProps, PropsConverters } from "./props";
 
 export interface FrameTransformerDeps {
@@ -58,17 +54,17 @@ export function createFrameTransformer({
       if (layoutComponent === "VStack") {
         const { direction, ...rest } = props;
 
-        return createElement("VStack", rest, processedChildren);
+        return createSeedReactElement("VStack", rest, processedChildren);
       }
 
       if (layoutComponent === "HStack") {
         const { direction, ...rest } = props;
 
-        return createElement("HStack", rest, processedChildren);
+        return createSeedReactElement("HStack", rest, processedChildren);
       }
 
       if (layoutComponent === "Box") {
-        return createElement("Box", props, processedChildren);
+        return createSeedReactElement("Box", props, processedChildren);
       }
     },
   );

--- a/packages/figma/src/codegen/targets/react/icon.ts
+++ b/packages/figma/src/codegen/targets/react/icon.ts
@@ -1,6 +1,7 @@
 import type { IconService } from "@/entities";
 import { pascalCase } from "change-case";
 import { type ElementNode, createElement } from "../../core";
+import { createMonochromeIconElement, createMulticolorIconElement } from "./element-factories";
 
 export interface IconHandler {
   isIconInstance: (node: { componentKey: string }) => boolean;
@@ -36,11 +37,15 @@ export function createIconHandler({
       return createElement("UnknownIcon");
     }
 
-    const { name, weight } = iconData;
+    const { name, weight, type } = iconData;
 
     const tagName = iconNameFormatter({ name, weight });
 
-    return createElement(tagName);
+    if (type === "multicolor") {
+      return createMulticolorIconElement(tagName);
+    }
+
+    return createMonochromeIconElement(tagName);
   }
 
   return {

--- a/packages/figma/src/codegen/targets/react/instance.ts
+++ b/packages/figma/src/codegen/targets/react/instance.ts
@@ -1,10 +1,10 @@
 import type { NormalizedInstanceNode } from "@/normalizer";
 import {
-  createElement,
   defineElementTransformer,
   type ComponentHandler,
   type ElementTransformer,
 } from "../../core";
+import { createSeedReactElement } from "./element-factories";
 import type { IconHandler } from "./icon";
 import type { PropsConverters } from "./props";
 
@@ -29,7 +29,7 @@ export function createInstanceTransformer({
         ...propsConverters.iconSelfLayout(node),
         ...propsConverters.vectorChildrenFill(node),
       };
-      return createElement("Icon", { svg: iconHandler.transform(node), ...props });
+      return createSeedReactElement("Icon", { svg: iconHandler.transform(node), ...props });
     }
 
     const componentHandler = componentSetKey

--- a/packages/figma/src/codegen/targets/react/shape.ts
+++ b/packages/figma/src/codegen/targets/react/shape.ts
@@ -4,6 +4,7 @@ import type {
   NormalizedVectorNode,
 } from "@/normalizer";
 import { createElement, defineElementTransformer, type ElementTransformer } from "../../core";
+import { createSeedReactElement } from "./element-factories";
 import type { PropsConverters } from "./props";
 
 export interface RectangleTransformerDeps {
@@ -14,23 +15,29 @@ export function createRectangleTransformer({
   propsConverters,
 }: RectangleTransformerDeps): ElementTransformer<NormalizedRectangleNode> {
   return defineElementTransformer((node: NormalizedRectangleNode) => {
-    return createElement(
+    return createSeedReactElement(
       "Box",
       { ...propsConverters.selfLayout(node), background: "palette.gray200" },
       undefined,
-      "Rectangle Node Placeholder",
+      {
+        comment: "Rectangle Node Placeholder",
+      },
     );
   });
 }
 
 export function createVectorTransformer(): ElementTransformer<NormalizedVectorNode> {
   return defineElementTransformer(() => {
-    return createElement("svg", {}, [], "Vector Node Placeholder");
+    return createElement("svg", {}, [], {
+      comment: "Vector Node Placeholder",
+    });
   });
 }
 
 export function createBooleanOperationTransformer(): ElementTransformer<NormalizedBooleanOperationNode> {
   return defineElementTransformer(() => {
-    return createElement("svg", {}, [], "Boolean Operation Node Placeholder");
+    return createElement("svg", {}, [], {
+      comment: "Boolean Operation Node Placeholder",
+    });
   });
 }

--- a/packages/figma/src/codegen/targets/react/text.ts
+++ b/packages/figma/src/codegen/targets/react/text.ts
@@ -1,6 +1,7 @@
 import type { NormalizedTextNode } from "@/normalizer";
 import { compactObject } from "@/utils/common";
-import { createElement, defineElementTransformer, type ElementTransformer } from "../../core";
+import { defineElementTransformer, type ElementTransformer } from "../../core";
+import { createSeedReactElement } from "./element-factories";
 import type { PropsConverters } from "./props";
 
 export interface TextTransformerDeps {
@@ -21,13 +22,10 @@ export function createTextTransformer({
       ...fillProps,
     });
 
-    return createElement(
-      "Text",
-      props,
-      node.characters.replace(/\n/g, "<br />"),
-      hasMultipleFills
+    return createSeedReactElement("Text", props, node.characters.replace(/\n/g, "<br />"), {
+      comment: hasMultipleFills
         ? "Multiple fills in Text node encountered, only the first fill is used."
-        : "",
-    );
+        : undefined,
+    });
   });
 }

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -183,11 +183,11 @@ export function registerTools(
         const original =
           noInferPipeline.generateCode(node, {
             shouldPrintSource: true,
-          }) ?? "Failed to generate summarized node info";
+          })?.jsx ?? "Failed to generate summarized node info";
         const inferred =
           inferPipeline.generateCode(node, {
             shouldPrintSource: true,
-          }) ?? "Failed to generate summarized node info";
+          })?.jsx ?? "Failed to generate summarized node info";
 
         return formatObjectResponse({
           original: {
@@ -231,11 +231,11 @@ export function registerTools(
             const original =
               noInferPipeline.generateCode(node, {
                 shouldPrintSource: true,
-              }) ?? "Failed to generate summarized node info";
+              })?.jsx ?? "Failed to generate summarized node info";
             const inferred =
               inferPipeline.generateCode(node, {
                 shouldPrintSource: true,
-              }) ?? "Failed to generate summarized node info";
+              })?.jsx ?? "Failed to generate summarized node info";
 
             return {
               nodeId,
@@ -271,12 +271,15 @@ export function registerTools(
           shouldInferVariableName: true,
           extend,
         });
-        const code =
-          pipeline.generateCode(normalizer(result.document), {
-            shouldPrintSource: false,
-          }) ?? "Failed to generate code";
+        const generated = pipeline.generateCode(normalizer(result.document), {
+          shouldPrintSource: false,
+        });
 
-        return formatTextResponse(code);
+        if (!generated) {
+          return formatTextResponse("Failed to generate code");
+        }
+
+        return formatTextResponse(`${generated.imports}\n\n${generated.jsx}`);
       } catch (error) {
         return formatErrorResponse("get_node_react_code", error);
       }

--- a/tools/figma-codegen/src/main.ts
+++ b/tools/figma-codegen/src/main.ts
@@ -1,6 +1,9 @@
 import { react, createPluginNormalizer } from "@seed-design/figma";
 
-const pipeline = react.createPipeline();
+const pipeline = react.createPipeline({
+  shouldInferAutoLayout: true,
+  shouldInferVariableName: true,
+});
 
 export default function () {
   if (figma.editorType === "dev" && figma.mode === "codegen") {
@@ -9,16 +12,30 @@ export default function () {
       try {
         const normalizer = createPluginNormalizer();
         const normalizedNode = await normalizer(node);
+        const generated = pipeline.generateCode(normalizedNode, {
+          shouldPrintSource: false,
+        });
+
+        if (!generated) {
+          return [
+            {
+              title: "React",
+              language: "TYPESCRIPT",
+              code: "Failed to generate code.",
+            },
+          ];
+        }
+
         return [
           {
             title: "React",
             language: "TYPESCRIPT",
-            code:
-              pipeline.generateCode(normalizedNode, {
-                shouldInferAutoLayout: true,
-                shouldInferVariableName: true,
-                shouldPrintSource: false,
-              }) ?? "Failed to generate code.",
+            code: generated.jsx,
+          },
+          {
+            title: "React",
+            language: "TYPESCRIPT",
+            code: generated.imports,
           },
         ];
       } catch (error) {


### PR DESCRIPTION
기본 패키지와 local snippet을 사용하는 방식에서 import path를 혼동하기 쉬운 문제를 해결하기 위해, codegen에서 import declaration을 함께 제공합니다.

- `ElementNode`에 `meta: { comment?, source?, importPath? }` 추가
- `createElement` 함수가 `meta` 객체를 받도록 수정
- `stringifyElement` 함수가 JSX와 함께 생성된 import 문자열을 반환하도록 변경
- 로컬 및 외부 컴포넌트에 대한 메타데이터 및 import 경로 관리를 단순화하기 위해 `createLocalSnippetElement` 및 `createSeedReactElement` 헬퍼 추가
- 새로운 엘리먼트 생성 및 메타데이터 규칙을 사용하도록 핸들러 변경
- mcp, figma-codegen이 import 문자열을 함께 제공하도록 개선

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 코드 생성 시 JSX 코드와 import 구문이 분리되어 제공됩니다.
  - 다양한 컴포넌트에 대해 import 경로가 자동으로 관리되는 새로운 요소 생성 방식이 도입되었습니다.

- **Refactor**
  - 여러 컴포넌트 핸들러에서 요소 생성 방식이 일관된 팩토리 함수 기반으로 변경되었습니다.
  - 주석 및 placeholder 전달 방식이 문자열에서 객체 기반으로 개선되었습니다.
  - 코드 생성 결과에 대한 오류 처리 및 반환 형식이 명확하게 개선되었습니다.

- **Bug Fixes**
  - 코드 생성 실패 시 안내 메시지가 명확하게 출력됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->