### PR TITLE
feat(pull-to-refresh): add disabled prop to PullToRefresh component

### DIFF
--- a/.changeset/red-donuts-chew.md
+++ b/.changeset/red-donuts-chew.md
@@ -1,0 +1,6 @@
+---
+"@seed-design/react-pull-to-refresh": patch
+"@seed-design/react": patch
+---
+
+PullToRefresh에 disabled prop을 추가합니다.

--- a/bun.lock
+++ b/bun.lock
@@ -536,6 +536,7 @@
       "version": "0.0.5",
       "dependencies": {
         "@radix-ui/react-compose-refs": "^1.1.2",
+        "@radix-ui/react-use-callback-ref": "^1.1.1",
         "@seed-design/dom-utils": "0.0.2",
         "@seed-design/react-primitive": "0.0.3",
       },

--- a/docs/components/example/pull-to-refresh-disabled.tsx
+++ b/docs/components/example/pull-to-refresh-disabled.tsx
@@ -1,0 +1,34 @@
+import { Box, HStack, Text } from "@seed-design/react";
+import { useState } from "react";
+import {
+  PullToRefreshContent,
+  PullToRefreshIndicator,
+  PullToRefreshRoot,
+} from "seed-design/ui/pull-to-refresh";
+import { Switch } from "seed-design/ui/switch";
+
+const PullToRefreshDisabled = () => {
+  const [disabled, setDisabled] = useState(false);
+
+  return (
+    <Box width="300px" height="500px" borderColor="stroke.neutral" borderWidth={1}>
+      <PullToRefreshRoot
+        onPtrReady={() => {}}
+        onPtrRefresh={async () => {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+        }}
+        disabled={disabled}
+      >
+        <PullToRefreshIndicator />
+        <PullToRefreshContent asChild>
+          <HStack px="spacingX.globalGutter" py="x4" align="center" justify="space-between">
+            <Text>Disabled</Text>
+            <Switch checked={disabled} onCheckedChange={setDisabled} />
+          </HStack>
+        </PullToRefreshContent>
+      </PullToRefreshRoot>
+    </Box>
+  );
+};
+
+export default PullToRefreshDisabled;

