### PR TITLE
fix: add missing storke-neutral-solid color

### DIFF
--- a/packages/css/all.css
+++ b/packages/css/all.css
@@ -397,6 +397,7 @@
   --seed-color-stroke-field-focused: var(--seed-color-palette-gray-800);
   --seed-color-stroke-neutral-muted: var(--seed-color-palette-gray-200);
   --seed-color-stroke-on-image: var(--seed-color-palette-static-black-alpha-50);
+  --seed-color-stroke-neutral-solid: var(--seed-color-palette-gray-300);
   --seed-color-manner-temp-l1-bg: #eff0f1;
   --seed-color-manner-temp-l1-text: #62666a;
   --seed-color-manner-temp-l2-bg: #e7f2fc;
@@ -554,6 +555,7 @@
   --seed-color-stroke-field-focused: var(--seed-color-palette-gray-800);
   --seed-color-stroke-neutral-muted: var(--seed-color-palette-gray-200);
   --seed-color-stroke-on-image: var(--seed-color-palette-static-black-alpha-50);
+  --seed-color-stroke-neutral-solid: var(--seed-color-palette-gray-400);
   --seed-color-manner-temp-l1-bg: #222226;
   --seed-color-manner-temp-l1-text: #b1b5b9;
   --seed-color-manner-temp-l2-bg: #16212b;

--- a/packages/css/base.css
+++ b/packages/css/base.css
@@ -397,6 +397,7 @@
   --seed-color-stroke-field-focused: var(--seed-color-palette-gray-800);
   --seed-color-stroke-neutral-muted: var(--seed-color-palette-gray-200);
   --seed-color-stroke-on-image: var(--seed-color-palette-static-black-alpha-50);
+  --seed-color-stroke-neutral-solid: var(--seed-color-palette-gray-300);
   --seed-color-manner-temp-l1-bg: #eff0f1;
   --seed-color-manner-temp-l1-text: #62666a;
   --seed-color-manner-temp-l2-bg: #e7f2fc;
@@ -554,6 +555,7 @@
   --seed-color-stroke-field-focused: var(--seed-color-palette-gray-800);
   --seed-color-stroke-neutral-muted: var(--seed-color-palette-gray-200);
   --seed-color-stroke-on-image: var(--seed-color-palette-static-black-alpha-50);
+  --seed-color-stroke-neutral-solid: var(--seed-color-palette-gray-400);
   --seed-color-manner-temp-l1-bg: #222226;
   --seed-color-manner-temp-l1-text: #b1b5b9;
   --seed-color-manner-temp-l2-bg: #16212b;

--- a/packages/css/vars/color/stroke.d.ts
+++ b/packages/css/vars/color/stroke.d.ts
@@ -8,3 +8,4 @@ export declare const positive = "var(--seed-color-stroke-positive)";
 export declare const fieldFocused = "var(--seed-color-stroke-field-focused)";
 export declare const neutralMuted = "var(--seed-color-stroke-neutral-muted)";
 export declare const onImage = "var(--seed-color-stroke-on-image)";
+export declare const neutralSolid = "var(--seed-color-stroke-neutral-solid)";

--- a/packages/css/vars/color/stroke.mjs
+++ b/packages/css/vars/color/stroke.mjs
@@ -8,3 +8,4 @@ export const positive = "var(--seed-color-stroke-positive)";
 export const fieldFocused = "var(--seed-color-stroke-field-focused)";
 export const neutralMuted = "var(--seed-color-stroke-neutral-muted)";
 export const onImage = "var(--seed-color-stroke-on-image)";
+export const neutralSolid = "var(--seed-color-stroke-neutral-solid)";


### PR DESCRIPTION
- 피그마 정의에서 누락된 storke-neutral-solid 컬러를 추가해요.
- 빠진 부분이 있으면 수정 부탁드려요~ 최근 커밋을 살펴보았는데 컬러하나 추가된건 못찾아서 예상되는 코드만 수정해뒀어요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 라이트 및 다크 모드에 중립 솔리드 스트로크 색상 변수가 추가되었습니다.  
  - 새로운 중립 스트로크 색상 옵션이 제공되어 다양한 테마에서 일관된 디자인 적용이 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->