### PR TITLE
feat(react): Text allow string prop

### DIFF
--- a/.changeset/bright-suns-act.md
+++ b/.changeset/bright-suns-act.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react": patch
+---
+
+Text 컴포넌트의 fontSize, lineHeight, color 속성에 string도 사용 가능하도록 변경했습니다.

--- a/packages/react/src/components/Text/Text.tsx
+++ b/packages/react/src/components/Text/Text.tsx
@@ -17,7 +17,7 @@ function handleColor(color: string | undefined) {
   }
   const [type, value] = color.split(".");
   // @ts-ignore
-  return vars.$color[type][value] ?? undefined;
+  return vars.$color[type]?.[value] ?? color;
 }
 
 function handleFontWeight(fontWeight: string | undefined) {
@@ -56,17 +56,17 @@ export interface TextProps
   /**
    * The color of the text.
    */
-  color?: ScopedColorFg | ScopedColorPalette;
+  color?: ScopedColorFg | ScopedColorPalette | (string & {});
 
   /**
    * The font size of the text. Partially overrides the textStyle.
    */
-  fontSize?: FontSize;
+  fontSize?: FontSize | (string & {});
 
   /**
    * The line height of the text. Partially overrides the textStyle.
    */
-  lineHeight?: LineHeight;
+  lineHeight?: LineHeight | (string & {});
 
   /**
    * The font weight of the text. Partially overrides the textStyle.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Text 컴포넌트가 fontSize, lineHeight, color에 문자열 값 입력을 지원합니다. 임의의 CSS 값 사용이 가능합니다.
* Bug Fixes
  * 색상 매핑이 없을 때 발생하던 런타임 오류를 방지하고, 매핑 실패 시 전달된 원본 문자열로 안전하게 폴백하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->