### PR TITLE
feat(chip): add `layout=withText` variant to spec

### DIFF
--- a/.changeset/bright-suits-create.md
+++ b/.changeset/bright-suits-create.md
@@ -1,0 +1,6 @@
+---
+"@seed-design/rootage-artifacts": patch
+"@seed-design/css": patch
+---
+
+Chip 컴포넌트 스펙에 `layout=withText` variant를 명시합니다. (스타일 변경사항 없음)

--- a/docs/public/rootage/components/chip.json
+++ b/docs/public/rootage/components/chip.json
@@ -133,9 +133,10 @@
         },
         "layout": {
           "values": {
+            "withText": {},
             "iconOnly": {}
           },
-          "defaultValue": "iconOnly"
+          "defaultValue": "withText"
         }
       }
     },
@@ -793,6 +794,12 @@
             }
           }
         ]
+      },
+      {
+        "variants": {
+          "layout": "withText"
+        },
+        "definitions": []
       },
       {
         "variants": {

--- a/packages/css/vars/component/chip.d.ts
+++ b/packages/css/vars/component/chip.d.ts
@@ -276,6 +276,7 @@ export declare const vars: {
       }
     }
   },
+  "layoutWithText": {},
   "sizeSmallLayoutIconOnly": {
     "enabled": {
       "root": {

--- a/packages/css/vars/component/chip.mjs
+++ b/packages/css/vars/component/chip.mjs
@@ -258,6 +258,7 @@ export const vars = {
       }
     }
   },
+  "layoutWithText": {},
   "sizeSmallLayoutIconOnly": {
     "enabled": {
       "root": {

--- a/packages/qvism-preset/src/vars/component/chip.d.ts
+++ b/packages/qvism-preset/src/vars/component/chip.d.ts
@@ -276,6 +276,7 @@ export declare const vars: {
       }
     }
   },
+  "layoutWithText": {},
   "sizeSmallLayoutIconOnly": {
     "enabled": {
       "root": {

--- a/packages/qvism-preset/src/vars/component/chip.mjs
+++ b/packages/qvism-preset/src/vars/component/chip.mjs
@@ -258,6 +258,7 @@ export const vars = {
       }
     }
   },
+  "layoutWithText": {},
   "sizeSmallLayoutIconOnly": {
     "enabled": {
       "root": {

--- a/packages/rootage/components/chip.yaml
+++ b/packages/rootage/components/chip.yaml
@@ -251,6 +251,8 @@ data:
         icon:
           size: $dimension.x4
 
+    layout=withText: {}
+
     size=small,layout=iconOnly:
       enabled:
         root:


### PR DESCRIPTION
## Summary
- Chip 컴포넌트 스펙에 `layout=withText` variant를 명시적으로 추가
- 기존에는 `iconOnly`만 명시되어 있었으나, 기본값인 `withText`도 명시하여 스펙을 명확하게 함
- 스타일 변경사항 없음 (기존 동작 유지)

## Test plan
- [ ] 기존 Chip 컴포넌트 동작에 영향 없는지 확인
- [ ] `layout=withText` variant가 정상적으로 인식되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * Chip 컴포넌트에 새로운 텍스트 레이아웃 변형(withText)이 추가되어 더 다양한 레이아웃 옵션을 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->