### PR TITLE
feat: use raw value of description rather than parsing it as markdown in llms.txt

### DIFF
--- a/docs/app/breeze/_llms/process-content.ts
+++ b/docs/app/breeze/_llms/process-content.ts
@@ -13,7 +13,10 @@ export async function processContent(path: string, content: string): Promise<str
     .use(remarkMdx)
     .use(remarkInclude)
     .use(remarkGfm)
-    .use(remarkReactTypeTable, { generator: typeTableGenerator })
+    .use(remarkReactTypeTable, {
+      generator: typeTableGenerator,
+      options: { parseDescriptionAsMarkdown: false },
+    })
     .use(remarkDocGen, { generators: [fileGenerator()] })
     .use(remarkNpm, { persist: { id: "package-manager" } })
     .use(remarkStringify)

--- a/docs/app/react/_llms/process-content.ts
+++ b/docs/app/react/_llms/process-content.ts
@@ -13,7 +13,10 @@ export async function processContent(path: string, content: string): Promise<str
     .use(remarkMdx)
     .use(remarkInclude)
     .use(remarkGfm)
-    .use(remarkReactTypeTable, { generator: typeTableGenerator })
+    .use(remarkReactTypeTable, {
+      generator: typeTableGenerator,
+      options: { parseDescriptionAsMarkdown: true },
+    })
     .use(remarkDocGen, { generators: [fileGenerator()] })
     .use(remarkNpm, { persist: { id: "package-manager" } })
     .use(remarkStringify)

--- a/docs/app/react/_llms/process-content.ts
+++ b/docs/app/react/_llms/process-content.ts
@@ -15,7 +15,7 @@ export async function processContent(path: string, content: string): Promise<str
     .use(remarkGfm)
     .use(remarkReactTypeTable, {
       generator: typeTableGenerator,
-      options: { parseDescriptionAsMarkdown: true },
+      options: { parseDescriptionAsMarkdown: false },
     })
     .use(remarkDocGen, { generators: [fileGenerator()] })
     .use(remarkNpm, { persist: { id: "package-manager" } })

--- a/docs/components/type-table/get-react-type-table.ts
+++ b/docs/components/type-table/get-react-type-table.ts
@@ -43,7 +43,9 @@ export interface ReactTypeTableProps {
    */
   type?: string;
 
-  options?: GenerateOptions;
+  options?: GenerateOptions & {
+    parseDescriptionAsMarkdown?: boolean;
+  };
 }
 
 export async function getReactTypeTableOutput({

--- a/docs/components/type-table/remark-react-type-table.tsx
+++ b/docs/components/type-table/remark-react-type-table.tsx
@@ -39,6 +39,7 @@ function expressionToAttribute(key: string, value: Expression): MdxJsxAttribute 
 async function mapProperty(
   entry: DocEntry,
   renderMarkdown: typeof renderMarkdownToHast,
+  options?: { parseDescriptionAsMarkdown?: boolean },
 ): Promise<Property> {
   const value = valueToEstree({
     type: entry.type,
@@ -46,10 +47,6 @@ async function mapProperty(
   }) as ObjectExpression;
 
   if (entry.description) {
-    const hast = toEstree(await renderMarkdown(entry.description), {
-      elementAttributeNameCase: "react",
-    }).body[0] as ExpressionStatement;
-
     value.properties.push({
       type: "Property",
       method: false,
@@ -60,7 +57,13 @@ async function mapProperty(
         name: "description",
       },
       kind: "init",
-      value: hast.expression,
+      value: options?.parseDescriptionAsMarkdown
+        ? (
+            toEstree(await renderMarkdown(entry.description), {
+              elementAttributeNameCase: "react",
+            }).body[0] as ExpressionStatement
+          ).expression
+        : { type: "Literal", value: entry.description },
     });
   }
 
@@ -144,7 +147,7 @@ export function remarkReactTypeTable({
 
         const rendered = output.map(async (doc) => {
           const properties = await Promise.all(
-            doc.entries.map((entry) => mapProperty(entry, renderMarkdown)),
+            doc.entries.map((entry) => mapProperty(entry, renderMarkdown, options)),
           );
 
           return {

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -48,7 +48,15 @@ export default defineConfig({
         },
       ],
       [remarkDocGen, { generators: [fileGenerator()] }],
-      [remarkReactTypeTable, { generator: typeTableGenerator }],
+      [
+        remarkReactTypeTable,
+        {
+          generator: typeTableGenerator,
+          options: {
+            parseDescriptionAsMarkdown: true,
+          },
+        },
+      ],
     ],
     rehypeCodeOptions: {
       lazy: true,


### PR DESCRIPTION
LLMs.txt 파일에서 `description`을 마크다운으로 파싱하지 않도록 변경해요. 사용자의 토큰을 절약하고 LLM이 더 쉽게 이해할 수 있도록 도와요

[Action Button llms.txt](https://seed-design.io/react/llms-components/action-button.txt)

### Before

```mdx
<ManualInstallation name="action-button" />

## Props

<TypeTable
  type={{
    color: {
        "type": "ScopedColorFg | ScopedColorPalette | undefined",
        "default": "\"fg.neutral\"",
        description: <><p>{"Color of the label and icons inside the button.\nWorks only when "}<code>{"variant"}</code>{" is "}<code>{"ghost"}</code>{"."}</p></>
    },
// ...
/>
```

### After

```mdx
<ManualInstallation name="action-button" />

## Props

<TypeTable
  type={{
    color: {
        "type": "ScopedColorFg | ScopedColorPalette | undefined",
        "default": "\"fg.neutral\"",
        description: "Color of the label and icons inside the button.\nWorks only when `variant` is `ghost`."
    },
// ...
/>
```