### PR TITLE
feat(react, stackflow): add 'use client' directive to components

### DIFF
--- a/.changeset/ready-news-double.md
+++ b/.changeset/ready-news-double.md
@@ -1,0 +1,20 @@
+---
+"@seed-design/react-segmented-control": patch
+"@seed-design/react-pull-to-refresh": patch
+"@seed-design/react-radio-group": patch
+"@seed-design/react-text-field": patch
+"@seed-design/react-checkbox": patch
+"@seed-design/react-progress": patch
+"@seed-design/react-snackbar": patch
+"@seed-design/react-popover": patch
+"@seed-design/react-avatar": patch
+"@seed-design/react-dialog": patch
+"@seed-design/react-portal": patch
+"@seed-design/react-switch": patch
+"@seed-design/react-toggle": patch
+"@seed-design/react-tabs": patch
+"@seed-design/stackflow": patch
+"@seed-design/react": patch
+---
+
+RSC 지원을 위한 "use client" directive를 추가합니다.

--- a/docs/components/migration/typography-migration-index.tsx
+++ b/docs/components/migration/typography-migration-index.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { getRootage } from "@/components/rootage";
 import { FoundationTokenMapping } from "@seed-design/migration-index";
 import { typographyMappings } from "@seed-design/migration-index/typography";

--- a/packages/react-headless/avatar/src/Avatar.tsx
+++ b/packages/react-headless/avatar/src/Avatar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { composeRefs } from "@radix-ui/react-compose-refs";
 import { mergeProps } from "@seed-design/dom-utils";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";

--- a/packages/react-headless/checkbox/src/Checkbox.tsx
+++ b/packages/react-headless/checkbox/src/Checkbox.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { mergeProps } from "@seed-design/dom-utils";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";
 import type * as React from "react";

--- a/packages/react-headless/dialog/src/Dialog.tsx
+++ b/packages/react-headless/dialog/src/Dialog.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { DismissableLayer } from "@radix-ui/react-dismissable-layer";
 import { FocusScope } from "@radix-ui/react-focus-scope";
 import { mergeProps } from "@seed-design/dom-utils";

--- a/packages/react-headless/popover/src/Popover.tsx
+++ b/packages/react-headless/popover/src/Popover.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { composeRefs } from "@radix-ui/react-compose-refs";
 import { mergeProps } from "@seed-design/dom-utils";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";

--- a/packages/react-headless/portal/src/Portal.tsx
+++ b/packages/react-headless/portal/src/Portal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Children,
   type PropsWithChildren,

--- a/packages/react-headless/progress/src/ProgressCircle.tsx
+++ b/packages/react-headless/progress/src/ProgressCircle.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { mergeProps } from "@seed-design/dom-utils";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";
 import { forwardRef } from "react";

--- a/packages/react-headless/pull-to-refresh/src/PullToRefresh.tsx
+++ b/packages/react-headless/pull-to-refresh/src/PullToRefresh.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { composeRefs } from "@radix-ui/react-compose-refs";
 import { mergeProps } from "@seed-design/dom-utils";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";

--- a/packages/react-headless/radio-group/src/RadioGroup.tsx
+++ b/packages/react-headless/radio-group/src/RadioGroup.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { mergeProps } from "@seed-design/dom-utils";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";
 import type * as React from "react";

--- a/packages/react-headless/segmented-control/src/SegmentedControl.tsx
+++ b/packages/react-headless/segmented-control/src/SegmentedControl.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { composeRefs } from "@radix-ui/react-compose-refs";
 import { mergeProps } from "@seed-design/dom-utils";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";

--- a/packages/react-headless/snackbar/src/Snackbar.tsx
+++ b/packages/react-headless/snackbar/src/Snackbar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { mergeProps } from "@seed-design/dom-utils";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";
 import * as React from "react";

--- a/packages/react-headless/switch/src/Switch.tsx
+++ b/packages/react-headless/switch/src/Switch.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { mergeProps } from "@seed-design/dom-utils";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";
 import type * as React from "react";

--- a/packages/react-headless/tabs/src/Tabs.tsx
+++ b/packages/react-headless/tabs/src/Tabs.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { composeRefs } from "@radix-ui/react-compose-refs";
 import { mergeProps } from "@seed-design/dom-utils";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";

--- a/packages/react-headless/text-field/src/TextField.tsx
+++ b/packages/react-headless/text-field/src/TextField.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { composeRefs } from "@radix-ui/react-compose-refs";
 import { mergeProps } from "@seed-design/dom-utils";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";

--- a/packages/react-headless/toggle/src/Toggle.tsx
+++ b/packages/react-headless/toggle/src/Toggle.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { mergeProps } from "@seed-design/dom-utils";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";
 import type * as React from "react";

--- a/packages/react/vite.config.mts
+++ b/packages/react/vite.config.mts
@@ -1,5 +1,6 @@
 import react from "@vitejs/plugin-react";
 import { globbySync } from "globby";
+import path from "node:path";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 import pkg from "./package.json";
@@ -35,6 +36,7 @@ export default defineConfig({
           preserveModulesRoot: "src",
           exports: "named",
           entryFileNames: "[name].cjs",
+          banner: ({ fileName }) => renderBanner(fileName),
         },
         {
           format: "es",
@@ -42,8 +44,21 @@ export default defineConfig({
           preserveModulesRoot: "src",
           exports: "named",
           entryFileNames: "[name].js",
+          banner: ({ fileName }) => renderBanner(fileName),
         },
       ],
     },
   },
 });
+
+const renderBanner = (fileName: string) => {
+  const file = path.parse(fileName);
+  if (isBarrelFile(file) || isNamespaceFile(file)) {
+    return "";
+  }
+  return `'use client';`;
+};
+
+const isBarrelFile = (file: path.ParsedPath) => ["index", "primitive", "vars"].includes(file.name);
+
+const isNamespaceFile = (file: path.ParsedPath) => file.name.includes("namespace");

--- a/packages/stackflow/vite.config.mts
+++ b/packages/stackflow/vite.config.mts
@@ -1,5 +1,6 @@
 import react from "@vitejs/plugin-react";
 import { globbySync } from "globby";
+import path from "node:path";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 import pkg from "./package.json";
@@ -35,6 +36,7 @@ export default defineConfig({
           preserveModulesRoot: "src",
           exports: "named",
           entryFileNames: "[name].cjs",
+          banner: ({ fileName }) => renderBanner(fileName),
         },
         {
           format: "es",
@@ -42,8 +44,21 @@ export default defineConfig({
           preserveModulesRoot: "src",
           exports: "named",
           entryFileNames: "[name].js",
+          banner: ({ fileName }) => renderBanner(fileName),
         },
       ],
     },
   },
 });
+
+const renderBanner = (fileName: string) => {
+  const file = path.parse(fileName);
+  if (isBarrelFile(file) || isNamespaceFile(file)) {
+    return "";
+  }
+  return `'use client';`;
+};
+
+const isBarrelFile = (file: path.ParsedPath) => ["index"].includes(file.name);
+
+const isNamespaceFile = (file: path.ParsedPath) => file.name.includes("namespace");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 다양한 UI 컴포넌트와 패키지에 클라이언트 컴포넌트 지원을 위한 내부 설정이 추가되었습니다.
  - 일부 문서 파일에서 불필요한 클라이언트 컴포넌트 지시문이 제거되었습니다.
  - 빌드 설정이 개선되어, 특정 파일에 클라이언트 컴포넌트 지시문이 자동으로 추가됩니다.  
  - 사용자 경험이나 기능에는 직접적인 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->