### PR TITLE
fix(tabs): resolve initial width issue for Tabs.Indicator

### DIFF
--- a/.changeset/thin-turkeys-win.md
+++ b/.changeset/thin-turkeys-win.md
@@ -1,0 +1,8 @@
+---
+"@seed-design/react-tabs": patch
+"@seed-design/react": patch
+---
+
+Tabs.Indicator의 width가 첫 렌더링 시 0으로 설정되는 문제를 수정합니다.
+
+Tabs의 불필요한 리렌더링을 줄입니다.

--- a/bun.lock
+++ b/bun.lock
@@ -630,7 +630,6 @@
         "@radix-ui/react-compose-refs": "^1.1.2",
         "@radix-ui/react-use-callback-ref": "^1.1.1",
         "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "^1.1.1",
         "@radix-ui/react-use-size": "^1.1.1",
         "@seed-design/dom-utils": "0.0.2",
         "@seed-design/react-primitive": "0.0.3",

--- a/packages/react-headless/tabs/package.json
+++ b/packages/react-headless/tabs/package.json
@@ -30,7 +30,6 @@
     "@radix-ui/react-compose-refs": "^1.1.2",
     "@radix-ui/react-use-callback-ref": "^1.1.1",
     "@radix-ui/react-use-controllable-state": "1.2.2",
-    "@radix-ui/react-use-layout-effect": "^1.1.1",
     "@radix-ui/react-use-size": "^1.1.1",
     "@seed-design/dom-utils": "0.0.2",
     "@seed-design/react-primitive": "0.0.3",

--- a/packages/react-headless/tabs/src/useTabs.ts
+++ b/packages/react-headless/tabs/src/useTabs.ts
@@ -2,7 +2,7 @@ import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import { useSize } from "@radix-ui/react-use-size";
 import { ariaAttr, buttonProps, dataAttr, elementProps } from "@seed-design/dom-utils";
 import type * as React from "react";
-import { useEffect, useId, useMemo, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useState } from "react";
 import * as dom from "./dom";
 import { getNextIndex, getPrevIndex, scrollTabIntoView } from "./utils";
 
@@ -50,115 +50,182 @@ function useTabsState(props: UseTabsStateProps) {
     }
   }, [selectedTriggerEl, listEl]);
 
