### PR TITLE
docs: fix styles in examples; add more component usage examples

### DIFF
--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -202,6 +202,7 @@
 }
 
 .example-reset {
+  line-height: normal;
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
 }

--- a/docs/components/example/menu-sheet-with-title.tsx
+++ b/docs/components/example/menu-sheet-with-title.tsx
@@ -1,0 +1,48 @@
+import { IconEyeSlashLine } from "@karrotmarket/react-monochrome-icon";
+import { PrefixIcon } from "@seed-design/react";
+import { ActionButton } from "seed-design/ui/action-button";
+import {
+  MenuSheetContent,
+  MenuSheetGroup,
+  MenuSheetItem,
+  MenuSheetRoot,
+  MenuSheetTrigger,
+} from "seed-design/ui/menu-sheet";
+
+const MenuSheetWithTitle = () => {
+  return (
+    <MenuSheetRoot>
+      <MenuSheetTrigger asChild>
+        <ActionButton>Open</ActionButton>
+      </MenuSheetTrigger>
+      <MenuSheetContent title="Menu Sheet">
+        <MenuSheetGroup>
+          <MenuSheetItem>
+            <PrefixIcon svg={<IconEyeSlashLine />} />
+            Action 1
+          </MenuSheetItem>
+          <MenuSheetItem>
+            <PrefixIcon svg={<IconEyeSlashLine />} />
+            Action 2
+          </MenuSheetItem>
+          <MenuSheetItem>
+            <PrefixIcon svg={<IconEyeSlashLine />} />
+            Action 3
+          </MenuSheetItem>
+        </MenuSheetGroup>
+        <MenuSheetGroup>
+          <MenuSheetItem>
+            <PrefixIcon svg={<IconEyeSlashLine />} />
+            Action 4
+          </MenuSheetItem>
+          <MenuSheetItem tone="critical">
+            <PrefixIcon svg={<IconEyeSlashLine />} />
+            Action 5
+          </MenuSheetItem>
+        </MenuSheetGroup>
+      </MenuSheetContent>
+    </MenuSheetRoot>
+  );
+};
+
+export default MenuSheetWithTitle;

--- a/docs/content/react/components/(tabs)/tabs.mdx
+++ b/docs/content/react/components/(tabs)/tabs.mdx
@@ -22,23 +22,23 @@ npx @seed-design/cli@latest add tabs
 
 ## Props
 
-### TabsRoot
+### `TabsRoot`
 
 <react-type-table path="./registry/ui/tabs.tsx" name="TabsRootProps" />
 
-### TabsList
+### `TabsList`
 
 <react-type-table path="./registry/ui/tabs.tsx" name="TabsListProps" />
 
-### TabsTrigger
+### `TabsTrigger`
 
 <react-type-table path="./registry/ui/tabs.tsx" name="TabsTriggerProps" />
 
-### TabsCarousel
+### `TabsCarousel`
 
 <react-type-table path="./registry/ui/tabs.tsx" name="TabsCarouselProps" />
 
-### TabsContent
+### `TabsContent`
 
 <react-type-table path="./registry/ui/tabs.tsx" name="TabsContentProps" />
 

--- a/docs/content/react/components/alert-dialog.mdx
+++ b/docs/content/react/components/alert-dialog.mdx
@@ -22,9 +22,53 @@ npx @seed-design/cli@latest add alert-dialog
 
 ## Props
 
+### `AlertDialogRoot`
+
 <react-type-table
   path="./registry/ui/alert-dialog.tsx"
   name="AlertDialogRootProps"
