### PR TITLE
feat: add `hideCloseButton` prop to bottom-sheet.tsx snippet

### DIFF
--- a/.changeset/two-suits-battle.md
+++ b/.changeset/two-suits-battle.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/figma": patch
+---
+
+Figma Codegen이 Bottom Sheet의 `hideCloseButton` prop을 사용하는 코드를 반환하도록 수정합니다.

--- a/docs/content/react/components/bottom-sheet.mdx
+++ b/docs/content/react/components/bottom-sheet.mdx
@@ -64,7 +64,7 @@ npx @seed-design/cli@latest add ui:bottom-sheet
 
 `<BottomSheetTrigger>`는 `asChild` 패턴을 사용해 자식 요소가 BottomSheet를 열 수 있도록 합니다.
 
-`<BottomSheetTrigger>`는 `BottomSheet`의 `open` 상태에 따라 `aria-expanded` 속성을 자동으로 설정합니다. 이 속성은 스크린 리더와 같은 보조 기술에 유용합니다.
+`<BottomSheetTrigger>`는 `aria-haspopup="dialog"` 속성을 설정하고, `BottomSheet`의 `open` 상태에 따라 `aria-expanded` 속성을 자동으로 설정합니다. 이 속성은 스크린 리더와 같은 보조 기술에 유용합니다.
 
 <ComponentExample name="react/bottom-sheet/trigger">
   ```json doc-gen:file
@@ -109,6 +109,19 @@ Trigger 외의 방식으로 BottomSheet를 열고 닫을 수 있습니다. 이 �
   ```json doc-gen:file
   {
     "file": "examples/react/bottom-sheet/bottom-inset.tsx",
+    "codeblock": true
+  }
+  ```
+</ComponentExample>
+
+### Hide Close Button
+
+`<BottomSheetContent>`에 `hideCloseButton` prop을 전달하여 닫기 버튼을 숨길 수 있습니다.
+
+<ComponentExample name="react/bottom-sheet/hide-close-button">
+  ```json doc-gen:file
+  {
+    "file": "examples/react/bottom-sheet/hide-close-button.tsx",
     "codeblock": true
   }
   ```

--- a/docs/examples/react/bottom-sheet/hide-close-button.tsx
+++ b/docs/examples/react/bottom-sheet/hide-close-button.tsx
@@ -1,0 +1,32 @@
+import { useState } from "react";
+import { ActionButton } from "seed-design/ui/action-button";
+import {
+  BottomSheetBody,
+  BottomSheetContent,
+  BottomSheetFooter,
+  BottomSheetRoot,
+  BottomSheetTrigger,
+} from "seed-design/ui/bottom-sheet";
+
+const BottomSheetHideCloseButton = () => {
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+
+  return (
+    <BottomSheetRoot open={isSheetOpen} onOpenChange={setIsSheetOpen}>
+      <BottomSheetTrigger asChild>
+        <ActionButton>Open</ActionButton>
+      </BottomSheetTrigger>
+      <BottomSheetContent title="제목" description="설명을 작성할 수 있어요" hideCloseButton>
+        {/* If you need to omit padding, pass px={0}. */}
+        <BottomSheetBody minHeight="x16">Content</BottomSheetBody>
+        <BottomSheetFooter>
+          <ActionButton variant="neutralSolid" onClick={() => setIsSheetOpen(false)}>
+            닫기
+          </ActionButton>
+        </BottomSheetFooter>
+      </BottomSheetContent>
+    </BottomSheetRoot>
+  );
+};
+
+export default BottomSheetHideCloseButton;

--- a/docs/registry/ui/bottom-sheet.tsx
+++ b/docs/registry/ui/bottom-sheet.tsx
@@ -29,10 +29,15 @@ export interface BottomSheetContentProps extends Omit<SeedBottomSheet.ContentPro
   description?: React.ReactNode;
 
   layerIndex?: number;
+
+  /**
+   * @default false
+   */
+  hideCloseButton?: boolean;
 }
 
 export const BottomSheetContent = forwardRef<HTMLDivElement, BottomSheetContentProps>(
-  ({ children, title, description, layerIndex, ...otherProps }, ref) => {
+  ({ children, title, description, layerIndex, hideCloseButton = false, ...otherProps }, ref) => {
     if (
       !title &&
       !otherProps["aria-labelledby"] &&
@@ -59,10 +64,12 @@ export const BottomSheetContent = forwardRef<HTMLDivElement, BottomSheetContentP
             </SeedBottomSheet.Header>
           )}
           {children}
-          {/* You may implement your own i18n for dismiss label */}
-          <SeedBottomSheet.CloseButton aria-label="닫기">
-            <Icon svg={<IconXmarkLine />} />
-          </SeedBottomSheet.CloseButton>
+          {!hideCloseButton && (
+            // You may implement your own i18n for dismiss label
+            <SeedBottomSheet.CloseButton aria-label="닫기">
+              <Icon svg={<IconXmarkLine />} />
+            </SeedBottomSheet.CloseButton>
+          )}
         </SeedBottomSheet.Content>
       </SeedBottomSheet.Positioner>
     );

--- a/packages/figma/src/codegen/targets/react/component/handlers/bottom-sheet.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/bottom-sheet.ts
@@ -29,7 +29,7 @@ export const createBottomSheetHandler = (_ctx: ComponentHandlerDeps) =>
         description: props["Description#19787:7"].value,
       }),
       ...(props["Show Close Button#19787:11"].value === false && {
-        showCloseButton: false,
+        hideCloseButton: true,
       }),
     };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - BottomSheetContent에 hideCloseButton 속성을 추가해 닫기 버튼을 선택적으로 숨길 수 있습니다.
  - 닫기 버튼을 숨기는 사용 예제가 추가되어 바로 확인할 수 있습니다.

- **문서**
  - BottomSheetTrigger의 접근성 안내를 보강해 aria-expanded와 함께 aria-haspopup="dialog" 사용을 명시했습니다.
  - BottomSheetContent에 “Hide Close Button” 섹션과 예제를 추가해 사용 방법과 동작을 설명했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->