### PR TITLE
fix: add cleanup for MutationObserver in useThemeSync

### DIFF
--- a/docs/hooks/useThemeSync.ts
+++ b/docs/hooks/useThemeSync.ts
@@ -24,5 +24,9 @@ export const useThemeSync = () => {
       attributes: true,
       attributeFilter: ["style"],
     });
+
+    return () => {
+      observer.disconnect();
+    };
   }, []);
 };


### PR DESCRIPTION
The MutationObserver was being created on every page navigation but never disconnected,
causing observers to accumulate in memory. This led to increasing CPU usage and eventual
page hanging after browsing multiple pages.

This fix adds proper cleanup by disconnecting the observer when the component unmounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 테마 동기화 기능에서 컴포넌트 언마운트 시 적절한 정리 로직을 추가하여 메모리 누수를 방지했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->