### PR TITLE
docs: add mdx component FigmaImage for rendering images in Figma CDN

### DIFF
--- a/.github/workflows/docs-deploy-alpha-pages.yml
+++ b/.github/workflows/docs-deploy-alpha-pages.yml
@@ -13,6 +13,8 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
+  FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
 
 name: Deploy seed-design-v3 docs (Alpha)
 

--- a/.github/workflows/docs-deploy-alpha-pages.yml
+++ b/.github/workflows/docs-deploy-alpha-pages.yml
@@ -10,6 +10,13 @@ on:
       - "packages/react/**"
       - "packages/stackflow/**"
       - ".github/workflows/docs-deploy-alpha-pages.yml"
+  workflow_dispatch:
+    inputs:
+      skip-figma-cache:
+        description: 'Skip Figma image cache (fetch fresh images)'
+        required: false
+        type: boolean
+        default: false
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -31,6 +38,7 @@ jobs:
           bun-version: "1.3.3"
 
       - name: Restore Figma image cache
+        if: ${{ !inputs.skip-figma-cache }}
         uses: actions/cache@v4
         with:
           path: docs/.cache/figma-image
@@ -56,6 +64,8 @@ jobs:
 
       - name: Build Docs
         working-directory: ./docs
+        env:
+          FIGMA_CACHE_DISABLED: ${{ inputs.skip-figma-cache && '1' || '0' }}
         run: |
           bun run build
 

--- a/.github/workflows/docs-deploy-alpha-pages.yml
+++ b/.github/workflows/docs-deploy-alpha-pages.yml
@@ -30,11 +30,18 @@ jobs:
         with:
           bun-version: "1.3.3"
 
-      - name: Restore cache
+      - name: Restore Figma image cache
         uses: actions/cache@v4
         with:
-          path: |
-            docs/.next/cache
+          path: docs/.cache/figma-image
+          key: ${{ runner.os }}-figma-images-${{ hashFiles('docs/**/*.mdx') }}
+          restore-keys: |
+            ${{ runner.os }}-figma-images-
+
+      - name: Restore Next.js cache
+        uses: actions/cache@v4
+        with:
+          path: docs/.next/cache
           # Generate a new cache whenever packages or source files change.
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/bun.lock') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
           # If source files changed but packages didn't, rebuild from a prior cache.

--- a/.github/workflows/docs-deploy-production-pages.yml
+++ b/.github/workflows/docs-deploy-production-pages.yml
@@ -10,6 +10,12 @@ on:
       - "packages/stackflow/**"
       - ".github/workflows/docs-deploy-production-pages.yml"
   workflow_dispatch:
+    inputs:
+      skip-figma-cache:
+        description: 'Skip Figma image cache (fetch fresh images)'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -35,6 +41,7 @@ jobs:
           bun-version: "1.3.3"
 
       - name: Restore Figma image cache
+        if: ${{ !inputs.skip-figma-cache }}
         uses: actions/cache@v4
         with:
           path: docs/.cache/figma-image
@@ -60,6 +67,8 @@ jobs:
 
       - name: Build Docs
         working-directory: ./docs
+        env:
+          FIGMA_CACHE_DISABLED: ${{ inputs.skip-figma-cache && '1' || '0' }}
         run: |
           bun run build
 

--- a/.github/workflows/docs-deploy-production-pages.yml
+++ b/.github/workflows/docs-deploy-production-pages.yml
@@ -17,6 +17,8 @@ concurrency:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
+  FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
 
 name: Deploy seed-design-v3 docs (Production)
 

--- a/.github/workflows/docs-deploy-production-pages.yml
+++ b/.github/workflows/docs-deploy-production-pages.yml
@@ -34,11 +34,18 @@ jobs:
         with:
           bun-version: "1.3.3"
 
-      - name: Restore cache
+      - name: Restore Figma image cache
         uses: actions/cache@v4
         with:
-          path: |
-            docs/.next/cache
+          path: docs/.cache/figma-image
+          key: ${{ runner.os }}-figma-images-${{ hashFiles('docs/**/*.mdx') }}
+          restore-keys: |
+            ${{ runner.os }}-figma-images-
+
+      - name: Restore Next.js cache
+        uses: actions/cache@v4
+        with:
+          path: docs/.next/cache
           # Generate a new cache whenever packages or source files change.
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/bun.lock') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
           # If source files changed but packages didn't, rebuild from a prior cache.

--- a/.github/workflows/docs-deploy-storybook-alpha-pages.yml
+++ b/.github/workflows/docs-deploy-storybook-alpha-pages.yml
@@ -14,6 +14,8 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
+  FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
 
 name: Deploy seed-design-v3 Storybook Alpha
 

--- a/.github/workflows/docs-deploy-storybook-production-pages.yml
+++ b/.github/workflows/docs-deploy-storybook-production-pages.yml
@@ -13,6 +13,8 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
+  FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
 
 name: Deploy seed-design-v3 Storybook
 

--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,6 @@
         "concurrently": "^9.2.1",
         "estree-util-value-to-estree": "^3.4.0",
         "figma-api": "^2.1.0-beta",
-        "find-cache-directory": "^6.0.0",
         "flat-cache": "^6.1.19",
         "hast-util-to-estree": "^3.1.3",
         "mdast-util-mdx-jsx": "^3.2.0",
@@ -3488,8 +3487,6 @@
 
     "find-cache-dir": ["find-cache-dir@2.1.0", "", { "dependencies": { "commondir": "^1.0.1", "make-dir": "^2.0.0", "pkg-dir": "^3.0.0" } }, "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ=="],
 
-    "find-cache-directory": ["find-cache-directory@6.0.0", "", { "dependencies": { "common-path-prefix": "^3.0.0", "pkg-dir": "^8.0.0" } }, "sha512-CvFd5ivA6HcSHbD+59P7CyzINHXzwhuQK8RY7CxJZtgDSAtRlHiCaQpZQ2lMR/WRyUIEmzUvL6G2AGurMfegZA=="],
-
     "find-up": ["find-up@7.0.0", "", { "dependencies": { "locate-path": "^7.2.0", "path-exists": "^5.0.0", "unicorn-magic": "^0.1.0" } }, "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g=="],
 
     "find-up-simple": ["find-up-simple@1.0.1", "", {}, "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ=="],
@@ -4390,7 +4387,7 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.0", "", {}, "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ=="],
 
-    "pkg-dir": ["pkg-dir@8.0.0", "", { "dependencies": { "find-up-simple": "^1.0.0" } }, "sha512-4peoBq4Wks0riS0z8741NVv+/8IiTvqnZAr8QGgtdifrtpdXbNw/FxRS1l6NFqm4EMzuS0EDqNNx4XGaz8cuyQ=="],
+    "pkg-dir": ["pkg-dir@5.0.0", "", { "dependencies": { "find-up": "^5.0.0" } }, "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA=="],
 
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 
@@ -5472,8 +5469,6 @@
 
     "@sanity/cli/esbuild": ["esbuild@0.25.11", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.11", "@esbuild/android-arm": "0.25.11", "@esbuild/android-arm64": "0.25.11", "@esbuild/android-x64": "0.25.11", "@esbuild/darwin-arm64": "0.25.11", "@esbuild/darwin-x64": "0.25.11", "@esbuild/freebsd-arm64": "0.25.11", "@esbuild/freebsd-x64": "0.25.11", "@esbuild/linux-arm": "0.25.11", "@esbuild/linux-arm64": "0.25.11", "@esbuild/linux-ia32": "0.25.11", "@esbuild/linux-loong64": "0.25.11", "@esbuild/linux-mips64el": "0.25.11", "@esbuild/linux-ppc64": "0.25.11", "@esbuild/linux-riscv64": "0.25.11", "@esbuild/linux-s390x": "0.25.11", "@esbuild/linux-x64": "0.25.11", "@esbuild/netbsd-arm64": "0.25.11", "@esbuild/netbsd-x64": "0.25.11", "@esbuild/openbsd-arm64": "0.25.11", "@esbuild/openbsd-x64": "0.25.11", "@esbuild/openharmony-arm64": "0.25.11", "@esbuild/sunos-x64": "0.25.11", "@esbuild/win32-arm64": "0.25.11", "@esbuild/win32-ia32": "0.25.11", "@esbuild/win32-x64": "0.25.11" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q=="],
 
-    "@sanity/cli/pkg-dir": ["pkg-dir@5.0.0", "", { "dependencies": { "find-up": "^5.0.0" } }, "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA=="],
-
     "@sanity/cli/prettier": ["prettier@3.6.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="],
 
     "@sanity/codegen/globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
@@ -5843,6 +5838,8 @@
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "peek-stream/through2": ["through2@2.0.5", "", { "dependencies": { "readable-stream": "~2.3.6", "xtend": "~4.0.1" } }, "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ=="],
+
+    "pkg-dir/find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
@@ -6246,8 +6243,6 @@
 
     "@sanity/cli/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.11", "", { "os": "win32", "cpu": "x64" }, "sha512-D7Hpz6A2L4hzsRpPaCYkQnGOotdUpDzSGRIv9I+1ITdHROSFUWW95ZPZWQmGka1Fg7W3zFJowyn9WGwMJ0+KPA=="],
 
-    "@sanity/cli/pkg-dir/find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
-
     "@sanity/codegen/globby/slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 
     "@sanity/export/rimraf/glob": ["glob@11.0.3", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.0.3", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA=="],
@@ -6615,6 +6610,10 @@
     "parallel-transform/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "peek-stream/through2/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "pkg-dir/find-up/locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "pkg-dir/find-up/path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "read-pkg-up/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
@@ -7006,10 +7005,6 @@
 
     "@rushstack/node-core-library/semver/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
