### PR TITLE
feat(rootage): add missing schema fields to 19 component YAML files

### DIFF
--- a/packages/rootage/components/avatar-stack.yaml
+++ b/packages/rootage/components/avatar-stack.yaml
@@ -4,6 +4,20 @@ metadata:
   id: avatar-stack
   name: Avatar Stack
 data:
+  schema:
+    slots:
+      root:
+        properties:
+          gap:
+            type: dimension
+      item:
+        properties:
+          cornerRadius:
+            type: dimension
+          strokeColor:
+            type: color
+          strokeWidth:
+            type: dimension
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/checkbox.yaml
+++ b/packages/rootage/components/checkbox.yaml
@@ -5,6 +5,42 @@ metadata:
   id: checkbox
   name: Checkbox
 data:
+  schema:
+    slots:
+      root:
+        properties:
+          gap:
+            type: dimension
+          minHeight:
+            type: dimension
+      label:
+        properties:
+          color:
+            type: color
+          fontWeight:
+            type: number
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+      control:
+        properties:
+          color:
+            type: color
+          strokeColor:
+            type: color
+          strokeWidth:
+            type: dimension
+          size:
+            type: dimension
+          cornerRadius:
+            type: dimension
+      icon:
+        properties:
+          color:
+            type: color
+          size:
+            type: dimension
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/chip-tab.yaml
+++ b/packages/rootage/components/chip-tab.yaml
@@ -4,6 +4,28 @@ metadata:
   id: chip-tab
   name: Chip Tab
 data:
+  schema:
+    slots:
+      root:
+        properties:
+          paddingX:
+            type: dimension
+          paddingY:
+            type: dimension
+          cornerRadius:
+            type: dimension
+          minHeight:
+            type: dimension
+          color:
+            type: color
+      label:
+        properties:
+          fontSize:
+            type: dimension
+          fontWeight:
+            type: number
+          color:
+            type: color
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/chip-tablist.yaml
+++ b/packages/rootage/components/chip-tablist.yaml
@@ -4,6 +4,14 @@ metadata:
   id: chip-tablist
   name: Chip Tablist
 data:
+  schema:
+    slots:
+      root:
+        properties:
+          paddingX:
+            type: dimension
+          gap:
+            type: dimension
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/contextual-floating-button.yaml
+++ b/packages/rootage/components/contextual-floating-button.yaml
@@ -4,6 +4,62 @@ metadata:
   id: contextual-floating-button
   name: Contextual Floating Button
 data:
+  schema:
+    slots:
+      root:
+        properties:
+          cornerRadius:
+            type: dimension
+          shadow:
+            type: shadow
+          colorDuration:
+            type: duration
+          colorTimingFunction:
+            type: cubicBezier
+          color:
+            type: color
+          minHeight:
+            type: dimension
+          paddingX:
+            type: dimension
+          paddingY:
+            type: dimension
+          gap:
+            type: dimension
+          size:
+            type: dimension
+      progressCircle:
+        properties:
+          size:
+            type: dimension
+          thickness:
+            type: dimension
+          trackColor:
+            type: color
+          rangeColor:
+            type: color
+      label:
+        properties:
+          color:
+            type: color
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+          fontWeight:
+            type: number
+      prefixIcon:
+        properties:
+          color:
+            type: color
+          size:
+            type: dimension
+      icon:
+        properties:
+          color:
+            type: color
+          size:
+            type: dimension
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/extended-fab.yaml
+++ b/packages/rootage/components/extended-fab.yaml
@@ -5,6 +5,40 @@ metadata:
   name: Extended Fab
   deprecated: Use contextual-floating-button instead.
 data:
+  schema:
+    slots:
+      root:
+        properties:
+          cornerRadius:
+            type: dimension
+          shadow:
+            type: shadow
+          color:
+            type: color
+          minHeight:
+            type: dimension
+          gap:
+            type: dimension
+          paddingX:
+            type: dimension
+          paddingY:
+            type: dimension
+      label:
+        properties:
+          color:
+            type: color
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+          fontWeight:
+            type: number
+      prefixIcon:
+        properties:
+          color:
+            type: color
+          size:
+            type: dimension
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/fab.yaml
+++ b/packages/rootage/components/fab.yaml
@@ -5,6 +5,24 @@ metadata:
   name: Fab
   deprecated: Use contextual-floating-button instead.
 data:
+  schema:
+    slots:
+      root:
+        properties:
+          color:
+            type: color
+          cornerRadius:
+            type: dimension
+          size:
+            type: dimension
+          shadow:
+            type: shadow
+      icon:
+        properties:
+          color:
+            type: color
+          size:
+            type: dimension
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/floating-action-button.yaml
+++ b/packages/rootage/components/floating-action-button.yaml
@@ -4,6 +4,54 @@ metadata:
   id: floating-action-button
   name: Floating Action Button
 data:
