### PR TITLE
feat: add a vertical `Divider`

### DIFF
--- a/.changeset/yellow-clouds-talk.md
+++ b/.changeset/yellow-clouds-talk.md
@@ -1,0 +1,9 @@
+---
+"@seed-design/react": patch
+---
+
+Divider 컴포넌트를 업데이트합니다.
+
+- `orientation`을 지정할 수 있습니다.
+- Divider를 `li`로 렌더링하여 `ol`, `ul` 내부에서 사용할 수 있습니다.
+- Divider를 `div` 또는 `li`로 렌더링하는 경우에도 `role="separator"`를 지정하여 스크린 리더가 Divider를 읽도록 할 수 있습니다.

--- a/docs/components/example/divider-orientation.tsx
+++ b/docs/components/example/divider-orientation.tsx
@@ -1,0 +1,18 @@
+import { Box, Divider, HStack, VStack } from "@seed-design/react";
+
+export default function DividerOrientation() {
+  return (
+    <VStack width="full" gap="x4">
+      <VStack flexGrow bg="bg.layerDefault" gap="x4">
+        <Box bg="palette.blue400" height="x8" />
+        <Divider />
+        <Box bg="palette.blue400" height="x8" />
+      </VStack>
+      <HStack flexGrow bg="bg.layerDefault" gap="x4" height="x16">
+        <Box bg="palette.blue400" flexGrow />
+        <Divider orientation="vertical" />
+        <Box bg="palette.blue400" flexGrow />
+      </HStack>
+    </VStack>
+  );
+}

--- a/docs/components/example/divider-preview.tsx
+++ b/docs/components/example/divider-preview.tsx
@@ -2,10 +2,13 @@ import { Box, Divider, VStack } from "@seed-design/react";
 
 export default function DividerPreview() {
   return (
-    <VStack width="full">
-      <Box bg="bg.layerDefault" height="100px" />
+    <VStack width="full" bg="bg.layerDefault" p="x4">
+      <Box p="x4">
+        Nisi elit pariatur incididunt quis fugiat mollit ipsum fugiat duis culpa esse incididunt
+        cupidatat.
+      </Box>
       <Divider />
-      <Box bg="bg.layerDefault" height="100px" />
+      <Box p="x4">Consectetur voluptate quis do culpa et culpa.</Box>
     </VStack>
   );
 }

--- a/docs/content/react/components/divider.mdx
+++ b/docs/content/react/components/divider.mdx
@@ -16,7 +16,7 @@ description: Divider는 구분선을 표시하는 컴포넌트입니다.
 
 <react-type-table path="../packages/react/src/components/Divider/Divider.tsx" name="DividerProps" />
 
-## Examples
+## Usage
 
 ```tsx
 import { Divider } from "@seed-design/react";
@@ -25,3 +25,24 @@ import { Divider } from "@seed-design/react";
 ```
 <Divider />
 ```
+
+## Screen Reader Behavior
+
+Divider는 기본적으로 `<hr />`을 렌더링합니다. **`<hr />`은 의미를 가진(semantic) 구분선이며, 스크린 리더 역시 해당 요소를 "수평(수직) 분할선"으로 읽습니다.**
+
+Divider가 의미를 가지지 않은 장식적 요소라면, `as` prop을 활용해 `<div>` 등으로 렌더링하여 스크린 리더가 해당 요소를 읽지 않도록 해야 합니다.
+
+반대로, Divider를 `<li>` 등 `<hr />`이 아닌 요소로 렌더링해야 하는 상황에서, 스크린 리더가 해당 요소를 읽어야 한다면, `role="separator"`를 명시적으로 지정해야 합니다.
+
+## Examples
+
+### Orientation
+
+<ComponentExample name="divider-orientation">
+  ```json doc-gen:file
+  {
+    "file": "./components/example/divider-orientation.tsx",
+    "codeblock": true
+  }
+  ```
+</ComponentExample>

--- a/packages/react/src/components/Divider/Divider.tsx
+++ b/packages/react/src/components/Divider/Divider.tsx
@@ -3,9 +3,12 @@ import { Box, type BoxProps } from "../Box/Box";
 
 export interface DividerProps {
   /**
+   * The HTML element to use for the divider.
+   * Keep in mind that "hr" elements are read by screen readers as a semantic break with an implicit role="separator"
+   * If the element should be read by screen readers but be rendered as an element other than "hr", give an explicit role="separator"
    * @default "hr"
    */
-  as?: "hr" | "div";
+  as?: "hr" | "div" | "li";
 
   /**
    * @default "stroke.neutral"
@@ -16,19 +19,40 @@ export interface DividerProps {
    * @default 1
    */
   thickness?: BoxProps["borderBottomWidth"];
+
+  /**
+   * @default "horizontal"
+   */
+  orientation?: "horizontal" | "vertical";
+
+  role?: Extract<React.AriaRole, "separator">;
 }
 
 export const Divider = React.forwardRef<HTMLHRElement, DividerProps>((props, ref) => {
-  const { as = "hr", color = "stroke.neutral", thickness = 1, ...rest } = props;
+  const {
+    as = "hr",
+    color = "stroke.neutral",
+    thickness = 1,
+    orientation = "horizontal",
+    role,
+    ...rest
+  } = props;
 
   return (
     <Box
       ref={ref}
       as={as}
+      role={role}
+      // if hr, aria-orientation=horizontal is implied if not specified
+      // if not hr, aria-orientation is needed
+      {...(((as === "hr" && orientation !== "horizontal") || as !== "hr") && {
+        "aria-orientation": orientation,
+      })}
       display="block"
       borderColor={color}
       borderWidth={0}
-      borderBottomWidth={thickness}
+      {...(orientation === "vertical" && { borderRightWidth: thickness })}
+      {...(orientation === "horizontal" && { borderBottomWidth: thickness })}
       {...rest}
     />
   );

--- a/packages/react/src/components/Divider/Divider.tsx
+++ b/packages/react/src/components/Divider/Divider.tsx
@@ -45,7 +45,8 @@ export const Divider = React.forwardRef<HTMLHRElement, DividerProps>((props, ref
       role={role}
       // if hr, aria-orientation=horizontal is implied if not specified
       // if not hr, aria-orientation is needed
-      {...(((as === "hr" && orientation !== "horizontal") || as !== "hr") && {
+      {...(((as === "hr" && orientation !== "horizontal") ||
+        (as !== "hr" && role === "separator")) && {
         "aria-orientation": orientation,
       })}
       display="block"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - Divider가 orientation(가로/세로) 지원 및 role="separator" 설정을 지원합니다.
  - as prop에 "li" 지원 추가로 목록 항목 내 구분선 사용이 가능합니다.
  - 방향에 따라 두께와 aria-orientation이 자동 반영됩니다.

- 문서
  - "Examples"를 "Usage"로 갱신하고 Screen Reader Behavior 섹션을 추가했습니다.
  - Divider 방향 예제와 미리보기 예제를 추가·개선해 사용 예시와 접근성을 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->