+/>
+
+### `AlertDialogTrigger`
+
+<react-type-table
+  path="./registry/ui/alert-dialog.tsx"
+  name="AlertDialogTriggerProps"
+/>
+
+### `AlertDialogContent`
+
+<react-type-table
+  path="./registry/ui/alert-dialog.tsx"
+  name="AlertDialogContentProps"
+/>
+
+### `AlertDialogHeader`
+
+<react-type-table
+  path="./registry/ui/alert-dialog.tsx"
+  name="AlertDialogHeaderProps"
+/>
+
+### `AlertDialogTitle`
+
+<react-type-table
+  path="./registry/ui/alert-dialog.tsx"
+  name="AlertDialogTitleProps"
+/>
+
+### `AlertDialogDescription`
+
+<react-type-table
+  path="./registry/ui/alert-dialog.tsx"
+  name="AlertDialogDescriptionProps"
+/>
+
+### `AlertDialogFooter`
+
+<react-type-table
+  path="./registry/ui/alert-dialog.tsx"
+  name="AlertDialogFooterProps"
 />
 
 ## Examples

--- a/docs/content/react/components/avatar.mdx
+++ b/docs/content/react/components/avatar.mdx
@@ -22,7 +22,18 @@ npx @seed-design/cli@latest add avatar
 
 ## Props
 
+### `Avatar`
+
 <react-type-table path="./registry/ui/avatar.tsx" name="AvatarProps" />
+
+### `AvatarBadge`
+
+<react-type-table path="./registry/ui/avatar.tsx" name="AvatarBadgeProps" />
+
+### `AvatarStack`
+
+<react-type-table path="./registry/ui/avatar.tsx" name="AvatarStackProps" />
+
 
 ## Examples
 

--- a/docs/content/react/components/bottom-sheet.mdx
+++ b/docs/content/react/components/bottom-sheet.mdx
@@ -22,10 +22,41 @@ npx @seed-design/cli@latest add bottom-sheet
 
 ## Props
 
+### `BottomSheetRoot`
+
 <react-type-table
   path="./registry/ui/bottom-sheet.tsx"
   name="BottomSheetRootProps"
 />
+
+### `BottomSheetTrigger`
+
+<react-type-table
+  path="./registry/ui/bottom-sheet.tsx"
+  name="BottomSheetTriggerProps"
+/>
+
+### `BottomSheetContent`
+
+<react-type-table
+  path="./registry/ui/bottom-sheet.tsx"
+  name="BottomSheetContentProps"
+/>
+
+### `BottomSheetBody`
+
+<react-type-table
+  path="./registry/ui/bottom-sheet.tsx"
+  name="BottomSheetBodyProps"
+/>
+
+### `BottomSheetFooter`
+
+<react-type-table
+  path="./registry/ui/bottom-sheet.tsx"
+  name="BottomSheetFooterProps"
+/>
+
 
 ## Examples
 

--- a/docs/content/react/components/divider.mdx
+++ b/docs/content/react/components/divider.mdx
@@ -12,16 +12,16 @@ description: Divider는 구분선을 표시하는 컴포넌트입니다.
   ```
 </ComponentExample>
 
-## Usage
+## Props
+
+<react-type-table path="../packages/react/src/components/Divider/Divider.tsx" name="DividerProps" />
+
+## Examples
 
 ```tsx
 import { Divider } from "@seed-design/react";
 ```
 
-```tsx
+```
 <Divider />
 ```
-
-## Props
-
-<react-type-table path="../packages/react/src/components/Divider/Divider.tsx" name="DividerProps" />

--- a/docs/content/react/components/extended-action-sheet.mdx
+++ b/docs/content/react/components/extended-action-sheet.mdx
@@ -28,11 +28,25 @@ npx @seed-design/cli@latest add extended-action-sheet
   name="ExtendedActionSheetRootProps"
 />
 
+### `ExtendedActionSheetTrigger`
+
+<react-type-table
+  path="./registry/ui/extended-action-sheet.tsx"
+  name="ExtendedActionSheetTriggerProps"
+/>
+
 ### `ExtendedActionSheetContent`
 
 <react-type-table
   path="./registry/ui/extended-action-sheet.tsx"
   name="ExtendedActionSheetContentProps"
