### PR TITLE
feat: add page actions; refactor serving txt files

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,6 @@
         "chalk": "^5.3.0",
         "chromatic": "^13.0.0",
         "globby": "^14.1.0",
-        "gray-matter": "^4.0.3",
         "postcss": "^8.5.3",
         "storybook": "^9.0.16",
         "tailwindcss": "^4.1.4",

--- a/bun.lock
+++ b/bun.lock
@@ -97,7 +97,6 @@
         "@types/react-dom": "^19.1.5",
         "chalk": "^5.3.0",
         "chromatic": "^13.0.0",
-        "globby": "^14.1.0",
         "postcss": "^8.5.3",
         "storybook": "^9.0.16",
         "tailwindcss": "^4.1.4",

--- a/docs/app/react/[[...slug]]/page.tsx
+++ b/docs/app/react/[[...slug]]/page.tsx
@@ -1,5 +1,8 @@
+import { shouldGenerateLLMFriendlyText } from "@/app/react/_llms/page-filter";
+import { getSourceUrl } from "@/app/react/_llms/url";
 import { reactSource } from "@/app/source";
 import { mdxComponents } from "@/components/mdx-components";
+import { LLMCopyButton, ViewOptions } from "@/components/page-actions";
 import { getComponentStatus } from "@/components/rootage";
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/page";
 import type { Metadata } from "next";
@@ -7,6 +10,7 @@ import { notFound } from "next/navigation";
 
 export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
   const params = await props.params;
+
   const page = reactSource.getPage(params.slug ?? []);
   if (!page) notFound();
 
@@ -24,6 +28,20 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
     <span>{page.data.description}</span>
   );
 
