### PR TITLE
chore: sync rootage json version with @seed-design/rootage-artifacts version in release PRs

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -58,3 +58,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
+      - name: 릴리즈 PR이 만들어지거나 업데이트된 경우 해당 PR의 base 브랜치를 체크아웃해요
+        if: steps.changesets.outputs.published == 'false'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: changeset-release/${{ github.ref_name }}
+
+      - name: rootage json 파일의 버전을 @seed-design/rootage-artifacts 버전에 맞춰요
+        if: steps.changesets.outputs.published == 'false'
+        run: |
+          bun install --frozen-lockfile
+          bun rootage:build
+          bun install # link
+          bun rootage:generate
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/public/rootage
+          git commit -m "Update public rootage version"
+          git push

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -75,5 +75,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add docs/public/rootage
-          git commit -m "Update public rootage version"
+          git commit -m "Update public rootage version" || echo "No changes to commit"
           git push

--- a/docs/public/rootage/index.json
+++ b/docs/public/rootage/index.json
@@ -1,6 +1,6 @@
 {
   "name": "Rootage",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "resources": [
     {
       "path": "/collections.json"


### PR DESCRIPTION
changeset이 릴리즈 PR을 만들거나 업데이트할 때, `@seed-design/rootage-artifacts` 패키지 버전에 맞춰 rootage json 파일의 버전을 수정해요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * GitHub Actions 워크플로우에서 패키지가 발행되지 않은 경우 루티지 버전을 자동으로 업데이트하고 커밋하는 단계가 추가되었습니다.

* **Documentation**
  * Rootage 리소스 메타데이터의 버전이 0.0.1에서 0.0.2로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->