+/>
+
+### `ExtendedActionSheetGroup`
+
+<react-type-table
+  path="./registry/ui/extended-action-sheet.tsx"
+  name="ExtendedActionSheetGroupProps"
 />
 
 ### `ExtendedActionSheetItem`

--- a/docs/content/react/components/help-bubble.mdx
+++ b/docs/content/react/components/help-bubble.mdx
@@ -22,9 +22,18 @@ npx @seed-design/cli@latest add help-bubble
 
 ## Props
 
+### `HelpBubbleTrigger`
+
 <react-type-table
   path="./registry/ui/help-bubble.tsx"
   name="HelpBubbleTriggerProps"
+/>
+
+### `HelpBubbleAnchor`
+
+<react-type-table
+  path="./registry/ui/help-bubble.tsx"
+  name="HelpBubbleAnchorProps"
 />
 
 ## Examples

--- a/docs/content/react/components/menu-sheet.mdx
+++ b/docs/content/react/components/menu-sheet.mdx
@@ -29,11 +29,25 @@ npx @seed-design/cli@latest add menu-sheet
   name="MenuSheetRootProps"
 />
 
+### `MenuSheetTrigger`
+
+<react-type-table
+  path="./registry/ui/menu-sheet.tsx"
+  name="MenuSheetTriggerProps"
+/>
+
 ### `MenuSheetContent`
 
 <react-type-table
   path="./registry/ui/menu-sheet.tsx"
   name="MenuSheetContentProps"
+/>
+
+### `MenuSheetGroup`
+
+<react-type-table
+  path="./registry/ui/menu-sheet.tsx"
+  name="MenuSheetGroupProps"
 />
 
 ### `MenuSheetItem`
@@ -44,6 +58,17 @@ npx @seed-design/cli@latest add menu-sheet
 />
 
 ## Examples
+
+### With Title
+
+<ComponentExample name="menu-sheet-with-title">
+  ```json doc-gen:file
+  {
+    "file": "./components/example/menu-sheet-with-title.tsx",
+    "codeblock": true
+  }
+  ```
+</ComponentExample>
 
 ### `labelAlign="left"` (with `PrefixIcon`)
 

--- a/docs/content/react/components/pull-to-refresh.mdx
+++ b/docs/content/react/components/pull-to-refresh.mdx
@@ -22,15 +22,15 @@ npx @seed-design/cli@latest add pull-to-refresh
 
 ## Props
 
-### PullToRefreshRoot
+### `PullToRefreshRoot`
 
 <react-type-table path="./registry/ui/pull-to-refresh.tsx" name="PullToRefreshRootProps" />
 
-### PullToRefreshIndicator
+### `PullToRefreshIndicator`
 
 <react-type-table path="./registry/ui/pull-to-refresh.tsx" name="PullToRefreshIndicatorProps" />
 
-### PullToRefreshContent
+### `PullToRefreshContent`
 
 <react-type-table path="./registry/ui/pull-to-refresh.tsx" name="PullToRefreshContentProps" />
 

--- a/docs/content/react/components/snackbar.mdx
+++ b/docs/content/react/components/snackbar.mdx
@@ -22,16 +22,20 @@ npx @seed-design/cli@latest add snackbar
 
 ## Props
 
-### Snackbar
+### `Snackbar`
 
 <react-type-table path="./registry/ui/snackbar.tsx" name="SnackbarProps" />
 
-### SnackbarAdapter.create
+### `SnackbarAdapter.create` Parameters (`CreateSnackbarOptions`)
 
 <react-type-table
   path="./registry/ui/snackbar.tsx"
   name="CreateSnackbarOptions"
 />
+
+### `SnackbarProvider`
+
+<react-type-table path="./registry/ui/snackbar.tsx" name="SnackbarProviderProps" />
 
 ## Examples
 

