### PR TITLE
fix: fix mcp referring to wrong key of data from the plugin; better type responses

### DIFF
--- a/.changeset/whole-lions-take.md
+++ b/.changeset/whole-lions-take.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/mcp": patch
+---
+
+Figma MCP가 `export_node_as_image` 툴과 `clone_node` 툴 호출 후 반환 결과를 정상적으로 파싱하지 못하는 문제를 수정합니다.

--- a/packages/mcp/src/responses.ts
+++ b/packages/mcp/src/responses.ts
@@ -1,23 +1,10 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { formatError } from "./logger";
-
-/**
- * Helper type for a tool response content item
- */
-export type ContentItem =
-  | { type: "text"; text: string }
-  | { type: "image"; data: string; mimeType: string };
-
-/**
- * Helper type for a tool response
- */
-export type ToolResponse = {
-  content: ContentItem[];
-};
 
 /**
  * Format an object response
  */
-export function formatObjectResponse(result: unknown): ToolResponse {
+export function formatObjectResponse(result: unknown): CallToolResult {
   return {
     content: [
       {
@@ -31,7 +18,7 @@ export function formatObjectResponse(result: unknown): ToolResponse {
 /**
  * Format a text response
  */
-export function formatTextResponse(text: string): ToolResponse {
+export function formatTextResponse(text: string): CallToolResult {
   return {
     content: [
       {
@@ -45,7 +32,7 @@ export function formatTextResponse(text: string): ToolResponse {
 /**
  * Format an image response
  */
-export function formatImageResponse(imageData: string, mimeType = "image/png"): ToolResponse {
+export function formatImageResponse(imageData: string, mimeType = "image/png"): CallToolResult {
   return {
     content: [
       {
@@ -60,7 +47,7 @@ export function formatImageResponse(imageData: string, mimeType = "image/png"): 
 /**
  * Format an error response
  */
-export function formatErrorResponse(toolName: string, error: unknown): ToolResponse {
+export function formatErrorResponse(toolName: string, error: unknown): CallToolResult {
   return {
     content: [
       {
@@ -74,7 +61,7 @@ export function formatErrorResponse(toolName: string, error: unknown): ToolRespo
 /**
  * Format a progress response with initial message
  */
-export function formatProgressResponse(initialMessage: string, result: unknown): ToolResponse {
+export function formatProgressResponse(initialMessage: string, result: unknown): CallToolResult {
   return {
     content: [
       {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -302,8 +302,8 @@ export function registerTools(
           format: format || "PNG",
           scale: scale || 1,
         });
-        const typedResult = result as { imageData: string; mimeType: string };
-        return formatImageResponse(typedResult.imageData, typedResult.mimeType || "image/png");
+        const typedResult = result as { base64: string; mimeType: string };
+        return formatImageResponse(typedResult.base64, typedResult.mimeType || "image/png");
       } catch (error) {
         return formatErrorResponse("export_node_as_image", error);
       }
@@ -346,9 +346,9 @@ export function registerEditingTools(server: McpServer, figmaClient: FigmaWebSoc
     async ({ nodeId, x, y }) => {
       try {
         const result = await sendCommandToFigma("clone_node", { nodeId, x, y });
-        const typedResult = result as { name: string; id: string };
+        const typedResult = result as { id: string; originalId: string; x?: number; y?: number; success: boolean };
         return formatTextResponse(
-          `Cloned node "${typedResult.name}" with new ID: ${typedResult.id}${x !== undefined && y !== undefined ? ` at position (${x}, ${y})` : ""}`,
+          `Cloned node with new ID: ${typedResult.id}${x !== undefined && y !== undefined ? ` at position (${x}, ${y})` : ""}`,
         );
       } catch (error) {
         return formatErrorResponse("clone_node", error);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 이미지 내보내기 후 결과 파싱 문제를 수정해 내보내기 결과가 올바르게 표시됩니다.
  * 노드 복제 도구의 응답 처리 오류를 해결해 복제 결과 메시지가 정확히 출력됩니다.

* **개선**
  * 도구 응답 형식이 일관되게 정리되어 다양한 응답의 표시 안정성이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->