+  const llmsSlugs = page.slugs.map((slug, index) => {
+    if (index === 0 && slug === "components") {
+      return "llms-components";
+    }
+
+    if (index === page.slugs.length - 1) {
+      return `${slug}.txt`;
+    }
+
+    return slug;
+  });
+
+  const markdownUrl = `/react/${llmsSlugs.join("/")}`;
+
   return (
     <DocsPage
       toc={toc}
@@ -36,6 +54,12 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
     >
       <DocsTitle>{displayTitle}</DocsTitle>
       <DocsDescription>{displayDescription}</DocsDescription>
+      {shouldGenerateLLMFriendlyText(page) && (
+        <div className="flex flex-row gap-2 items-center mb-3 justify-end">
+          <LLMCopyButton markdownUrl={markdownUrl} />
+          <ViewOptions markdownUrl={markdownUrl} githubUrl={getSourceUrl(page.path)} />
+        </div>
+      )}
       <DocsBody>
         <MDX components={mdxComponents} />
       </DocsBody>

--- a/docs/app/react/_llms/page-filter.ts
+++ b/docs/app/react/_llms/page-filter.ts
@@ -1,0 +1,12 @@
+import type { Page } from "fumadocs-core/source";
+
+export function shouldGenerateLLMFriendlyText({ slugs }: Page) {
+  const [firstSlug, secondSlug] = slugs;
+
+  // include components/** but exclude components/concepts
+  if (firstSlug !== "components" || (firstSlug === "components" && secondSlug === "concepts")) {
+    return false;
+  }
+
+  return true;
+}

--- a/docs/app/react/_llms/page-filter.ts
+++ b/docs/app/react/_llms/page-filter.ts
@@ -3,10 +3,11 @@ import type { Page } from "fumadocs-core/source";
 export function shouldGenerateLLMFriendlyText({ slugs }: Page) {
   const [firstSlug, secondSlug] = slugs;
 
-  // include components/** but exclude components/concepts
-  if (firstSlug !== "components" || (firstSlug === "components" && secondSlug === "concepts")) {
-    return false;
-  }
+  // include components/**
+  if (firstSlug !== "components") return false;
+
+  // exclude components/concepts
+  if (secondSlug === "concepts") return false;
 
   return true;
 }

--- a/docs/app/react/_llms/process-content.ts
+++ b/docs/app/react/_llms/process-content.ts
@@ -1,6 +1,7 @@
 import { typeTableGenerator } from "@/components/type-table/generator";
 import { remarkReactTypeTable } from "@/components/type-table/remark-react-type-table";
-import { fileGenerator, remarkDocGen, remarkInstall } from "fumadocs-docgen";
+import { fileGenerator, remarkDocGen } from "fumadocs-docgen";
+import { remarkNpm } from "fumadocs-core/mdx-plugins";
 import { remarkInclude } from "fumadocs-mdx/config";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
@@ -14,7 +15,7 @@ export async function processContent(path: string, content: string): Promise<str
     .use(remarkGfm)
     .use(remarkReactTypeTable, { generator: typeTableGenerator })
     .use(remarkDocGen, { generators: [fileGenerator()] })
-    .use(remarkInstall, { persist: { id: "package-manager" } })
+    .use(remarkNpm, { persist: { id: "package-manager" } })
     .use(remarkStringify)
     .process({
       path,

--- a/docs/app/react/_llms/url.ts
+++ b/docs/app/react/_llms/url.ts
@@ -1,0 +1,6 @@
+const OWNER = "daangn";
+const REPO = "seed-design";
+
+export function getSourceUrl(pagePath: string) {
+  return `https://github.com/${OWNER}/${REPO}/blob/dev/docs/content/react/${pagePath}`;
+}

--- a/docs/app/react/llms-changelog.txt/route.ts
+++ b/docs/app/react/llms-changelog.txt/route.ts
@@ -1,27 +1,22 @@
-import { globby } from "globby";
-import matter from "gray-matter";
-import * as fs from "node:fs/promises";
 import { processContent } from "../_llms/process-content";
+import { reactSource } from "@/app/source";
+import { notFound } from "next/navigation";
 
 export const revalidate = false;
 
 export async function GET() {
-  const files = await globby(["./content/react/get-started/changelog.mdx"]);
+  const page = reactSource.getPage(["get-started", "changelog"]);
 
-  if (files.length === 0) {
-    return new Response("Changelog not found", { status: 404 });
-  }
+  if (!page) return notFound();
 
-  const fileContent = await fs.readFile(files[0]);
-  const { content } = matter(fileContent.toString());
-  const processed = await processContent(files[0], content);
+  const processed = await processContent(page.path, page.data.content);
 
-  const llmsContent = `# SEED Design React - Changelog
+  const response = `# SEED Design React - Changelog
 
 이 파일은 SEED Design React의 변경사항과 업데이트 내역을 담고 있습니다.
 각 버전별 변경사항, 새로운 기능, 버그 수정 등을 확인할 수 있습니다.
 
 ${processed}`;
 
-  return new Response(llmsContent);
+  return new Response(response);
 }

--- a/docs/app/react/llms-components.txt/route.ts
+++ b/docs/app/react/llms-components.txt/route.ts
@@ -1,30 +1,39 @@
-import { globby } from "globby";
+import type { NextRequest } from "next/server";
+import { reactSource } from "@/app/source";
 
 export const revalidate = false;
-
-const BASE_URL = "https://seed-design.io";
 
 /**
  * This is an entry point for accessing individual component documentation.
  * Each component can be accessed through its specific endpoint.
  */
-export async function GET() {
-  const files = await globby([
-    "./content/react/components/**/*.mdx",
-    "!./content/react/components/concepts/**/*.mdx", // Exclude concept pages
-  ]);
+export async function GET({ nextUrl }: NextRequest) {
+  const componentPages = reactSource.getPages().filter((page) => {
+    const [firstSlug, secondSlug] = page.slugs;
 
-  const components = files
-    .map((file) => {
-      const relativePath = file.replace("./content/react/components/", "");
-      const componentPath = relativePath.replace(".mdx", "");
-      const cleanPath = componentPath.replace(/\(([^)]+)\)\//g, "$1/");
-      const apiUrl = `${BASE_URL}/react/llms-components/${cleanPath}.txt`;
-      return `- [${cleanPath}](${apiUrl})`;
+    return firstSlug === "components" && secondSlug !== "concepts";
+  });
+
+  const components = componentPages
+    .map(({ data, slugs }) => {
+      const [_firstSlug, ...restSlugs] = slugs;
+
+      // Attach .txt extension to the last slug
+      const path = restSlugs
+        .map((slug, index) => {
+          if (index === restSlugs.length - 1) return `${slug}.txt`;
+
+          return slug;
+        })
+        .join("/");
+
+      const txtUrl = new URL(`/react/llms-components/${path}`, nextUrl.origin);
+
+      return `- [${data.title}](${txtUrl})`;
     })
-    .sort();
+    .sort((a, b) => a.localeCompare(b));
 
-  const entryContent = `# SEED Design React Components - LLM Reference Entry
+  const response = `# SEED Design React Components - LLM Reference Entry
 
 This is an entry point for accessing individual component documentation.
 Each component can be accessed through its specific endpoint.
@@ -36,7 +45,7 @@ ${components.join("\n")}
 ## Usage
 
 To get information about a specific component, access its endpoint:
-Example: /react/llms-components/action-button
+Example: /react/llms-components/action-button.txt
 
 The response will include the full MDX content for that component, processed and ready for LLM consumption.
 
@@ -46,10 +55,5 @@ The response will include the full MDX content for that component, processed and
 - Changelog: /react/llms-changelog.txt
 `;
 
-  return new Response(entryContent, {
-    headers: {
-      "Content-Type": "text/plain; charset=utf-8",
-      "Content-Disposition": 'inline; filename="llms-components.txt"',
-    },
-  });
+  return new Response(response);
 }

--- a/docs/app/react/llms-components.txt/route.ts
+++ b/docs/app/react/llms-components.txt/route.ts
@@ -1,14 +1,15 @@
-import type { NextRequest } from "next/server";
 import { reactSource } from "@/app/source";
 import { shouldGenerateLLMFriendlyText } from "@/app/react/_llms/page-filter";
 
 export const revalidate = false;
 
+const BASE_URL = "https://seed-design.io";
+
 /**
  * This is an entry point for accessing individual component documentation.
  * Each component can be accessed through its specific endpoint.
  */
-export async function GET({ nextUrl }: NextRequest) {
+export async function GET() {
   const componentPages = reactSource.getPages().filter(shouldGenerateLLMFriendlyText);
 
   const components = componentPages
@@ -24,7 +25,7 @@ export async function GET({ nextUrl }: NextRequest) {
         })
         .join("/");
 
-      const txtUrl = new URL(`/react/llms-components/${path}`, nextUrl.origin);
+      const txtUrl = new URL(`/react/llms-components/${path}`, BASE_URL);
 
       return `- [${data.title}](${txtUrl})`;
     })

--- a/docs/app/react/llms-components.txt/route.ts
+++ b/docs/app/react/llms-components.txt/route.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from "next/server";
 import { reactSource } from "@/app/source";
+import { shouldGenerateLLMFriendlyText } from "@/app/react/_llms/page-filter";
 
 export const revalidate = false;
 
@@ -8,11 +9,7 @@ export const revalidate = false;
  * Each component can be accessed through its specific endpoint.
  */
 export async function GET({ nextUrl }: NextRequest) {
-  const componentPages = reactSource.getPages().filter((page) => {
-    const [firstSlug, secondSlug] = page.slugs;
-
-    return firstSlug === "components" && secondSlug !== "concepts";
-  });
+  const componentPages = reactSource.getPages().filter(shouldGenerateLLMFriendlyText);
 
   const components = componentPages
     .map(({ data, slugs }) => {

--- a/docs/app/react/llms-components/[...path]/route.ts
+++ b/docs/app/react/llms-components/[...path]/route.ts
@@ -1,4 +1,6 @@
+import { shouldGenerateLLMFriendlyText } from "@/app/react/_llms/page-filter";
 import { processContent } from "@/app/react/_llms/process-content";
+import { getSourceUrl } from "@/app/react/_llms/url";
 import { reactSource } from "@/app/source";
 import { notFound } from "next/navigation";
 
@@ -15,15 +17,11 @@ export const revalidate = false;
 export async function generateStaticParams(): Promise<StaticParams[]> {
   const componentPageSlugs = reactSource
     .getPages()
-    .map(({ slugs }) => {
-      const [firstSlug, secondSlug] = slugs;
-
-      // include components/** but exclude components/concepts
-      if (firstSlug !== "components" || secondSlug === "concepts") return undefined;
-
+    .filter(shouldGenerateLLMFriendlyText)
+    .map((page) => {
       // Attach .txt extension to the last slug
-      const slugsExtensionAttached = slugs.map((slug, index) => {
-        if (index === slugs.length - 1) return `${slug}.txt`;
+      const slugsExtensionAttached = page.slugs.map((slug, index) => {
+        if (index === page.slugs.length - 1) return `${slug}.txt`;
 
         return slug;
       });
@@ -52,9 +50,10 @@ export async function GET(_: Request, { params }: { params: Promise<StaticParams
 
   const processed = await processContent(page.path, page.data.content);
 
-  const response = `file: ${page.path}
+  const response = `# ${page.data.title}
 
-# ${page.data.title}
+URL: ${page.url}
+Source: ${getSourceUrl(page.path)}
 
 ${page.data.description ?? ""}
 

--- a/docs/app/react/llms-components/[...path]/route.ts
+++ b/docs/app/react/llms-components/[...path]/route.ts
@@ -1,7 +1,10 @@
-import { globby } from "globby";
-import matter from "gray-matter";
-import * as fs from "node:fs/promises";
-import { processContent } from "../../_llms/process-content";
+import { processContent } from "@/app/react/_llms/process-content";
+import { reactSource } from "@/app/source";
+import { notFound } from "next/navigation";
+
+type StaticParams = {
+  path: string[];
+};
 
 export const revalidate = false;
 
@@ -9,98 +12,53 @@ export const revalidate = false;
  * This is an entry point for accessing individual component documentation.
  * Each component can be accessed through its specific endpoint.
  */
-export async function generateStaticParams() {
-  const files = await globby([
-    "./content/react/components/**/*.mdx",
-    "!./content/react/components/concepts/**/*.mdx",
-  ]);
+export async function generateStaticParams(): Promise<StaticParams[]> {
+  const componentPageSlugs = reactSource
+    .getPages()
+    .map(({ slugs }) => {
+      const [firstSlug, secondSlug] = slugs;
 
-  const params = files.map((file) => {
-    const relativePath = file.replace("./content/react/components/", "");
-    const componentPath = relativePath.replace(".mdx", "");
-    const cleanPath = componentPath.replace(/\(([^)]+)\)\//g, "$1/");
-    const pathArray = cleanPath.split("/");
-    
-    // Add .txt extension to the last segment
-    pathArray[pathArray.length - 1] += ".txt";
+      // include components/** but exclude components/concepts
+      if (firstSlug !== "components" || secondSlug === "concepts") return undefined;
 
-    return {
-      path: pathArray,
-    };
-  });
+      // Attach .txt extension to the last slug
+      const slugsExtensionAttached = slugs.map((slug, index) => {
+        if (index === slugs.length - 1) return `${slug}.txt`;
 
-  return params;
+        return slug;
+      });
+
+      return slugsExtensionAttached;
+    })
+    .filter((slugs) => slugs !== undefined)
+    .map(([_firstSlug, ...restSlugs]) => ({ path: restSlugs }));
+
+  return componentPageSlugs;
 }
 
-export async function GET(_: Request, { params }: { params: Promise<{ path: string[] }> }) {
+export async function GET(_: Request, { params }: { params: Promise<StaticParams> }) {
   const { path } = await params;
-  
-  // Remove .txt extension from the last segment for processing
-  const lastSegment = path[path.length - 1];
-  if (lastSegment?.endsWith(".txt")) {
-    path[path.length - 1] = lastSegment.slice(0, -4);
-  }
 
-  const componentPath = path.join("/");
-
-  try {
-    const possiblePaths = [`./content/react/components/${componentPath}.mdx`];
-
-    if (path.length > 1) {
-      const [firstSegment, ...restSegments] = path;
-      possiblePaths.push(
-        `./content/react/components/(${firstSegment})/${restSegments.join("/")}.mdx`,
-      );
+  const slugsExtensionRemoved = path.map((slug, index) => {
+    if (index === path.length - 1) {
+      return slug.replace(/\.txt$/, "");
     }
 
-    let filePath: string | null = null;
-    let fileContent: Buffer | null = null;
+    return slug;
+  });
 
-    for (const path of possiblePaths) {
-      try {
-        fileContent = await fs.readFile(path);
-        filePath = path;
-        break;
-      } catch {}
-    }
+  const page = reactSource.getPage(["components", ...slugsExtensionRemoved]);
+  if (!page) return notFound();
 
-    if (!filePath || !fileContent) {
-      return new Response(`Component not found: ${componentPath}`, {
-        status: 404,
-        headers: {
-          "Content-Type": "text/markdown; charset=utf-8",
-          "X-Content-Type-Options": "nosniff",
-        },
-      });
-    }
+  const processed = await processContent(page.path, page.data.content);
 
-    const { content, data } = matter(fileContent.toString());
-    const processed = await processContent(filePath, content);
-    const response = `file: ${filePath}
-# ${data.title}
+  const response = `file: ${page.path}
 
-${data.description ?? ""}
+# ${page.data.title}
+
+${page.data.description ?? ""}
 
 ${processed}`;
 
-    return new Response(response, {
-      headers: {
-        "Content-Type": "text/markdown; charset=utf-8",
-        "X-Content-Type-Options": "nosniff",
-        "Cache-Control": "public, max-age=0",
-      },
-    });
-  } catch (error) {
-    console.error("Error processing component:", error);
-    return new Response(
-      `Error processing component ${componentPath}: ${error instanceof Error ? error.message : "Unknown error"}`,
-      {
-        status: 500,
-        headers: {
-          "Content-Type": "text/markdown; charset=utf-8",
-          "X-Content-Type-Options": "nosniff",
-        },
-      },
-    );
-  }
+  return new Response(response);
 }

--- a/docs/app/react/llms-full.txt/route.ts
+++ b/docs/app/react/llms-full.txt/route.ts
@@ -1,28 +1,29 @@
-import { globby } from "globby";
-import matter from "gray-matter";
-import * as fs from "node:fs/promises";
-import { processContent } from "../_llms/process-content";
+import { processContent } from "@/app/react/_llms/process-content";
+import { reactSource } from "@/app/source";
 
 export const revalidate = false;
 
 export async function GET() {
-  const files = await globby([
-    "./content/react/**/*.mdx",
-    "!./content/react/index.mdx",
-    "./content/react/get-started/changelog.mdx",
-  ]);
+  const pages = reactSource
+    .getPages()
+    .filter(({ path }) => {
+      if (["get-started/changelog.mdx", "index.mdx"].includes(path)) return false;
+
+      return true;
+    })
+    // components/** -> get-started/** -> iconography/**
+    .sort((a, b) => a.path.localeCompare(b.path));
 
   const results = await Promise.all(
-    files.map(async (file) => {
-      const fileContent = await fs.readFile(file);
-      const { content, data } = matter(fileContent.toString());
+    pages.map(async (page) => {
+      const processed = await processContent(page.path, page.data.content);
 
-      const processed = await processContent(file, content);
-      return `file: ${file}
-# ${data.title}
+      return `file: ${page.path}
 
-${data.description ?? ""}
-        
+# ${page.data.title}
+
+${page.data.description ?? ""}
+
 ${processed}`;
     }),
   );

--- a/docs/app/react/llms.txt/route.ts
+++ b/docs/app/react/llms.txt/route.ts
@@ -3,8 +3,7 @@ export const revalidate = false;
 const BASE_URL = "https://seed-design.io";
 
 export async function GET() {
-  return new Response(`
-# SEED Design React Documentation for LLMs
+  return new Response(`# SEED Design React Documentation for LLMs
 
 ## Documentation Sets
 

--- a/docs/components/page-actions.tsx
+++ b/docs/components/page-actions.tsx
@@ -78,7 +78,7 @@ export function ViewOptions({
   const items = useMemo(() => {
     const fullMarkdownUrl =
       typeof window !== "undefined" ? new URL(markdownUrl, window.location.origin) : "loading";
-    const q = `Read ${fullMarkdownUrl}, I want to ask questions about it.`;
+    const q = `문서에 대한 몇 가지 질문을 하고 싶어. 다음 문서를 읽어줘: ${fullMarkdownUrl}`;
 
     return [
       {

--- a/docs/components/page-actions.tsx
+++ b/docs/components/page-actions.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Check, ChevronDown, Copy, ExternalLinkIcon } from "lucide-react";
+import { useCopyButton } from "fumadocs-ui/utils/use-copy-button";
+import { buttonVariants } from "fumadocs-ui/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "fumadocs-ui/components/ui/popover";
+import { cva } from "class-variance-authority";
+
+const cache = new Map<string, string>();
+
+export function LLMCopyButton({
+  /**
+   * A URL to fetch the raw Markdown/MDX content of page
+   */
+  markdownUrl,
+}: {
+  markdownUrl: string;
+}) {
+  const [isLoading, setLoading] = useState(false);
+  const [checked, onClick] = useCopyButton(async () => {
+    const cached = cache.get(markdownUrl);
+    if (cached) return navigator.clipboard.writeText(cached);
+
+    setLoading(true);
+
+    try {
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          "text/plain": fetch(markdownUrl).then(async (res) => {
+            const content = await res.text();
+            cache.set(markdownUrl, content);
+
+            return content;
+          }),
+        }),
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  });
+
+  return (
+    <button
+      type="button"
+      disabled={isLoading}
+      className={buttonVariants({
+        color: "secondary",
+        size: "sm",
+        className: "gap-2 [&_svg]:size-3.5 [&_svg]:text-fd-muted-foreground",
+      })}
+      onClick={onClick}
+    >
+      {checked ? <Check /> : <Copy />}
+      마크다운 복사
+    </button>
+  );
+}
+
+const optionVariants = cva(
+  "text-sm p-2 rounded-lg inline-flex items-center gap-2 hover:text-fd-accent-foreground hover:bg-fd-accent [&_svg]:size-4",
+);
+
+export function ViewOptions({
+  markdownUrl,
+  githubUrl,
+}: {
+  /**
+   * A URL to the raw Markdown/MDX content of page
+   */
+  markdownUrl: string;
+
+  /**
+   * Source file URL on GitHub
+   */
+  githubUrl: string;
+}) {
+  const items = useMemo(() => {
+    const fullMarkdownUrl =
+      typeof window !== "undefined" ? new URL(markdownUrl, window.location.origin) : "loading";
+    const q = `Read ${fullMarkdownUrl}, I want to ask questions about it.`;
+
+    return [
+      {
+        title: "ChatGPT에게 묻기",
+        href: `https://chatgpt.com/?${new URLSearchParams({
+          hints: "search",
+          q,
+        })}`,
+        icon: (
+          <svg
+            role="img"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title>OpenAI</title>
+            <path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" />
+          </svg>
+        ),
+      },
+      {
+        title: "Claude에게 묻기",
+        href: `https://claude.ai/new?${new URLSearchParams({
+          q,
+        })}`,
+        icon: (
+          <svg
+            fill="currentColor"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title>Anthropic</title>
+            <path d="M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z" />
+          </svg>
+        ),
+      },
+      {
+        title: "GitHub에서 읽기",
+        href: githubUrl,
+        icon: (
+          <svg fill="currentColor" role="img" viewBox="0 0 24 24">
+            <title>GitHub</title>
+            <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+          </svg>
+        ),
+      },
+    ];
+  }, [githubUrl, markdownUrl]);
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        className={buttonVariants({
+          color: "secondary",
+          size: "sm",
+          className: "gap-2 items-end",
+        })}
+      >
+        다른 도구로 열기
+        <ChevronDown className="size-3.5 text-fd-muted-foreground" />
+      </PopoverTrigger>
+      <PopoverContent className="flex flex-col overflow-auto">
+        {items.map((item) => (
+          <a
+            key={item.href}
+            href={item.href}
+            rel="noreferrer noopener"
+            target="_blank"
+            className={optionVariants()}
+          >
+            {item.icon}
+            {item.title}
+            <ExternalLinkIcon className="text-fd-muted-foreground size-3.5 ms-auto" />
+          </a>
+        ))}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/docs/content/react/get-started/llms-txt.mdx
+++ b/docs/content/react/get-started/llms-txt.mdx
@@ -7,12 +7,12 @@ description: 대규모 언어 모델(LLM)이 SEED Design React를 쉽게 이해�
 
 다음과 같은 LLMs.txt 파일들을 제공합니다:
 
-- [llms.txt](/react/llms.txt): LLMs.txt 파일들의 구조를 제공하는 메인 파일입니다.
-- [llms-full.txt](/react/llms-full.txt): SEED Design React의 모든 문서를 포함합니다.
-- [llms-changelog.txt](/react/llms-changelog.txt): 최신 업데이트와 변경사항을 포함하여 버전별 변경 내역을 확인할 수 있습니다.
-- [llms-components.txt](/react/llms-components.txt): 각 컴포넌트의 문서의 진입점입니다.
-  - [llms-components/action-button.txt](/react/llms-components/action-button.txt)
-  - [llms-components/chip.txt](/react/llms-components/chip.txt)
+- [llms.txt](https://seed-design.io/react/llms.txt): LLMs.txt 파일들의 구조를 제공하는 메인 파일입니다.
+- [llms-full.txt](https://seed-design.io/react/llms-full.txt): SEED Design React의 모든 문서를 포함합니다.
+- [llms-changelog.txt](https://seed-design.io/react/llms-changelog.txt): 최신 업데이트와 변경사항을 포함하여 버전별 변경 내역을 확인할 수 있습니다.
+- [llms-components.txt](https://seed-design.io/react/llms-components.txt): 각 컴포넌트의 문서의 진입점입니다.
+  - [llms-components/action-button.txt](https://seed-design.io/react/llms-components/action-button.txt)
+  - [llms-components/chip.txt](https://seed-design.io/react/llms-components/chip.txt)
   - etc...
 
 ## AI 도구와 함께 사용하기

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -7,14 +7,7 @@ const config = {
   output: "export",
   reactStrictMode: true,
   transpilePackages: ["@seed-design/react", "@seed-design/stackflow"],
-  experimental: {
-    serverComponentsExternalPackages: [
-      "ts-morph",
-      "typescript",
-      "oxc-transform",
-      "@shikijs/twoslash",
-    ],
-  },
+  serverExternalPackages: ["ts-morph", "typescript", "oxc-transform", "@shikijs/twoslash"],
   images: {
     // FIXME: temporal use for static export; will remove after image optimization setup
     unoptimized: true,

--- a/docs/package.json
+++ b/docs/package.json
@@ -80,7 +80,6 @@
     "chalk": "^5.3.0",
     "chromatic": "^13.0.0",
     "globby": "^14.1.0",
-    "gray-matter": "^4.0.3",
     "postcss": "^8.5.3",
     "storybook": "^9.0.16",
     "tailwindcss": "^4.1.4",

--- a/docs/package.json
+++ b/docs/package.json
@@ -79,7 +79,6 @@
     "@types/react-dom": "^19.1.5",
     "chalk": "^5.3.0",
     "chromatic": "^13.0.0",
-    "globby": "^14.1.0",
     "postcss": "^8.5.3",
     "storybook": "^9.0.16",
     "tailwindcss": "^4.1.4",

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -1,4 +1,5 @@
-import { fileGenerator, remarkDocGen, remarkInstall } from "fumadocs-docgen";
+import { fileGenerator, remarkDocGen } from "fumadocs-docgen";
+import { remarkNpm } from "fumadocs-core/mdx-plugins";
 import { defineConfig, defineDocs, frontmatterSchema } from "fumadocs-mdx/config";
 import { typeTableGenerator } from "./components/type-table/generator";
 import { remarkReactTypeTable } from "./components/type-table/remark-react-type-table";
@@ -29,7 +30,7 @@ export default defineConfig({
   mdxOptions: {
     remarkPlugins: [
       [
-        remarkInstall,
+        remarkNpm,
         {
           persist: {
             id: "package-manager",


### PR DESCRIPTION
- 모든 llms*.txt 파일 생성 과정에서 파일을 직접 읽고 파싱하는 대신 `source`에서 제공하는 정보를 활용하도록 리팩토링합니다.
  - gray-matter, globby 의존성을 제거합니다.
  - 이후 문서 폴더 구조가 변경될 경우 수정이 쉽습니다.
- txt 파일이 존재하는 mdx 파일의 경우 (`shouldGenerateLLMFriendlyText`) 문서 페이지에 [Page Action](https://fumadocs.dev/docs/ui/llms#page-actions)을 표시합니다.
  - 마크다운 복사 & 외부 챗봇에서 열기 버튼을 추가합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * LLM 친화적 텍스트 복사 버튼 및 외부 AI 도구(예: ChatGPT, Claude, GitHub)로 열기 기능 추가
  * LLM 친화적 문서(.txt) 및 전체 문서 일괄 제공 기능 추가

* **버그 수정**
  * 일부 문서 경로 및 확장자 처리 방식 개선

* **리팩터링**
  * 파일 시스템 기반 문서 로딩을 통합 소스 API 기반으로 변경하여 성능 및 유지보수성 향상
  * 불필요한 의존성(globby, gray-matter) 제거 및 관련 코드 정리
  * 마크다운 처리 플러그인 교체 및 코드 간소화

* **설정**
  * Next.js 서버 외부 패키지 설정을 최신 방식으로 업데이트

* **문서**
  * LLM 친화적 문서 및 복사/외부 열기 기능에 대한 UI 및 안내 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->