### PR TITLE
feat: allow boolean for `flex*` props; prepend img children if figma frame has an image fill

### DIFF
--- a/.changeset/five-swans-drive.md
+++ b/.changeset/five-swans-drive.md
@@ -1,0 +1,8 @@
+---
+"@seed-design/figma": patch
+"@seed-design/react": patch
+---
+
+레이아웃 컴포넌트를 사용할 때 `flexGrow`, `flexShrink`, `flexWrap`에도 `true`를 사용할 수 있도록 수정합니다.
+
+Figma 레이어가 이미지 Fill을 가지고 있는 경우 `<img />` 요소를 prepend합니다.

--- a/docs/components/example/check-select-box-react-hook-form.tsx
+++ b/docs/components/example/check-select-box-react-hook-form.tsx
@@ -58,7 +58,7 @@ export default function CheckSelectBoxReactHookForm() {
         <ActionButton type="button" variant="neutralWeak" onClick={() => setValue("mango", true)}>
           mango 선택
         </ActionButton>
-        <ActionButton type="submit" flexGrow={1}>
+        <ActionButton type="submit" flexGrow>
           제출
         </ActionButton>
       </HStack>

--- a/docs/components/example/checkbox-react-hook-form.tsx
+++ b/docs/components/example/checkbox-react-hook-form.tsx
@@ -55,12 +55,12 @@ export default function CheckboxReactHookForm() {
         <ActionButton
           type="button"
           variant="neutralWeak"
-          flexGrow={1}
+          flexGrow
           onClick={() => setValue("mango", true)}
         >
           mango 선택
         </ActionButton>
-        <ActionButton type="submit" flexGrow={1}>
+        <ActionButton type="submit" flexGrow>
           제출
         </ActionButton>
       </HStack>

--- a/docs/components/example/demo/components/article-author.tsx
+++ b/docs/components/example/demo/components/article-author.tsx
@@ -5,7 +5,7 @@ import { HStack } from "@seed-design/react";
 
 export function ArticleAuthor({ author }: { author: string }) {
   return (
-    <HStack gap="x1_5" align="center" flexGrow={1}>
+    <HStack gap="x1_5" align="center" flexGrow>
       <Avatar
         fallback={<IdentityPlaceholder identity="person" />}
         size="20"

--- a/docs/components/example/flex-preview.tsx
+++ b/docs/components/example/flex-preview.tsx
@@ -9,7 +9,7 @@ export default function FlexPreview() {
         gap="x1_5"
         px="x2"
         py="x2"
-        flexGrow={1}
+        flexGrow
         borderRadius="r2"
       >
         <Flex bg="bg.neutralWeak" px="x4" py="x3" borderRadius="r1">
@@ -25,7 +25,7 @@ export default function FlexPreview() {
         gap="x1_5"
         px="x2"
         py="x2"
-        flexGrow={1}
+        flexGrow
         borderRadius="r2"
       >
         <Flex bg="bg.neutralWeak" px="x4" py="x3" borderRadius="r1">

--- a/docs/components/example/multiline-text-field-form.tsx
+++ b/docs/components/example/multiline-text-field-form.tsx
@@ -109,7 +109,7 @@ export default function MultilineTextFieldForm() {
         <ActionButton type="reset" variant="neutralWeak">
           초기화
         </ActionButton>
-        <ActionButton type="submit" flexGrow={1}>
+        <ActionButton type="submit" flexGrow>
           제출
         </ActionButton>
       </HStack>

--- a/docs/components/example/multiline-text-field-react-hook-form.tsx
+++ b/docs/components/example/multiline-text-field-react-hook-form.tsx
@@ -91,7 +91,7 @@ export default function MultilineTextFieldReactHookForm() {
         <ActionButton type="reset" variant="neutralWeak">
           초기화
         </ActionButton>
-        <ActionButton type="submit" flexGrow={1}>
+        <ActionButton type="submit" flexGrow>
           제출
         </ActionButton>
       </HStack>

--- a/docs/components/example/radio-select-box-react-hook-form.tsx
+++ b/docs/components/example/radio-select-box-react-hook-form.tsx
@@ -50,7 +50,7 @@ export default function RadioSelectBoxReactHookForm() {
         >
           mango 선택
         </ActionButton>
-        <ActionButton type="submit" flexGrow={1}>
+        <ActionButton type="submit" flexGrow>
           제출
         </ActionButton>
       </HStack>

--- a/docs/components/example/text-field-form.tsx
+++ b/docs/components/example/text-field-form.tsx
@@ -109,7 +109,7 @@ export default function TextFieldForm() {
         <ActionButton type="reset" variant="neutralWeak">
           초기화
         </ActionButton>
-        <ActionButton type="submit" flexGrow={1}>
+        <ActionButton type="submit" flexGrow>
           제출
         </ActionButton>
       </HStack>

--- a/docs/components/example/text-field-react-hook-form.tsx
+++ b/docs/components/example/text-field-react-hook-form.tsx
@@ -80,7 +80,7 @@ export default function TextFieldReactHookForm() {
         <ActionButton type="reset" variant="neutralWeak">
           초기화
         </ActionButton>
-        <ActionButton type="submit" flexGrow={1}>
+        <ActionButton type="submit" flexGrow>
           제출
         </ActionButton>
       </HStack>

--- a/packages/figma/src/codegen/targets/react/frame.ts
+++ b/packages/figma/src/codegen/targets/react/frame.ts
@@ -3,7 +3,12 @@ import type {
   NormalizedFrameNode,
   NormalizedInstanceNode,
 } from "@/normalizer";
-import { cloneElement, defineElementTransformer, type ElementTransformer } from "../../core";
+import {
+  cloneElement,
+  createElement,
+  defineElementTransformer,
+  type ElementTransformer,
+} from "../../core";
 import { createSeedReactElement } from "./element-factories";
 import type { ContainerLayoutProps, PropsConverters } from "./props";
 
@@ -43,28 +48,34 @@ export function createFrameTransformer({
       };
 
       const isStretch = props.align === undefined || props.align === "stretch";
-      const processedChildren = isStretch
-        ? transformedChildren.map((child) =>
-            child ? cloneElement(child, { alignSelf: undefined }) : child,
-          )
-        : transformedChildren;
 
       const layoutComponent = inferLayoutComponent(props, isFlex);
 
-      if (layoutComponent === "VStack") {
-        const { direction, ...rest } = props;
+      const hasImageFill = node.fills.some(({ type }) => type === "IMAGE");
+      const imgElement = hasImageFill
+        ? createElement("img", {
+            src: `https://placehold.co/${node.absoluteBoundingBox?.width ?? 100}x${node.absoluteBoundingBox?.height ?? 100}`,
+          })
+        : undefined;
 
-        return createSeedReactElement("VStack", rest, processedChildren);
-      }
+      const processedChildren = [
+        imgElement,
+        ...(isStretch
+          ? transformedChildren.map((child) =>
+              child ? cloneElement(child, { alignSelf: undefined }) : child,
+            )
+          : transformedChildren),
+      ];
 
-      if (layoutComponent === "HStack") {
-        const { direction, ...rest } = props;
+      switch (layoutComponent) {
+        case "VStack":
+        case "HStack": {
+          const { direction: _direction, ...rest } = props;
 
-        return createSeedReactElement("HStack", rest, processedChildren);
-      }
-
-      if (layoutComponent === "Box") {
-        return createSeedReactElement("Box", props, processedChildren);
+          return createSeedReactElement(layoutComponent, rest, processedChildren);
+        }
+        case "Box":
+          return createSeedReactElement("Box", props, processedChildren);
       }
     },
   );

--- a/packages/react/src/components/Flex/Flex.tsx
+++ b/packages/react/src/components/Flex/Flex.tsx
@@ -14,7 +14,6 @@ export interface FlexProps extends Omit<BoxProps, "display"> {
 
   /**
    * Shorthand for `flexWrap`.
-   * If true, flex-wrap will be set to `wrap`.
    */
   wrap?: BoxProps["flexWrap"];
 
@@ -30,7 +29,6 @@ export interface FlexProps extends Omit<BoxProps, "display"> {
 
   /**
    * Shorthand for `flexGrow`.
-   * If true, flex-grow will be set to `1`.
    */
   grow?: BoxProps["flexGrow"];
 

--- a/packages/react/src/components/Flex/Flex.tsx
+++ b/packages/react/src/components/Flex/Flex.tsx
@@ -16,7 +16,7 @@ export interface FlexProps extends Omit<BoxProps, "display"> {
    * Shorthand for `flexWrap`.
    * If true, flex-wrap will be set to `wrap`.
    */
-  wrap?: BoxProps["flexWrap"] | true;
+  wrap?: BoxProps["flexWrap"];
 
   /**
    * Shorthand for `alignItems`.
@@ -32,7 +32,7 @@ export interface FlexProps extends Omit<BoxProps, "display"> {
    * Shorthand for `flexGrow`.
    * If true, flex-grow will be set to `1`.
    */
-  grow?: BoxProps["flexGrow"] | true;
+  grow?: BoxProps["flexGrow"];
 
   /**
    * Shorthand for `flexShrink`.
@@ -48,10 +48,10 @@ export const Flex = React.forwardRef<HTMLDivElement, FlexProps>((props, ref) => 
       ref={ref}
       display="flex"
       flexDirection={direction}
-      flexWrap={wrap === true ? "wrap" : wrap}
+      flexWrap={wrap}
       alignItems={align}
       justifyContent={justify}
-      flexGrow={grow === true ? 1 : grow}
+      flexGrow={grow}
       flexShrink={shrink}
       {...rest}
     />

--- a/packages/react/src/utils/styled.tsx
+++ b/packages/react/src/utils/styled.tsx
@@ -427,8 +427,14 @@ export interface StyleProps {
 
   zIndex?: number | (string & {});
 
+  /**
+   * If true, flex-grow will be set to `1`.
+   */
   flexGrow?: 0 | 1 | (number & {}) | true;
 
+  /**
+   * If true, flex-shrink will be set to `1`.
+   */
   flexShrink?: 0 | (number & {}) | true;
 
   // Flex
@@ -440,6 +446,9 @@ export interface StyleProps {
     | "rowReverse" // @deprecated Use `row-reverse` instead.
     | "columnReverse"; // @deprecated Use `column-reverse` instead.
 
+  /**
+   * If true, flex-wrap will be set to `wrap`.
+   */
   flexWrap?: "wrap" | "wrap-reverse" | "nowrap" | true;
 
   justifyContent?:

--- a/packages/react/src/utils/styled.tsx
+++ b/packages/react/src/utils/styled.tsx
@@ -427,9 +427,9 @@ export interface StyleProps {
 
   zIndex?: number | (string & {});
 
-  flexGrow?: 0 | 1 | (number & {});
+  flexGrow?: 0 | 1 | (number & {}) | true;
 
-  flexShrink?: 0 | (number & {});
+  flexShrink?: 0 | (number & {}) | true;
 
   // Flex
   flexDirection?:
@@ -440,7 +440,7 @@ export interface StyleProps {
     | "rowReverse" // @deprecated Use `row-reverse` instead.
     | "columnReverse"; // @deprecated Use `column-reverse` instead.
 
-  flexWrap?: "wrap" | "wrap-reverse" | "nowrap";
+  flexWrap?: "wrap" | "wrap-reverse" | "nowrap" | true;
 
   justifyContent?:
     | "flex-start"
@@ -619,10 +619,10 @@ export function useStyleProps<T extends UseStyleProps>(
       "--seed-box-overflow-x": overflowX,
       "--seed-box-overflow-y": overflowY,
       "--seed-box-z-index": zIndex,
-      "--seed-box-flex-grow": flexGrow,
-      "--seed-box-flex-shrink": flexShrink,
+      "--seed-box-flex-grow": flexGrow === true ? 1 : flexGrow,
+      "--seed-box-flex-shrink": flexShrink === true ? 1 : flexShrink,
       "--seed-box-flex-direction": handleFlexDirection(flexDirection),
-      "--seed-box-flex-wrap": flexWrap,
+      "--seed-box-flex-wrap": flexWrap === true ? "wrap" : flexWrap,
       "--seed-box-justify-content": handleJustifyContent(justifyContent),
       "--seed-box-align-items": handleAlignItems(alignItems),
       "--seed-box-align-content": handleAlignItems(alignContent),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 레이아웃/스타일 속성에서 flexGrow, flexShrink, flexWrap에 true 사용을 지원해 더 간결한 작성이 가능합니다.
  - Figma 레이어에 이미지 Fill이 있으면 출력의 맨 앞에 이미지가 자동으로 추가되어 렌더링됩니다.
- 문서
  - 예제 코드에서 flexGrow={1}를 flexGrow 형태로 일괄 업데이트했습니다.
- Chores
  - 의존성을 패치 버전으로 업데이트하고 변경 기록을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->