### PR TITLE
docs: remove image component background

### DIFF
--- a/docs/components/guideline/do-image.tsx
+++ b/docs/components/guideline/do-image.tsx
@@ -18,7 +18,7 @@ export function DoImage({ src, alt, body, className }: DoImageProps) {
         alt={alt}
         width={773}
         height={396}
-        className="w-full object-cover border border-bg-positive-solid rounded-r2 [&_img]:my-0 bg-palette-gray-100 dark:bg-palette-gray-900"
+        className="w-full object-cover border border-bg-positive-solid rounded-r2 [&_img]:my-0"
         loading="lazy"
         draggable={false}
       />

--- a/docs/components/guideline/dont-image.tsx
+++ b/docs/components/guideline/dont-image.tsx
@@ -18,7 +18,7 @@ export function DontImage({ src, alt, body, className }: DontImageProps) {
         alt={alt}
         width={773}
         height={396}
-        className="w-full object-cover border border-bg-critical-solid rounded-r2 [&_img]:my-0 bg-palette-gray-100 dark:bg-palette-gray-900"
+        className="w-full object-cover border border-bg-critical-solid rounded-r2 [&_img]:my-0"
         loading="lazy"
         draggable={false}
       />

--- a/docs/components/mdx-components.tsx
+++ b/docs/components/mdx-components.tsx
@@ -41,13 +41,7 @@ export const mdxComponents: MDXComponents = {
   ...defaultMdxComponents,
 
   img: ({ className, ...rest }) => (
-    <ImageZoom
-      className={clsx(
-        className,
-        "bg-palette-gray-100 dark:bg-palette-gray-900 rounded-r2 overflow-hidden",
-      )}
-      {...rest}
-    />
+    <ImageZoom className={clsx(className, "rounded-r2 overflow-hidden")} {...rest} />
   ),
 
   // Layout


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 문서 내 이미지 구성 요소에서 불필요한 배경색 스타일을 제거하여 더욱 간결하고 깔끔한 시각적 표현을 제공합니다. 이미지는 이제 배경색 없이 표시되어 문서의 전체적인 시각 디자인이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->