### PR TITLE
feat(figma): enhance figma xml generation with component metadata

### DIFF
--- a/.changeset/hungry-experts-press.md
+++ b/.changeset/hungry-experts-press.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/figma": patch
+---
+
+Figma XML 타겟에서 instance 노드의 컴포넌트 정보를 제공합니다.

--- a/packages/figma/src/codegen/core/codegen.ts
+++ b/packages/figma/src/codegen/core/codegen.ts
@@ -25,6 +25,14 @@ export interface CodeGeneratorDeps {
   shouldInferAutoLayout: boolean;
 }
 
+export interface CodeGenerator {
+  generateJsxTree: (node: NormalizedSceneNode) => ElementNode | undefined;
+  generateCode: (
+    node: NormalizedSceneNode,
+    options: { shouldPrintSource: boolean },
+  ) => { imports: string; jsx: string } | undefined;
+}
+
 export function createCodeGenerator({
   frameTransformer,
   textTransformer,
@@ -33,7 +41,7 @@ export function createCodeGenerator({
   vectorTransformer,
   booleanOperationTransformer,
   shouldInferAutoLayout,
-}: CodeGeneratorDeps) {
+}: CodeGeneratorDeps): CodeGenerator {
   function traverse(node: NormalizedSceneNode): ElementNode | undefined {
     if ("visible" in node && !node.visible) {
       return;

--- a/packages/figma/src/codegen/targets/figma/instance.ts
+++ b/packages/figma/src/codegen/targets/figma/instance.ts
@@ -1,14 +1,34 @@
+import type { ComponentRepository } from "@/entities";
 import type { NormalizedInstanceNode } from "@/normalizer";
-import { defineElementTransformer, type ElementTransformer } from "../../core";
+import { camelCase } from "change-case";
+import { createElement, defineElementTransformer, type ElementTransformer } from "../../core";
 
 export interface InstanceTransformerDeps {
   frameTransformer: ElementTransformer<NormalizedInstanceNode>;
+  componentRepository?: ComponentRepository;
 }
 
 export function createInstanceTransformer({
   frameTransformer,
+  componentRepository,
 }: InstanceTransformerDeps): ElementTransformer<NormalizedInstanceNode> {
   const transform = defineElementTransformer((node: NormalizedInstanceNode, traverse) => {
+    const component = componentRepository?.getOne(node.componentSetKey ?? node.componentKey);
+
+    if (component) {
+      return createElement("Instance", {
+        componentName: component.name,
+        ...Object.fromEntries(
+          Object.entries(node.componentProperties)
+            .filter(([_, props]) => props.type === "VARIANT" || props.type === "TEXT")
+            .map(([key, props]) => [
+              camelCase(key.split("#")[0]),
+              camelCase(props.value as string),
+            ]),
+        ),
+      });
+    }
+
     return frameTransformer(node, traverse);
   });
 

--- a/packages/figma/src/codegen/targets/figma/pipeline.ts
+++ b/packages/figma/src/codegen/targets/figma/pipeline.ts
@@ -1,5 +1,7 @@
 import { createCodeGenerator, createValueResolver } from "@/codegen/core";
+import type { CodeGenerator } from "@/codegen/core/codegen";
 import { styleService, variableService } from "@/codegen/default-services";
+import { componentRepository } from "@/entities";
 import { createFrameTransformer } from "./frame";
 import { createInstanceTransformer } from "./instance";
 import {
@@ -29,7 +31,7 @@ export interface CreatePipelineConfig {
   shouldInferVariableName?: boolean;
 }
 
-export function createPipeline(options: CreatePipelineConfig = {}) {
+export function createPipeline(options: CreatePipelineConfig = {}): CodeGenerator {
   const { shouldInferAutoLayout = true, shouldInferVariableName = true } = options;
 
   const valueResolver = createValueResolver({
@@ -66,6 +68,7 @@ export function createPipeline(options: CreatePipelineConfig = {}) {
   });
   const instanceTransformer = createInstanceTransformer({
     frameTransformer,
+    componentRepository,
   });
   const textTransformer = createTextTransformer({
     propsConverters,

--- a/packages/figma/src/entities/component.interface.ts
+++ b/packages/figma/src/entities/component.interface.ts
@@ -1,0 +1,7 @@
+import type { ComponentPropertyDefinition } from "@/codegen";
+
+export interface ComponentMetadata {
+  name: string;
+  key: string;
+  componentPropertyDefinitions: Record<string, ComponentPropertyDefinition>;
+}

--- a/packages/figma/src/entities/component.repository.ts
+++ b/packages/figma/src/entities/component.repository.ts
@@ -1,7 +1,7 @@
 import type { ComponentMetadata } from "./component.interface";
 
 export interface ComponentRepository {
-  getOne(key: string): ComponentMetadata;
+  getOne(key: string): ComponentMetadata | undefined;
 }
 
 export function createStaticComponentRepository(data: Record<string, ComponentMetadata>) {

--- a/packages/figma/src/entities/component.repository.ts
+++ b/packages/figma/src/entities/component.repository.ts
@@ -1,0 +1,16 @@
+import type { ComponentMetadata } from "./component.interface";
+
+export interface ComponentRepository {
+  getOne(key: string): ComponentMetadata;
+}
+
+export function createStaticComponentRepository(data: Record<string, ComponentMetadata>) {
+  const componentRecord: Record<string, ComponentMetadata> = {};
+  Object.values(data).forEach((component) => {
+    componentRecord[component.key] = component;
+  });
+
+  return {
+    getOne: (key: string) => componentRecord[key],
+  };
+}

--- a/packages/figma/src/entities/index.ts
+++ b/packages/figma/src/entities/index.ts
@@ -3,8 +3,10 @@ import { FIGMA_ICONS } from "./data/icons";
 import { FIGMA_TEXT_STYLES } from "./data/styles";
 import { FIGMA_VARIABLE_COLLECTIONS } from "./data/variable-collections";
 import { FIGMA_VARIABLES } from "./data/variables";
+import * as FIGMA_COMPONENTS from "./data/__generated__/component-sets";
 import { createStaticStyleRepository } from "./style.repository";
 import { createStaticVariableRepository } from "./variable.repository";
+import { createStaticComponentRepository } from "./component.repository";
 
 export * from "./icon.interface";
 export * from "./icon.repository";
@@ -15,6 +17,8 @@ export * from "./style.service";
 export * from "./variable.interface";
 export * from "./variable.repository";
 export * from "./variable.service";
+export * from "./component.interface";
+export * from "./component.repository";
 
 export const styleRepository = createStaticStyleRepository(FIGMA_TEXT_STYLES);
 export const variableRepository = createStaticVariableRepository({
@@ -22,6 +26,7 @@ export const variableRepository = createStaticVariableRepository({
   variableCollections: FIGMA_VARIABLE_COLLECTIONS,
 });
 export const iconRepository = createStaticIconRepository(FIGMA_ICONS);
+export const componentRepository = createStaticComponentRepository(FIGMA_COMPONENTS);
 
 export function getFigmaVariableKey(name: string) {
   return variableRepository.findVariableByName(name)?.key;

--- a/packages/figma/test/test.ts
+++ b/packages/figma/test/test.ts
@@ -1,6 +1,6 @@
 import type { GetFileNodesResponse } from "@figma/rest-api-spec";
 import fs from "fs";
-import { react } from "../src/codegen";
+import { react, figma } from "../src/codegen";
 import { createRestNormalizer } from "../src/normalizer/from-rest";
 
 const node = JSON.parse(
@@ -12,7 +12,7 @@ const normalizer = createRestNormalizer({
   components: node.components,
   componentSets: node.componentSets,
 });
-const pipeline = react.createPipeline();
+const pipeline = figma.createPipeline();
 const normalizedNode = normalizer(node.document);
 const code = pipeline.generateCode(normalizedNode, {
   shouldInferAutoLayout: true,
@@ -22,4 +22,4 @@ const simplifiedDesign = {
   name: node.document.name,
   code,
 };
-console.log(simplifiedDesign.code);
+console.log(simplifiedDesign.code.jsx);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - Figma XML 타겟에서 인스턴스 노드에 대한 컴포넌트 정보를 제공하는 기능이 추가되었습니다.
  - Figma 컴포넌트 지원이 도입되어, 컴포넌트 메타데이터 및 저장소가 통합되었습니다.

- **버그 수정**
  - 없음.

- **기타**
  - 코드 생성기 및 파이프라인의 내부 구조가 명확해지고 확장성이 향상되었습니다.  
  - 테스트 코드가 최신 구조에 맞게 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->