### PR TITLE
fix(stackflow): fix stale swipe-back-state when cancel transition completes

### DIFF
--- a/.changeset/polite-parts-travel.md
+++ b/.changeset/polite-parts-travel.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/stackflow": patch
+---
+
+AppScreen 스와이프 중 취소 시 트랜지션이 끝난 뒤에도 `GlobalInteraction`의 `data-swipe-back-state`가 `idle`로 되돌아가지 않고 `canceling`으로 남아 있는 문제를 수정합니다.

--- a/packages/stackflow/src/primitive/GlobalInteraction/useSwipeBack.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/useSwipeBack.ts
@@ -25,6 +25,11 @@ export function useSwipeBack(props: UseSwipeBackProps) {
             events.reset();
           }
         },
+        onTransitionEnd: (e) => {
+          if (e.target === e.currentTarget) {
+            events.reset();
+          }
+        },
       } as React.HTMLAttributes<HTMLDivElement>,
       edgeProps: {
         tabIndex: -1,


### PR DESCRIPTION
## Summary
Fixes the issue where `data-swipe-back-state` remains stuck as `"canceling"` after a swipe cancel transition completes, preventing subsequent swipe gestures from working correctly.

## Root Cause
The layer element uses CSS **transitions** (not animations) during swipe cancel/complete states:
```css
[data-swipe-back-state="canceling"] .seed-app-screen__layer {
  transition: transform .35s ..., opacity .35s ...;
  animation: none !important;
}
```

However, the code only listened for `animationend` events. Since CSS transitions fire `transitionend` events (not `animationend`), the `reset()` function never executed, leaving the state permanently stuck as `"canceling"`.

## Solution
Added an `onTransitionEnd` handler alongside the existing `onAnimationEnd` handler to properly handle both:
- **CSS Animations** (`enter-active`, `exit-active` states) → `animationend` 
- **CSS Transitions** (`canceling`, `completing` states) → `transitionend`

Both handlers use the same `e.target === e.currentTarget` check to prevent event bubbling from child elements.

## Changes
- Added `onTransitionEnd` handler in `useSwipeBack.ts` (lines 28-32)
- Handler safely calls `reset()` (idempotent, safe from double-firing)

## Test plan
- [x] Swipe back and cancel (don't meet threshold) - verify state returns to `"idle"`
- [x] Check DOM: `data-swipe-back-state` should be `"idle"` after cancel animation completes
- [x] Multiple rapid swipes - verify consistent behavior
- [x] Complete swipe (meet threshold) - verify state returns to `"idle"` after completing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* AppScreen에서 스와이프 제스처를 취소할 때 발생하는 상태 관리 버그를 수정했습니다. 이전에는 사용자가 스와이프를 취소한 후 화면 전환 애니메이션이 완료되어도 상호작용 상태가 "취소 중" 상태로 남아있어 이후의 사용자 상호작용이 올바르게 처리되지 않을 수 있었습니다. 이제 화면 전환 애니메이션이 완료되는 순간 상태가 자동으로 초기화되어 모든 사용자 상호작용이 정상적으로 처리됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->