--- a/docs/content/react/components/pull-to-refresh.mdx
+++ b/docs/content/react/components/pull-to-refresh.mdx
@@ -46,3 +46,16 @@ npx @seed-design/cli@latest add pull-to-refresh
   }
   ```
 </StackflowExample>
+
+### Disabled
+
+`disabled` 속성을 사용하여 PTR를 비활성화할 수 있습니다.
+
+<ComponentExample name="pull-to-refresh-disabled">
+  ```json doc-gen:file
+  {
+    "file": "./components/example/pull-to-refresh-disabled.tsx",
+    "codeblock": true
+  }
+  ```
+</ComponentExample>

--- a/packages/react-headless/pull-to-refresh/package.json
+++ b/packages/react-headless/pull-to-refresh/package.json
@@ -27,6 +27,7 @@
     "lint:publish": "bun publint"
   },
   "dependencies": {
+    "@radix-ui/react-use-callback-ref": "^1.1.1",
     "@radix-ui/react-compose-refs": "^1.1.2",
     "@seed-design/dom-utils": "0.0.2",
     "@seed-design/react-primitive": "0.0.3"

--- a/packages/react-headless/pull-to-refresh/src/PullToRefresh.tsx
+++ b/packages/react-headless/pull-to-refresh/src/PullToRefresh.tsx
@@ -21,6 +21,7 @@ export const PullToRefreshRoot = forwardRef<HTMLDivElement, PullToRefreshRootPro
     const {
       displacementMultiplier,
       threshold,
+      disabled,
       onPtrPullStart,
       onPtrPullMove,
       onPtrPullEnd,
@@ -31,6 +32,7 @@ export const PullToRefreshRoot = forwardRef<HTMLDivElement, PullToRefreshRootPro
     const api = usePullToRefresh({
       displacementMultiplier,
       threshold,
+      disabled,
       onPtrPullStart,
       onPtrPullMove,
       onPtrPullEnd,

--- a/packages/react-headless/pull-to-refresh/src/usePullToRefresh.ts
+++ b/packages/react-headless/pull-to-refresh/src/usePullToRefresh.ts
@@ -1,5 +1,6 @@
+import { useCallbackRef } from "@radix-ui/react-use-callback-ref";
 import { dataAttr, elementProps } from "@seed-design/dom-utils";
-import { useRef, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { getClientY, isLeftPress, touchEnd, touchMove } from "./normalize-event";
 import { Store } from "./store";
 
@@ -41,6 +42,12 @@ interface UsePullToRefreshStateProps {
    * Callback when the pull-to-refresh is released after ready.
    */
   onPtrRefresh?: () => Promise<void>;
+
+  /**
+   * Whether to disable the pull-to-refresh.
+   * @default false
+   */
+  disabled?: boolean;
 }
 
 interface PullToRefreshContext {
@@ -58,6 +65,7 @@ export type PullToRefreshState = "idle" | "pulling" | "ready" | "loading";
 function usePullToRefreshState(props: UsePullToRefreshStateProps) {
   const threshold = props.threshold ?? 44;
   const displacementMultiplier = props.displacementMultiplier ?? 0.5;
+  const disabled = props.disabled ?? false;
 
   // We use useSyncExternalStore to only re-render indicator area on drag
   const [contextStore] = useState(
@@ -72,23 +80,35 @@ function usePullToRefreshState(props: UsePullToRefreshStateProps) {
   const [state, setState] = useState<PullToRefreshState>("idle");
   const rootRef = useRef<HTMLDivElement | null>(null);
 
-  function setContext({ y0, y, displacement }: Omit<PullToRefreshContext, "displacementRatio">) {
-    contextStore.setState({
-      y0,
-      y,
-      displacement,
-      displacementRatio: Math.min(displacement / threshold, 1),
-    });
-    rootRef.current?.style.setProperty("--ptr-displacement", `${displacement}px`);
-  }
+  const setContext = useCallback(
+    ({ y0, y, displacement }: Omit<PullToRefreshContext, "displacementRatio">) => {
+      contextStore.setState({
+        y0,
+        y,
+        displacement,
+        displacementRatio: Math.min(displacement / threshold, 1),
+      });
+      rootRef.current?.style.setProperty("--ptr-displacement", `${displacement}px`);
+    },
+    [contextStore, threshold],
+  );
 
-  const events = {
-    move: ({ y, scrollTop }: { y: number; scrollTop: number }) => {
+  const onPtrPullStart = useCallbackRef(props.onPtrPullStart);
+  const onPtrPullMove = useCallbackRef(props.onPtrPullMove);
+  const onPtrPullEnd = useCallbackRef(props.onPtrPullEnd);
+  const onPtrReady = useCallbackRef(props.onPtrReady);
+  const onPtrRefresh = useCallbackRef(props.onPtrRefresh);
+  const isPtrRefreshProvided = !!props.onPtrRefresh;
+
+  const moveEvent = useCallback(
+    ({ y, scrollTop }: { y: number; scrollTop: number }) => {
+      if (disabled) return;
+
       if (state === "idle") {
         const ctx = contextStore.getState();
         if (scrollTop <= 0 && ctx.y !== -1 && y > ctx.y) {
           setContext({ y0: y, y, displacement: 0 });
-          props.onPtrPullStart?.(contextStore.getState());
+          onPtrPullStart?.(contextStore.getState());
           setState("pulling");
         } else {
           contextStore.setState({ ...ctx, y });
@@ -98,33 +118,78 @@ function usePullToRefreshState(props: UsePullToRefreshStateProps) {
         const { y0 } = contextStore.getState();
         const displacement = (y - y0) * displacementMultiplier;
         setContext({ y0, y, displacement });
-        props.onPtrPullMove?.(contextStore.getState());
+        onPtrPullMove?.(contextStore.getState());
 
         if (displacement > threshold) {
           setState("ready");
-          props.onPtrReady?.();
+          onPtrReady?.();
         } else {
           setState("pulling");
         }
       }
     },
-    end: () => {
-      if (state === "pulling" || state === "ready") {
-        props.onPtrPullEnd?.(contextStore.getState());
-      }
-      if (state === "ready" && props.onPtrRefresh) {
-        setState("loading");
-        setContext({ y0: 0, y: -1, displacement: threshold });
-        props.onPtrRefresh().then(() => {
-          setState("idle");
-          setContext({ y0: 0, y: -1, displacement: 0 });
-        });
-      } else if (state === "ready" || state === "pulling") {
+    [
+      state,
+      contextStore,
+      displacementMultiplier,
+      threshold,
+      disabled,
+      setContext,
+      onPtrPullStart,
+      onPtrPullMove,
+      onPtrReady,
+    ],
+  );
+
+  const endEvent = useCallback(() => {
+    if (disabled) return;
+
+    if (state === "pulling" || state === "ready") {
+      onPtrPullEnd?.(contextStore.getState());
+    }
+    if (state === "ready" && isPtrRefreshProvided) {
+      setState("loading");
+      setContext({ y0: 0, y: -1, displacement: threshold });
+      onPtrRefresh().then(() => {
         setState("idle");
         setContext({ y0: 0, y: -1, displacement: 0 });
-      }
-    },
+      });
+    } else if (state === "ready" || state === "pulling") {
+      setState("idle");
+      setContext({ y0: 0, y: -1, displacement: 0 });
+    }
+  }, [
+    state,
+    contextStore,
+    threshold,
+    disabled,
+    isPtrRefreshProvided,
+    setContext,
+    onPtrPullEnd,
+    onPtrRefresh,
+  ]);
+
+  const disableEvent = useCallback(() => {
+    if (!disabled) return;
+
+    // If loading, we let props.onPtrRefresh handle the state change.
+    if (state === "pulling" || state === "ready") {
+      setState("idle");
+      setContext({ y0: 0, y: -1, displacement: 0 });
+    }
+  }, [disabled, state, setContext]);
+
+  const events = {
+    move: moveEvent,
+    end: endEvent,
+    disable: disableEvent,
   };
+
+  useEffect(() => {
+    if (disabled) {
+      events.disable();
+    }
+  }, [disabled, events.disable]);
 
   return {
     state,


### PR DESCRIPTION
PullToRefresh에 disabled prop을 추가합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - PullToRefresh 컴포넌트에 `disabled` 속성이 추가되어, 사용자가 풀 투 리프레시 기능을 비활성화할 수 있습니다.

- **Documentation**
  - PullToRefresh의 `disabled` 속성 사용법과 예시가 공식 문서에 추가되었습니다.  
  - `disabled` 속성 적용 예제 컴포넌트가 새롭게 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->