### PR TITLE
fix: filter null/undefined before mapping in TagGroupRoot

### DIFF
--- a/.changeset/cuddly-donuts-cross.md
+++ b/.changeset/cuddly-donuts-cross.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react": patch
+---
+
+`TagGroupRoot`의 children이 `null` 또는 `undefined`를 포함하는 경우 불필요한 separator가 표시되는 문제를 수정합니다.

--- a/packages/react/src/components/TagGroup/TagGroup.tsx
+++ b/packages/react/src/components/TagGroup/TagGroup.tsx
@@ -5,7 +5,7 @@ import {
   type TagGroupItemVariantProps,
 } from "@seed-design/css/recipes/tag-group-item";
 import { createRecipeContext } from "../../utils/createRecipeContext";
-import { forwardRef, Children } from "react";
+import { forwardRef, Children, Fragment } from "react";
 import clsx from "clsx";
 import { splitMultipleVariantsProps } from "../../utils/splitMultipleVariantsProps";
 import { mergeProps } from "@seed-design/dom-utils";
@@ -29,16 +29,19 @@ export const TagGroupRoot = forwardRef<HTMLSpanElement, TagGroupRootProps>(
     return (
       <PropsProvider value={tagGroupItemVariantProps}>
         <Primitive.span ref={ref} className={clsx(classNames.root, className)} {...otherProps}>
-          {Children.map(children, (child, index) => (
-            <>
-              {index > 0 && (
-                <Primitive.span aria-hidden className={classNames.separator}>
-                  {separator}
-                </Primitive.span>
-              )}
-              {child}
-            </>
-          ))}
+          {Children.toArray(children)
+            .filter((child) => child !== null && child !== undefined)
+            .map((child, index) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: those fragments won't change order
+              <Fragment key={index}>
+                {index > 0 && (
+                  <Primitive.span aria-hidden className={classNames.separator}>
+                    {separator}
+                  </Primitive.span>
+                )}
+                {child}
+              </Fragment>
+            ))}
         </Primitive.span>
       </PropsProvider>
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * TagGroup 컴포넌트에서 null 또는 undefined 자식 요소가 포함될 때 불필요한 구분선이 표시되던 문제를 해결했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->