### PR TITLE
docs: update coverImageFigmaId to new Figma node IDs

### DIFF
--- a/docs/content/docs/components/action-button.mdx
+++ b/docs/content/docs/components/action-button.mdx
@@ -1,7 +1,7 @@
 ---
 title: Action Button
 description: 명확한 액션을 쉽게 수행할 수 있도록 돕는 기본 인터랙션 컴포넌트입니다.
-coverImageFigmaId: 2:28270
+coverImageFigmaId: 39:21478
 ---
 
 <PlatformStatusTable componentId="action-button" />

--- a/docs/content/docs/components/alert-dialog.mdx
+++ b/docs/content/docs/components/alert-dialog.mdx
@@ -1,7 +1,7 @@
 ---
 title: Alert Dialog
 description: 사용자의 확인이 반드시 필요한 경우 강력한 표현 및 경고 수단으로 활용하는 컴포넌트입니다.
-coverImageFigmaId: 2:37556
+coverImageFigmaId: 39:21485
 ---
 
 <PlatformStatusTable componentId="alert-dialog" />

--- a/docs/content/docs/components/avatar.mdx
+++ b/docs/content/docs/components/avatar.mdx
@@ -1,7 +1,7 @@
 ---
 title: Avatar
 description: 사용자의 프로필 이미지를 표시하는 컴포넌트입니다.
-coverImageFigmaId: 2:41718
+coverImageFigmaId: 39:21492
 ---
 
 <PlatformStatusTable componentId="avatar" />

--- a/docs/content/docs/components/badge.mdx
+++ b/docs/content/docs/components/badge.mdx
@@ -1,7 +1,7 @@
 ---
 title: Badge
 description: 객체의 속성이나 상태를 시각적으로 표현하는 작은 텍스트 라벨입니다. 사용자의 주의를 끌고 콘텐츠의 빠른 인지와 탐색을 돕기 위해 사용됩니다.
-coverImageFigmaId: 2:76869
+coverImageFigmaId: 39:21494
 ---
 
 <PlatformStatusTable componentId="badge" />

--- a/docs/content/docs/components/bottom-navigation.mdx
+++ b/docs/content/docs/components/bottom-navigation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bottom Navigation
 description: 앱의 루트 페이지 하단에 고정되어 있는 네비게이션 바로, 다섯 개의 상위 탭 간 이동을 제공합니다.
-coverImageFigmaId: 2:48080
+coverImageFigmaId: 39:21514
 ---
 
 <PlatformStatusTable componentId="bottom-navigation" />

--- a/docs/content/docs/components/bottom-sheet.mdx
+++ b/docs/content/docs/components/bottom-sheet.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bottom Sheet
 description: 화면 하단에서 올라오는 모달 컴포넌트입니다. 추가 정보나 액션 목록을 제공하면서도 현재 컨텍스트를 유지할 때 사용됩니다.
-coverImageFigmaId: 2:52133
+coverImageFigmaId: 39:21517
 ---
 
 <PlatformStatusTable componentId="bottom-sheet" />

--- a/docs/content/docs/components/callout.mdx
+++ b/docs/content/docs/components/callout.mdx
@@ -1,7 +1,7 @@
 ---
 title: Callout
 description: 사용자에게 중요한 정보나 팁을 시각적으로 강조하여 전달하는 메시지 컴포넌트입니다.
-coverImageFigmaId: 2:89471
+coverImageFigmaId: 39:21526
 ---
 
 <PlatformStatusTable componentId="callout" />

--- a/docs/content/docs/components/checkbox.mdx
+++ b/docs/content/docs/components/checkbox.mdx
@@ -1,7 +1,7 @@
 ---
 title: Checkbox
 description: 사용자가 하나 이상의 옵션을 선택할 수 있게 해주는 컴포넌트입니다. 목록에서 여러 항목을 선택하거나 약관 동의와 같은 선택적 작업에 사용됩니다.
-coverImageFigmaId: 2:93106
+coverImageFigmaId: 39:21528
 ---
 
 <PlatformStatusTable componentId="checkbox" />

--- a/docs/content/docs/components/chip.mdx
+++ b/docs/content/docs/components/chip.mdx
@@ -1,7 +1,7 @@
 ---
 title: Chip
 description: 사용자가 선택하거나 입력하는 값을 표시하는 컴포넌트입니다.
-coverImageFigmaId: 2:59317
+coverImageFigmaId: 39:21520
 ---
 
 <PlatformStatusTable componentId="chip" />

--- a/docs/content/docs/components/contextual-floating-button.mdx
+++ b/docs/content/docs/components/contextual-floating-button.mdx
@@ -1,7 +1,7 @@
 ---
 title: Contextual Floating Button
 description: 화면 위에 떠 있으며 특정 상황에서만 나타나는 보조적인 동작을 위한 버튼입니다.
