### PR TITLE
fix(stackflow): Prevent transitions from being played based on stale DOM attributes

### DIFF
--- a/.changeset/whole-bananas-arrive.md
+++ b/.changeset/whole-bananas-arrive.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/stackflow": patch
+---
+
+Prevent transitions from being played based on stale DOM attributes

--- a/packages/stackflow/src/primitive/private/useTopActivity.ts
+++ b/packages/stackflow/src/primitive/private/useTopActivity.ts
@@ -1,5 +1,5 @@
 import { useStack } from "@stackflow/react";
-import { useEffect, useState } from "react";
+import { useLayoutEffect, useState } from "react";
 
 export function useTopActivity() {
   const stack = useStack();
@@ -17,7 +17,7 @@ export function useTopActivity() {
   const [topEl, setTopEl] = useState<HTMLElement | null>(null);
   const activityType = topEl?.dataset["activityType"];
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!topId) return;
 
     const el = document.querySelector<HTMLElement>(`[data-activity-id="${topId}"]`);


### PR DESCRIPTION
- 액티비티 push 애니메이션 양상을 결정하는 `activityType` 값은 DOM에서 불러와요.
- 불러오는 작업을 `useEffect`에서 수행해서 종종 stale한 DOM 상태에 기반해 애니메이션이 재생될 때가 있어요.
- `useLayoutEffect`를 사용해 fresh한 DOM 상태를 항상 바라보도록 & repaint 전에 적절한 애니메이션을 선택할 수 있도록 수정했어요.
- DOM에서 값을 읽어오는 지금 구현이나, `useLayoutEffect` 사용 모두 best practice는 아니나 현재 이슈를 해결할 수 있는 가장 경제적인 접근이라 이 방법을 택했어요.
- 퍼포먼스에 영향을 적지 않게 줄 거라, activityType을 React state와 분리해서 취급하거나 activityType을 DOM이 아닌 다른 레이어에서 추적하는 방법으로 장기적으로는 전환이 필요해요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 활동 요소 감지 타이밍을 DOM 레이아웃 단계로 옮겨 UI 업데이트 안정성과 성능을 개선했습니다. 공개 API는 변경되지 않았습니다.
* **Bug Fixes**
  * 오래된 DOM 속성으로 인해 발생할 수 있던 전환 재생 문제를 방지했습니다.
* **Chores**
  * 패키지 버전 기록(변경셋)을 추가하여 패치 릴리스가 관리되도록 했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->