### PR TITLE
feat(react-tabs): add onSwipeStart and onSwipeEnd callbacks to TabsCarousel component

### DIFF
--- a/.changeset/smart-ends-happen.md
+++ b/.changeset/smart-ends-happen.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react-tabs": patch
+---
+
+TabsCarousel에 onSwipeStart, onSwipeEnd 이벤트 콜백을 추가합니다.

--- a/packages/react-headless/tabs/src/Tabs.tsx
+++ b/packages/react-headless/tabs/src/Tabs.tsx
@@ -132,8 +132,8 @@ export interface TabsCarouselProps
     React.HTMLAttributes<HTMLDivElement> {}
 
 export const TabsCarousel = forwardRef<HTMLDivElement, TabsCarouselProps>((props, ref) => {
-  const { dragThreshold, loop, swipeable, autoHeight, onSettle, ...otherProps } = props;
-  const api = useTabsCarousel({ dragThreshold, loop, swipeable, onSettle, autoHeight });
+  const { dragThreshold, loop, swipeable, autoHeight, onSettle, onSwipeStart, onSwipeEnd, ...otherProps } = props;
+  const api = useTabsCarousel({ dragThreshold, loop, swipeable, onSettle, autoHeight, onSwipeStart, onSwipeEnd });
 
   return (
     <TabsCarouselProvider value={api}>

--- a/packages/react-headless/tabs/src/useTabsCarousel.ts
+++ b/packages/react-headless/tabs/src/useTabsCarousel.ts
@@ -16,6 +16,16 @@ export interface UseTabsCarouselStateProps {
   dragThreshold?: number;
 
   onSettle?: () => void;
+
+  /**
+   * 스와이프 시작 시 호출됩니다.
+   */
+  onSwipeStart?: () => void;
+
+  /**
+   * 스와이프 종료 시 호출됩니다.
+   */
+  onSwipeEnd?: () => void;
 }
 
 const autoHeight = AutoHeight();
@@ -41,6 +51,8 @@ const useTabsCarouselState = (props: UseTabsCarouselStateProps) => {
   );
 
   const onSettle = useCallbackRef(props.onSettle);
+  const onSwipeStart = useCallbackRef(props.onSwipeStart);
+  const onSwipeEnd = useCallbackRef(props.onSwipeEnd);
 
   useEffect(() => {
     const select = emblaApi?.on("select", () => {
@@ -52,11 +64,21 @@ const useTabsCarouselState = (props: UseTabsCarouselStateProps) => {
       onSettle?.();
     });
 
+    const pointerDown = emblaApi?.on("pointerDown", () => {
+      onSwipeStart?.();
+    });
+
+    const pointerUp = emblaApi?.on("pointerUp", () => {
+      onSwipeEnd?.();
+    });
+
     return () => {
       select?.clear();
       settle?.clear();
+      pointerDown?.clear();
+      pointerUp?.clear();
     };
-  }, [emblaApi, api.setContentIndex, onSettle]);
+  }, [emblaApi, api.setContentIndex, onSettle, onSwipeStart, onSwipeEnd]);
 
   const getContentIndex = useCallbackRef(() => api.contentIndex);
   useEffect(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * TabsCarousel 컴포넌트에 swipe 이벤트 콜백 추가: onSwipeStart와 onSwipeEnd 콜백을 통해 사용자가 swipe 시작 및 종료 시점에 커스텀 로직을 실행할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->