### PR TITLE
fix(headless/tabs): add scrollTo on reinit event

### DIFF
--- a/.changeset/slick-peaches-search.md
+++ b/.changeset/slick-peaches-search.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react-tabs": patch
+---
+
+Tabs.Carousel의 reInit 이벤트 시 탭 인덱스가 변경되지 않는 문제를 수정합니다.

--- a/packages/react-headless/tabs/src/useTabsCarousel.ts
+++ b/packages/react-headless/tabs/src/useTabsCarousel.ts
@@ -58,11 +58,16 @@ const useTabsCarouselState = (props: UseTabsCarouselStateProps) => {
     };
   }, [emblaApi, api.setContentIndex, onSettle]);
 
+  const getContentIndex = useCallbackRef(() => api.contentIndex);
   useEffect(() => {
-    emblaApi?.on("reInit", () => {
-      emblaApi?.scrollTo(api.contentIndex, true);
+    const reInit = emblaApi?.on("reInit", () => {
+      emblaApi?.scrollTo(getContentIndex(), true);
     });
-  }, [api.contentIndex, emblaApi]);
+
+    return () => {
+      reInit?.clear();
+    };
+  }, [getContentIndex, emblaApi]);
 
   useEffect(() => {
     if (!emblaApi) return;

--- a/packages/react-headless/tabs/src/useTabsCarousel.ts
+++ b/packages/react-headless/tabs/src/useTabsCarousel.ts
@@ -59,6 +59,12 @@ const useTabsCarouselState = (props: UseTabsCarouselStateProps) => {
   }, [emblaApi, api.setContentIndex, onSettle]);
 
   useEffect(() => {
+    emblaApi?.on("reInit", () => {
+      emblaApi?.scrollTo(api.contentIndex, true);
+    });
+  }, [api.contentIndex, emblaApi]);
+
+  useEffect(() => {
     if (!emblaApi) return;
 
     const { dragHandler } = emblaApi.internalEngine();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 버그 수정
  * Tabs.Carousel이 재초기화(reInit) 후 탭 인덱스가 갱신되지 않아 선택된 탭과 패널이 불일치하던 문제를 해결했습니다. 재초기화 시 현재 콘텐츠 인덱스로 즉시 스크롤되어 탭과 패널이 안정적으로 동기화되며 뷰포트 변경 등 상황에서도 일관된 동작을 보장합니다.
* Chores
  * 패치 릴리스를 위한 변경 기록을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->