### PR TITLE
feat(cli): replace --overwrite flag with --on-diff option

### DIFF
--- a/.changeset/tidy-candies-strive.md
+++ b/.changeset/tidy-candies-strive.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/cli": patch
+---
+
+`--on-diff` flag를 추가하고 `--overwrite` flag를 `--on-diff=overwrite`로 대체합니다. `--on-diff=backup`을 사용하여 변경사항이 있는 모든 snippet에 대해 이전 파일을 유지할 수 있습니다.

--- a/packages/cli/src/commands/add-all.ts
+++ b/packages/cli/src/commands/add-all.ts
@@ -18,7 +18,7 @@ const addAllOptionsSchema = z.object({
   includeDeprecated: z.boolean().optional(),
   cwd: z.string(),
   baseUrl: z.string().optional(),
-  overwrite: z.boolean().optional(),
+  onDiff: z.enum(["overwrite", "backup"]).optional(),
 });
 
 export const addAllCommand = (cli: CAC) => {
@@ -38,9 +38,7 @@ export const addAllCommand = (cli: CAC) => {
       "the base url of the registry. defaults to the current directory.",
       { default: BASE_URL },
     )
-    .option("--overwrite", "Overwrite existing files without confirmation", {
-      default: false,
-    })
+    .option("--on-diff <mode>", "Action when file differs: overwrite or backup")
     .example("seed-design add-all ui --include-deprecated")
     .example("seed-design add-all ui lib breeze")
     .action(async (registryIds, opts) => {
@@ -166,7 +164,7 @@ export const addAllCommand = (cli: CAC) => {
         cwd,
         baseUrl,
         config,
-        overwrite: options.overwrite,
+        onDiff: options.onDiff,
       });
 
       try {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -20,7 +20,7 @@ const addOptionsSchema = z.object({
   all: z.boolean(),
   cwd: z.string(),
   baseUrl: z.string().optional(),
-  overwrite: z.boolean().optional(),
+  onDiff: z.enum(["overwrite", "backup"]).optional(),
 });
 
 export const addCommand = (cli: CAC) => {
@@ -37,9 +37,7 @@ export const addCommand = (cli: CAC) => {
       "the base url of the registry. defaults to the current directory.",
       { default: BASE_URL },
     )
-    .option("--overwrite", "Overwrite existing files without confirmation", {
-      default: false,
-    })
+    .option("--on-diff <mode>", "Action when file differs: overwrite or backup")
     .example("seed-design add ui:action-button")
     .example("seed-design add ui:alert-dialog")
     .action(async (itemIds, opts) => {
@@ -184,7 +182,7 @@ export const addCommand = (cli: CAC) => {
         cwd,
         baseUrl,
         config,
-        overwrite: options.overwrite,
+        onDiff: options.onDiff,
       });
 
       try {

--- a/packages/cli/src/utils/write.ts
+++ b/packages/cli/src/utils/write.ts
@@ -15,14 +15,14 @@ export async function writeRegistryItemSnippets({
   cwd,
   baseUrl,
   config,
-  overwrite = false,
+  onDiff,
 }: {
   registryItemsToAdd: { registryId: string; items: PublicRegistry["items"] }[];
   rootPath: string;
   cwd: string;
   baseUrl: string;
   config: Config;
-  overwrite?: boolean;
+  onDiff?: "overwrite" | "backup";
 }) {
   const registryResult: { name: string; path: string }[] = [];
 
@@ -74,9 +74,17 @@ export async function writeRegistryItemSnippets({
             continue;
           }
 
+          const filename = path.basename(filePath);
+          const ext = path.extname(filePath);
+          const base = path.basename(filePath, ext);
+          const timestamp = Date.now();
+          const legacyFilename = `legacy-${base}-${timestamp}${ext}`;
+
           // diff가 있는 경우
-          if (!overwrite) {
-            // diff 생성 및 색상 적용
+          const action = await (async () => {
+            if (onDiff) return onDiff;
+
+            // interactive mode
             const patch = createPatch(relativePath, existingContent, content);
             const coloredDiff = colorize(patch);
 
@@ -85,13 +93,7 @@ export async function writeRegistryItemSnippets({
             );
             p.log.message(coloredDiff);
 
-            const filename = path.basename(filePath);
-            const ext = path.extname(filePath);
-            const base = path.basename(filePath, ext);
-            const timestamp = Date.now();
-            const legacyFilename = `legacy-${base}-${timestamp}${ext}`;
-
-            const action = await p.select({
+            return p.select({
               message:
                 "현재 파일에 스타일 변경, 로깅 등 커스터마이징이 적용되어 있는 경우 신규 파일에 동일한 커스터마이징을 적용하는 것을 검토해보세요.",
               options: [
@@ -103,20 +105,20 @@ export async function writeRegistryItemSnippets({
                 { value: "skip", label: "새 파일 받지 않고 그대로 두기" },
               ],
             });
+          })();
 
-            if (p.isCancel(action) || action === "skip") {
-              p.log.info(`${highlight(relativePath)}: 파일을 받지 않고 건너뛰었어요.`);
-              continue;
-            }
+          if (p.isCancel(action) || action === "skip") {
+            p.log.info(`${highlight(relativePath)}: 파일을 받지 않고 건너뛰었어요.`);
+            continue;
+          }
 
-            if (action === "backup") {
-              const dir = path.dirname(filePath);
-              const legacyPath = path.join(dir, legacyFilename);
-              await fs.rename(filePath, legacyPath);
-              p.log.info(
-                `${highlight(relativePath)}: 기존 파일을 ${highlight(path.relative(cwd, legacyPath))}로 옮겼어요.`,
-              );
-            }
+          if (action === "backup") {
+            const dir = path.dirname(filePath);
+            const legacyPath = path.join(dir, legacyFilename);
+            await fs.rename(filePath, legacyPath);
+            p.log.info(
+              `${highlight(relativePath)}: 기존 파일을 ${highlight(path.relative(cwd, legacyPath))}로 옮겼어요.`,
+            );
           }
         }
 


### PR DESCRIPTION
## Summary
- `--overwrite` boolean 플래그를 `--on-diff=<mode>` enum 옵션으로 변경
- 지원 모드: `overwrite` (덮어쓰기), `backup` (백업 후 새 파일 쓰기)
- 옵션 미지정 시 기존처럼 interactive prompt 표시

## Test plan
- [ ] `seed-design add ui:action-button --on-diff=overwrite` - 파일 덮어쓰기 확인
- [ ] `seed-design add ui:action-button --on-diff=backup` - 백업 파일 생성 확인
- [ ] `seed-design add ui:action-button` - interactive prompt 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * CLI의 add 및 add-all 명령에서 파일 충돌 처리 옵션이 개선되어 기존 --overwrite 플래그가 --on-diff 옵션으로 대체되었습니다. --on-diff=overwrite 또는 --on-diff=backup 중 선택해 덮어쓰기 또는 백업 동작을 명확히 지정할 수 있습니다. 대화형 선택 동작은 유지됩니다.

* **문서**
  * 도움말과 변경 안내에 --on-diff 옵션 사용법과 --overwrite의 권고 대체가 반영되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->