+  schema:
+    slots:
+      root:
+        properties:
+          color:
+            type: color
+          cornerRadius:
+            type: dimension
+          shadow:
+            type: shadow
+          colorDuration:
+            type: duration
+          colorTimingFunction:
+            type: cubicBezier
+          layoutDuration:
+            type: duration
+          layoutTimingFunction:
+            type: cubicBezier
+          gap:
+            type: dimension
+          paddingX:
+            type: dimension
+          paddingY:
+            type: dimension
+          minHeight:
+            type: dimension
+          size:
+            type: dimension
+      icon:
+        properties:
+          color:
+            type: color
+          sizeDuration:
+            type: duration
+          sizeTimingFunction:
+            type: cubicBezier
+          size:
+            type: dimension
+      label:
+        properties:
+          color:
+            type: color
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+          fontWeight:
+            type: number
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/identity-placeholder.yaml
+++ b/packages/rootage/components/identity-placeholder.yaml
@@ -4,6 +4,16 @@ metadata:
   id: identity-placeholder
   name: Identity Placeholder
 data:
+  schema:
+    slots:
+      root:
+        properties:
+          color:
+            type: color
+      image:
+        properties:
+          color:
+            type: color
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/notification-badge.yaml
+++ b/packages/rootage/components/notification-badge.yaml
@@ -4,6 +4,38 @@ metadata:
   id: notification-badge
   name: Notification Badge
 data:
+  schema:
+    slots:
+      root:
+        properties:
+          color:
+            type: color
+          minHeight:
+            type: dimension
+          paddingX:
+            type: dimension
+          paddingY:
+            type: dimension
+          cornerRadius:
+            type: dimension
+          iconAttachedInsetEnd:
+            type: dimension
+          iconAttachedInsetTop:
+            type: dimension
+          textAttachedGap:
+            type: dimension
+          size:
+            type: dimension
+      label:
+        properties:
+          color:
+            type: color
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+          fontWeight:
+            type: number
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/reaction-button.yaml
+++ b/packages/rootage/components/reaction-button.yaml
@@ -4,6 +4,66 @@ metadata:
   id: reaction-button
   name: Reaction Button
 data:
+  schema:
+    slots:
+      root:
+        properties:
+          color:
+            type: color
+          colorDuration:
+            type: duration
+          colorTimingFunction:
+            type: cubicBezier
+          strokeColor:
+            type: color
+          strokeWidth:
+            type: dimension
+          minHeight:
+            type: dimension
+          cornerRadius:
+            type: dimension
+          gap:
+            type: dimension
+          paddingX:
+            type: dimension
+          paddingY:
+            type: dimension
+      label:
+        properties:
+          color:
+            type: color
+          fontWeight:
+            type: number
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+      count:
+        properties:
+          color:
+            type: color
+          fontWeight:
+            type: number
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+      prefixIcon:
+        properties:
+          color:
+            type: color
+          size:
+            type: dimension
+      progressCircle:
+        properties:
+          trackColor:
+            type: color
+          rangeColor:
+            type: color
+          size:
+            type: dimension
+          thickness:
+            type: dimension
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/segmented-control-item.yaml
+++ b/packages/rootage/components/segmented-control-item.yaml
@@ -5,6 +5,30 @@ metadata:
   id: segmented-control-item
   name: Segmented Control Item
 data:
+  schema:
+    slots:
+      root:
+        properties:
+          height:
+            type: dimension
+          cornerRadius:
+            type: dimension
+          paddingX:
+            type: dimension
+          minWidth:
+            type: dimension
+          color:
+            type: color
+      label:
+        properties:
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+          fontWeight:
+            type: number
+          color:
+            type: color
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/segmented-control.yaml
+++ b/packages/rootage/components/segmented-control.yaml
@@ -5,6 +5,28 @@ metadata:
   id: segmented-control
   name: Segmented Control
 data:
+  schema:
+    slots:
+      root:
+        properties:
+          padding:
+            type: dimension
+          cornerRadius:
+            type: dimension
+          color:
+            type: color
+      indicator:
+        properties:
+          color:
+            type: color
+          cornerRadius:
+            type: dimension
+          shadow:
+            type: shadow
+          transformDuration:
+            type: duration
+          transformTimingFunction:
+            type: cubicBezier
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/switch.yaml
+++ b/packages/rootage/components/switch.yaml
@@ -5,6 +5,50 @@ metadata:
   id: switch
   name: Switch
 data:
+  schema:
+    slots:
+      root:
+        properties:
+          height:
+            type: dimension
+          gap:
+            type: dimension
+          opacity:
+            type: number
+      control:
+        properties:
+          color:
+            type: color
+          cornerRadius:
+            type: dimension
+          height:
+            type: dimension
+          width:
+            type: dimension
+          paddingX:
+            type: dimension
+          paddingY:
+            type: dimension
+      thumb:
+        properties:
+          color:
+            type: color
+          cornerRadius:
+            type: dimension
+          height:
+            type: dimension
+          width:
+            type: dimension
+          shadow:
+            type: shadow
+      label:
+        properties:
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+          fontWeight:
+            type: number
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/tab.yaml
+++ b/packages/rootage/components/tab.yaml
@@ -4,6 +4,26 @@ metadata:
   id: tab
   name: Tab
 data:
