### PR TITLE
chore: add `@radix/react-dialog` in `@seed-design/react`

### DIFF
--- a/.changeset/breezy-owls-dance.md
+++ b/.changeset/breezy-owls-dance.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react": patch
+---
+
+`@radix-ui/react-dialog` 의존성을 추가해 React 패키지를 Portable하게 수정합니다

--- a/bun.lock
+++ b/bun.lock
@@ -417,6 +417,7 @@
       "version": "1.1.3",
       "dependencies": {
         "@radix-ui/react-compose-refs": "^1.1.2",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-use-layout-effect": "^1.1.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@radix-ui/react-compose-refs": "^1.1.2",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-use-controllable-state": "1.2.2",
     "@radix-ui/react-use-layout-effect": "^1.1.1",


### PR DESCRIPTION
- `@seed-design/react-dialog` 에서 사용중인 `@radix/react-dialog` 패키지를 deps에 포함시켜 portable하게 변경합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Chores**
  * React 패키지에 대한 의존성 업데이트로 더 나은 상호운용성을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->