### PR TITLE
feat(stackflow): prevent AppScreen from touch events during transition

### DIFF
--- a/.changeset/witty-coats-attack.md
+++ b/.changeset/witty-coats-attack.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/stackflow": patch
+---
+
+화면 전환 중 터치 입력이 차단합니다.

--- a/packages/stackflow/src/primitive/AppScreen/AppScreen.tsx
+++ b/packages/stackflow/src/primitive/AppScreen/AppScreen.tsx
@@ -1,6 +1,7 @@
+import { composeRefs } from "@radix-ui/react-compose-refs";
 import { mergeProps } from "@seed-design/dom-utils";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";
-import { forwardRef } from "react";
+import { forwardRef, useRef } from "react";
 import { useAppScreen, type UseAppScreenProps } from "./useAppScreen";
 import { AppScreenProvider, useAppScreenContext } from "./useAppScreenContext";
 import { usePreventTouchDuringTransition } from "@stackflow/react-ui-core";
@@ -19,6 +20,7 @@ export const AppScreenRoot = forwardRef<HTMLDivElement, AppScreenRootProps>((pro
     onSwipeBackStart,
     ...otherProps
   } = props;
+  const innerRef = useRef<HTMLDivElement>(null);
   const api = useAppScreen({
     swipeBackDisplacementRatioThreshold,
     swipeBackVelocityThreshold,
@@ -26,15 +28,14 @@ export const AppScreenRoot = forwardRef<HTMLDivElement, AppScreenRootProps>((pro
     onSwipeBackMove,
     onSwipeBackStart,
   });
-
   usePreventTouchDuringTransition({
-    appScreenRef: ref as React.RefObject<HTMLDivElement>,
+    appScreenRef: innerRef as React.RefObject<HTMLDivElement>,
   });
 
   return (
     <AppScreenProvider value={api}>
       <Primitive.div
-        ref={ref}
+        ref={composeRefs(innerRef, ref)}
         data-stackflow-component-name="AppScreen"
         {...mergeProps(api.activityProps, otherProps)}
       />

--- a/packages/stackflow/src/primitive/AppScreen/AppScreen.tsx
+++ b/packages/stackflow/src/primitive/AppScreen/AppScreen.tsx
@@ -3,6 +3,7 @@ import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";
 import { forwardRef } from "react";
 import { useAppScreen, type UseAppScreenProps } from "./useAppScreen";
 import { AppScreenProvider, useAppScreenContext } from "./useAppScreenContext";
+import { usePreventTouchDuringTransition } from "@stackflow/react-ui-core";
 
 export interface AppScreenRootProps
   extends PrimitiveProps,
@@ -24,6 +25,10 @@ export const AppScreenRoot = forwardRef<HTMLDivElement, AppScreenRootProps>((pro
     onSwipeBackEnd,
     onSwipeBackMove,
     onSwipeBackStart,
+  });
+
+  usePreventTouchDuringTransition({
+    appScreenRef: ref as React.RefObject<HTMLDivElement>,
   });
 
   return (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 화면 전환 중 터치 입력이 차단되어, 더 안정적인 화면 전환이 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->