### PR TITLE
fix: fix style props passed into BottomSheetBody not being applied

### DIFF
--- a/.changeset/fair-parrots-reply.md
+++ b/.changeset/fair-parrots-reply.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react": patch
+---
+
+BottomSheetBody에 제공한 style 관련 prop(`paddingX` 등)이 적용되지 않고 DOM으로 bleed되는 문제를 수정합니다.

--- a/packages/react/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/react/src/components/BottomSheet/BottomSheet.tsx
@@ -2,7 +2,7 @@ import { bottomSheet, type BottomSheetVariantProps } from "@seed-design/css/reci
 import { Drawer } from "@seed-design/react-drawer";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";
 import { createSlotRecipeContext } from "../../utils/createSlotRecipeContext";
-import type { StyleProps } from "../../utils/styled";
+import { withStyleProps, type StyleProps } from "../../utils/styled";
 
 const { withRootProvider, withContext } = createSlotRecipeContext(bottomSheet);
 
@@ -89,7 +89,7 @@ export interface BottomSheetBodyProps
     React.HTMLAttributes<HTMLDivElement> {}
 
 export const BottomSheetBody = withContext<HTMLDivElement, BottomSheetBodyProps>(
-  Primitive.div,
+  withStyleProps(Primitive.div),
   "body",
 );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * BottomSheetBody 컴포넌트의 스타일 관련 속성(예: paddingX)이 올바르게 적용되지 않고 DOM에 노출되는 문제를 해결했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->