### PR TITLE
feat(docs): make Figma credentials optional with placeholder fallback

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,9 +5,6 @@ name: "Chromatic"
 
 env:
   GITHUB_TOKEN: ${{ github.token }}
-  # running fumadocs-mdx in docs requires these
-  FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
-  FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
 
 # Event for the workflow
 on:

--- a/.github/workflows/docs-deploy-alpha-pages.yml
+++ b/.github/workflows/docs-deploy-alpha-pages.yml
@@ -13,15 +13,13 @@ on:
   workflow_dispatch:
     inputs:
       skip-figma-cache:
-        description: 'Skip Figma image cache (fetch fresh images)'
+        description: "Skip Figma image cache (fetch fresh images)"
         required: false
         type: boolean
         default: false
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
-  FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
 
 name: Deploy seed-design-v3 docs (Alpha)
 

--- a/.github/workflows/docs-deploy-alpha-pages.yml
+++ b/.github/workflows/docs-deploy-alpha-pages.yml
@@ -20,6 +20,8 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
+  FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
 
 name: Deploy seed-design-v3 docs (Alpha)
 

--- a/.github/workflows/docs-deploy-production-pages.yml
+++ b/.github/workflows/docs-deploy-production-pages.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       skip-figma-cache:
-        description: 'Skip Figma image cache (fetch fresh images)'
+        description: "Skip Figma image cache (fetch fresh images)"
         required: false
         type: boolean
         default: false
@@ -23,8 +23,6 @@ concurrency:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
-  FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
 
 name: Deploy seed-design-v3 docs (Production)
 

--- a/.github/workflows/docs-deploy-production-pages.yml
+++ b/.github/workflows/docs-deploy-production-pages.yml
@@ -23,6 +23,8 @@ concurrency:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
+  FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
 
 name: Deploy seed-design-v3 docs (Production)
 

--- a/.github/workflows/docs-deploy-qa-pages.yml
+++ b/.github/workflows/docs-deploy-qa-pages.yml
@@ -13,9 +13,6 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # running fumadocs-mdx in docs requires these
-  FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
-  FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
 
 name: Deploy seed-design-v3 QA app
 

--- a/.github/workflows/docs-deploy-storybook-alpha-pages.yml
+++ b/.github/workflows/docs-deploy-storybook-alpha-pages.yml
@@ -14,8 +14,6 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
-  FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
 
 name: Deploy seed-design-v3 Storybook Alpha
 

--- a/.github/workflows/docs-deploy-storybook-production-pages.yml
+++ b/.github/workflows/docs-deploy-storybook-production-pages.yml
@@ -13,8 +13,6 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
-  FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
 
 name: Deploy seed-design-v3 Storybook
 

--- a/.github/workflows/react-headless-test.yml
+++ b/.github/workflows/react-headless-test.yml
@@ -8,9 +8,6 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # running fumadocs-mdx in docs requires these
-  FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
-  FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
 
 permissions:
   contents: read

--- a/.github/workflows/react-test.yml
+++ b/.github/workflows/react-test.yml
@@ -8,9 +8,6 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # running fumadocs-mdx in docs requires these
-  FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
-  FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
 
 permissions:
   contents: read

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -16,9 +16,6 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # running fumadocs-mdx in docs requires these
-  FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
-  FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
 
 jobs:
   release:

--- a/docs/app/env.ts
+++ b/docs/app/env.ts
@@ -1,0 +1,19 @@
+export const env = {
+  figmaFileKey: warnIfUndefined(
+    process.env.FIGMA_FILE_KEY,
+    "Missing environment variable: FIGMA_FILE_KEY, continuing build without Figma integration...",
+  ),
+  figmaPersonalAccessToken: warnIfUndefined(
+    process.env.FIGMA_PERSONAL_ACCESS_TOKEN,
+    "Missing environment variable: FIGMA_PERSONAL_ACCESS_TOKEN, continuing build without Figma integration...",
+  ),
+  figmaCacheDisabled: process.env.FIGMA_CACHE_DISABLED === "1",
+};
+
+function warnIfUndefined<T>(v: T | undefined, warningMessage: string): T | undefined {
+  if (v === undefined) {
+    console.warn(warningMessage);
+  }
+
+  return v;
+}