--- a/docs/content/react/components/stackflow/app-screen.mdx
+++ b/docs/content/react/components/stackflow/app-screen.mdx
@@ -15,20 +15,36 @@ npx @seed-design/cli@latest add app-screen
 
 ## Props
 
-### AppScreen
+### App Screen
+
+#### `AppScreen`
 
 <react-type-table path="./registry/ui/app-screen.tsx" name="AppScreenProps" />
 
-### AppBar
+#### `AppScreenContent`
+
+<react-type-table path="./registry/ui/app-screen.tsx" name="AppScreenContentProps" />
+
+### App Bar
+
+#### `AppBar`
 
 <react-type-table path="./registry/ui/app-bar.tsx" name="AppBarProps" />
 
-### AppBarMain
+#### `AppBarLeft`
+
+<react-type-table path="./registry/ui/app-bar.tsx" name="AppBarLeftProps" />
+
+#### `AppBarMain`
 
 <react-type-table path="./registry/ui/app-bar.tsx" name="AppBarMainProps" />
 
+#### `AppBarRight`
+
+<react-type-table path="./registry/ui/app-bar.tsx" name="AppBarRightProps" />
+
 ## Examples
 
-### Transparent app bar
+### Transparent App Bar
 
 <StackflowExample names={["app-screen-transparent-bar"]} />

--- a/docs/content/react/get-started/llms-txt.mdx
+++ b/docs/content/react/get-started/llms-txt.mdx
@@ -7,12 +7,12 @@ description: 대규모 언어 모델(LLM)이 SEED Design React를 쉽게 이해�
 
 다음과 같은 LLMs.txt 파일들을 제공합니다:
 
-- [llms.txt](https://seed-design.io/react/llms.txt): LLMs.txt 파일들의 구조를 제공하는 메인 파일입니다.
-- [llms-full.txt](https://seed-design.io/react/llms-full.txt): SEED Design React의 모든 문서를 포함합니다.
-- [llms-changelog.txt](https://seed-design.io/react/llms-changelog.txt): 최신 업데이트와 변경사항을 포함하여 버전별 변경 내역을 확인할 수 있습니다.
-- [llms-components.txt](https://seed-design.io/react/llms-components.txt): 각 컴포넌트의 문서의 진입점입니다.
-  - [llms-components/action-button.txt](https://seed-design.io/react/llms-components/action-button.txt)
-  - [llms-components/chip.txt](https://seed-design.io/react/llms-components/chip.txt)
+- [llms.txt](/react/llms.txt): LLMs.txt 파일들의 구조를 제공하는 메인 파일입니다.
+- [llms-full.txt](/react/llms-full.txt): SEED Design React의 모든 문서를 포함합니다.
+- [llms-changelog.txt](/react/llms-changelog.txt): 최신 업데이트와 변경사항을 포함하여 버전별 변경 내역을 확인할 수 있습니다.
+- [llms-components.txt](/react/llms-components.txt): 각 컴포넌트의 문서의 진입점입니다.
+  - [llms-components/action-button.txt](/react/llms-components/action-button.txt)
+  - [llms-components/chip.txt](/react/llms-components/chip.txt)
   - etc...
 
 ## AI 도구와 함께 사용하기


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 새로운 메뉴 시트 예제 컴포넌트가 추가되었습니다.

* **Documentation**
  * Alert Dialog, Bottom Sheet, Extended Action Sheet, Help Bubble, Menu Sheet, Snackbar 등 다양한 컴포넌트의 props 문서가 세분화되고 표로 정리되어 가독성이 향상되었습니다.
  * Avatar, Divider, Stackflow App Screen, Tabs, Pull To Refresh 등 문서 구조와 스타일이 개선되었습니다.
  * LLMs.txt 관련 문서 링크가 절대경로에서 상대경로로 변경되었습니다.

* **Style**
  * `.example-reset` 클래스에 `line-height: normal;` 스타일이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->