-  const actions = useMemo(
-    () => ({
-      selectPrev: () => {
-        const prevValue = enabledValues[prevIndex];
-        if (!prevValue) return;
-        setValue(prevValue);
-      },
-      selectNext: () => {
-        const nextValue = enabledValues[nextIndex];
-        if (!nextValue) return;
-        setValue(nextValue);
-      },
-      selectFirst: () => {
-        const firstValue = enabledValues[0];
-        if (!firstValue) return;
-        setValue(firstValue);
-      },
-      selectLast: () => {
-        const lastValue = enabledValues[enabledValues.length - 1];
-        if (!lastValue) return;
-        setValue(lastValue);
-      },
-      setFocusedValue: (value: string) => {
-        setFocusedValue(value);
-      },
-      clearFocusedValue: () => {
-        setFocusedValue(null);
-      },
-      setValue: (value: string) => {
-        setValue(value);
-      },
-    }),
-    [enabledValues, prevIndex, nextIndex, setValue],
+  const selectPrevAction = useCallback(() => {
+    const prevValue = enabledValues[prevIndex];
+    if (!prevValue) return;
+    setValue(prevValue);
+  }, [enabledValues, prevIndex, setValue]);
+
+  const selectNextAction = useCallback(() => {
+    const nextValue = enabledValues[nextIndex];
+    if (!nextValue) return;
+    setValue(nextValue);
+  }, [enabledValues, nextIndex, setValue]);
+
+  const selectFirstAction = useCallback(() => {
+    const firstValue = enabledValues[0];
+    if (!firstValue) return;
+    setValue(firstValue);
+  }, [enabledValues, setValue]);
+
+  const selectLastAction = useCallback(() => {
+    const lastValue = enabledValues[enabledValues.length - 1];
+    if (!lastValue) return;
+    setValue(lastValue);
+  }, [enabledValues, setValue]);
+
+  const setFocusedValueAction = useCallback((value: string) => {
+    setFocusedValue(value);
+  }, []);
+
+  const clearFocusedValueAction = useCallback(() => {
+    setFocusedValue(null);
+  }, []);
+
+  const setValueAction = useCallback(
+    (value: string) => {
+      setValue(value);
+    },
+    [setValue],
   );
 
-  const events = useMemo(
-    () => ({
-      arrowPrev: () => {
-        if (interactionState === "focused") {
-          actions.selectPrev();
-          setIsFocusVisible(true);
-        }
-      },
-      arrowNext: () => {
-        if (interactionState === "focused") {
-          actions.selectNext();
-          setIsFocusVisible(true);
-        }
-      },
-      arrowUp: () => {
-        if (interactionState === "focused") {
-          actions.selectPrev();
-          setIsFocusVisible(true);
-        }
-      },
-      arrowDown: () => {
-        if (interactionState === "focused") {
-          actions.selectNext();
-          setIsFocusVisible(true);
-        }
-      },
-      home: () => {
-        if (interactionState === "focused") {
-          actions.selectFirst();
-          setIsFocusVisible(true);
-        }
-      },
-      end: () => {
-        if (interactionState === "focused") {
-          actions.selectLast();
-          setIsFocusVisible(true);
-        }
-      },
-      tabFocus: (value: string) => {
-        actions.setFocusedValue(value);
-        if (interactionState === "idle") {
-          setInteractionState("focused");
-        }
-      },
-      tabBlur: () => {
-        if (interactionState === "focused") {
-          actions.clearFocusedValue();
-          setInteractionState("idle");
-        }
-      },
-      tabClick: (value: string) => {
-        actions.setFocusedValue(value);
-        actions.setValue(value);
-        if (interactionState === "idle") {
-          setInteractionState("focused");
-        }
-      },
+  const actions = {
+    selectPrev: selectPrevAction,
+    selectNext: selectNextAction,
+    selectFirst: selectFirstAction,
+    selectLast: selectLastAction,
+    setFocusedValue: setFocusedValueAction,
+    clearFocusedValue: clearFocusedValueAction,
+    setValue: setValueAction,
+  };
 
-      setValue: actions.setValue,
-      selectNext: actions.selectNext,
-      selectPrev: actions.selectPrev,
-      setContentIndex: (index: number) => {
-        const valueFromIndex = enabledValues[index];
-        if (!valueFromIndex) return;
+  const arrowPrevEvent = useCallback(() => {
+    if (interactionState === "focused") {
+      actions.selectPrev();
+      setIsFocusVisible(true);
+    }
+  }, [interactionState, actions.selectPrev]);
 
-        setValue(valueFromIndex);
-      },
+  const arrowNextEvent = useCallback(() => {
+    if (interactionState === "focused") {
+      actions.selectNext();
+      setIsFocusVisible(true);
+    }
+  }, [interactionState, actions.selectNext]);
 
-      setIsFocusVisible,
+  const arrowUpEvent = useCallback(() => {
+    if (interactionState === "focused") {
+      actions.selectPrev();
+      setIsFocusVisible(true);
+    }
+  }, [interactionState, actions.selectPrev]);
 
-      setSelectedTriggerEl,
-    }),
-    [actions, interactionState, enabledValues, setValue],
+  const arrowDownEvent = useCallback(() => {
+    if (interactionState === "focused") {
+      actions.selectNext();
+      setIsFocusVisible(true);
+    }
+  }, [interactionState, actions.selectNext]);
+
+  const homeEvent = useCallback(() => {
+    if (interactionState === "focused") {
+      actions.selectFirst();
+      setIsFocusVisible(true);
+    }
+  }, [interactionState, actions.selectFirst]);
+
+  const endEvent = useCallback(() => {
+    if (interactionState === "focused") {
+      actions.selectLast();
+      setIsFocusVisible(true);
+    }
+  }, [interactionState, actions.selectLast]);
+
+  const tabFocusEvent = useCallback(
+    (value: string) => {
+      actions.setFocusedValue(value);
+      if (interactionState === "idle") {
+        setInteractionState("focused");
+      }
+    },
+    [interactionState, actions.setFocusedValue],
   );
+
+  const tabBlurEvent = useCallback(() => {
+    if (interactionState === "focused") {
+      actions.clearFocusedValue();
+      setInteractionState("idle");
+    }
+  }, [interactionState, actions.clearFocusedValue]);
+
+  const tabClickEvent = useCallback(
+    (value: string) => {
+      actions.setValue(value);
+      if (interactionState === "idle") {
+        setInteractionState("focused");
+      }
+    },
+    [interactionState, actions.setValue],
+  );
+
+  const setValueEvent = useCallback(
+    (value: string) => {
+      actions.setValue(value);
+    },
+    [actions.setValue],
+  );
+
+  const selectNextEvent = useCallback(() => {
+    if (interactionState === "focused") {
+      actions.selectNext();
+      setIsFocusVisible(true);
+    }
+  }, [interactionState, actions.selectNext]);
+
+  const selectPrevEvent = useCallback(() => {
+    if (interactionState === "focused") {
+      actions.selectPrev();
+      setIsFocusVisible(true);
+    }
+  }, [interactionState, actions.selectPrev]);
+
+  const setContentIndexEvent = useCallback(
+    (index: number) => {
+      const valueFromIndex = enabledValues[index];
+      if (!valueFromIndex) return;
+      actions.setValue(valueFromIndex);
+    },
+    [actions.setValue, enabledValues],
+  );
+
+  const setIsFocusVisibleEvent = useCallback((isFocusVisible: boolean) => {
+    setIsFocusVisible(isFocusVisible);
+  }, []);
+
+  const setSelectedTriggerElEvent = useCallback((element: HTMLElement) => {
+    setSelectedTriggerEl(element);
+  }, []);
+
+  const events = {
+    arrowPrev: arrowPrevEvent,
+    arrowNext: arrowNextEvent,
+    arrowUp: arrowUpEvent,
+    arrowDown: arrowDownEvent,
+    home: homeEvent,
+    end: endEvent,
+    tabFocus: tabFocusEvent,
+    tabBlur: tabBlurEvent,
+    tabClick: tabClickEvent,
+
+    setValue: setValueEvent,
+    selectNext: selectNextEvent,
+    selectPrev: selectPrevEvent,
+    setContentIndex: setContentIndexEvent,
+
+    setIsFocusVisible: setIsFocusVisibleEvent,
+
+    setSelectedTriggerEl: setSelectedTriggerElEvent,
+  };
 
   const refs = useMemo(
     () => ({
@@ -232,169 +299,154 @@ export function useTabs(props: UseTabsProps) {
     [orientation, focused, isSSR],
   );
 
-  return useMemo(
-    () => ({
-      refs,
-      value,
-      contentIndex,
-      triggerRect,
+  return {
+    refs,
+    value,
+    contentIndex,
+    triggerRect,
 
-      selectNext: events.selectNext,
-      selectPrev: events.selectPrev,
-      setValue: events.setValue,
-      setContentIndex: events.setContentIndex,
+    selectNext: events.selectNext,
+    selectPrev: events.selectPrev,
+    setValue: events.setValue,
+    setContentIndex: events.setContentIndex,
 
-      stateProps,
+    stateProps,
 
-      rootProps: elementProps({
-        ...stateProps,
-        style: {
-          "--indicator-left": `${triggerRect.left}px`,
-          "--indicator-width": `${triggerRect.width}px`,
-        } as React.CSSProperties,
-      }),
+    rootProps: elementProps({
+      ...stateProps,
+      style: {
+        "--indicator-left": `${triggerRect.left}px`,
+        "--indicator-width": `${triggerRect.width}px`,
+      } as React.CSSProperties,
+    }),
 
-      listProps: elementProps({
-        id: dom.getListId(autoId),
-        role: "tablist",
-        "aria-orientation": orientation,
-        ...stateProps,
+    listProps: elementProps({
+      id: dom.getListId(autoId),
+      role: "tablist",
+      "aria-orientation": orientation,
+      ...stateProps,
 
-        onKeyDown(event) {
-          if (event.defaultPrevented) return;
-          if (event.nativeEvent.isComposing) return;
+      onKeyDown(event) {
+        if (event.defaultPrevented) return;
+        if (event.nativeEvent.isComposing) return;
 
-          // TODO: support activationMode="manual"
-          switch (event.key) {
-            case "ArrowLeft":
-              if (orientation !== "horizontal") return;
-              events.arrowPrev();
-              break;
-            case "ArrowRight":
-              if (orientation !== "horizontal") return;
-              events.arrowNext();
-              break;
-            case "ArrowUp":
-              if (orientation !== "vertical") return;
-              events.arrowPrev();
-              break;
-            case "ArrowDown":
-              if (orientation !== "vertical") return;
-              events.arrowNext();
-              break;
-            case "Home": {
-              events.home();
-              break;
-            }
-            case "End": {
-              events.end();
-              break;
-            }
+        // TODO: support activationMode="manual"
+        switch (event.key) {
+          case "ArrowLeft":
+            if (orientation !== "horizontal") return;
+            events.arrowPrev();
+            break;
+          case "ArrowRight":
+            if (orientation !== "horizontal") return;
+            events.arrowNext();
+            break;
+          case "ArrowUp":
+            if (orientation !== "vertical") return;
+            events.arrowPrev();
+            break;
+          case "ArrowDown":
+            if (orientation !== "vertical") return;
+            events.arrowNext();
+            break;
+          case "Home": {
+            events.home();
+            break;
           }
-        },
-      }),
-
-      getTriggerProps: (props: UseTabsTriggerProps) => {
-        const { disabled: isDisabled, value: triggerValue } = props;
-
-        const itemState = {
-          isDisabled,
-          isSelected: value === triggerValue,
-          isFocused: focusedValue === triggerValue,
-        };
-
-        const itemStateProps = {
-          "data-focus": dataAttr(itemState.isFocused),
-          "data-focus-visible": dataAttr(itemState.isFocused && isFocusVisible),
-          "data-selected": dataAttr(itemState.isSelected),
-          "data-disabled": dataAttr(itemState.isDisabled),
-          "data-ssr": dataAttr(isSSR),
-          "aria-disabled": ariaAttr(itemState.isDisabled),
-          "aria-selected": ariaAttr(itemState.isSelected),
-        };
-
-        const ref = (element: HTMLButtonElement | null) => {
-          if (element && triggerValue === value) {
-            events.setSelectedTriggerEl(element);
+          case "End": {
+            events.end();
+            break;
           }
-        };
-
-        return {
-          ...itemState,
-
-          refs: {
-            root: ref,
-          },
-
-          stateProps: itemStateProps,
-
-          rootProps: buttonProps({
-            id: dom.getTriggerId(triggerValue, autoId),
-            role: "tab",
-            type: "button",
-            disabled: isDisabled,
-            tabIndex: itemState.isSelected ? 0 : -1,
-            ...itemStateProps,
-            "data-value": triggerValue,
-            "data-orientation": orientation,
-            "data-ownedby": dom.getListId(autoId),
-            "aria-controls": dom.getContentId(triggerValue, autoId),
-            onClick(event) {
-              if (itemState.isDisabled) return;
-              if (event.defaultPrevented) return;
-              events.tabClick(triggerValue);
-            },
-            onFocus(event) {
-              events.tabFocus(props.value);
-              events.setIsFocusVisible(event.target.matches(":focus-visible"));
-            },
-            onBlur(event) {
-              const target = event.relatedTarget as HTMLElement | null;
-              if (target?.getAttribute("role") !== "tab") {
-                events.tabBlur();
-              }
-              events.setIsFocusVisible(false);
-            },
-          }),
-        };
+        }
       },
+    }),
 
-      getContentProps: (props: UseTabsContentProps) => {
-        const { value: contentValue } = props;
-        const triggerId = dom.getTriggerId(contentValue, autoId);
-        const isSelected = value === contentValue;
+    getTriggerProps: (props: UseTabsTriggerProps) => {
+      const { disabled: isDisabled, value: triggerValue } = props;
 
-        return elementProps({
-          id: dom.getContentId(contentValue, autoId),
-          tabIndex: -1,
+      const itemState = {
+        isDisabled,
+        isSelected: value === triggerValue,
+        isFocused: focusedValue === triggerValue,
+      };
 
-          role: "tabpanel",
-          "aria-labelledby": triggerId,
-          "aria-selected": ariaAttr(isSelected),
-          "aria-hidden": !isSelected,
+      const itemStateProps = {
+        "data-focus": dataAttr(itemState.isFocused),
+        "data-focus-visible": dataAttr(itemState.isFocused && isFocusVisible),
+        "data-selected": dataAttr(itemState.isSelected),
+        "data-disabled": dataAttr(itemState.isDisabled),
+        "data-ssr": dataAttr(isSSR),
+        "aria-disabled": ariaAttr(itemState.isDisabled),
+        "aria-selected": ariaAttr(itemState.isSelected),
+      };
 
-          "data-selected": dataAttr(isSelected),
+      const ref = (element: HTMLButtonElement | null) => {
+        if (element && triggerValue === value) {
+          events.setSelectedTriggerEl(element);
+        }
+      };
+
+      return {
+        ...itemState,
+
+        refs: {
+          root: ref,
+        },
+
+        stateProps: itemStateProps,
+
+        rootProps: buttonProps({
+          id: dom.getTriggerId(triggerValue, autoId),
+          role: "tab",
+          type: "button",
+          disabled: isDisabled,
+          tabIndex: itemState.isSelected ? 0 : -1,
+          ...itemStateProps,
+          "data-value": triggerValue,
           "data-orientation": orientation,
           "data-ownedby": dom.getListId(autoId),
-        });
-      },
+          "aria-controls": dom.getContentId(triggerValue, autoId),
+          onClick(event) {
+            if (itemState.isDisabled) return;
+            if (event.defaultPrevented) return;
+            events.tabClick(triggerValue);
+          },
+          onFocus(event) {
+            events.tabFocus(props.value);
+            events.setIsFocusVisible(event.target.matches(":focus-visible"));
+          },
+          onBlur(event) {
+            const target = event.relatedTarget as HTMLElement | null;
+            if (target?.getAttribute("role") !== "tab") {
+              events.tabBlur();
+            }
+            events.setIsFocusVisible(false);
+          },
+        }),
+      };
+    },
 
-      indicatorProps: elementProps({
-        ...stateProps,
-      }),
+    getContentProps: (props: UseTabsContentProps) => {
+      const { value: contentValue } = props;
+      const triggerId = dom.getTriggerId(contentValue, autoId);
+      const isSelected = value === contentValue;
+
+      return elementProps({
+        id: dom.getContentId(contentValue, autoId),
+        tabIndex: -1,
+
+        role: "tabpanel",
+        "aria-labelledby": triggerId,
+        "aria-selected": ariaAttr(isSelected),
+        "aria-hidden": !isSelected,
+
+        "data-selected": dataAttr(isSelected),
+        "data-orientation": orientation,
+        "data-ownedby": dom.getListId(autoId),
+      });
+    },
+
+    indicatorProps: elementProps({
+      ...stateProps,
     }),
-    [
-      refs,
-      value,
-      contentIndex,
-      events,
-      stateProps,
-      isSSR,
-      autoId,
-      orientation,
-      focusedValue,
-      isFocusVisible,
-      triggerRect,
-    ],
-  );
+  };
 }

--- a/packages/react-headless/tabs/src/useTabs.ts
+++ b/packages/react-headless/tabs/src/useTabs.ts
@@ -1,9 +1,8 @@
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
-import { useLayoutEffect } from "@radix-ui/react-use-layout-effect";
 import { useSize } from "@radix-ui/react-use-size";
 import { ariaAttr, buttonProps, dataAttr, elementProps } from "@seed-design/dom-utils";
 import type * as React from "react";
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import * as dom from "./dom";
 import { getNextIndex, getPrevIndex, scrollTabIntoView } from "./utils";
 
@@ -33,8 +32,7 @@ function useTabsState(props: UseTabsStateProps) {
   }, []);
 
   const [listEl, listRef] = useState<HTMLElement | null>(null);
-  const [triggerEls, setTriggerEls] = useState<Record<string, HTMLElement>>({});
-  const selectedTriggerEl = value ? triggerEls[value] : null;
+  const [selectedTriggerEl, setSelectedTriggerEl] = useState<HTMLElement | null>(null);
   const selectedTriggerSize = useSize(selectedTriggerEl);
 
   const enabledValues = useMemo(() => (listEl ? dom.getEnabledValues(listEl) : []), [listEl]);
@@ -52,132 +50,137 @@ function useTabsState(props: UseTabsStateProps) {
     }
   }, [selectedTriggerEl, listEl]);
 
-  const actions = {
-    selectPrev: () => {
-      const prevValue = enabledValues[prevIndex];
-      if (!prevValue) return;
-      setValue(prevValue);
-    },
-    selectNext: () => {
-      const nextValue = enabledValues[nextIndex];
-      if (!nextValue) return;
-      setValue(nextValue);
-    },
-    selectFirst: () => {
-      const firstValue = enabledValues[0];
-      if (!firstValue) return;
-      setValue(firstValue);
-    },
-    selectLast: () => {
-      const lastValue = enabledValues[enabledValues.length - 1];
-      if (!lastValue) return;
-      setValue(lastValue);
-    },
-    setFocusedValue: (value: string) => {
-      setFocusedValue(value);
-    },
-    clearFocusedValue: () => {
-      setFocusedValue(null);
-    },
-    setValue: (value: string) => {
-      setValue(value);
-    },
-  };
+  const actions = useMemo(
+    () => ({
+      selectPrev: () => {
+        const prevValue = enabledValues[prevIndex];
+        if (!prevValue) return;
+        setValue(prevValue);
+      },
+      selectNext: () => {
+        const nextValue = enabledValues[nextIndex];
+        if (!nextValue) return;
+        setValue(nextValue);
+      },
+      selectFirst: () => {
+        const firstValue = enabledValues[0];
+        if (!firstValue) return;
+        setValue(firstValue);
+      },
+      selectLast: () => {
+        const lastValue = enabledValues[enabledValues.length - 1];
+        if (!lastValue) return;
+        setValue(lastValue);
+      },
+      setFocusedValue: (value: string) => {
+        setFocusedValue(value);
+      },
+      clearFocusedValue: () => {
+        setFocusedValue(null);
+      },
+      setValue: (value: string) => {
+        setValue(value);
+      },
+    }),
+    [enabledValues, prevIndex, nextIndex, setValue],
+  );
 
-  const events = {
-    arrowPrev: () => {
-      if (interactionState === "focused") {
-        actions.selectPrev();
-        setIsFocusVisible(true);
-      }
-    },
-    arrowNext: () => {
-      if (interactionState === "focused") {
-        actions.selectNext();
-        setIsFocusVisible(true);
-      }
-    },
-    arrowUp: () => {
-      if (interactionState === "focused") {
-        actions.selectPrev();
-        setIsFocusVisible(true);
-      }
-    },
-    arrowDown: () => {
-      if (interactionState === "focused") {
-        actions.selectNext();
-        setIsFocusVisible(true);
-      }
-    },
-    home: () => {
-      if (interactionState === "focused") {
-        actions.selectFirst();
-        setIsFocusVisible(true);
-      }
-    },
-    end: () => {
-      if (interactionState === "focused") {
-        actions.selectLast();
-        setIsFocusVisible(true);
-      }
-    },
-    tabFocus: (value: string) => {
-      actions.setFocusedValue(value);
-      if (interactionState === "idle") {
-        setInteractionState("focused");
-      }
-    },
-    tabBlur: () => {
-      if (interactionState === "focused") {
-        actions.clearFocusedValue();
-        setInteractionState("idle");
-      }
-    },
-    tabClick: (value: string) => {
-      actions.setFocusedValue(value);
-      actions.setValue(value);
-      if (interactionState === "idle") {
-        setInteractionState("focused");
-      }
-    },
+  const events = useMemo(
+    () => ({
+      arrowPrev: () => {
+        if (interactionState === "focused") {
+          actions.selectPrev();
+          setIsFocusVisible(true);
+        }
+      },
+      arrowNext: () => {
+        if (interactionState === "focused") {
+          actions.selectNext();
+          setIsFocusVisible(true);
+        }
+      },
+      arrowUp: () => {
+        if (interactionState === "focused") {
+          actions.selectPrev();
+          setIsFocusVisible(true);
+        }
+      },
+      arrowDown: () => {
+        if (interactionState === "focused") {
+          actions.selectNext();
+          setIsFocusVisible(true);
+        }
+      },
+      home: () => {
+        if (interactionState === "focused") {
+          actions.selectFirst();
+          setIsFocusVisible(true);
+        }
+      },
+      end: () => {
+        if (interactionState === "focused") {
+          actions.selectLast();
+          setIsFocusVisible(true);
+        }
+      },
+      tabFocus: (value: string) => {
+        actions.setFocusedValue(value);
+        if (interactionState === "idle") {
+          setInteractionState("focused");
+        }
+      },
+      tabBlur: () => {
+        if (interactionState === "focused") {
+          actions.clearFocusedValue();
+          setInteractionState("idle");
+        }
+      },
+      tabClick: (value: string) => {
+        actions.setFocusedValue(value);
+        actions.setValue(value);
+        if (interactionState === "idle") {
+          setInteractionState("focused");
+        }
+      },
 
-    setValue: actions.setValue,
-    selectNext: actions.selectNext,
-    selectPrev: actions.selectPrev,
-    setContentIndex: useCallback(
-      (index: number) => {
+      setValue: actions.setValue,
+      selectNext: actions.selectNext,
+      selectPrev: actions.selectPrev,
+      setContentIndex: (index: number) => {
         const valueFromIndex = enabledValues[index];
         if (!valueFromIndex) return;
 
         setValue(valueFromIndex);
       },
-      [enabledValues, setValue],
-    ),
-    setIsFocusVisible,
 
-    mountTrigger: (value: string, el: HTMLElement) => {
-      setTriggerEls((prev) => ({ ...prev, [value]: el }));
-    },
-    unmountTrigger: (value: string) => {
-      setTriggerEls((prev) => {
-        const { [value]: _, ...rest } = prev;
-        return rest;
-      });
-    },
-  };
+      setIsFocusVisible,
+
+      setSelectedTriggerEl,
+    }),
+    [actions, interactionState, enabledValues, setValue],
+  );
+
+  const refs = useMemo(
+    () => ({
+      list: listRef,
+    }),
+    [],
+  );
+
+  const triggerRect = useMemo(
+    () => ({
+      width: selectedTriggerSize?.width ?? selectedTriggerEl?.offsetWidth ?? 0,
+      left: selectedTriggerEl?.offsetLeft ?? 0,
+    }),
+    [selectedTriggerSize, selectedTriggerEl],
+  );
 
   return {
-    refs: {
-      list: listRef,
-    },
+    refs,
     interactionState,
     value,
     isSSR,
-    triggerRect: {
-      width: selectedTriggerSize?.width || 0,
-      height: selectedTriggerSize?.height || 0,
-      left: selectedTriggerEl?.offsetLeft || 0,
-    },
+    triggerRect,
     focusedValue,
     isFocusVisible,
     contentIndex,
@@ -219,166 +222,179 @@ export function useTabs(props: UseTabsProps) {
   const { orientation = "horizontal" } = props;
   const focused = interactionState === "focused";
 
-  const stateProps = elementProps({
-    "data-orientation": orientation,
-    "data-focus": dataAttr(focused),
-    "data-ssr": dataAttr(isSSR),
-  });
-
-  return {
-    refs,
-    value,
-    contentIndex,
-    triggerRect,
-
-    selectNext: events.selectNext,
-    selectPrev: events.selectPrev,
-    setValue: events.setValue,
-    setContentIndex: events.setContentIndex,
-
-    stateProps,
-
-    rootProps: elementProps({
-      ...stateProps,
-      style: {
-        "--indicator-left": `${triggerRect.left}px`,
-        "--indicator-width": `${triggerRect.width}px`,
-      } as React.CSSProperties,
-    }),
-
-    listProps: elementProps({
-      id: dom.getListId(autoId),
-      role: "tablist",
-      "aria-orientation": orientation,
-      ...stateProps,
-
-      onKeyDown(event) {
-        if (event.defaultPrevented) return;
-        if (event.nativeEvent.isComposing) return;
-
-        // TODO: support activationMode="manual"
-        switch (event.key) {
-          case "ArrowLeft":
-            if (orientation !== "horizontal") return;
-            events.arrowPrev();
-            break;
-          case "ArrowRight":
-            if (orientation !== "horizontal") return;
-            events.arrowNext();
-            break;
-          case "ArrowUp":
-            if (orientation !== "vertical") return;
-            events.arrowPrev();
-            break;
-          case "ArrowDown":
-            if (orientation !== "vertical") return;
-            events.arrowNext();
-            break;
-          case "Home": {
-            events.home();
-            break;
-          }
-          case "End": {
-            events.end();
-            break;
-          }
-        }
-      },
-    }),
-
-    getTriggerProps: (props: UseTabsTriggerProps) => {
-      const { disabled: isDisabled, value: triggerValue } = props;
-
-      const itemState = {
-        isDisabled,
-        isSelected: value === triggerValue,
-        isFocused: focusedValue === triggerValue,
-      };
-
-      const itemStateProps = {
-        "data-focus": dataAttr(itemState.isFocused),
-        "data-focus-visible": dataAttr(itemState.isFocused && isFocusVisible),
-        "data-selected": dataAttr(itemState.isSelected),
-        "data-disabled": dataAttr(itemState.isDisabled),
+  const stateProps = useMemo(
+    () =>
+      elementProps({
+        "data-orientation": orientation,
+        "data-focus": dataAttr(focused),
         "data-ssr": dataAttr(isSSR),
-        "aria-disabled": ariaAttr(itemState.isDisabled),
-        "aria-selected": ariaAttr(itemState.isSelected),
-      };
+      }),
+    [orientation, focused, isSSR],
+  );
 
-      const ref = useRef<HTMLButtonElement>(null);
+  return useMemo(
+    () => ({
+      refs,
+      value,
+      contentIndex,
+      triggerRect,
 
-      useLayoutEffect(() => {
-        if (ref.current) {
-          events.mountTrigger(triggerValue, ref.current);
-        }
+      selectNext: events.selectNext,
+      selectPrev: events.selectPrev,
+      setValue: events.setValue,
+      setContentIndex: events.setContentIndex,
 
-        () => {
-          events.unmountTrigger(triggerValue);
-        };
-      }, [triggerValue]);
+      stateProps,
 
-      return {
-        ...itemState,
+      rootProps: elementProps({
+        ...stateProps,
+        style: {
+          "--indicator-left": `${triggerRect.left}px`,
+          "--indicator-width": `${triggerRect.width}px`,
+        } as React.CSSProperties,
+      }),
 
-        refs: {
-          root: ref,
+      listProps: elementProps({
+        id: dom.getListId(autoId),
+        role: "tablist",
+        "aria-orientation": orientation,
+        ...stateProps,
+
+        onKeyDown(event) {
+          if (event.defaultPrevented) return;
+          if (event.nativeEvent.isComposing) return;
+
+          // TODO: support activationMode="manual"
+          switch (event.key) {
+            case "ArrowLeft":
+              if (orientation !== "horizontal") return;
+              events.arrowPrev();
+              break;
+            case "ArrowRight":
+              if (orientation !== "horizontal") return;
+              events.arrowNext();
+              break;
+            case "ArrowUp":
+              if (orientation !== "vertical") return;
+              events.arrowPrev();
+              break;
+            case "ArrowDown":
+              if (orientation !== "vertical") return;
+              events.arrowNext();
+              break;
+            case "Home": {
+              events.home();
+              break;
+            }
+            case "End": {
+              events.end();
+              break;
+            }
+          }
         },
+      }),
 
-        stateProps: itemStateProps,
+      getTriggerProps: (props: UseTabsTriggerProps) => {
+        const { disabled: isDisabled, value: triggerValue } = props;
 
-        rootProps: buttonProps({
-          id: dom.getTriggerId(triggerValue, autoId),
-          role: "tab",
-          type: "button",
-          disabled: isDisabled,
-          tabIndex: itemState.isSelected ? 0 : -1,
-          ...itemStateProps,
-          "data-value": triggerValue,
+        const itemState = {
+          isDisabled,
+          isSelected: value === triggerValue,
+          isFocused: focusedValue === triggerValue,
+        };
+
+        const itemStateProps = {
+          "data-focus": dataAttr(itemState.isFocused),
+          "data-focus-visible": dataAttr(itemState.isFocused && isFocusVisible),
+          "data-selected": dataAttr(itemState.isSelected),
+          "data-disabled": dataAttr(itemState.isDisabled),
+          "data-ssr": dataAttr(isSSR),
+          "aria-disabled": ariaAttr(itemState.isDisabled),
+          "aria-selected": ariaAttr(itemState.isSelected),
+        };
+
+        const ref = (element: HTMLButtonElement | null) => {
+          if (element && triggerValue === value) {
+            events.setSelectedTriggerEl(element);
+          }
+        };
+
+        return {
+          ...itemState,
+
+          refs: {
+            root: ref,
+          },
+
+          stateProps: itemStateProps,
+
+          rootProps: buttonProps({
+            id: dom.getTriggerId(triggerValue, autoId),
+            role: "tab",
+            type: "button",
+            disabled: isDisabled,
+            tabIndex: itemState.isSelected ? 0 : -1,
+            ...itemStateProps,
+            "data-value": triggerValue,
+            "data-orientation": orientation,
+            "data-ownedby": dom.getListId(autoId),
+            "aria-controls": dom.getContentId(triggerValue, autoId),
+            onClick(event) {
+              if (itemState.isDisabled) return;
+              if (event.defaultPrevented) return;
+              events.tabClick(triggerValue);
+            },
+            onFocus(event) {
+              events.tabFocus(props.value);
+              events.setIsFocusVisible(event.target.matches(":focus-visible"));
+            },
+            onBlur(event) {
+              const target = event.relatedTarget as HTMLElement | null;
+              if (target?.getAttribute("role") !== "tab") {
+                events.tabBlur();
+              }
+              events.setIsFocusVisible(false);
+            },
+          }),
+        };
+      },
+
+      getContentProps: (props: UseTabsContentProps) => {
+        const { value: contentValue } = props;
+        const triggerId = dom.getTriggerId(contentValue, autoId);
+        const isSelected = value === contentValue;
+
+        return elementProps({
+          id: dom.getContentId(contentValue, autoId),
+          tabIndex: -1,
+
+          role: "tabpanel",
+          "aria-labelledby": triggerId,
+          "aria-selected": ariaAttr(isSelected),
+          "aria-hidden": !isSelected,
+
+          "data-selected": dataAttr(isSelected),
           "data-orientation": orientation,
           "data-ownedby": dom.getListId(autoId),
-          "aria-controls": dom.getContentId(triggerValue, autoId),
-          onClick(event) {
-            if (itemState.isDisabled) return;
-            if (event.defaultPrevented) return;
-            events.tabClick(triggerValue);
-          },
-          onFocus(event) {
-            events.tabFocus(props.value);
-            events.setIsFocusVisible(event.target.matches(":focus-visible"));
-          },
-          onBlur(event) {
-            const target = event.relatedTarget as HTMLElement | null;
-            if (target?.getAttribute("role") !== "tab") {
-              events.tabBlur();
-            }
-            events.setIsFocusVisible(false);
-          },
-        }),
-      };
-    },
+        });
+      },
 
-    getContentProps: (props: UseTabsContentProps) => {
-      const { value: contentValue } = props;
-      const triggerId = dom.getTriggerId(contentValue, autoId);
-      const isSelected = value === contentValue;
-
-      return elementProps({
-        id: dom.getContentId(contentValue, autoId),
-        tabIndex: -1,
-
-        role: "tabpanel",
-        "aria-labelledby": triggerId,
-        "aria-selected": ariaAttr(isSelected),
-        "aria-hidden": !isSelected,
-
-        "data-selected": dataAttr(isSelected),
-        "data-orientation": orientation,
-        "data-ownedby": dom.getListId(autoId),
-      });
-    },
-
-    indicatorProps: elementProps({
-      ...stateProps,
+      indicatorProps: elementProps({
+        ...stateProps,
+      }),
     }),
-  };
+    [
+      refs,
+      value,
+      contentIndex,
+      events,
+      stateProps,
+      isSSR,
+      autoId,
+      orientation,
+      focusedValue,
+      isFocusVisible,
+      triggerRect,
+    ],
+  );
 }


### PR DESCRIPTION
- Tabs.Indicator의 width가 첫 렌더링 시 0으로 설정되는 문제를 수정합니다.
- Tabs의 불필요한 리렌더링을 줄입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - Tabs.Indicator 컴포넌트의 너비가 첫 렌더 시 0으로 설정되는 문제를 수정했습니다.
  - Tabs 컴포넌트의 불필요한 리렌더링이 줄어들었습니다.

- **리팩터**
  - 탭 관련 내부 상태 및 이벤트 관리 방식이 개선되어 성능이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->