--- a/docs/components/component-grid.tsx
+++ b/docs/components/component-grid.tsx
@@ -4,8 +4,11 @@ import {
   createFigmaClient,
   fetchFigmaImageUrls,
 } from "@/components/figma-image/fetch-figma-image-urls";
+import { env } from "@/app/env";
 
-const client = createFigmaClient(process.env.FIGMA_PERSONAL_ACCESS_TOKEN!);
+const client = env.figmaPersonalAccessToken
+  ? createFigmaClient(env.figmaPersonalAccessToken)
+  : undefined;
 
 function getCategoryFromPath(path: string): string | null {
   const match = path.match(/components\/\(([^)]+)\)\//);
@@ -52,18 +55,20 @@ export async function ComponentGrid() {
               <li key={page.url}>
                 <ComponentCard
                   className="h-full"
-                  {...(page.data.coverImageFigmaId && {
-                    coverImageSrc: (
-                      await fetchFigmaImageUrls({
-                        client,
-                        fileKey: process.env.FIGMA_FILE_KEY!,
-                        nodeIds: [page.data.coverImageFigmaId],
-                        options: {
-                          scale: 3,
-                        },
-                      })
-                    ).get(page.data.coverImageFigmaId),
-                  })}
+                  {...(page.data.coverImageFigmaId &&
+                    env.figmaFileKey &&
+                    client && {
+                      coverImageSrc: (
+                        await fetchFigmaImageUrls({
+                          client,
+                          fileKey: env.figmaFileKey,
+                          nodeIds: [page.data.coverImageFigmaId],
+                          options: {
+                            scale: 3,
+                          },
+                        })
+                      ).get(page.data.coverImageFigmaId),
+                    })}
                   title={page.data.title}
                   description={page.data.description}
                   href={page.url}

--- a/docs/components/figma-image/fetch-figma-image-urls.ts
+++ b/docs/components/figma-image/fetch-figma-image-urls.ts
@@ -2,13 +2,12 @@ import { Api as Figma } from "figma-api";
 import * as FigmaRestAPI from "@figma/rest-api-spec";
 import { FlatCache } from "flat-cache";
 import path from "node:path";
+import { env } from "@/app/env";
 
 const LOG_PREFIX = "\n[remark-figma-image]";
 const MAX_RETRIES = 7;
 const CACHE_TTL_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 const CACHE_ID = "urls";
-
-const isCacheDisabled = process.env.FIGMA_CACHE_DISABLED === "1";
 
 // Store cache in docs/.cache/figma-image (gitignored. persisted via Actions cache)
 const cacheDir = path.resolve(process.cwd(), ".cache/figma-image");
@@ -25,6 +24,7 @@ export type FetchFigmaImageUrlsOptions = Omit<FigmaRestAPI.GetImagesQueryParams,
 
 export function createFigmaClient(accessToken: string): Figma {
   if (!accessToken) throw new Error("FIGMA_PERSONAL_ACCESS_TOKEN is required");
+
   return new Figma({ personalAccessToken: accessToken });
 }
 
@@ -49,7 +49,7 @@ export async function fetchFigmaImageUrls({
   imageUrlCache.load(CACHE_ID, cacheDir);
 
   for (const nodeId of nodeIds) {
-    const cached = isCacheDisabled
+    const cached = env.figmaCacheDisabled
       ? undefined
       : imageUrlCache.get<string>(getCacheKey(nodeId, options));
 

--- a/docs/components/figma-image/remark-figma-image.ts
+++ b/docs/components/figma-image/remark-figma-image.ts
@@ -21,8 +21,8 @@ const DEFAULT_IMAGE_SIZE = {
 export type Root = typeof remark extends Processor<infer R, any, any, any, any> ? R : never;
 
 export interface RemarkFigmaImageOptions {
-  fileKey: string;
-  accessToken: string;
+  fileKey?: string;
+  accessToken?: string;
   fetchUrlsOptions?: FetchFigmaImageUrlsOptions;
 }
 
@@ -31,6 +31,10 @@ interface NodeEntry {
   index: number;
   parent: { children: unknown[] };
 }
+
+// Gray placeholder with "Figma" text
+const PLACEHOLDER_DATA_URI =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='300' viewBox='0 0 400 300'%3E%3Crect fill='%23e5e5e5' width='400' height='300'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-family='system-ui,sans-serif' font-size='24' fill='%23737373'%3EFigma%3C/text%3E%3C/svg%3E";
 
 /**
  * Remark plugin that transforms Figma node IDs into image URLs at build time.
@@ -62,13 +66,16 @@ export function remarkFigmaImage({
 
     if (figmaNodes.size === 0) return;
 
-    const client = createFigmaClient(accessToken);
-    const imageUrls = await fetchFigmaImageUrls({
-      client,
-      fileKey,
-      nodeIds: Array.from(figmaNodes.keys()),
-      options: fetchUrlsOptions,
-    });
+    const usePlaceholder = !accessToken || !fileKey;
+
+    const imageUrls: Map<string, string> = usePlaceholder
+      ? new Map(Array.from(figmaNodes.keys()).map((id) => [id, PLACEHOLDER_DATA_URI]))
+      : await fetchFigmaImageUrls({
+          client: createFigmaClient(accessToken),
+          fileKey,
+          nodeIds: Array.from(figmaNodes.keys()),
+          options: fetchUrlsOptions,
+        });
 
     for (const [figmaId, entries] of figmaNodes) {
       const url = imageUrls.get(figmaId);

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -5,6 +5,7 @@ import { typeTableGenerator } from "./components/type-table/generator";
 import { remarkReactTypeTable } from "./components/type-table/remark-react-type-table";
 import lastModified from "fumadocs-mdx/plugins/last-modified";
 import z from "zod";
+import { env } from "@/app/env";
 
 export const docs = defineDocs({
   dir: "content/docs",
@@ -72,10 +73,6 @@ export const aiIntegrationDocs = defineDocs({
   },
 });
 
-if (!process.env.FIGMA_FILE_KEY || !process.env.FIGMA_PERSONAL_ACCESS_TOKEN) {
-  throw new Error("FIGMA_FILE_KEY and FIGMA_PERSONAL_ACCESS_TOKEN are required");
-}
-
 export default defineConfig({
   plugins: [lastModified()],
   mdxOptions: {
@@ -98,8 +95,8 @@ export default defineConfig({
       [
         remarkFigmaImage,
         {
-          fileKey: process.env.FIGMA_FILE_KEY,
-          accessToken: process.env.FIGMA_PERSONAL_ACCESS_TOKEN,
+          fileKey: env.figmaFileKey,
+          accessToken: env.figmaPersonalAccessToken,
           fetchUrlsOptions: {
             format: "png",
             scale: 2,


### PR DESCRIPTION
## Summary
- Figma credentials 없이도 문서 빌드 가능하도록 개선
- credentials 없으면 placeholder SVG 이미지 사용
- CI workflows 정리: docs deploy 외 workflows에서 불필요한 Figma 환경 변수 제거

## Changes
- `docs/app/env.ts`: 환경 변수 중앙화 모듈 추가
- `remark-figma-image.ts`: placeholder fallback 로직 추가
- `source.config.ts`: 필수 credential 체크 제거
- `component-grid.tsx`: optional credential 처리
- GitHub workflows: docs deploy가 아닌 workflows에서 `FIGMA_*` 환경 변수 제거
  - Alpha/Production docs deploy는 실제 Figma 이미지가 필요하므로 유지

## Test plan
- [ ] `FIGMA_*` 환경 변수 없이 `pnpm dev` 실행 확인
- [ ] Placeholder 이미지가 정상적으로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Figma 구성 관리를 중앙화해 환경값 사용을 통일했습니다.
  * Figma 자격증명이 없을 때 회색 플레이스홀더로 안전하게 폴백하여 빌드 안정성을 높였습니다.

* **Chores**
  * CI 워크플로우에서 Figma 관련 비밀 환경 변수 제거 및 설명 문자열 표기 통일로 설정을 간소화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->