-coverImageFigmaId: 2:95152
+coverImageFigmaId: 39:21531
 ---
 
 <PlatformStatusTable componentId="contextual-floating-button" />

--- a/docs/content/docs/components/divider.mdx
+++ b/docs/content/docs/components/divider.mdx
@@ -1,7 +1,7 @@
 ---
 title: Divider
 description: 시각적 구분자로써 역할을 하며, 콘텐츠 간의 구획을 명확히 나누는 데 사용하는 컴포넌트입니다.
-coverImageFigmaId: 2:126799
+coverImageFigmaId: 39:21535
 ---
 
 <PlatformStatusTable componentId="divider" />

--- a/docs/content/docs/components/floating-action-button.mdx
+++ b/docs/content/docs/components/floating-action-button.mdx
@@ -1,7 +1,7 @@
 ---
 title: Floating Action Button
 description: 화면 상에 떠 있으며 주요 액션을 실행하는 버튼입니다.
-coverImageFigmaId: 2:132112
+coverImageFigmaId: 39:21552
 ---
 
 <PlatformStatusTable componentId="floating-action-button" />

--- a/docs/content/docs/components/help-bubble.mdx
+++ b/docs/content/docs/components/help-bubble.mdx
@@ -1,7 +1,7 @@
 ---
 title: Help Bubble
 description: 사용자에게 컴포넌트의 상태나 특정 기능에 대한 추가 정보를 제공하는 컴포넌트입니다.
-coverImageFigmaId: 2:134823
+coverImageFigmaId: 39:21555
 ---
 
 <PlatformStatusTable componentId="help-bubble" />

--- a/docs/content/docs/components/list.mdx
+++ b/docs/content/docs/components/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: List
 description: 가로 행으로 구성된 콘텐츠를 표현하는 컴포넌트입니다.
-coverImageFigmaId: 2:137478
+coverImageFigmaId: 39:21557
 ---
 
 <PlatformStatusTable componentId="list" />

--- a/docs/content/docs/components/manner-temp.mdx
+++ b/docs/content/docs/components/manner-temp.mdx
@@ -1,5 +1,6 @@
 ---
 title: Manner Temp
+coverImageFigmaId: 39:21559
 description: 매너온도를 시각적으로 표현하는 컴포넌트입니다.
 ---
 

--- a/docs/content/docs/components/menu-sheet.mdx
+++ b/docs/content/docs/components/menu-sheet.mdx
@@ -1,7 +1,7 @@
 ---
 title: Menu Sheet
 description: 사용자의 작업과 관련된 선택지를 제공하는 시트 형태의 컴포넌트입니다.
-coverImageFigmaId: 2:142913
+coverImageFigmaId: 39:21561
 ---
 
 <PlatformStatusTable componentId="menu-sheet" />

--- a/docs/content/docs/components/notification-badge.mdx
+++ b/docs/content/docs/components/notification-badge.mdx
@@ -1,7 +1,7 @@
 ---
 title: Notification Badge
 description: 아이콘, 버튼, 메뉴 등 UI 요소에 표시되어 새로운 알림이나 읽지 않은 메시지 수를 나타내는 컴포넌트입니다.
-coverImageFigmaId: 2:145065
+coverImageFigmaId: 39:21574
 ---
 
 <PlatformStatusTable componentId="notification-badge" />

--- a/docs/content/docs/components/page-banner.mdx
+++ b/docs/content/docs/components/page-banner.mdx
@@ -1,7 +1,7 @@
 ---
 title: Page Banner
 description: 페이지 상단에 위치하며 사용자에게 전체적인 상태나 중요한 메시지를 전달하는 상위 레벨 메시지 컴포넌트입니다.
-coverImageFigmaId: 2:150700
+coverImageFigmaId: 39:21576
 ---
 
 <PlatformStatusTable componentId="page-banner" />

--- a/docs/content/docs/components/progress-circle.mdx
+++ b/docs/content/docs/components/progress-circle.mdx
@@ -1,7 +1,7 @@
 ---
 title: Progress Circle
 description: 작업이 진행 중임을 알리거나 작업 시간을 시각적으로 나타내는 데 사용됩니다.
-coverImageFigmaId: 2:158451
+coverImageFigmaId: 39:21579
 ---
 
 <PlatformStatusTable componentId="progress-circle" />

--- a/docs/content/docs/components/radio.mdx
+++ b/docs/content/docs/components/radio.mdx
@@ -1,7 +1,7 @@
 ---
 title: Radio
 description: 여러 옵션 중 하나를 선택할 수 있도록 할 때 사용하는 컴포넌트입니다.
-coverImageFigmaId: 2:161631
+coverImageFigmaId: 39:21581
 ---
 
 <PlatformStatusTable componentId="radio" />