-    "@sanity/cli/pkg-dir/find-up/locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
-
-    "@sanity/cli/pkg-dir/find-up/path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
-
     "@sanity/export/rimraf/glob/jackspeak": ["jackspeak@4.1.1", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" } }, "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ=="],
 
     "@sanity/export/rimraf/glob/path-scurry": ["path-scurry@2.0.0", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg=="],
@@ -7082,6 +7077,8 @@
 
     "peek-stream/through2/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
+    "pkg-dir/find-up/locate-path/p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
     "read-pkg-up/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
     "renderkid/css-select/domutils/dom-serializer": ["dom-serializer@1.4.1", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.0", "entities": "^2.0.0" } }, "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="],
@@ -7140,8 +7137,6 @@
 
     "webpack-dev-server/webpack-dev-middleware/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
-    "@sanity/cli/pkg-dir/find-up/locate-path/p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
-
     "@sanity/runtime-cli/ora/cli-cursor/restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "@seed-design/tailwind3-plugin/tailwindcss/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -7164,13 +7159,13 @@
 
     "log-symbols/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
+    "pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
     "renderkid/css-select/domutils/dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 
     "sanity/jsdom/@asamuzakjp/dom-selector/css-tree/mdn-data": ["mdn-data@2.0.30", "", {}, "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="],
 
     "sanity/jsdom/cssstyle/@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "@sanity/cli/pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "@storybook/react-docgen-typescript-plugin/find-cache-dir/pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
@@ -7178,6 +7173,6 @@
 
     "eslint/find-up/locate-path/p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "@sanity/cli/pkg-dir/find-up/locate-path/p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+    "pkg-dir/find-up/locate-path/p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -111,6 +111,8 @@
         "concurrently": "^9.2.1",
         "estree-util-value-to-estree": "^3.4.0",
         "figma-api": "^2.1.0-beta",
+        "find-cache-directory": "^6.0.0",
+        "flat-cache": "^6.1.19",
         "hast-util-to-estree": "^3.1.3",
         "mdast-util-mdx-jsx": "^3.2.0",
         "postcss": "^8.5.3",
@@ -1392,6 +1394,10 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.2", "", { "os": "win32", "cpu": "x64" }, "sha512-6Ee9P26DTb4D8sN9nXxgbi9Dw5vSOfH98M7UlmkjKB2vtUbrRqCbZiNfryGiwnPIpd6YUoTl7rLVD2/x1CyEHQ=="],
 
+    "@cacheable/memory": ["@cacheable/memory@2.0.6", "", { "dependencies": { "@cacheable/utils": "^2.3.2", "@keyv/bigmap": "^1.3.0", "hookified": "^1.13.0", "keyv": "^5.5.4" } }, "sha512-7e8SScMocHxcAb8YhtkbMhGG+EKLRIficb1F5sjvhSYsWTZGxvg4KIDp8kgxnV2PUJ3ddPe6J9QESjKvBWRDkg=="],
+
+    "@cacheable/utils": ["@cacheable/utils@2.3.2", "", { "dependencies": { "hashery": "^1.2.0", "keyv": "^5.5.4" } }, "sha512-8kGE2P+HjfY8FglaOiW+y8qxcaQAfAhVML+i66XJR3YX5FtyDqn6Txctr3K2FrbxLKixRRYYBWMbuGciOhYNDg=="],
+
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.0.13", "", { "dependencies": { "@changesets/config": "^3.1.1", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-BIW7bofD2yAWoE8H4V40FikC+1nNFEKBisMECccS16W1rt6qqhNTBDmIw5HaqmMgtLNz9e7oiALiEUuKrQ4oHg=="],
 
     "@changesets/assemble-release-plan": ["@changesets/assemble-release-plan@6.0.9", "", { "dependencies": { "@changesets/errors": "^0.2.0", "@changesets/get-dependents-graph": "^2.1.3", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "semver": "^7.5.3" } }, "sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ=="],
@@ -1743,6 +1749,10 @@
     "@karrotmarket/react-monochrome-icon": ["@karrotmarket/react-monochrome-icon@1.8.0", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-FAgGZnNVSD2dGBBNcEmiWk81LT2cbkVhvessImgikZW2+tO/Cy1sybvByqKHKD/tho9GeL9ez2EqfjTgocjhWA=="],
 
     "@karrotmarket/react-multicolor-icon": ["@karrotmarket/react-multicolor-icon@1.5.0", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-XjlVNXEbrM4klCJxTTy3u1kkhYlqsxxU/4MkygZStSLJ7jCtL5dLrK2x6qlLU4m8hGDBZVGH2V64p5ydnI6tSg=="],
+
+    "@keyv/bigmap": ["@keyv/bigmap@1.3.0", "", { "dependencies": { "hashery": "^1.2.0", "hookified": "^1.13.0" }, "peerDependencies": { "keyv": "^5.5.4" } }, "sha512-KT01GjzV6AQD5+IYrcpoYLkCu1Jod3nau1Z7EsEuViO3TZGRacSbO9MfHmbJ1WaOXFtWLxPVj169cn2WNKPkIg=="],
+
+    "@keyv/serialize": ["@keyv/serialize@1.1.1", "", {}, "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA=="],
 
     "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
 
@@ -2926,6 +2936,8 @@
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
+    "cacheable": ["cacheable@2.3.0", "", { "dependencies": { "@cacheable/memory": "^2.0.6", "@cacheable/utils": "^2.3.2", "hookified": "^1.13.0", "keyv": "^5.5.4", "qified": "^0.5.2" } }, "sha512-HHiAvOBmlcR2f3SQ7kdlYD8+AUJG+wlFZ/Ze8tl1Vzvz0MdOh8IYA/EFU4ve8t1/sZ0j4MGi7ST5MoTwHessQA=="],
+
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
@@ -3476,6 +3488,8 @@
 
     "find-cache-dir": ["find-cache-dir@2.1.0", "", { "dependencies": { "commondir": "^1.0.1", "make-dir": "^2.0.0", "pkg-dir": "^3.0.0" } }, "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ=="],
 
+    "find-cache-directory": ["find-cache-directory@6.0.0", "", { "dependencies": { "common-path-prefix": "^3.0.0", "pkg-dir": "^8.0.0" } }, "sha512-CvFd5ivA6HcSHbD+59P7CyzINHXzwhuQK8RY7CxJZtgDSAtRlHiCaQpZQ2lMR/WRyUIEmzUvL6G2AGurMfegZA=="],
+
     "find-up": ["find-up@7.0.0", "", { "dependencies": { "locate-path": "^7.2.0", "path-exists": "^5.0.0", "unicorn-magic": "^0.1.0" } }, "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g=="],
 
     "find-up-simple": ["find-up-simple@1.0.1", "", {}, "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ=="],
@@ -3484,7 +3498,7 @@
 
     "findup-sync": ["findup-sync@5.0.0", "", { "dependencies": { "detect-file": "^1.0.0", "is-glob": "^4.0.3", "micromatch": "^4.0.4", "resolve-dir": "^1.0.1" } }, "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ=="],
 
-    "flat-cache": ["flat-cache@3.2.0", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.3", "rimraf": "^3.0.2" } }, "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw=="],
+    "flat-cache": ["flat-cache@6.1.19", "", { "dependencies": { "cacheable": "^2.2.0", "flatted": "^3.3.3", "hookified": "^1.13.0" } }, "sha512-l/K33newPTZMTGAnnzaiqSl6NnH7Namh8jBNjrgjprWxGmZUuxx/sJNIRaijOh3n7q7ESbhNZC+pvVZMFdeU4A=="],
 
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
 
@@ -3628,6 +3642,8 @@
 
     "hash.js": ["hash.js@1.1.7", "", { "dependencies": { "inherits": "^2.0.3", "minimalistic-assert": "^1.0.1" } }, "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA=="],
 
+    "hashery": ["hashery@1.3.0", "", { "dependencies": { "hookified": "^1.13.0" } }, "sha512-fWltioiy5zsSAs9ouEnvhsVJeAXRybGCNNv0lvzpzNOSDbULXRy7ivFWwCCv4I5Am6kSo75hmbsCduOoc2/K4w=="],
+
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
@@ -3657,6 +3673,8 @@
     "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
 
     "homedir-polyfill": ["homedir-polyfill@1.0.3", "", { "dependencies": { "parse-passwd": "^1.0.0" } }, "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA=="],
+
+    "hookified": ["hookified@1.13.0", "", {}, "sha512-6sPYUY8olshgM/1LDNW4QZQN0IqgKhtl/1C8koNZBJrKLBk3AZl6chQtNwpNztvfiApHMEwMHek5rv993PRbWw=="],
 
     "hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
 
@@ -3878,7 +3896,7 @@
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
-    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+    "keyv": ["keyv@5.5.4", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-eohl3hKTiVyD1ilYdw9T0OiB4hnjef89e3dMYKz+mVKDzj+5IteTseASUsOB+EU9Tf6VNTCjDePcP6wkDGmLKQ=="],
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
@@ -4372,7 +4390,7 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.0", "", {}, "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ=="],
 
-    "pkg-dir": ["pkg-dir@5.0.0", "", { "dependencies": { "find-up": "^5.0.0" } }, "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA=="],
+    "pkg-dir": ["pkg-dir@8.0.0", "", { "dependencies": { "find-up-simple": "^1.0.0" } }, "sha512-4peoBq4Wks0riS0z8741NVv+/8IiTvqnZAr8QGgtdifrtpdXbNw/FxRS1l6NFqm4EMzuS0EDqNNx4XGaz8cuyQ=="],
 
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 
@@ -4507,6 +4525,8 @@
     "pumpify": ["pumpify@1.5.1", "", { "dependencies": { "duplexify": "^3.6.0", "inherits": "^2.0.3", "pump": "^2.0.0" } }, "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "qified": ["qified@0.5.2", "", { "dependencies": { "hookified": "^1.13.0" } }, "sha512-7gJ6mxcQb9vUBOtbKm5mDevbe2uRcOEVp1g4gb/Q+oLntB3HY8eBhOYRxFI2mlDFlY1e4DOSCptzxarXRvzxCA=="],
 
     "qs": ["qs@6.14.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w=="],
 
@@ -5452,6 +5472,8 @@
 
     "@sanity/cli/esbuild": ["esbuild@0.25.11", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.11", "@esbuild/android-arm": "0.25.11", "@esbuild/android-arm64": "0.25.11", "@esbuild/android-x64": "0.25.11", "@esbuild/darwin-arm64": "0.25.11", "@esbuild/darwin-x64": "0.25.11", "@esbuild/freebsd-arm64": "0.25.11", "@esbuild/freebsd-x64": "0.25.11", "@esbuild/linux-arm": "0.25.11", "@esbuild/linux-arm64": "0.25.11", "@esbuild/linux-ia32": "0.25.11", "@esbuild/linux-loong64": "0.25.11", "@esbuild/linux-mips64el": "0.25.11", "@esbuild/linux-ppc64": "0.25.11", "@esbuild/linux-riscv64": "0.25.11", "@esbuild/linux-s390x": "0.25.11", "@esbuild/linux-x64": "0.25.11", "@esbuild/netbsd-arm64": "0.25.11", "@esbuild/netbsd-x64": "0.25.11", "@esbuild/openbsd-arm64": "0.25.11", "@esbuild/openbsd-x64": "0.25.11", "@esbuild/openharmony-arm64": "0.25.11", "@esbuild/sunos-x64": "0.25.11", "@esbuild/win32-arm64": "0.25.11", "@esbuild/win32-ia32": "0.25.11", "@esbuild/win32-x64": "0.25.11" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q=="],
 
+    "@sanity/cli/pkg-dir": ["pkg-dir@5.0.0", "", { "dependencies": { "find-up": "^5.0.0" } }, "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA=="],
+
     "@sanity/cli/prettier": ["prettier@3.6.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="],
 
     "@sanity/codegen/globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
@@ -5525,6 +5547,8 @@
     "@storybook/nextjs/style-loader": ["style-loader@3.3.4", "", { "peerDependencies": { "webpack": "^5.0.0" } }, "sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w=="],
 
     "@storybook/react-docgen-typescript-plugin/find-cache-dir": ["find-cache-dir@3.3.2", "", { "dependencies": { "commondir": "^1.0.1", "make-dir": "^3.0.2", "pkg-dir": "^4.1.0" } }, "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig=="],
+
+    "@storybook/react-docgen-typescript-plugin/flat-cache": ["flat-cache@3.2.0", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.3", "rimraf": "^3.0.2" } }, "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.7.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-pJdKGq/1iquWYtv1RRSljZklxHCOCAJFJrImO5ZLKPJVJlVUcs8yFwNQlqS0Lo8xT1VAXXTCZocF9n26FWEKsw=="],
 
@@ -5680,8 +5704,6 @@
 
     "find-yarn-workspace-root2/pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
-    "flat-cache/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
-
     "fork-ts-checker-webpack-plugin/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "fork-ts-checker-webpack-plugin/cosmiconfig": ["cosmiconfig@8.3.6", "", { "dependencies": { "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0", "path-type": "^4.0.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA=="],
@@ -5821,8 +5843,6 @@
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "peek-stream/through2": ["through2@2.0.5", "", { "dependencies": { "readable-stream": "~2.3.6", "xtend": "~4.0.1" } }, "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ=="],
-
-    "pkg-dir/find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
@@ -6226,6 +6246,8 @@
 
     "@sanity/cli/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.11", "", { "os": "win32", "cpu": "x64" }, "sha512-D7Hpz6A2L4hzsRpPaCYkQnGOotdUpDzSGRIv9I+1ITdHROSFUWW95ZPZWQmGka1Fg7W3zFJowyn9WGwMJ0+KPA=="],
 
+    "@sanity/cli/pkg-dir/find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
     "@sanity/codegen/globby/slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 
     "@sanity/export/rimraf/glob": ["glob@11.0.3", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.0.3", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA=="],
@@ -6281,6 +6303,10 @@
     "@storybook/react-docgen-typescript-plugin/find-cache-dir/make-dir": ["make-dir@3.1.0", "", { "dependencies": { "semver": "^6.0.0" } }, "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw=="],
 
     "@storybook/react-docgen-typescript-plugin/find-cache-dir/pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
+
+    "@storybook/react-docgen-typescript-plugin/flat-cache/keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "@storybook/react-docgen-typescript-plugin/flat-cache/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
 
@@ -6415,6 +6441,8 @@
     "execa/npm-run-path/unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
 
     "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "file-entry-cache/flat-cache/keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -6587,10 +6615,6 @@
     "parallel-transform/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "peek-stream/through2/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
-
-    "pkg-dir/find-up/locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
-
-    "pkg-dir/find-up/path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "read-pkg-up/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
@@ -6982,6 +7006,10 @@
 
     "@rushstack/node-core-library/semver/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
+    "@sanity/cli/pkg-dir/find-up/locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "@sanity/cli/pkg-dir/find-up/path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
     "@sanity/export/rimraf/glob/jackspeak": ["jackspeak@4.1.1", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" } }, "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ=="],
 
     "@sanity/export/rimraf/glob/path-scurry": ["path-scurry@2.0.0", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg=="],
@@ -7054,8 +7082,6 @@
 
     "peek-stream/through2/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
-    "pkg-dir/find-up/locate-path/p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
-
     "read-pkg-up/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
     "renderkid/css-select/domutils/dom-serializer": ["dom-serializer@1.4.1", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.0", "entities": "^2.0.0" } }, "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="],
@@ -7114,6 +7140,8 @@
 
     "webpack-dev-server/webpack-dev-middleware/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
+    "@sanity/cli/pkg-dir/find-up/locate-path/p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
     "@sanity/runtime-cli/ora/cli-cursor/restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "@seed-design/tailwind3-plugin/tailwindcss/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -7136,13 +7164,13 @@
 
     "log-symbols/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
-    "pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
-
     "renderkid/css-select/domutils/dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 
     "sanity/jsdom/@asamuzakjp/dom-selector/css-tree/mdn-data": ["mdn-data@2.0.30", "", {}, "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="],
 
     "sanity/jsdom/cssstyle/@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "@sanity/cli/pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "@storybook/react-docgen-typescript-plugin/find-cache-dir/pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
@@ -7150,6 +7178,6 @@
 
     "eslint/find-up/locate-path/p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "pkg-dir/find-up/locate-path/p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+    "@sanity/cli/pkg-dir/find-up/locate-path/p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -96,6 +96,7 @@
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^4.0.1",
+        "@figma/rest-api-spec": "^0.34.0",
         "@storybook/builder-webpack5": "^10.0.0",
         "@storybook/nextjs": "^10.0.0",
         "@tailwindcss/postcss": "^4.0.6",
@@ -109,6 +110,7 @@
         "chromatic": "^13.0.0",
         "concurrently": "^9.2.1",
         "estree-util-value-to-estree": "^3.4.0",
+        "figma-api": "^2.1.0-beta",
         "hast-util-to-estree": "^3.1.3",
         "mdast-util-mdx-jsx": "^3.2.0",
         "postcss": "^8.5.3",
@@ -2836,7 +2838,7 @@
 
     "aws4": ["aws4@1.13.2", "", {}, "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="],
 
-    "axios": ["axios@0.27.2", "", { "dependencies": { "follow-redirects": "^1.14.9", "form-data": "^4.0.0" } }, "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ=="],
+    "axios": ["axios@1.13.2", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA=="],
 
     "b4a": ["b4a@1.7.3", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q=="],
 
@@ -3448,7 +3450,7 @@
 
     "fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
-    "figma-api": ["figma-api@2.0.1-beta", "", { "dependencies": { "@types/node": "^22.8.7", "axios": "^0.27.2" } }, "sha512-Hegr8g5UGIr3T5yRGUQsMy43OkQgx25zL1w7k5KRf6ady11mXIDq0k9DOpgWRyUltcd4GI001wOZz37J6osOkg=="],
+    "figma-api": ["figma-api@2.1.0-beta", "", { "dependencies": { "@figma/rest-api-spec": "^0.27.0", "axios": "^1.12.2" } }, "sha512-DLDUOhdab70A3+KRfIB3udXYuVd+4uY/3Q+VMBwkHFRdSg7pRxGqfpPb05eGFkoDQs2pY0S5292lp4ZF/3dxtA=="],
 
     "figma-mcp": ["figma-mcp@workspace:tools/figma-mcp"],
 
@@ -4490,6 +4492,8 @@
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
     "ps-list": ["ps-list@7.2.0", "", {}, "sha512-v4Bl6I3f2kJfr5o80ShABNHAokIgY+wFDTQfE+X3zWYgSGQOCBeYptLZUpoOALBqO5EawmDN/tjTldJesd0ujQ=="],
 
     "psl": ["psl@1.15.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w=="],
@@ -5504,6 +5508,8 @@
 
     "@seed-design/docs/zod": ["zod@4.1.12", "", {}, "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ=="],
 
+    "@seed-design/figma-extractor/figma-api": ["figma-api@2.0.1-beta", "", { "dependencies": { "@types/node": "^22.8.7", "axios": "^0.27.2" } }, "sha512-Hegr8g5UGIr3T5yRGUQsMy43OkQgx25zL1w7k5KRf6ady11mXIDq0k9DOpgWRyUltcd4GI001wOZz37J6osOkg=="],
+
     "@seed-design/tailwind3-plugin/tailwindcss": ["tailwindcss@3.4.18", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ=="],
 
     "@sindresorhus/slugify/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
@@ -5662,7 +5668,7 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "figma-api/@types/node": ["@types/node@22.19.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-xpr/lmLPQEj+TUnHmR+Ab91/glhJvsqcjB+yY0Ix9GO70H6Lb4FHH5GeqdOE5btAx7eIMwuHkp4H2MSkLcqWbA=="],
+    "figma-api/@figma/rest-api-spec": ["@figma/rest-api-spec@0.27.0", "", {}, "sha512-jRGYwBLdybit9X7puOmztx8XUt1dq9a7jtBO2KEK4OrxP8GKGX5yY2+efV/XNRHnqTbzFue0qdZklSBs/EaGNw=="],
 
     "file-entry-cache/flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
@@ -6254,6 +6260,10 @@
 
     "@sanity/sdk/@sanity/mutate/nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
 
+    "@seed-design/figma-extractor/figma-api/@types/node": ["@types/node@22.19.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-xpr/lmLPQEj+TUnHmR+Ab91/glhJvsqcjB+yY0Ix9GO70H6Lb4FHH5GeqdOE5btAx7eIMwuHkp4H2MSkLcqWbA=="],
+
+    "@seed-design/figma-extractor/figma-api/axios": ["axios@0.27.2", "", { "dependencies": { "follow-redirects": "^1.14.9", "form-data": "^4.0.0" } }, "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ=="],
+
     "@seed-design/tailwind3-plugin/tailwindcss/arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
 
     "@seed-design/tailwind3-plugin/tailwindcss/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
@@ -6405,8 +6415,6 @@
     "execa/npm-run-path/unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
 
     "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "figma-api/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -6985,6 +6993,8 @@
     "@sanity/runtime-cli/ora/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
     "@sanity/sdk/@sanity/message-protocol/@sanity/comlink/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+
+    "@seed-design/figma-extractor/figma-api/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@seed-design/tailwind3-plugin/tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -9,6 +9,7 @@
 # test & build
 /coverage
 /.next/
+/.cache/
 /out/
 /build
 *.tsbuildinfo

--- a/docs/app/sitemap.ts
+++ b/docs/app/sitemap.ts
@@ -1,12 +1,17 @@
 import type { MetadataRoute } from "next";
 import { baseUrl } from "@/app/metadata";
-import { source, reactSource } from "@/app/source";
+import { source, reactSource, breezeSource, lynxSource } from "@/app/source";
 
 export const dynamic = "force-static";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   return await Promise.all(
-    [...source.getPages(), ...reactSource.getPages()].map(async (page) => {
+    [
+      ...source.getPages(),
+      ...reactSource.getPages(),
+      ...breezeSource.getPages(),
+      ...lynxSource.getPages(),
+    ].map(async (page) => {
       const { lastModified } = await page.data.load();
 
       return {

--- a/docs/components/component-card.tsx
+++ b/docs/components/component-card.tsx
@@ -9,10 +9,10 @@ interface ComponentCardProps {
   title: string;
   description?: string;
   href: string;
-  imagePath: string;
+  coverImageSrc?: string;
 }
 
-export function ComponentCard({ title, description, href, imagePath }: ComponentCardProps) {
+export function ComponentCard({ title, description, href, coverImageSrc }: ComponentCardProps) {
   const [error, setError] = useState<SyntheticEvent<HTMLImageElement, Event> | null>(null);
 
   return (
@@ -21,11 +21,11 @@ export function ComponentCard({ title, description, href, imagePath }: Component
       className="group flex flex-col overflow-hidden rounded-lg border border-fd-border bg-fd-card transition-colors hover:bg-fd-accent/50"
     >
       <div className="relative aspect-4/3 w-full overflow-hidden bg-fd-muted flex items-center justify-center">
-        {error ? (
+        {!coverImageSrc || error ? (
           <IconPictureFill className="h-10 w-10 text-fd-muted-foreground/20 group-hover:scale-105 transition-transform" />
         ) : (
           <Image
-            src={imagePath}
+            src={coverImageSrc}
             alt={`${title} anatomy`}
             onError={setError}
             fill

--- a/docs/components/component-card.tsx
+++ b/docs/components/component-card.tsx
@@ -1,45 +1,37 @@
+"use client";
+
+import { IconPictureFill } from "@karrotmarket/react-monochrome-icon";
 import Image from "next/image";
 import Link from "next/link";
+import { useState, type SyntheticEvent } from "react";
 
 interface ComponentCardProps {
   title: string;
   description?: string;
   href: string;
-  imagePath?: string;
+  imagePath: string;
 }
 
 export function ComponentCard({ title, description, href, imagePath }: ComponentCardProps) {
+  const [error, setError] = useState<SyntheticEvent<HTMLImageElement, Event> | null>(null);
+
   return (
     <Link
       href={href}
       className="group flex flex-col overflow-hidden rounded-lg border border-fd-border bg-fd-card transition-colors hover:bg-fd-accent/50"
     >
-      <div className="relative aspect-[4/3] w-full overflow-hidden bg-fd-muted">
-        {imagePath ? (
+      <div className="relative aspect-4/3 w-full overflow-hidden bg-fd-muted flex items-center justify-center">
+        {error ? (
+          <IconPictureFill className="h-10 w-10 text-fd-muted-foreground/20 group-hover:scale-105 transition-transform" />
+        ) : (
           <Image
             src={imagePath}
             alt={`${title} anatomy`}
+            onError={setError}
             fill
             className="object-cover transition-transform group-hover:scale-105"
             sizes="(max-width: 768px) 50vw, 33vw"
           />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-fd-muted to-fd-muted/50">
-            <svg
-              className="h-10 w-10 text-fd-muted-foreground/20"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={1.5}
-                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-              />
-            </svg>
-          </div>
         )}
       </div>
       <div className="flex flex-col gap-1.5 p-4">

--- a/docs/components/component-grid.tsx
+++ b/docs/components/component-grid.tsx
@@ -16,7 +16,7 @@ export function ComponentGrid() {
       // Only include pages under /docs/components/
       if (!page.url.startsWith("/docs/components/")) return false;
 
-      if (page.data.deprecated) return true;
+      if (page.data.deprecated) return false;
 
       return true;
     })

--- a/docs/components/component-grid.tsx
+++ b/docs/components/component-grid.tsx
@@ -1,5 +1,11 @@
 import { source } from "@/app/source";
 import { ComponentCard } from "@/components/component-card";
+import {
+  createFigmaClient,
+  fetchFigmaImageUrls,
+} from "@/components/figma-image/fetch-figma-image-urls";
+
+const client = createFigmaClient(process.env.FIGMA_PERSONAL_ACCESS_TOKEN!);
 
 export function ComponentGrid() {
   // Get all component pages
@@ -10,34 +16,36 @@ export function ComponentGrid() {
       // Only include pages under /docs/components/
       if (!page.url.startsWith("/docs/components/")) return false;
 
-      // Exclude the index page itself
-      if (page.url === "/docs/components") return false;
-
-      // Exclude deprecated components
-      if (page.url.includes("deprecated")) return false;
+      if (page.data.deprecated) return true;
 
       return true;
     })
     .sort((a, b) => {
       // Sort alphabetically by title
-      const titleA = a.data.title || "";
-      const titleB = b.data.title || "";
+      const titleA = a.data.title;
+      const titleB = b.data.title;
+
       return titleA.localeCompare(titleB);
     });
 
   return (
     <div className="grid grid-cols-2 md:grid-cols-3 gap-4 pb-10 not-prose">
-      {componentPages.map((page) => {
-        // Extract component slug from URL
-        const componentSlug = page.url.split("/").pop() || "";
-
+      {componentPages.map(async (page) => {
         return (
           <ComponentCard
+            {...(page.data.coverImageFigmaId && {
+              coverImageSrc: (
+                await fetchFigmaImageUrls({
+                  client,
+                  fileKey: process.env.FIGMA_FILE_KEY!,
+                  nodeIds: [page.data.coverImageFigmaId],
+                })
+              ).get(page.data.coverImageFigmaId),
+            })}
             key={page.url}
-            title={page.data.title || componentSlug}
+            title={page.data.title}
             description={page.data.description}
             href={page.url}
-            imagePath={`/docs/components/${componentSlug}/anatomy.webp`}
           />
         );
       })}

--- a/docs/components/figma-image/fetch-figma-image-urls.ts
+++ b/docs/components/figma-image/fetch-figma-image-urls.ts
@@ -1,32 +1,60 @@
 import { Api as Figma } from "figma-api";
 import * as FigmaRestAPI from "@figma/rest-api-spec";
+import { FlatCache } from "flat-cache";
+import findCacheDirectory from "find-cache-directory";
 
-// Retry logic for rate limits (429)
-const maxRetries = 3;
+const LOG_PREFIX = "[remark-figma-image]";
+const MAX_RETRIES = 3;
+const CACHE_TTL_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 
-// In-memory cache to avoid hitting rate limits during dev server hot reloads
-// Persists for the duration of the dev server session
-const imageUrlCache = new Map<string, string>();
+const isCacheDisabled = process.env.FIGMA_CACHE_DISABLED === "1";
 
-function getCacheKey(fileKey: string, nodeId: string): string {
-  return `${fileKey}:${nodeId}`;
-}
+// will be node_modules/.cache/remark-figma-image
+const cacheDir = findCacheDirectory({ name: "remark-figma-image" });
+
+if (!cacheDir) throw new Error("Could not determine cache directory");
+
+const imageUrlCache = new FlatCache({
+  cacheDir,
+  cacheId: "urls",
+  ttl: CACHE_TTL_MS,
+});
+
+// imageUrlCache.load("urls", cacheDir);
+
+// Figma API
 
 export type FetchFigmaImageUrlsOptions = Omit<FigmaRestAPI.GetImagesQueryParams, "ids" | "version">;
 
-export async function fetchFigmaImageUrls(
-  client: Figma,
-  fileKey: string,
-  nodeIds: string[],
-  options: FetchFigmaImageUrlsOptions = {},
-): Promise<Map<string, string>> {
+export function createFigmaClient(accessToken: string): Figma {
+  if (!accessToken) throw new Error("FIGMA_PERSONAL_ACCESS_TOKEN is required");
+  return new Figma({ personalAccessToken: accessToken });
+}
+
+export async function fetchFigmaImageUrls({
+  client,
+  fileKey,
+  nodeIds,
+  options = {},
+}: {
+  client: Figma;
+  fileKey: string;
+  nodeIds: string[];
+  options?: FetchFigmaImageUrlsOptions;
+}): Promise<Map<string, string>> {
   if (nodeIds.length === 0) return new Map();
 
   const result = new Map<string, string>();
   const uncachedIds: string[] = [];
 
+  // nextjs calls fetchFigmaImageUrls multiple times in parallel even with a single FigmaImage
+  // so we load the cache here to ensure we always have the latest data
+  imageUrlCache.load("urls", cacheDir);
+
   for (const nodeId of nodeIds) {
-    const cached = imageUrlCache.get(getCacheKey(fileKey, nodeId));
+    const cached = isCacheDisabled
+      ? undefined
+      : imageUrlCache.get<string>(getCacheKey(fileKey, nodeId));
 
     if (cached) {
       result.set(nodeId, cached);
@@ -35,20 +63,21 @@ export async function fetchFigmaImageUrls(
     }
   }
 
+  if (result.size > 0) {
+    console.log(`${LOG_PREFIX} Cache hit for ${result.size} image(s)`);
+  }
+
   if (uncachedIds.length === 0) {
-    console.log(`[remark-figma-image] Cache hit for ${nodeIds.length} image(s)`);
     return result;
   }
 
   console.log(
-    result.size > 0
-      ? `[remark-figma-image] Cache hit: ${result.size}, fetching: ${uncachedIds.length}`
-      : `[remark-figma-image] Fetching ${uncachedIds.length} image(s) from Figma API...`,
+    `${LOG_PREFIX} Fetching ${uncachedIds.length} image(s) from Figma API... (options: ${JSON.stringify(options)})`,
   );
 
   let lastError: Error | null = null;
 
-  for (let attempt = 0; attempt < maxRetries; attempt++) {
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
       const response = await client.getImages(
         { file_key: fileKey },
@@ -60,40 +89,46 @@ export async function fetchFigmaImageUrls(
       const images = response.images ?? {};
 
       for (const [nodeId, url] of Object.entries(images)) {
-        if (url) {
-          result.set(nodeId, url);
+        if (!url) continue;
 
-          imageUrlCache.set(getCacheKey(fileKey, nodeId), url);
-        }
+        result.set(nodeId, url);
+        imageUrlCache.set(getCacheKey(fileKey, nodeId), url);
       }
+
+      imageUrlCache.save();
 
       return result;
     } catch (error) {
-      // TODO: check if this is how figma gives rate limit errors
-      if (error instanceof Error && error.message.includes("429")) {
-        lastError = error;
+      lastError = error instanceof Error ? error : new Error(String(error));
 
-        const waitTime = 2 ** attempt * 3000; // 3s, 6s, 12s
+      if (!isRetryableError(error)) throw error;
 
-        console.log(`[remark-figma-image] Rate limited, waiting ${waitTime}ms before retry...`);
+      const waitTime = 2 ** attempt * 3000; // 3s, 6s, 12s
 
-        await delay(waitTime);
+      console.log(
+        `${LOG_PREFIX} ${lastError.message}, waiting ${waitTime}ms (attempt ${attempt + 1}/${MAX_RETRIES})...`,
+      );
 
-        continue;
-      }
-
-      // Non-rate-limit errors: throw immediately
-      throw error;
+      await delay(waitTime);
     }
   }
 
   throw lastError ?? new Error("Failed to fetch Figma images after retries");
 }
 
-export function createFigmaClient(accessToken: string): Figma {
-  if (!accessToken) throw new Error("FIGMA_PERSONAL_ACCESS_TOKEN is required");
+// Helpers
 
-  return new Figma({ personalAccessToken: accessToken });
+function getCacheKey(fileKey: string, nodeId: string): string {
+  return `${fileKey}:${nodeId}`;
 }
 
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRetryableError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+
+  // TODO: Improve error detection
+  return false;
+}

--- a/docs/components/figma-image/fetch-figma-image-urls.ts
+++ b/docs/components/figma-image/fetch-figma-image-urls.ts
@@ -3,9 +3,10 @@ import * as FigmaRestAPI from "@figma/rest-api-spec";
 import { FlatCache } from "flat-cache";
 import findCacheDirectory from "find-cache-directory";
 
-const LOG_PREFIX = "[remark-figma-image]";
+const LOG_PREFIX = "\n[remark-figma-image]";
 const MAX_RETRIES = 3;
 const CACHE_TTL_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
+const CACHE_ID = "urls";
 
 const isCacheDisabled = process.env.FIGMA_CACHE_DISABLED === "1";
 
@@ -16,11 +17,11 @@ if (!cacheDir) throw new Error("Could not determine cache directory");
 
 const imageUrlCache = new FlatCache({
   cacheDir,
-  cacheId: "urls",
+  cacheId: CACHE_ID,
   ttl: CACHE_TTL_MS,
 });
 
-// imageUrlCache.load("urls", cacheDir);
+// imageUrlCache.load(CACHE_ID, cacheDir);
 
 // Figma API
 
@@ -49,7 +50,7 @@ export async function fetchFigmaImageUrls({
 
   // nextjs calls fetchFigmaImageUrls multiple times in parallel even with a single FigmaImage
   // so we load the cache here to ensure we always have the latest data
-  imageUrlCache.load("urls", cacheDir);
+  imageUrlCache.load(CACHE_ID, cacheDir);
 
   for (const nodeId of nodeIds) {
     const cached = isCacheDisabled

--- a/docs/components/figma-image/fetch-figma-image-urls.ts
+++ b/docs/components/figma-image/fetch-figma-image-urls.ts
@@ -1,0 +1,99 @@
+import { Api as Figma } from "figma-api";
+import * as FigmaRestAPI from "@figma/rest-api-spec";
+
+// Retry logic for rate limits (429)
+const maxRetries = 3;
+
+// In-memory cache to avoid hitting rate limits during dev server hot reloads
+// Persists for the duration of the dev server session
+const imageUrlCache = new Map<string, string>();
+
+function getCacheKey(fileKey: string, nodeId: string): string {
+  return `${fileKey}:${nodeId}`;
+}
+
+export type FetchFigmaImageUrlsOptions = Omit<FigmaRestAPI.GetImagesQueryParams, "ids" | "version">;
+
+export async function fetchFigmaImageUrls(
+  client: Figma,
+  fileKey: string,
+  nodeIds: string[],
+  options: FetchFigmaImageUrlsOptions = {},
+): Promise<Map<string, string>> {
+  if (nodeIds.length === 0) return new Map();
+
+  const result = new Map<string, string>();
+  const uncachedIds: string[] = [];
+
+  for (const nodeId of nodeIds) {
+    const cached = imageUrlCache.get(getCacheKey(fileKey, nodeId));
+
+    if (cached) {
+      result.set(nodeId, cached);
+    } else {
+      uncachedIds.push(nodeId);
+    }
+  }
+
+  if (uncachedIds.length === 0) {
+    console.log(`[remark-figma-image] Cache hit for ${nodeIds.length} image(s)`);
+    return result;
+  }
+
+  console.log(
+    result.size > 0
+      ? `[remark-figma-image] Cache hit: ${result.size}, fetching: ${uncachedIds.length}`
+      : `[remark-figma-image] Fetching ${uncachedIds.length} image(s) from Figma API...`,
+  );
+
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const response = await client.getImages(
+        { file_key: fileKey },
+        { ids: uncachedIds.join(","), ...options },
+      );
+
+      if (response.err) throw new Error(`Figma API error: ${response.err}`);
+
+      const images = response.images ?? {};
+
+      for (const [nodeId, url] of Object.entries(images)) {
+        if (url) {
+          result.set(nodeId, url);
+
+          imageUrlCache.set(getCacheKey(fileKey, nodeId), url);
+        }
+      }
+
+      return result;
+    } catch (error) {
+      // TODO: check if this is how figma gives rate limit errors
+      if (error instanceof Error && error.message.includes("429")) {
+        lastError = error;
+
+        const waitTime = 2 ** attempt * 3000; // 3s, 6s, 12s
+
+        console.log(`[remark-figma-image] Rate limited, waiting ${waitTime}ms before retry...`);
+
+        await delay(waitTime);
+
+        continue;
+      }
+
+      // Non-rate-limit errors: throw immediately
+      throw error;
+    }
+  }
+
+  throw lastError ?? new Error("Failed to fetch Figma images after retries");
+}
+
+export function createFigmaClient(accessToken: string): Figma {
+  if (!accessToken) throw new Error("FIGMA_PERSONAL_ACCESS_TOKEN is required");
+
+  return new Figma({ personalAccessToken: accessToken });
+}
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/docs/components/figma-image/fetch-figma-image-urls.ts
+++ b/docs/components/figma-image/fetch-figma-image-urls.ts
@@ -1,7 +1,7 @@
 import { Api as Figma } from "figma-api";
 import * as FigmaRestAPI from "@figma/rest-api-spec";
 import { FlatCache } from "flat-cache";
-import findCacheDirectory from "find-cache-directory";
+import path from "node:path";
 
 const LOG_PREFIX = "\n[remark-figma-image]";
 const MAX_RETRIES = 3;
@@ -10,18 +10,14 @@ const CACHE_ID = "urls";
 
 const isCacheDisabled = process.env.FIGMA_CACHE_DISABLED === "1";
 
-// will be node_modules/.cache/remark-figma-image
-const cacheDir = findCacheDirectory({ name: "remark-figma-image" });
-
-if (!cacheDir) throw new Error("Could not determine cache directory");
+// Store cache in docs/.cache/figma-image (gitignored. persisted via Actions cache)
+const cacheDir = path.resolve(process.cwd(), ".cache/figma-image");
 
 const imageUrlCache = new FlatCache({
   cacheDir,
   cacheId: CACHE_ID,
   ttl: CACHE_TTL_MS,
 });
-
-// imageUrlCache.load(CACHE_ID, cacheDir);
 
 // Figma API
 
@@ -53,9 +49,7 @@ export async function fetchFigmaImageUrls({
   imageUrlCache.load(CACHE_ID, cacheDir);
 
   for (const nodeId of nodeIds) {
-    const cached = isCacheDisabled
-      ? undefined
-      : imageUrlCache.get<string>(getCacheKey(fileKey, nodeId));
+    const cached = isCacheDisabled ? undefined : imageUrlCache.get<string>(getCacheKey(nodeId));
 
     if (cached) {
       result.set(nodeId, cached);
@@ -93,7 +87,7 @@ export async function fetchFigmaImageUrls({
         if (!url) continue;
 
         result.set(nodeId, url);
-        imageUrlCache.set(getCacheKey(fileKey, nodeId), url);
+        imageUrlCache.set(getCacheKey(nodeId), url);
       }
 
       imageUrlCache.save();
@@ -119,8 +113,8 @@ export async function fetchFigmaImageUrls({
 
 // Helpers
 
-function getCacheKey(fileKey: string, nodeId: string): string {
-  return `${fileKey}:${nodeId}`;
+function getCacheKey(nodeId: string): string {
+  return nodeId;
 }
 
 function delay(ms: number): Promise<void> {

--- a/docs/components/figma-image/remark-figma-image.ts
+++ b/docs/components/figma-image/remark-figma-image.ts
@@ -1,0 +1,136 @@
+import type { Processor, Transformer } from "unified";
+import type { remark } from "remark";
+import { visit } from "unist-util-visit";
+import type { MdxJsxAttribute, MdxJsxFlowElement } from "mdast-util-mdx-jsx";
+import {
+  createFigmaClient,
+  fetchFigmaImageUrls,
+  type FetchFigmaImageUrlsOptions,
+} from "./fetch-figma-image-urls";
+
+const DEFAULT_IMAGE_WIDTH = 1080;
+const DEFAULT_IMAGE_HEIGHT = 720;
+
+const FIMGA_ID_PROP_SUPPORTED_COMPONENTS = ["DoImage", "DontImage"];
+
+// Root type derived from remark processor (same pattern as remark-react-type-table)
+// biome-ignore lint/suspicious/noExplicitAny: this is for removing mdast dependency which is actually deprecated
+export type Root = typeof remark extends Processor<infer R, any, any, any, any> ? R : never;
+
+export interface RemarkFigmaImageOptions {
+  fileKey: string;
+  accessToken: string;
+  fetchUrlsOptions?: FetchFigmaImageUrlsOptions;
+}
+
+/**
+ * Remark plugin that transforms Figma node IDs into image URLs at build time.
+ *
+ * Transforms:
+ * - `<FigmaImage id="..." alt="..." />` → `<img src="..." alt="..." />`
+ * - `<DoImage figmaId="..." />` → `<DoImage src="..." />`
+ * - `<DontImage figmaId="..." />` → `<DontImage src="..." />`
+ */
+export function remarkFigmaImage({
+  accessToken,
+  fileKey,
+  fetchUrlsOptions,
+}: RemarkFigmaImageOptions): Transformer<Root, Root> {
+  return async (tree) => {
+    const figmaNodes: Map<string, MdxJsxFlowElement[]> = new Map();
+
+    visit(tree, "mdxJsxFlowElement", (node: MdxJsxFlowElement) => {
+      const figmaId = extractFigmaId(node);
+
+      if (figmaId) {
+        if (!figmaNodes.has(figmaId)) figmaNodes.set(figmaId, []);
+
+        figmaNodes.get(figmaId)!.push(node);
+      }
+    });
+
+    if (figmaNodes.size === 0) return;
+
+    const client = createFigmaClient(accessToken);
+    const imageUrls = await fetchFigmaImageUrls(
+      client,
+      fileKey,
+      Array.from(figmaNodes.keys()),
+      fetchUrlsOptions,
+    );
+
+    for (const [figmaId, nodes] of figmaNodes) {
+      const url = imageUrls.get(figmaId);
+
+      if (!url)
+        throw new Error(`[remark-figma-image] Failed to get image URL for Figma node: ${figmaId}`);
+
+      for (const node of nodes) {
+        transformNode(node, url);
+      }
+    }
+  };
+}
+
+/**
+ * Extract Figma node ID from JSX element attributes
+ */
+function extractFigmaId({ name, attributes }: MdxJsxFlowElement): string | null {
+  if (!name) return null;
+
+  // For <FigmaImage id="..." />
+  if (name === "FigmaImage") {
+    const idAttr = attributes.find(
+      (attr): attr is MdxJsxAttribute => attr.type === "mdxJsxAttribute" && attr.name === "id",
+    );
+
+    return typeof idAttr?.value === "string" ? idAttr.value : null;
+  }
+
+  // For components like <DoImage figmaId="..." /> and <DontImage figmaId="..." />
+  if (FIMGA_ID_PROP_SUPPORTED_COMPONENTS.includes(name)) {
+    const figmaIdAttr = attributes.find(
+      (attr): attr is MdxJsxAttribute => attr.type === "mdxJsxAttribute" && attr.name === "figmaId",
+    );
+
+    return typeof figmaIdAttr?.value === "string" ? figmaIdAttr.value : null;
+  }
+
+  return null;
+}
+
+/**
+ * Transform JSX node by replacing figmaId/id with resolved src URL
+ */
+function transformNode(node: MdxJsxFlowElement, imageUrl: string): void {
+  if (node.name === "FigmaImage") {
+    // Validate alt prop is present
+    const hasAlt = node.attributes.some(
+      (attr) => attr.type === "mdxJsxAttribute" && attr.name === "alt",
+    );
+    if (!hasAlt) {
+      throw new Error("[remark-figma-image] FigmaImage requires an 'alt' prop for accessibility");
+    }
+
+    // Transform <FigmaImage id="..." /> to <ImageZoom src="..." width={773} height={396} />
+    node.name = "ImageZoom";
+    node.attributes = node.attributes.filter(
+      (attr) => !(attr.type === "mdxJsxAttribute" && attr.name === "id"),
+    );
+    node.attributes.push(
+      { type: "mdxJsxAttribute", name: "src", value: imageUrl },
+      { type: "mdxJsxAttribute", name: "width", value: `${DEFAULT_IMAGE_WIDTH}` },
+      { type: "mdxJsxAttribute", name: "height", value: `${DEFAULT_IMAGE_HEIGHT}` },
+    );
+
+    return;
+  }
+
+  // For DoImage/DontImage: remove figmaId and any existing src, then add resolved src
+  node.attributes = node.attributes.filter(
+    (attr) =>
+      !(attr.type === "mdxJsxAttribute" && (attr.name === "figmaId" || attr.name === "src")),
+  );
+
+  node.attributes.push({ type: "mdxJsxAttribute", name: "src", value: imageUrl });
+}

--- a/docs/components/figma-image/remark-figma-image.ts
+++ b/docs/components/figma-image/remark-figma-image.ts
@@ -52,12 +52,12 @@ export function remarkFigmaImage({
     if (figmaNodes.size === 0) return;
 
     const client = createFigmaClient(accessToken);
-    const imageUrls = await fetchFigmaImageUrls(
+    const imageUrls = await fetchFigmaImageUrls({
       client,
       fileKey,
-      Array.from(figmaNodes.keys()),
-      fetchUrlsOptions,
-    );
+      nodeIds: Array.from(figmaNodes.keys()),
+      options: fetchUrlsOptions,
+    });
 
     for (const [figmaId, nodes] of figmaNodes) {
       const url = imageUrls.get(figmaId);

--- a/docs/components/figma-image/remark-figma-image.ts
+++ b/docs/components/figma-image/remark-figma-image.ts
@@ -27,7 +27,7 @@ export interface RemarkFigmaImageOptions {
  * Remark plugin that transforms Figma node IDs into image URLs at build time.
  *
  * Transforms:
- * - `<FigmaImage id="..." alt="..." />` → `<img src="..." alt="..." />`
+ * - `<FigmaImage id="..." alt="..." />` → `<ImageZoom src="..." alt="..." />`
  * - `<DoImage figmaId="..." />` → `<DoImage src="..." />`
  * - `<DontImage figmaId="..." />` → `<DontImage src="..." />`
  */
@@ -112,7 +112,7 @@ function transformNode(node: MdxJsxFlowElement, imageUrl: string): void {
       throw new Error("[remark-figma-image] FigmaImage requires an 'alt' prop for accessibility");
     }
 
-    // Transform <FigmaImage id="..." /> to <ImageZoom src="..." width={773} height={396} />
+    // Transform <FigmaImage id="..." /> to <ImageZoom src="..." width={...} height={...} />
     node.name = "ImageZoom";
     node.attributes = node.attributes.filter(
       (attr) => !(attr.type === "mdxJsxAttribute" && attr.name === "id"),

--- a/docs/components/guideline/do-image.tsx
+++ b/docs/components/guideline/do-image.tsx
@@ -6,10 +6,11 @@ import { ImageZoom } from "fumadocs-ui/components/image-zoom";
 interface DoImageProps {
   src: string;
   alt: string;
+  body: string;
   className?: string;
 }
 
-export function DoImage({ src, alt, className }: DoImageProps) {
+export function DoImage({ src, alt, body, className }: DoImageProps) {
   return (
     <figure className={clsx("flex flex-col", className)}>
       <ImageZoom
@@ -28,7 +29,7 @@ export function DoImage({ src, alt, className }: DoImageProps) {
           size={16}
         />
         <span className="text-fg-positive-contrast text-sm font-bold shrink-0">Do</span>
-        <span className="text-fg-positive-contrast text-sm">{alt}</span>
+        <span className="text-fg-positive-contrast text-sm">{body}</span>
       </div>
     </figure>
   );

--- a/docs/components/guideline/dont-image.tsx
+++ b/docs/components/guideline/dont-image.tsx
@@ -6,10 +6,11 @@ import { ImageZoom } from "fumadocs-ui/components/image-zoom";
 interface DontImageProps {
   src: string;
   alt: string;
+  body: string;
   className?: string;
 }
 
-export function DontImage({ src, alt, className }: DontImageProps) {
+export function DontImage({ src, alt, body, className }: DontImageProps) {
   return (
     <figure className={clsx("flex flex-col", className)}>
       <ImageZoom
@@ -28,7 +29,7 @@ export function DontImage({ src, alt, className }: DontImageProps) {
           size={16}
         />
         <span className="text-fg-critical-contrast text-sm font-bold shrink-0">Don&apos;t</span>
-        <span className="text-fg-critical-contrast text-sm">{alt}</span>
+        <span className="text-fg-critical-contrast text-sm">{body}</span>
       </div>
     </figure>
   );

--- a/docs/components/mdx-components.tsx
+++ b/docs/components/mdx-components.tsx
@@ -79,4 +79,6 @@ export const mdxComponents: MDXComponents = {
   DontImage,
 
   ImageZoom,
+
+  FigmaImage: () => null,
 };

--- a/docs/components/mdx-components.tsx
+++ b/docs/components/mdx-components.tsx
@@ -77,4 +77,6 @@ export const mdxComponents: MDXComponents = {
   // Guidelines
   DoImage,
   DontImage,
+
+  ImageZoom,
 };

--- a/docs/content/docs/components/action-button.mdx
+++ b/docs/content/docs/components/action-button.mdx
@@ -7,36 +7,36 @@ description: 사용자가 특정 액션을 실행할 수 있도록 도와주는 
 
 ## Anatomy
 
-![Anatomy Image](/docs/components/action-button/anatomy.webp)
+<FigmaImage id="46072:20760" alt="Action Button의 Anatomy 이미지" />
 
 ## Props
 
-| 속성        | 값                                                                                     | 기본값    |
-| ----------- | -------------------------------------------------------------------------------------- | --------- |
-| size        | xsmall, small, medium, large                                                           | medium    |
+| 속성        | 값                                                                                       | 기본값    |
+| ----------- | ---------------------------------------------------------------------------------------- | --------- |
+| size        | xsmall, small, medium, large                                                             | medium    |
 | variant     | brand solid, neutral solid, neutral weak, critical solid, brand outline, neutral outline |           |
-| layout      | with text, icon only                                                                   | with text |
-| disabled    | true, false                                                                            | false     |
-| loading     | true, false                                                                            | false     |
-| prefix icon | icon                                                                                   |           |
-| suffix icon | icon                                                                                   |           |
+| layout      | with text, icon only                                                                     | with text |
+| disabled    | true, false                                                                              | false     |
+| loading     | true, false                                                                              | false     |
+| prefix icon | icon                                                                                     |           |
+| suffix icon | icon                                                                                     |           |
 
 ### Size
 
-![Size](/docs/components/action-button/props-size.webp)
+![Action Button이 지원하는 Size 나열](/docs/components/action-button/props-size.webp)
 
 - Action Button은 XSmall, Small, Medium, Large 네 가지 사이즈로 제공됩니다.
 - Small 과 Medium은 화면 중앙에서 범용적으로 사용되며, large는 주로 CTA 역할로 사용됩니다. XSmall은 작은 공간에서 효율적으로 사용할 수 있는 Pill 형태로 제공됩니다.
 
 ### Variant
 
-![Variant](/docs/components/action-button/props-variant.webp)
+![Action Button이 지원하는 Variant 나열](/docs/components/action-button/props-variant.webp)
 
 - Action Button은 Neutral Solid, Brand Solid, Neutral Weak, Brand Outline, Neutral Outline, Critical Solid 총 6가지 Variant로 구성됩니다.
 
 ### Layout
 
-![Layout](/docs/components/action-button/props-layout.webp)
+![Action Button이 지원하는 Layout 나열](/docs/components/action-button/props-layout.webp)
 
 - Action Button은 라벨과 아이콘의 조합으로 구성되며, 아이콘은 버튼의 목적을 시각적으로 강조하거나 동작을 보조합니다.
 - 라벨 앞, 뒤 또는 아이콘만으로 구성할 수 있어 상황에 맞게 유연하게 활용할 수 있습니다. 다만, 라벨 가독성을 해치지않도록 아이콘은 제한적으로 사용하는 것을 권장합니다.
@@ -44,13 +44,13 @@ description: 사용자가 특정 액션을 실행할 수 있도록 도와주는 
 
 ### State
 
-![State](/docs/components/action-button/props-state.webp)
+![Action Button이 가질 수 있는 상태 나열](/docs/components/action-button/props-state.webp)
 
 - Action Button은 Enabled, Pressed, Loading, Disabled 상태를 가집니다.
 
 ### Width
 
-![Width](/docs/components/action-button/props-width.webp)
+![Action Button의 두 가지 너비 정책](/docs/components/action-button/props-width.webp)
 
 - Action Button은 컨테이너의 전체 너비를 채우거나 콘텐츠에 맞게 조정할 수 있습니다. 각 Size마다 기본 최소 너비가 설정되어 있으며, 필요에 따라 최소 너비와 최대 너비를 지정할 수 있습니다.
 
@@ -58,25 +58,24 @@ description: 사용자가 특정 액션을 실행할 수 있도록 도와주는 
 
 ### Hierarchy
 
-![Action Button Hierarchy](/docs/components/action-button/guidelines-hierarchy-1.webp)
+![High emphasis: Brand Solid, Neutral Solid, Critical Solid. Medium emphasis: Neutral Weak. Low emphasis: Brand Outline, Neutral Outline, Ghost](/docs/components/action-button/guidelines-hierarchy-1.webp)
 
-
-| Emphasis   | Variant                        | 화면 내 개수             | Usage    |
-| ---------- | -----------------------------  | ----------------------------- | --------- |
-| High       |  Brand Solid, Neutral Solid, Critical Solid   | 1        |  가장 중요한 역할의 CTA에 사용            |
-| Medium     |  Neutral Weak, Brand Outline, Neutral Outline | 여러 개        |        대부분의 액션에 사용, High emphasis 버튼과 조합하여 사용      |
-| Low        |  Ghost                                | 여러 개        |     중요도가 낮은 보조 액션을 표현할 때 사용, Brand Outline, Neutral Outline을 조합하여 사용         |
+| Emphasis | Variant                                    | 화면 내 개수 | 사용 예                                                                                  |
+| -------- | ------------------------------------------ | ------------ | ---------------------------------------------------------------------------------------- |
+| High     | Brand Solid, Neutral Solid, Critical Solid | 1            | 가장 중요한 역할의 CTA에 사용                                                            |
+| Medium   | Neutral Weak                               | 여러 개      | 대부분의 액션에 사용, High emphasis 버튼과 조합하여 사용                                 |
+| Low      | Brand Outline, Neutral Outline, Ghost      | 여러 개      | 중요도가 낮은 보조 액션을 표현할 때 사용, Brand Outline, Neutral Outline을 조합하여 사용 |
 
 - Action Button의 시각적 주목도는 배경색 대비에 따라 달라집니다.
 - 화면에서 강조하려는 정도에 따라 적절한 Variant를 선택해서 사용해주세요.
 
 ### Variant Usage
 
-![Variant Usage](/docs/components/action-button/guidelines-variant-usage-1.webp)
+![Brand Solid 및 Neutral Solid 사용 예](/docs/components/action-button/guidelines-variant-usage-1.webp)
 
-![Variant Usage](/docs/components/action-button/guidelines-variant-usage-2.webp)
+![Critical Solid 및 Neutral Weak 사용 예](/docs/components/action-button/guidelines-variant-usage-2.webp)
 
-![Variant Usage](/docs/components/action-button/guidelines-variant-usage-3.webp)
+![Neutral Outline 및 Brand Outline 사용 예](/docs/components/action-button/guidelines-variant-usage-3.webp)
 
 화면 내 중요도에 따라 적절한 Variant를 선택해서 사용합니다.
 
@@ -89,9 +88,13 @@ description: 사용자가 특정 액션을 실행할 수 있도록 도와주는 
 
 ### Brand Color Usage
 
-![Brand Color Usage](/docs/components/action-button/guidelines-brand-color-usage-1.webp)
+![Brand Variant 사용 예](/docs/components/action-button/guidelines-brand-color-usage-1.webp)
 
-<DontImage src="/docs/components/action-button/guidelines-brand-color-dont-usage-1.webp" alt="무분별하게 Brand 컬러를 사용하지 않습니다." />
+<DontImage
+  src="/docs/components/action-button/guidelines-brand-color-dont-usage-1.webp"
+  alt="Brand 컬러를 무분별하게 사용하는 예시 이미지"
+  body="무분별하게 Brand 컬러를 사용하지 않습니다."
+/>
 
 - Brand 컬러는 브랜드의 정체성과 가치를 전달하는 중요 자산으로, 로고, 대표 버튼, 핵심 메시지 등 브랜드 상징 요소에 집중 사용해야 합니다.
 - Brand 컬러를 과다 사용하면 의미와 강조도가 분산됩니다. '이웃 간의 연결' 의미를 전달하는 곳에 사용하세요.
@@ -101,43 +104,55 @@ description: 사용자가 특정 액션을 실행할 수 있도록 도와주는 
 
 #### Solid Combination
 
-![Solid Combination](/docs/components/action-button/guidelines-multiple-variant-combination-usage-1.webp)
+![Solid Variant 사용 예](/docs/components/action-button/guidelines-multiple-variant-combination-usage-1.webp)
 
 Neutral Weak와 Neutral Solid 또는 Brand Solid 버튼을 조합하면 액션의 위계를 명확하게 표현할 수 있습니다. 이 조합은 시각적 부담을 줄이면서도 직관적인 경험을 제공하며, 사용자가 의사결정을 빠르고 쉽게 내릴 수 있도록 돕습니다.
 
 #### Outline Combination
 
-![Outline Combination](/docs/components/action-button/guidelines-multiple-variant-combination-usage-2.webp)
+![Outline Variant 사용 예](/docs/components/action-button/guidelines-multiple-variant-combination-usage-2.webp)
 
 Neutral Outline과 Brand Outline은 강조도가 낮은 서브 액션을 표현하는 데 적합합니다. 두 버튼을 나란히 조합하면 위계를 명확히 전달할 수 있습니다. 한 화면에 버튼이 여러 번 나타날 때 사용을 권장합니다.
 
 #### Layout
 
-![Layout](/docs/components/action-button/guidelines-multiple-layout-usage-1.webp)
+![너비가 다른 두 버튼 사용 예](/docs/components/action-button/guidelines-multiple-layout-usage-1.webp)
 
 - 2개 이상의 버튼을 조합하여 사용하는 경우 상황에 따라 적절한 레이아웃을 구성해야 합니다.
 - Solid 조합에서 Neutral Weak가 초기화, 닫기와 같이 Dismiss의 의미를 가질 경우 3:7 비율을 활용해 액션 위계를 명확히 표현하는 것을 권장합니다.
 - Neutral Weak처럼 강조 위계가 낮은 Variant는 비슷한 위계의 액션 두 개를 나란히 사용할 수 있습니다. 액션이 두 개를 초과할 경우, Icon Only 버튼을 활용해 사용자가 추가 액션을 확인할 수 있도록 합니다.
 
 <Grid>
-  <DoImage src="/docs/components/action-button/guidelines-multiple-layout-do-usage-1.webp" alt="Neutral Weak 버튼을 나란히 사용할 수 있습니다." />
-  <DontImage src="/docs/components/action-button/guidelines-multiple-layout-dont-usage-1.webp" alt="버튼을 4개 이상 나란히 사용하지 않습니다." />
+  <DoImage
+    src="/docs/components/action-button/guidelines-multiple-layout-do-usage-1.webp"
+    body="Neutral Weak 버튼을 나란히 사용할 수 있습니다."
+  />
+  <DontImage
+    src="/docs/components/action-button/guidelines-multiple-layout-dont-usage-1.webp"
+    body="버튼을 4개 이상 나란히 사용하지 않습니다."
+  />
 </Grid>
 
 ### Long Label
 
-![Long Label](/docs/components/action-button/guidelines-long-label-usage-1.webp)
+![버튼의 레이블이 길어지는 경우 레이아웃이 wrap된 모습](/docs/components/action-button/guidelines-long-label-usage-1.webp)
 
 - 긴 Label이 필요하거나 번역했을 때 의도하지 않게 길어지는 경우, 폰트 스케일링으로 큰 텍스트를 사용하는 경우 Action Button 레이아웃이 Overflow될 수 있습니다.
 - 이 경우 구현체에서 [Responsive Pair](/react/components/alert-dialog#responsive-wrapping) 유틸리티를 사용하여 설정된 로직에 따라서 자동으로 레이아웃을 전환할 수 있습니다.
 
 ### With Icon
 
-![With Icon](/docs/components/action-button/guidelines-with-icon-usage-1.webp)
+![아이콘과 함께 사용한 버튼](/docs/components/action-button/guidelines-with-icon-usage-1.webp)
 
 <Grid>
-  <DontImage src="/docs/components/action-button/guidelines-with-icon-dont-usage-1.webp" alt="아이콘을 무분별하게 사용하지 않습니다." />
-  <DontImage src="/docs/components/action-button/guidelines-with-icon-dont-usage-2.webp" alt="라벨의 앞과 뒤에 아이콘을 동시에 표시할 수 없습니다." />
+  <DontImage
+    src="/docs/components/action-button/guidelines-with-icon-dont-usage-1.webp"
+    body="아이콘을 무분별하게 사용하지 않습니다."
+  />
+  <DontImage
+    src="/docs/components/action-button/guidelines-with-icon-dont-usage-2.webp"
+    body="라벨의 앞과 뒤에 아이콘을 동시에 표시할 수 없습니다."
+  />
 </Grid>
 
 - 아이콘은 버튼의 동작을 시각적으로 표현하고 강조하는 데 도움을 줍니다.
@@ -148,21 +163,21 @@ Neutral Outline과 Brand Outline은 강조도가 낮은 서브 액션을 표현�
 
 ### Action Button vs Chip
 
-![Action Button vs Chip](/docs/components/action-button/comparision-action-button-vs-chip-1.webp)
+![Action Button과 Chip](/docs/components/action-button/comparision-action-button-vs-chip-1.webp)
 
 Action Button과 Chip은 유사한 형태를 가진 컴포넌트이지만, 사용 목적과 제공하는 기능에 차이가 있습니다.
 
-|    | Action Button                        | Chip             | 
-| ---------- | -----------------------------  | ----------------------------- |
-| 목적       |   액션 실행   |  정보 표현 + 선택 표현       | 
-| 예시       |  ‘완료’, ‘제출’, ‘다음’, ‘삭제’    |    필터 (‘서초4동 외 34'), 옵션 선택 (‘0~6개월')     | 
-| 표현       | Label만 봐도 액션이 예상됨     |    선택하거나 활성화된 내용을 표시     | 
-| 목적       |   어떠한 행동을 하는지 인지하는 것이 중요   |  현재 어떤 조건/정보가 활성 상태인지 확인하는 게 중요       | 
-| 패턴       | 단일로도 사용 가능     |    2개 이상 그룹으로 사용 권장     | 
+|      | Action Button                           | Chip                                                 |
+| ---- | --------------------------------------- | ---------------------------------------------------- |
+| 목적 | 액션 실행                               | 정보 표현 + 선택 표현                                |
+| 예시 | ‘완료’, ‘제출’, ‘다음’, ‘삭제’          | 필터 (‘서초4동 외 34'), 옵션 선택 (‘0~6개월')        |
+| 표현 | Label만 봐도 액션이 예상됨              | 선택하거나 활성화된 내용을 표시                      |
+| 목적 | 어떠한 행동을 하는지 인지하는 것이 중요 | 현재 어떤 조건/정보가 활성 상태인지 확인하는 게 중요 |
+| 패턴 | 단일로도 사용 가능                      | 2개 이상 그룹으로 사용 권장                          |
 
 ## Differences from V2
 
-![Differences from V2](/docs/components/action-button/differences-with-v2-1.webp)
+![V2 Box Button의 Variant 나열과 V3 Action Button의 Variant 나열](/docs/components/action-button/differences-with-v2-1.webp)
 
 - Variants: Neutral Solid, Brand Outline, Neutral Outline 타입이 추가되고 V2의 Primary Low가 삭제됐습니다.
 - Shape: 더 둥근 형태로 Radius 값이 변경되어, 부드러운 인상으로 개선됐습니다.

--- a/docs/content/docs/components/action-button.mdx
+++ b/docs/content/docs/components/action-button.mdx
@@ -126,10 +126,12 @@ Neutral Outline과 Brand Outline은 강조도가 낮은 서브 액션을 표현�
   <DoImage
     src="/docs/components/action-button/guidelines-multiple-layout-do-usage-1.webp"
     body="Neutral Weak 버튼을 나란히 사용할 수 있습니다."
+    alt="두 개의 Neutral Weak 버튼을 나란히 사용한 예시 이미지"
   />
   <DontImage
     src="/docs/components/action-button/guidelines-multiple-layout-dont-usage-1.webp"
     body="버튼을 4개 이상 나란히 사용하지 않습니다."
+    alt="네 개의 버튼을 나란히 사용한 예시 이미지"
   />
 </Grid>
 
@@ -148,10 +150,12 @@ Neutral Outline과 Brand Outline은 강조도가 낮은 서브 액션을 표현�
   <DontImage
     src="/docs/components/action-button/guidelines-with-icon-dont-usage-1.webp"
     body="아이콘을 무분별하게 사용하지 않습니다."
+    alt="두 개의 Action Button에 모두 아이콘이 사용된 예시 이미지"
   />
   <DontImage
     src="/docs/components/action-button/guidelines-with-icon-dont-usage-2.webp"
     body="라벨의 앞과 뒤에 아이콘을 동시에 표시할 수 없습니다."
+    alt="Action Button의 라벨 앞과 뒤에 아이콘이 모두 사용된 예시 이미지"
   />
 </Grid>
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -90,6 +90,8 @@
     "concurrently": "^9.2.1",
     "estree-util-value-to-estree": "^3.4.0",
     "figma-api": "^2.1.0-beta",
+    "find-cache-directory": "^6.0.0",
+    "flat-cache": "^6.1.19",
     "hast-util-to-estree": "^3.1.3",
     "mdast-util-mdx-jsx": "^3.2.0",
     "postcss": "^8.5.3",

--- a/docs/package.json
+++ b/docs/package.json
@@ -90,7 +90,6 @@
     "concurrently": "^9.2.1",
     "estree-util-value-to-estree": "^3.4.0",
     "figma-api": "^2.1.0-beta",
-    "find-cache-directory": "^6.0.0",
     "flat-cache": "^6.1.19",
     "hast-util-to-estree": "^3.1.3",
     "mdast-util-mdx-jsx": "^3.2.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -75,6 +75,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.0.1",
+    "@figma/rest-api-spec": "^0.34.0",
     "@storybook/builder-webpack5": "^10.0.0",
     "@storybook/nextjs": "^10.0.0",
     "@tailwindcss/postcss": "^4.0.6",
@@ -88,6 +89,7 @@
     "chromatic": "^13.0.0",
     "concurrently": "^9.2.1",
     "estree-util-value-to-estree": "^3.4.0",
+    "figma-api": "^2.1.0-beta",
     "hast-util-to-estree": "^3.1.3",
     "mdast-util-mdx-jsx": "^3.2.0",
     "postcss": "^8.5.3",

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -1,6 +1,6 @@
 import { fileGenerator, remarkDocGen } from "fumadocs-docgen";
-import { remarkNpm } from "fumadocs-core/mdx-plugins";
 import { defineConfig, defineDocs, frontmatterSchema } from "fumadocs-mdx/config";
+import { remarkFigmaImage } from "./components/figma-image/remark-figma-image";
 import { typeTableGenerator } from "./components/type-table/generator";
 import { remarkReactTypeTable } from "./components/type-table/remark-react-type-table";
 import z from "zod";
@@ -45,18 +45,19 @@ export const lynxDocs = defineDocs({
   },
 });
 
+if (!process.env.FIGMA_FILE_KEY || !process.env.FIGMA_PERSONAL_ACCESS_TOKEN) {
+  throw new Error("FIGMA_FILE_KEY and FIGMA_PERSONAL_ACCESS_TOKEN are required");
+}
+
 export default defineConfig({
   lastModifiedTime: "git",
   mdxOptions: {
+    remarkNpmOptions: {
+      persist: {
+        id: "package-manager",
+      },
+    },
     remarkPlugins: [
-      [
-        remarkNpm,
-        {
-          persist: {
-            id: "package-manager",
-          },
-        },
-      ],
       [remarkDocGen, { generators: [fileGenerator()] }],
       [
         remarkReactTypeTable,
@@ -64,6 +65,17 @@ export default defineConfig({
           generator: typeTableGenerator,
           options: {
             parseDescriptionAsMarkdown: true,
+          },
+        },
+      ],
+      [
+        remarkFigmaImage,
+        {
+          fileKey: process.env.FIGMA_FILE_KEY,
+          accessToken: process.env.FIGMA_PERSONAL_ACCESS_TOKEN,
+          fetchUrlsOptions: {
+            format: "jpg",
+            scale: 2,
           },
         },
       ],

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -11,6 +11,7 @@ export const docs = defineDocs({
     async: true,
     schema: frontmatterSchema.extend({
       deprecated: z.string().optional(),
+      coverImageFigmaId: z.string().optional(),
     }),
   },
 });


### PR DESCRIPTION
### Usage

`FIGMA_FILE_KEY` 및 `FIGMA_PERSONAL_ACCESS_TOKEN` 설정 후

```mdx
<FigmaImage id="46072:20760" alt="Action Button의 Anatomy 이미지" />
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * Figma 참조를 문서 빌드 시 실제 이미지 및 ImageZoom으로 변환하는 통합 기능 추가
  * 사이트맵에 추가 소스(breeze, lynx) 포함

* **개선**
  * 컴포넌트 카드의 이미지 처리 개선(페이지별 Figma 커버 이미지 지원, 로드 오류 시 대체 아이콘 표시)
  * Do/Dont 이미지에 본문(body) 텍스트 추가로 설명성 향상

* **문서**
  * 컴포넌트 가이드 대대적 개편 및 접근성·설명 보강

* **잡일**
  * 배포 워크플로, 캐시 동작, 환경변수 및 .gitignore에 Figma 이미지 캐시 관련 설정 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->