### PR TITLE
fix(drawer): prevent auto-close when transitioning from Dialog

### DIFF
--- a/.changeset/crisp-results-smile.md
+++ b/.changeset/crisp-results-smile.md
@@ -1,0 +1,8 @@
+---
+"@seed-design/react-drawer": patch
+---
+
+AlertDialog 닫힐 때 focus 복원으로 인해 BottomSheet가 즉시 닫히는 문제 수정
+
+- onFocusOutside에서 항상 preventDefault 호출
+- onInteractOutside에서 defaultPrevented 체크 추가

--- a/packages/react-headless/drawer/src/Drawer.tsx
+++ b/packages/react-headless/drawer/src/Drawer.tsx
@@ -209,10 +209,10 @@ export const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>((pro
         }
       }}
       onFocusOutside={(e) => {
-        if (!modal) {
-          e.preventDefault();
-          return;
-        }
+        props.onFocusOutside?.(e);
+        // Always prevent focusOutside to avoid conflicts when focus moves between modals
+        // (e.g., when Dialog closes and restores focus while BottomSheet is opening)
+        e.preventDefault();
       }}
       onPointerMove={(event) => {
         lastKnownPointerEventRef.current = event;
@@ -251,7 +251,8 @@ export const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>((pro
         }
       }}
       onInteractOutside={(e) => {
-        if (dismissible && closeOnInteractOutside) {
+        // Only close if event is not prevented (e.g., by onFocusOutside or onPointerDownOutside)
+        if (dismissible && closeOnInteractOutside && !e.defaultPrevented) {
           closeDrawer();
         }
         props.onInteractOutside?.(e);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* AlertDialog를 닫을 때 BottomSheet가 함께 닫히는 버그를 수정했습니다.
* 외부 상호작용 이벤트 처리 로직을 개선하여 드로어의 의도하지 않은 종료를 방지했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->