--- a/docs/content/docs/components/reaction-button.mdx
+++ b/docs/content/docs/components/reaction-button.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reaction Button
+coverImageFigmaId: 39:21584
 description: 사용자가 콘텐츠에 대한 반응을 표현할 수 있게 해주는 컴포넌트입니다. 좋아요, 관심있어요 등의 감정적 피드백을 간편하게 제공할 때 사용됩니다.
 ---
 

--- a/docs/content/docs/components/segmented-control.mdx
+++ b/docs/content/docs/components/segmented-control.mdx
@@ -1,7 +1,7 @@
 ---
 title: Segmented Control
 description: 여러 옵션 중 하나를 선택하여 관련 콘텐츠를 즉시 필터링하거나 전환할 때 사용하는 컴포넌트입니다.
-coverImageFigmaId: 2:175859
+coverImageFigmaId: 39:21588
 ---
 
 <PlatformStatusTable componentId="segmented-control" />

--- a/docs/content/docs/components/select-box.mdx
+++ b/docs/content/docs/components/select-box.mdx
@@ -1,5 +1,6 @@
 ---
 title: Select Box
+coverImageFigmaId: 39:21590
 ---
 
 <PlatformStatusTable componentId="select-box" />

--- a/docs/content/docs/components/skeleton.mdx
+++ b/docs/content/docs/components/skeleton.mdx
@@ -1,7 +1,7 @@
 ---
 title: Skeleton
 description: 콘텐츠가 로딩되는 동안 이후 나타날 요소의 윤곽을 미리 보여주어 로딩 시간을 짧게 느끼게 하는 UI 요소입니다.
-coverImageFigmaId: 2:182681
+coverImageFigmaId: 39:21593
 ---
 
 <PlatformStatusTable componentId="skeleton" />

--- a/docs/content/docs/components/slider.mdx
+++ b/docs/content/docs/components/slider.mdx
@@ -1,7 +1,7 @@
 ---
 title: Slider
 description: 지정된 범위 내에서 하나 또는 두 개의 값을 선택해 입력할 수 있는 컴포넌트입니다.
-coverImageFigmaId: 2:185865
+coverImageFigmaId: 39:21595
 ---
 
 <PlatformStatusTable componentId="slider" />

--- a/docs/content/docs/components/snackbar.mdx
+++ b/docs/content/docs/components/snackbar.mdx
@@ -1,7 +1,7 @@
 ---
 title: Snackbar
 description: 화면 하단에 일시적으로 나타나 상태나 결과를 안내하는 컴포넌트입니다.
-coverImageFigmaId: 32:92509
+coverImageFigmaId: 39:21603
 ---
 
 <PlatformStatusTable componentId="snackbar" />

--- a/docs/content/docs/components/switch.mdx
+++ b/docs/content/docs/components/switch.mdx
@@ -1,7 +1,7 @@
 ---
 title: Switch
 description: 특정 설정 및 상태를 즉시 켜거나 끌 수 있도록 하는 컴포넌트입니다.
-coverImageFigmaId: 2:195161
+coverImageFigmaId: 39:21605
 ---
 
 <PlatformStatusTable componentId="switch" />

--- a/docs/content/docs/components/tabs.mdx
+++ b/docs/content/docs/components/tabs.mdx
@@ -1,7 +1,7 @@
 ---
 title: Tabs
 description: 한 화면 내에서 콘텐츠를 탭 단위로 구분하여 전환할 수 있는 컴포넌트입니다.
-coverImageFigmaId: 2:198581
+coverImageFigmaId: 39:21608
 ---
 
 <PlatformStatusTable componentId="tabs" />

--- a/docs/content/docs/components/text-field.mdx
+++ b/docs/content/docs/components/text-field.mdx
@@ -1,5 +1,6 @@
 ---
 title: Text Field
+coverImageFigmaId: 39:21550
 description: 사용자가 텍스트를 입력할 수 있는 컴포넌트입니다. 레이블, 도움말 텍스트, 에러 메시지 등을 포함하여 다양한 폼 입력 상황에 사용됩니다.
 ---
 

--- a/docs/content/docs/components/top-navigation.mdx
+++ b/docs/content/docs/components/top-navigation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Top Navigation
 description: 화면 상단에 위치하여 탐색 인터페이스를 제공하는 네비게이션 컴포넌트입니다.
-coverImageFigmaId: 2:207913
+coverImageFigmaId: 39:21615
 ---
 
 <PlatformStatusTable componentId="top-navigation" />


### PR DESCRIPTION
Update all component documentation coverImageFigmaId values from old format (2:xxxxx) to new format (39:xxxxx). Also add coverImageFigmaId to components that were missing it (select-box, manner-temp, reaction-button, text-field).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 모든 컴포넌트 문서의 커버 이미지 메타데이터가 업데이트되었습니다. 액션 버튼, 알림 다이얼로그, 아바타, 뱃지 등 25개 이상의 컴포넌트 문서에서 이미지 참조가 개선되었습니다. 컴포넌트 기능 및 동작에는 변경 사항이 없습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->