+  schema:
+    slots:
+      root:
+        properties:
+          minHeight:
+            type: dimension
+          paddingX:
+            type: dimension
+          paddingY:
+            type: dimension
+      label:
+        properties:
+          color:
+            type: color
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+          fontWeight:
+            type: number
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/tablist.yaml
+++ b/packages/rootage/components/tablist.yaml
@@ -4,6 +4,32 @@ metadata:
   id: tablist
   name: Tablist
 data:
+  schema:
+    slots:
+      root:
+        properties:
+          color:
+            type: color
+          strokeBottomWidth:
+            type: dimension
+          strokeColor:
+            type: color
+          paddingX:
+            type: dimension
+          height:
+            type: dimension
+      indicator:
+        properties:
+          height:
+            type: dimension
+          color:
+            type: color
+          transformDuration:
+            type: duration
+          transformTimingFunction:
+            type: cubicBezier
+          insetX:
+            type: dimension
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/text-field.yaml
+++ b/packages/rootage/components/text-field.yaml
@@ -4,6 +4,146 @@ metadata:
   id: text-field
   name: Text Field
 data:
+  schema:
+    slots:
+      header:
+        properties:
+          paddingBottom:
+            type: dimension
+          gap:
+            type: dimension
+      label:
+        properties:
+          color:
+            type: color
+          fontWeight:
+            type: number
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+      indicator:
+        properties:
+          color:
+            type: color
+          fontWeight:
+            type: number
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+      field:
+        properties:
+          color:
+            type: color
+          strokeWidth:
+            type: dimension
+          strokeColor:
+            type: color
+          minHeight:
+            type: dimension
+          cornerRadius:
+            type: dimension
+          gap:
+            type: dimension
+          paddingX:
+            type: dimension
+          paddingY:
+            type: dimension
+      value:
+        properties:
+          color:
+            type: color
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+      placeholder:
+        properties:
+          color:
+            type: color
+      prefixText:
+        properties:
+          color:
+            type: color
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+      prefixIcon:
+        properties:
+          color:
+            type: color
+          size:
+            type: dimension
+      suffixText:
+        properties:
+          color:
+            type: color
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+      suffixIcon:
+        properties:
+          color:
+            type: color
+          size:
+            type: dimension
+      footer:
+        properties:
+          gap:
+            type: dimension
+          paddingTop:
+            type: dimension
+          minHeight:
+            type: dimension
+      description:
+        properties:
+          color:
+            type: color
+          fontWeight:
+            type: number
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+      errorMessage:
+        properties:
+          color:
+            type: color
+          fontWeight:
+            type: number
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+      errorIcon:
+        properties:
+          size:
+            type: dimension
+          marginRight:
+            type: dimension
+      characterCount:
+        properties:
+          color:
+            type: color
+          fontWeight:
+            type: number
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+      maxCharacterCount:
+        properties:
+          color:
+            type: color
+          fontWeight:
+            type: number
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/top-navigation.yaml
+++ b/packages/rootage/components/top-navigation.yaml
@@ -5,6 +5,44 @@ metadata:
   id: top-navigation
   name: Top Navigation
 data:
+  schema:
+    slots:
+      root:
+        properties:
+          minHeight:
+            type: dimension
+          paddingX:
+            type: dimension
+          color:
+            type: color
+          strokeColor:
+            type: color
+          strokeWidth:
+            type: dimension
+      icon:
+        properties:
+          size:
+            type: dimension
+          targetSize:
+            type: dimension
+          color:
+            type: color
+      title:
+        properties:
+          color:
+            type: color
+          fontSize:
+            type: dimension
+          fontWeight:
+            type: number
+      subtitle:
+        properties:
+          color:
+            type: color
+          fontSize:
+            type: dimension
+          fontWeight:
+            type: number
   definitions:
     theme=cupertino:
       enabled:

--- a/packages/rootage/components/typography.yaml
+++ b/packages/rootage/components/typography.yaml
@@ -4,6 +4,16 @@ metadata:
   id: typography
   name: Typography
 data:
+  schema:
+    slots:
+      root:
+        properties:
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+          fontWeight:
+            type: number
   definitions:
     textStyle=screenTitle:
       enabled:


### PR DESCRIPTION
스키마 필드 정의가 누락된 19개의 컴포넌트 스펙 파일에 대해 `schema` 필드를 추가합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 다양한 컴포넌트에 슬롯별 속성과 타입이 명시된 새로운 스키마 섹션이 추가되었습니다.  
  * 각 컴포넌트의 슬롯(예: root, label, icon 등)에 대해 사용 가능한 스타일 속성과 타입이 명확하게 문서화되어, 커스터마이징 및 툴링 지원이 향상되었습니다.  
  * 기존 동작이나 스타일에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->