### PR TITLE
feat: use generated keys 100%; implement SelectBox, CheckboxGroup & RadioGroup handlers

### DIFF
--- a/.changeset/breezy-bats-play.md
+++ b/.changeset/breezy-bats-play.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/figma": patch
+---
+
+Figma 엔티티를 업데이트합니다. 모든 구성 요소에 대해 generated 데이터를 사용하여 안정성을 개선합니다.

--- a/packages/figma/figma-extractor.config.ts
+++ b/packages/figma/figma-extractor.config.ts
@@ -13,7 +13,7 @@ function getSafeIdentifierName(name: string) {
   return reservedWords.includes(transformed) ? `_${transformed}` : transformed;
 }
 
-const PRIVATE_COMPONENT_SET_PATTERNS: RegExp[] = [
+const PRIVATE_PATTERNS: RegExp[] = [
   /Field/,
   /Text Input/,
   /Textarea/,
@@ -27,10 +27,12 @@ const PRIVATE_COMPONENT_SET_PATTERNS: RegExp[] = [
   /Ghost Button/,
   /Chip/,
   /Segmented Control/,
+  /Select Box/,
   /List Item/,
   /Slider/,
   /Tag/,
   /Page Banner/,
+  /Bottom Action Bar/,
 
   // FAB
   /Button Type/,
@@ -75,7 +77,7 @@ const config = createConfig({
             ([id, set]) =>
               !publishedComponentIdSet.has(id) &&
               !set.remote &&
-              PRIVATE_COMPONENT_SET_PATTERNS.some((pattern) => pattern.test(set.name)),
+              PRIVATE_PATTERNS.some((pattern) => pattern.test(set.name)),
           )
           .map(([id]) => id);
         const privateTemplateIds = Object.entries(templatesFile.componentSets)
@@ -83,7 +85,7 @@ const config = createConfig({
             ([id, set]) =>
               !publishedTemplateIdSet.has(id) &&
               !set.remote &&
-              PRIVATE_COMPONENT_SET_PATTERNS.some((pattern) => pattern.test(set.name)),
+              PRIVATE_PATTERNS.some((pattern) => pattern.test(set.name)),
           )
           .map(([id]) => id);
 
@@ -113,7 +115,6 @@ const config = createConfig({
         ];
       })
       .sort((a, b) => a.document.name.localeCompare(b.document.name))
-      .filter(({ document }) => !!(document as ComponentSetNode).componentPropertyDefinitions)
       .transform(({ document: _document, componentSets, prefix }) => {
         const document = _document as ComponentSetNode;
         const { name, key, componentPropertyDefinitions } = {
@@ -134,8 +135,20 @@ const config = createConfig({
         };
       })
       .write(async (items, { utils, write, pipelineName }) => {
-        const mjs = items.map((item) => utils.toMjs(item.name, item).trim()).join("\n\n");
-        const dts = items.map((item) => utils.toDts(item.name, item).trim()).join("\n\n");
+        const nameCount = new Map<string, number>();
+        for (const item of items) {
+          nameCount.set(item.name, (nameCount.get(item.name) ?? 0) + 1);
+        }
+
+        const getIdentifier = (item: (typeof items)[number]) => {
+          const count = nameCount.get(item.name);
+          return count !== undefined && count > 1
+            ? `${item.name}_${item.key.slice(0, 3)}`
+            : item.name;
+        };
+
+        const mjs = items.map((item) => utils.toMjs(getIdentifier(item), item).trim()).join("\n\n");
+        const dts = items.map((item) => utils.toDts(getIdentifier(item), item).trim()).join("\n\n");
 
         await Promise.all([
           write(`${pipelineName}/index.mjs`, mjs),
@@ -153,17 +166,22 @@ const config = createConfig({
             sources.components({ ...ctx, fileKey: ENV.FIGMA_TEMPLATES_FILE_KEY }),
           ]);
 
-        // published IDs from sources.components()
-        const publishedComponentIdSet = new Set(publishedComponents.map((c) => c.id));
-        const publishedTemplateIdSet = new Set(publishedTemplates.map((c) => c.id));
+        // published IDs from sources.components() - exclude components that belong to a component set
+        const publishedComponentIdSet = new Set(
+          publishedComponents.filter((c) => !c.componentSetId).map((c) => c.id),
+        );
+        const publishedTemplateIdSet = new Set(
+          publishedTemplates.filter((c) => !c.componentSetId).map((c) => c.id),
+        );
 
-        // allowlisted private IDs from getFile() (exclude already published)
+        // allowlisted private IDs from getFile() (exclude already published and components in component sets)
         const privateComponentIds = Object.entries(componentsFile.components)
           .filter(
             ([id, comp]) =>
               !publishedComponentIdSet.has(id) &&
               !comp.remote &&
-              PRIVATE_COMPONENT_SET_PATTERNS.some((pattern) => pattern.test(comp.name)),
+              !comp.componentSetId &&
+              PRIVATE_PATTERNS.some((pattern) => pattern.test(comp.name)),
           )
           .map(([id]) => id);
         const privateTemplateIds = Object.entries(templatesFile.components)
@@ -171,7 +189,8 @@ const config = createConfig({
             ([id, comp]) =>
               !publishedTemplateIdSet.has(id) &&
               !comp.remote &&
-              PRIVATE_COMPONENT_SET_PATTERNS.some((pattern) => pattern.test(comp.name)),
+              !comp.componentSetId &&
+              PRIVATE_PATTERNS.some((pattern) => pattern.test(comp.name)),
           )
           .map(([id]) => id);
 
@@ -201,7 +220,6 @@ const config = createConfig({
         ];
       })
       .sort((a, b) => a.document.name.localeCompare(b.document.name))
-      .filter(({ document }) => !!(document as ComponentNode).componentPropertyDefinitions)
       .transform(({ document: _document, components, prefix }) => {
         const document = _document as ComponentNode;
         const { name, key, componentPropertyDefinitions } = {
@@ -222,8 +240,20 @@ const config = createConfig({
         };
       })
       .write(async (items, { utils, write, pipelineName }) => {
-        const mjs = items.map((item) => utils.toMjs(item.name, item).trim()).join("\n\n");
-        const dts = items.map((item) => utils.toDts(item.name, item).trim()).join("\n\n");
+        const nameCount = new Map<string, number>();
+        for (const item of items) {
+          nameCount.set(item.name, (nameCount.get(item.name) ?? 0) + 1);
+        }
+
+        const getIdentifier = (item: (typeof items)[number]) => {
+          const count = nameCount.get(item.name);
+          return count !== undefined && count > 1
+            ? `${item.name}_${item.key.slice(0, 3)}`
+            : item.name;
+        };
+
+        const mjs = items.map((item) => utils.toMjs(getIdentifier(item), item).trim()).join("\n\n");
+        const dts = items.map((item) => utils.toDts(getIdentifier(item), item).trim()).join("\n\n");
 
         await Promise.all([
           write(`${pipelineName}/index.mjs`, mjs),

--- a/packages/figma/src/codegen/component-properties.ts
+++ b/packages/figma/src/codegen/component-properties.ts
@@ -174,6 +174,18 @@ export type SegmentedControlItemProperties = InferComponentDefinition<
   typeof sets.privateComponentSegmentedControlItem.componentPropertyDefinitions
 >;
 
+export type SelectBoxGroupProperties = InferComponentDefinition<
+  typeof sets.componentSelectBoxGroup.componentPropertyDefinitions
+>;
+
+export type SelectBoxHorizontalProperties = InferComponentDefinition<
+  typeof sets.componentSelectBoxItemHorizontal.componentPropertyDefinitions
+>;
+
+export type SelectBoxVerticalProperties = InferComponentDefinition<
+  typeof sets.componentSelectBoxItemVertical.componentPropertyDefinitions
+>;
+
 export type SkeletonProperties = InferComponentDefinition<
   typeof sets.componentSkeleton.componentPropertyDefinitions
 >;

--- a/packages/figma/src/codegen/component-properties.ts
+++ b/packages/figma/src/codegen/component-properties.ts
@@ -186,6 +186,10 @@ export type SelectBoxVerticalProperties = InferComponentDefinition<
   typeof sets.componentSelectBoxItemVertical.componentPropertyDefinitions
 >;
 
+export type SelectBoxPrefixIconProperties = InferComponentDefinition<
+  typeof components.componentSelectBoxItemPrefixIcon.componentPropertyDefinitions
+>;
+
 export type SkeletonProperties = InferComponentDefinition<
   typeof sets.componentSkeleton.componentPropertyDefinitions
 >;

--- a/packages/figma/src/codegen/component-properties.ts
+++ b/packages/figma/src/codegen/component-properties.ts
@@ -42,6 +42,10 @@ export type CheckboxProperties = InferComponentDefinition<
   typeof sets.componentCheckbox.componentPropertyDefinitions
 >;
 
+export type CheckboxGroupFieldProperties = InferComponentDefinition<
+  typeof sets.templateCheckboxGroupField.componentPropertyDefinitions
+>;
+
 export type CheckmarkProperties = InferComponentDefinition<
   typeof sets.componentCheckmark.componentPropertyDefinitions
 >;
@@ -144,6 +148,10 @@ export type ProgressCircleProperties = InferComponentDefinition<
 
 export type RadioProperties = InferComponentDefinition<
   typeof sets.componentRadio.componentPropertyDefinitions
+>;
+
+export type RadioGroupFieldProperties = InferComponentDefinition<
+  typeof sets.templateRadioGroupField.componentPropertyDefinitions
 >;
 
 export type RadiomarkProperties = InferComponentDefinition<

--- a/packages/figma/src/codegen/component-properties.ts
+++ b/packages/figma/src/codegen/component-properties.ts
@@ -43,7 +43,7 @@ export type CheckboxProperties = InferComponentDefinition<
 >;
 
 export type CheckboxGroupFieldProperties = InferComponentDefinition<
-  typeof sets.templateCheckboxGroupField.componentPropertyDefinitions
+  typeof sets.templateCheckboxField.componentPropertyDefinitions
 >;
 
 export type CheckmarkProperties = InferComponentDefinition<
@@ -67,7 +67,7 @@ export type DividerProperties = InferComponentDefinition<
 >;
 
 export type FieldHeaderProperties = InferComponentDefinition<
-  typeof sets.privateComponentFieldHeader.componentPropertyDefinitions
+  typeof sets.componentFieldHeader.componentPropertyDefinitions
 >;
 
 export type FieldIndicatorProperties = InferComponentDefinition<
@@ -75,7 +75,7 @@ export type FieldIndicatorProperties = InferComponentDefinition<
 >;
 
 export type FieldFooterProperties = InferComponentDefinition<
-  typeof sets.privateComponentFieldFooter.componentPropertyDefinitions
+  typeof sets.componentFieldFooter.componentPropertyDefinitions
 >;
 
 export type FieldCharacterCountProperties = InferComponentDefinition<
@@ -151,7 +151,7 @@ export type RadioProperties = InferComponentDefinition<
 >;
 
 export type RadioGroupFieldProperties = InferComponentDefinition<
-  typeof sets.templateRadioGroupField.componentPropertyDefinitions
+  typeof sets.templateRadioField.componentPropertyDefinitions
 >;
 
 export type RadiomarkProperties = InferComponentDefinition<
@@ -275,7 +275,7 @@ export type TextInputFieldProperties = InferComponentDefinition<
 >;
 
 export type TextInputOutlineProperties = InferComponentDefinition<
-  typeof sets.privateComponentTextInput.componentPropertyDefinitions
+  typeof sets.componentTextInput.componentPropertyDefinitions
 >;
 
 export type TextInputOutlinePrefixProperties = InferComponentDefinition<
@@ -295,7 +295,7 @@ export type TextInputUnderlineSuffixProperties = InferComponentDefinition<
 >;
 
 export type TextInputUnderlineProperties = InferComponentDefinition<
-  typeof sets.privateComponentUnderlineTextInput.componentPropertyDefinitions
+  typeof sets.componentUnderlineTextInput.componentPropertyDefinitions
 >;
 
 export type TextareaFieldProperties = InferComponentDefinition<
@@ -303,7 +303,7 @@ export type TextareaFieldProperties = InferComponentDefinition<
 >;
 
 export type TextareaProperties = InferComponentDefinition<
-  typeof sets.privateComponentTextarea.componentPropertyDefinitions
+  typeof sets.componentTextarea.componentPropertyDefinitions
 >;
 
 export type FieldButtonProperties = InferComponentDefinition<
@@ -311,7 +311,7 @@ export type FieldButtonProperties = InferComponentDefinition<
 >;
 
 export type InputButtonProperties = InferComponentDefinition<
-  typeof sets.privateComponentInputButton.componentPropertyDefinitions
+  typeof sets.componentInputButton.componentPropertyDefinitions
 >;
 
 export type InputButtonPrefixProperties = InferComponentDefinition<

--- a/packages/figma/src/codegen/component-properties.ts
+++ b/packages/figma/src/codegen/component-properties.ts
@@ -174,6 +174,10 @@ export type SegmentedControlItemProperties = InferComponentDefinition<
   typeof sets.privateComponentSegmentedControlItem.componentPropertyDefinitions
 >;
 
+export type SelectBoxGroupFieldProperties = InferComponentDefinition<
+  typeof sets.templateSelectBoxField.componentPropertyDefinitions
+>;
+
 export type SelectBoxGroupProperties = InferComponentDefinition<
   typeof sets.componentSelectBoxGroup.componentPropertyDefinitions
 >;

--- a/packages/figma/src/codegen/targets/react/component/handlers/archive/checkbox.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/archive/checkbox.ts
@@ -36,6 +36,8 @@ export const createCheckboxHandler = (_ctx: ComponentHandlerDeps) =>
         }),
       };
 
-      return createLocalSnippetElement("Checkbox", commonProps);
+      return createLocalSnippetElement("Checkbox", commonProps, undefined, {
+        comment: "CheckboxGroup으로 묶어서 사용하는 것을 권장합니다.",
+      });
     },
   );

--- a/packages/figma/src/codegen/targets/react/component/handlers/archive/field-button.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/archive/field-button.ts
@@ -58,11 +58,11 @@ export const createFieldButtonHandler = (ctx: ComponentHandlerDeps) => {
       });
 
       // maxGraphemeCount and required can't be props of FieldButton
-      const { required: __required, ...headerProps } =
+      const { required: _required, ...headerProps } =
         props["Show Header#40606:8"].value && fieldHeader
           ? (fieldHeaderHandler.transform(fieldHeader, traverse).props as FieldHeaderProps)
           : {};
-      const { maxGraphemeCount: __maxGraphemeCount, ...footerProps } =
+      const { maxGraphemeCount: _maxGraphemeCount, ...footerProps } =
         props["Show Footer#40606:9"].value && fieldFooter
           ? (fieldFooterHandler.transform(fieldFooter, traverse).props as FieldFooterProps)
           : {};

--- a/packages/figma/src/codegen/targets/react/component/handlers/archive/index.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/archive/index.ts
@@ -11,7 +11,6 @@ export * from "./checkmark";
 export * from "./chip";
 export * from "./contextual-floating-button";
 export * from "./divider";
-export { createFieldHeaderHandler, createFieldFooterHandler } from "./field";
 export * from "./field-button";
 export * from "./floating-action-button";
 export * from "./help-bubble";

--- a/packages/figma/src/codegen/targets/react/component/handlers/archive/slider.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/archive/slider.ts
@@ -56,11 +56,11 @@ export const createSliderFieldHandler = (ctx: ComponentHandlerDeps) => {
       const sliderProps = sliderHandler.transform(slider, traverse).props;
 
       // maxGraphemeCount and required can't be props of Slider
-      const { required: __required, ...headerProps } =
+      const { required: _required, ...headerProps } =
         props["Show Header#40606:8"].value && fieldHeader
           ? (fieldHeaderHandler.transform(fieldHeader, traverse).props as FieldHeaderProps)
           : {};
-      const { maxGraphemeCount: __maxGraphemeCount, ...footerProps } =
+      const { maxGraphemeCount: _maxGraphemeCount, ...footerProps } =
         props["Show Footer#40606:9"].value && fieldFooter
           ? (fieldFooterHandler.transform(fieldFooter, traverse).props as FieldFooterProps)
           : {};

--- a/packages/figma/src/codegen/targets/react/component/handlers/bottom-sheet.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/bottom-sheet.ts
@@ -1,6 +1,7 @@
 import type { BottomSheetProperties } from "@/codegen/component-properties";
 import { createElement, defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
+import * as components from "@/entities/data/__generated__/components";
 import { match } from "ts-pattern";
 import { createLocalSnippetHelper } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
@@ -9,10 +10,6 @@ import { findAllInstances } from "@/utils/figma-node";
 const { createLocalSnippetElement } = createLocalSnippetHelper("bottom-sheet");
 const { createLocalSnippetElement: createLocalSnippetElementTrigger } =
   createLocalSnippetHelper("action-button");
-
-// TODO: Bottom Action Bar (WIP) handler의 키. 해당 컴포넌트(템플릿) 핸들러 작성 시 handler.transform()으로 대체
-const BOTTOM_SHEET_FOOTER_KEY = "6475aac366b2b18edf8cbabff4f84a9f1619253a";
-const BOTTOM_SHEET_BODY_KEY = "e68b006d572300d3c987776192c8ab387fa45e05";
 
 export const createBottomSheetHandler = (_ctx: ComponentHandlerDeps) =>
   defineComponentHandler<BottomSheetProperties>(
@@ -36,7 +33,7 @@ export const createBottomSheetHandler = (_ctx: ComponentHandlerDeps) =>
 
       const bodyNodes = findAllInstances({
         node,
-        key: BOTTOM_SHEET_BODY_KEY,
+        key: components.privateComponentBottomSheetContentsPlaceholder.key,
       });
 
       const bottomSheetBody =
@@ -50,7 +47,8 @@ export const createBottomSheetHandler = (_ctx: ComponentHandlerDeps) =>
 
       const footerNodes = findAllInstances({
         node,
-        key: BOTTOM_SHEET_FOOTER_KEY,
+        // TODO: Bottom Action Bar (WIP) handler의 키. 해당 컴포넌트(템플릿) 핸들러 작성 시 handler.transform()으로 대체
+        key: metadata.componentBottomActionBarFigmaOnly.key,
       });
 
       const bottomSheetFooter =

--- a/packages/figma/src/codegen/targets/react/component/handlers/checkbox.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/checkbox.ts
@@ -79,14 +79,14 @@ export const createCheckboxGroupFieldHandler = (ctx: ComponentHandlerDeps) => {
 
       // maxGraphemeCount / required / invalid can't be props of CheckboxGroup
       const { required: _required, ...headerProps } =
-        props["Show Header#40606:8"] && fieldHeader
+        props["Show Header#40606:8"].value && fieldHeader
           ? (fieldHeaderHandler.transform(fieldHeader, traverse).props as FieldHeaderProps)
           : {};
       const {
         maxGraphemeCount: _maxGraphemeCount,
         invalid: _invalid,
         ...footerProps
-      } = props["Show Footer#40606:9"] && fieldFooter
+      } = props["Show Footer#40606:9"].value && fieldFooter
         ? (fieldFooterHandler.transform(fieldFooter, traverse).props as FieldFooterProps)
         : {};
 

--- a/packages/figma/src/codegen/targets/react/component/handlers/checkbox.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/checkbox.ts
@@ -36,6 +36,8 @@ export const createCheckboxHandler = (_ctx: ComponentHandlerDeps) =>
         }),
       };
 
-      return createLocalSnippetElement("Checkbox", commonProps);
+      return createLocalSnippetElement("Checkbox", commonProps, undefined, {
+        comment: "CheckboxGroup으로 묶어서 사용하는 것을 권장합니다.",
+      });
     },
   );

--- a/packages/figma/src/codegen/targets/react/component/handlers/checkbox.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/checkbox.ts
@@ -1,4 +1,9 @@
-import type { CheckboxProperties } from "@/codegen/component-properties";
+import type {
+  CheckboxGroupFieldProperties,
+  CheckboxProperties,
+  FieldFooterProperties,
+  FieldHeaderProperties,
+} from "@/codegen/component-properties";
 import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import { camelCase } from "change-case";
@@ -6,6 +11,13 @@ import { createLocalSnippetHelper } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
 import { handleSizeProp } from "../size";
 import { match } from "ts-pattern";
+import {
+  createFieldFooterHandler,
+  createFieldHeaderHandler,
+  type FieldFooterProps,
+  type FieldHeaderProps,
+} from "@/codegen/targets/react/component/handlers/field";
+import { findAllInstances } from "@/utils/figma-node";
 
 const { createLocalSnippetElement } = createLocalSnippetHelper("checkbox");
 
@@ -41,3 +53,77 @@ export const createCheckboxHandler = (_ctx: ComponentHandlerDeps) =>
       });
     },
   );
+
+export const createCheckboxGroupFieldHandler = (ctx: ComponentHandlerDeps) => {
+  const checkboxHandler = createCheckboxHandler(ctx);
+  const fieldHeaderHandler = createFieldHeaderHandler(ctx);
+  const fieldFooterHandler = createFieldFooterHandler(ctx);
+
+  return defineComponentHandler<CheckboxGroupFieldProperties>(
+    metadata.templateCheckboxGroupField.key,
+    (node, traverse) => {
+      const { componentProperties: props } = node;
+
+      const items = findAllInstances<CheckboxProperties>({
+        node,
+        key: checkboxHandler.key,
+      });
+      const [fieldHeader] = findAllInstances<FieldHeaderProperties>({
+        node,
+        key: metadata.privateComponentFieldHeader.key,
+      });
+      const [fieldFooter] = findAllInstances<FieldFooterProperties>({
+        node,
+        key: metadata.privateComponentFieldFooter.key,
+      });
+
+      // maxGraphemeCount / required / invalid can't be props of CheckboxGroup
+      const { required: _required, ...headerProps } =
+        props["Show Header#40606:8"] && fieldHeader
+          ? (fieldHeaderHandler.transform(fieldHeader, traverse).props as FieldHeaderProps)
+          : {};
+      const {
+        maxGraphemeCount: _maxGraphemeCount,
+        invalid: _invalid,
+        ...footerProps
+      } = props["Show Footer#40606:9"] && fieldFooter
+        ? (fieldFooterHandler.transform(fieldFooter, traverse).props as FieldFooterProps)
+        : {};
+
+      const commonProps = {
+        ...headerProps,
+        ...footerProps,
+      };
+
+      return createLocalSnippetElement(
+        "CheckboxGroup",
+        commonProps,
+        items.map((item) => {
+          const result = checkboxHandler.transform(item, traverse);
+
+          return {
+            ...result,
+            meta: {
+              ...result.meta,
+
+              // remove comment from individual Checkbox items
+              comment: undefined,
+            },
+          };
+        }),
+        {
+          comment: [
+            headerProps.label
+              ? undefined
+              : "label을 제공하지 않는 경우 aria-label이나 aria-labelledby 중 하나를 제공해야 합니다.",
+            footerProps.errorMessage
+              ? "errorMessage를 표시하는 경우, 접근성을 위해 개별 Checkbox 중 무효한 항목에 invalid를 설정해주세요."
+              : undefined,
+          ]
+            .filter(Boolean)
+            .join(" "),
+        },
+      );
+    },
+  );
+};

--- a/packages/figma/src/codegen/targets/react/component/handlers/checkbox.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/checkbox.ts
@@ -70,11 +70,11 @@ export const createCheckboxGroupFieldHandler = (ctx: ComponentHandlerDeps) => {
       });
       const [fieldHeader] = findAllInstances<FieldHeaderProperties>({
         node,
-        key: metadata.componentFieldHeader.key,
+        key: fieldHeaderHandler.key,
       });
       const [fieldFooter] = findAllInstances<FieldFooterProperties>({
         node,
-        key: metadata.componentFieldFooter.key,
+        key: fieldFooterHandler.key,
       });
 
       // maxGraphemeCount / required / invalid can't be props of CheckboxGroup

--- a/packages/figma/src/codegen/targets/react/component/handlers/checkbox.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/checkbox.ts
@@ -60,7 +60,7 @@ export const createCheckboxGroupFieldHandler = (ctx: ComponentHandlerDeps) => {
   const fieldFooterHandler = createFieldFooterHandler(ctx);
 
   return defineComponentHandler<CheckboxGroupFieldProperties>(
-    metadata.templateCheckboxGroupField.key,
+    metadata.templateCheckboxField.key,
     (node, traverse) => {
       const { componentProperties: props } = node;
 
@@ -70,11 +70,11 @@ export const createCheckboxGroupFieldHandler = (ctx: ComponentHandlerDeps) => {
       });
       const [fieldHeader] = findAllInstances<FieldHeaderProperties>({
         node,
-        key: metadata.privateComponentFieldHeader.key,
+        key: metadata.componentFieldHeader.key,
       });
       const [fieldFooter] = findAllInstances<FieldFooterProperties>({
         node,
-        key: metadata.privateComponentFieldFooter.key,
+        key: metadata.componentFieldFooter.key,
       });
 
       // maxGraphemeCount / required / invalid can't be props of CheckboxGroup

--- a/packages/figma/src/codegen/targets/react/component/handlers/chip.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/chip.ts
@@ -52,7 +52,7 @@ export const createChipHandler = (ctx: ComponentHandlerDeps) => {
       .with("Avatar", () => {
         const [avatar] = findAllInstances<AvatarProperties>({
           node,
-          key: metadata.componentAvatar.key,
+          key: avatarHandler.key,
         });
         if (!avatar) return undefined;
 

--- a/packages/figma/src/codegen/targets/react/component/handlers/field-button.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/field-button.ts
@@ -53,11 +53,11 @@ export const createFieldButtonHandler = (ctx: ComponentHandlerDeps) => {
       });
 
       // maxGraphemeCount and required can't be props of FieldButton
-      const { required: __required, ...headerProps } =
+      const { required: _required, ...headerProps } =
         props["Show Header#40606:8"].value && fieldHeader
           ? (fieldHeaderHandler.transform(fieldHeader, traverse).props as FieldHeaderProps)
           : {};
-      const { maxGraphemeCount: __maxGraphemeCount, ...footerProps } =
+      const { maxGraphemeCount: _maxGraphemeCount, ...footerProps } =
         props["Show Footer#40606:9"].value && fieldFooter
           ? (fieldFooterHandler.transform(fieldFooter, traverse).props as FieldFooterProps)
           : {};

--- a/packages/figma/src/codegen/targets/react/component/handlers/field-button.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/field-button.ts
@@ -1,5 +1,6 @@
 import { defineComponentHandler } from "@/codegen/core";
 import * as sets from "@/entities/data/__generated__/component-sets";
+import * as components from "@/entities/data/__generated__/components";
 import { createLocalSnippetHelper } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
 import {
@@ -22,14 +23,6 @@ import { findAllInstances, findOne } from "@/utils/figma-node";
 import type { NormalizedTextNode } from "@/normalizer";
 
 const { createLocalSnippetElement } = createLocalSnippetHelper("field-button");
-
-// published but taken down now
-const FIELD_BUTTON_KEYS = {
-  selectField: "a2138764f60a9b5a35e22ff40bc6cd701c660260",
-  datePickerField: "c161d1326a1087258e4f762aa3c378c098308d98",
-  timePickerField: "e38df17cf1e0f96e09774b015739dfde30d46115",
-  addressPickerField: "4af06df28eca43fe2be5fe5ba5e6019587de9fac",
-} as const;
 
 export const createFieldButtonHandler = (ctx: ComponentHandlerDeps) => {
   const fieldHeaderHandler = createFieldHeaderHandler(ctx);
@@ -138,7 +131,7 @@ export const createSelectFieldHandler = (ctx: ComponentHandlerDeps) => {
   const fieldButtonHandler = createFieldButtonHandler(ctx);
 
   return defineComponentHandler<GenericFieldButtonProps>(
-    FIELD_BUTTON_KEYS.selectField,
+    components.privateTemplateSelectField.key,
     (node, traverse) => {
       const [fieldButton] = findAllInstances<FieldButtonProperties>({
         node,
@@ -154,7 +147,7 @@ export const createDatePickerFieldHandler = (ctx: ComponentHandlerDeps) => {
   const fieldButtonHandler = createFieldButtonHandler(ctx);
 
   return defineComponentHandler<GenericFieldButtonProps>(
-    FIELD_BUTTON_KEYS.datePickerField,
+    components.privateTemplateDatePickerField.key,
     (node, traverse) => {
       const [fieldButton] = findAllInstances<FieldButtonProperties>({
         node,
@@ -170,7 +163,7 @@ export const createTimePickerFieldHandler = (ctx: ComponentHandlerDeps) => {
   const fieldButtonHandler = createFieldButtonHandler(ctx);
 
   return defineComponentHandler<GenericFieldButtonProps>(
-    FIELD_BUTTON_KEYS.timePickerField,
+    components.privateTemplateTimePickerField.key,
     (node, traverse) => {
       const [fieldButton] = findAllInstances<FieldButtonProperties>({
         node,
@@ -186,7 +179,7 @@ export const createAddressFieldHandler = (ctx: ComponentHandlerDeps) => {
   const fieldButtonHandler = createFieldButtonHandler(ctx);
 
   return defineComponentHandler<GenericFieldButtonProps>(
-    FIELD_BUTTON_KEYS.addressPickerField,
+    components.privateTemplateAddressPickerField.key,
     (node, traverse) => {
       const [fieldButton] = findAllInstances<FieldButtonProperties>({
         node,

--- a/packages/figma/src/codegen/targets/react/component/handlers/field-button.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/field-button.ts
@@ -35,7 +35,7 @@ export const createFieldButtonHandler = (ctx: ComponentHandlerDeps) => {
 
       const [inputButton] = findAllInstances<InputButtonProperties>({
         node,
-        key: sets.privateComponentInputButton.key,
+        key: sets.componentInputButton.key,
       });
 
       const [clearButton] = findAllInstances<ActionButtonGhostProperties>({
@@ -45,11 +45,11 @@ export const createFieldButtonHandler = (ctx: ComponentHandlerDeps) => {
 
       const [fieldHeader] = findAllInstances<FieldHeaderProperties>({
         node,
-        key: sets.privateComponentFieldHeader.key,
+        key: sets.componentFieldHeader.key,
       });
       const [fieldFooter] = findAllInstances<FieldFooterProperties>({
         node,
-        key: sets.privateComponentFieldFooter.key,
+        key: sets.componentFieldFooter.key,
       });
 
       // maxGraphemeCount and required can't be props of FieldButton

--- a/packages/figma/src/codegen/targets/react/component/handlers/field.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/field.ts
@@ -24,7 +24,7 @@ export const createFieldHeaderHandler = (ctx: ComponentHandlerDeps) => {
   const indicatorHandler = createFieldIndicatorHandler(ctx);
 
   return defineComponentHandler<FieldHeaderProperties>(
-    metadata.privateComponentFieldHeader.key,
+    metadata.componentFieldHeader.key,
     (node, traverse) => {
       const { componentProperties: props } = node;
 
@@ -94,7 +94,7 @@ export const createFieldFooterHandler = (ctx: ComponentHandlerDeps) => {
   const characterCountHandler = createFieldCharacterCountHandler(ctx);
 
   return defineComponentHandler<FieldFooterProperties>(
-    metadata.privateComponentFieldFooter.key,
+    metadata.componentFieldFooter.key,
     (node, traverse) => {
       const { componentProperties: props } = node;
 

--- a/packages/figma/src/codegen/targets/react/component/handlers/field.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/field.ts
@@ -30,7 +30,7 @@ export const createFieldHeaderHandler = (ctx: ComponentHandlerDeps) => {
 
       const [indicator] = findAllInstances<FieldIndicatorProperties>({
         node,
-        key: metadata.privateComponentFieldHeaderIndicator.key,
+        key: indicatorHandler.key,
       });
 
       // only returns some nice common props for Slider, TextField and more
@@ -110,7 +110,7 @@ export const createFieldFooterHandler = (ctx: ComponentHandlerDeps) => {
         .with("Character Count", () => {
           const [characterCount] = findAllInstances<FieldCharacterCountProperties>({
             node,
-            key: metadata.privateComponentFieldFooterCharacterCount.key,
+            key: characterCountHandler.key,
           });
 
           return {

--- a/packages/figma/src/codegen/targets/react/component/handlers/index.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/index.ts
@@ -29,6 +29,7 @@ export * from "./radiomark";
 export * from "./reaction-button";
 export * from "./result-section";
 export * from "./segmented-control";
+export * from "./select-box";
 export * from "./skeleton";
 export * from "./slider";
 export * from "./snackbar";

--- a/packages/figma/src/codegen/targets/react/component/handlers/index.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/index.ts
@@ -11,7 +11,6 @@ export * from "./checkmark";
 export * from "./chip";
 export * from "./contextual-floating-button";
 export * from "./divider";
-export * from "./field";
 export * from "./field-button";
 export * from "./floating-action-button";
 export * from "./help-bubble";

--- a/packages/figma/src/codegen/targets/react/component/handlers/legacy-select-box.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/legacy-select-box.ts
@@ -11,7 +11,7 @@ import type { ComponentHandlerDeps } from "../deps.interface";
 
 const { createLocalSnippetElement } = createLocalSnippetHelper("select-box");
 
-export const createLegacySelectBoxHandler = (_ctx: ComponentHandlerDeps) =>
+const createLegacySelectBoxHandler = (_ctx: ComponentHandlerDeps) =>
   defineComponentHandler<LegacySelectBoxProperties>(
     metadata.componentDeprecatedSelectBox.key,
     ({ componentProperties: props }) => {

--- a/packages/figma/src/codegen/targets/react/component/handlers/list-item.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/list-item.ts
@@ -14,26 +14,26 @@ import { match } from "ts-pattern";
 
 const { createLocalSnippetElement } = createLocalSnippetHelper("list");
 
-const PREFIX_KEYS = {
-  checkmark: "563275de82ea1282cece0c35c0cd8d1625bc3a9d",
-  radiomark: "51f7c0917ebc559d81e63d0639cb632a792f40de",
-  icon: components.componentListItemPrefixIcon.key,
-  avatar: "27e33754113178be97e07195528c4ea020b3d3b7",
-  image: "d06216ff143a960844799c0b8f9212628f78c69d",
-  custom: "b8059f5e0f85e0745fc61ff70f04571177c2cdfc",
-};
+const PREFIX_KEYS = [
+  components.componentListItemPrefixCheckbox.key,
+  components.componentListItemPrefixRadiomark.key,
+  components.componentListItemPrefixIcon.key,
+  components.componentListItemPrefixAvatar.key,
+  components.componentListItemPrefixImage.key,
+  components.componentListItemPrefixCustom.key,
+];
 
-const SUFFIX_KEYS = {
-  checkmark: "385ba8d607029e15e0d38ab415f783016488b185",
-  radiomark: "09871d64c5c30407da586fb34425c2e83e147c81",
-  chevron: components.componentListItemSuffixChevron.key,
-  switch: "0c26bd64e117e168b06eea69be903e4be762a728",
-  custom: "26b86c9f8965d38aa5a1181a5cdc89fa487988d1",
-  icon: components.componentListItemSuffixIcon.key,
-  chevronWithText: components.componentListItemSuffixChevronWithText.key,
-  iconButton: metadata.componentListItemSuffixIconButton.key,
-  actionButton: metadata.componentListItemSuffixActionButton.key,
-};
+const SUFFIX_KEYS = [
+  components.componentListItemSuffixCheckbox.key,
+  components.componentListItemSuffixRadiomark.key,
+  components.componentListItemSuffixChevron.key,
+  components.componentListItemSuffixSwitch.key,
+  components.componentListItemSuffixCustom.key,
+  components.componentListItemSuffixIcon.key,
+  components.componentListItemSuffixChevronWithText.key,
+  metadata.componentListItemSuffixIconButton.key,
+  metadata.componentListItemSuffixActionButton.key,
+];
 
 export const createListItemHandler = (ctx: ComponentHandlerDeps) =>
   defineComponentHandler<ListItemProperties>(metadata.componentListItem.key, (node, traverse) => {
@@ -55,7 +55,7 @@ export const createListItemHandler = (ctx: ComponentHandlerDeps) =>
     const prefixNode = (() => {
       if (props["Has Prefix#28452:85"].value === false) return null;
 
-      for (const key of Object.values(PREFIX_KEYS)) {
+      for (const key of PREFIX_KEYS) {
         const [found] = findAllInstances<ListItemPrefixIconProperties | {}>({ node, key });
 
         if (found) return found;
@@ -79,7 +79,7 @@ export const createListItemHandler = (ctx: ComponentHandlerDeps) =>
     const suffixNode = (() => {
       if (props["Has Suffix#28452:64"].value === false) return null;
 
-      for (const key of Object.values(SUFFIX_KEYS)) {
+      for (const key of SUFFIX_KEYS) {
         const [found] = findAllInstances<ListItemSuffixIconProperties | {}>({ node, key });
 
         if (found) return found;

--- a/packages/figma/src/codegen/targets/react/component/handlers/radio-group.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/radio-group.ts
@@ -59,11 +59,11 @@ export const createRadioGroupFieldHandler = (ctx: ComponentHandlerDeps) => {
       });
       const [fieldHeader] = findAllInstances<FieldHeaderProperties>({
         node,
-        key: metadata.componentFieldHeader.key,
+        key: fieldHeaderHandler.key,
       });
       const [fieldFooter] = findAllInstances<FieldFooterProperties>({
         node,
-        key: metadata.componentFieldFooter.key,
+        key: fieldFooterHandler.key,
       });
 
       // maxGraphemeCount and required can't be props of RadioGroup

--- a/packages/figma/src/codegen/targets/react/component/handlers/radio-group.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/radio-group.ts
@@ -10,22 +10,25 @@ import { match } from "ts-pattern";
 const { createLocalSnippetElement } = createLocalSnippetHelper("radio-group");
 
 export const createRadioGroupItemHandler = (_ctx: ComponentHandlerDeps) =>
-  defineComponentHandler<RadioProperties>(metadata.componentRadio.key, ({ componentProperties: props }) => {
-    const tone = match(props.Tone.value)
-      .with("Neutral", () => "neutral")
-      .with("🚫[Deprecated]Brand", () => "brand")
-      .exhaustive();
+  defineComponentHandler<RadioProperties>(
+    metadata.componentRadio.key,
+    ({ componentProperties: props }) => {
+      const tone = match(props.Tone.value)
+        .with("Neutral", () => "neutral")
+        .with("🚫[Deprecated]Brand", () => "brand")
+        .exhaustive();
 
-    const commonProps = {
-      ...(props.State.value === "Disabled" && {
-        disabled: true,
-      }),
-      label: props["Label#49990:171"].value,
-      value: props["Label#49990:171"].value,
-      size: handleSizeProp(props.Size.value),
-      tone,
-      weight: camelCase(props.Weight.value),
-    };
+      const commonProps = {
+        ...(props.State.value === "Disabled" && {
+          disabled: true,
+        }),
+        label: props["Label#49990:171"].value,
+        value: props["Label#49990:171"].value,
+        size: handleSizeProp(props.Size.value),
+        tone,
+        weight: camelCase(props.Weight.value),
+      };
 
-    return createLocalSnippetElement("RadioGroupItem", commonProps);
-  });
+      return createLocalSnippetElement("RadioGroupItem", commonProps);
+    },
+  );

--- a/packages/figma/src/codegen/targets/react/component/handlers/radio-group.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/radio-group.ts
@@ -68,11 +68,11 @@ export const createRadioGroupFieldHandler = (ctx: ComponentHandlerDeps) => {
 
       // maxGraphemeCount and required can't be props of RadioGroup
       const { required: _required, ...headerProps } =
-        props["Show Header#40606:8"] && fieldHeader
+        props["Show Header#40606:8"].value && fieldHeader
           ? (fieldHeaderHandler.transform(fieldHeader, traverse).props as FieldHeaderProps)
           : {};
       const { maxGraphemeCount: _maxGraphemeCount, ...footerProps } =
-        props["Show Footer#40606:9"] && fieldFooter
+        props["Show Footer#40606:9"].value && fieldFooter
           ? (fieldFooterHandler.transform(fieldFooter, traverse).props as FieldFooterProps)
           : {};
 

--- a/packages/figma/src/codegen/targets/react/component/handlers/radio-group.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/radio-group.ts
@@ -1,4 +1,4 @@
-import type { RadioProperties } from "@/codegen/component-properties";
+import type { RadioGroupFieldProperties, RadioProperties } from "@/codegen/component-properties";
 import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import { createLocalSnippetHelper } from "../../element-factories";
@@ -6,6 +6,14 @@ import type { ComponentHandlerDeps } from "../deps.interface";
 import { handleSizeProp } from "../size";
 import { camelCase } from "change-case";
 import { match } from "ts-pattern";
+import {
+  createFieldFooterHandler,
+  createFieldHeaderHandler,
+  type FieldFooterProps,
+  type FieldHeaderProps,
+} from "@/codegen/targets/react/component/handlers/field";
+import { findAllInstances } from "@/utils/figma-node";
+import type { FieldFooterProperties, FieldHeaderProperties } from "@/codegen/component-properties";
 
 const { createLocalSnippetElement } = createLocalSnippetHelper("radio-group");
 
@@ -29,6 +37,73 @@ export const createRadioGroupItemHandler = (_ctx: ComponentHandlerDeps) =>
         weight: camelCase(props.Weight.value),
       };
 
-      return createLocalSnippetElement("RadioGroupItem", commonProps);
+      return createLocalSnippetElement("RadioGroupItem", commonProps, undefined, {
+        comment: "RadioGroup으로 묶어서 사용하세요.",
+      });
     },
   );
+
+export const createRadioGroupFieldHandler = (ctx: ComponentHandlerDeps) => {
+  const radioItemHandler = createRadioGroupItemHandler(ctx);
+  const fieldHeaderHandler = createFieldHeaderHandler(ctx);
+  const fieldFooterHandler = createFieldFooterHandler(ctx);
+
+  return defineComponentHandler<RadioGroupFieldProperties>(
+    metadata.templateRadioGroupField.key,
+    (node, traverse) => {
+      const { componentProperties: props } = node;
+
+      const items = findAllInstances<RadioProperties>({
+        node,
+        key: radioItemHandler.key,
+      });
+      const [fieldHeader] = findAllInstances<FieldHeaderProperties>({
+        node,
+        key: metadata.privateComponentFieldHeader.key,
+      });
+      const [fieldFooter] = findAllInstances<FieldFooterProperties>({
+        node,
+        key: metadata.privateComponentFieldFooter.key,
+      });
+
+      // maxGraphemeCount and required can't be props of RadioGroup
+      const { required: _required, ...headerProps } =
+        props["Show Header#40606:8"] && fieldHeader
+          ? (fieldHeaderHandler.transform(fieldHeader, traverse).props as FieldHeaderProps)
+          : {};
+      const { maxGraphemeCount: _maxGraphemeCount, ...footerProps } =
+        props["Show Footer#40606:9"] && fieldFooter
+          ? (fieldFooterHandler.transform(fieldFooter, traverse).props as FieldFooterProps)
+          : {};
+
+      const selectedItem = items.find((item) => item.componentProperties.Selected.value === "True");
+
+      const commonProps = {
+        ...headerProps,
+        ...footerProps,
+
+        ...(selectedItem && {
+          defaultValue: selectedItem.componentProperties["Label#49990:171"].value,
+        }),
+      };
+
+      return createLocalSnippetElement(
+        "RadioGroup",
+        commonProps,
+        items.map((item) => {
+          const result = radioItemHandler.transform(item, traverse);
+
+          return {
+            ...result,
+            meta: {
+              ...result.meta,
+
+              // remove comment from individual RadioGroupItem items
+              comment: undefined,
+            },
+          };
+        }),
+      );
+    },
+  );
+};

--- a/packages/figma/src/codegen/targets/react/component/handlers/radio-group.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/radio-group.ts
@@ -49,7 +49,7 @@ export const createRadioGroupFieldHandler = (ctx: ComponentHandlerDeps) => {
   const fieldFooterHandler = createFieldFooterHandler(ctx);
 
   return defineComponentHandler<RadioGroupFieldProperties>(
-    metadata.templateRadioGroupField.key,
+    metadata.templateRadioField.key,
     (node, traverse) => {
       const { componentProperties: props } = node;
 
@@ -59,11 +59,11 @@ export const createRadioGroupFieldHandler = (ctx: ComponentHandlerDeps) => {
       });
       const [fieldHeader] = findAllInstances<FieldHeaderProperties>({
         node,
-        key: metadata.privateComponentFieldHeader.key,
+        key: metadata.componentFieldHeader.key,
       });
       const [fieldFooter] = findAllInstances<FieldFooterProperties>({
         node,
-        key: metadata.privateComponentFieldFooter.key,
+        key: metadata.componentFieldFooter.key,
       });
 
       // maxGraphemeCount and required can't be props of RadioGroup

--- a/packages/figma/src/codegen/targets/react/component/handlers/select-box.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/select-box.ts
@@ -1,4 +1,7 @@
 import type {
+  FieldFooterProperties,
+  FieldHeaderProperties,
+  SelectBoxGroupFieldProperties,
   SelectBoxGroupProperties,
   SelectBoxHorizontalProperties,
   SelectBoxPrefixIconProperties,
@@ -11,6 +14,12 @@ import { findAllInstances } from "@/utils/figma-node";
 import { match } from "ts-pattern";
 import { createLocalSnippetHelper, createSeedReactElement } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
+import {
+  createFieldFooterHandler,
+  createFieldHeaderHandler,
+  type FieldFooterProps,
+  type FieldHeaderProps,
+} from "@/codegen/targets/react/component/handlers/field";
 
 const PREFIX_KEYS = [
   components.componentSelectBoxItemPrefixIcon.key,
@@ -24,7 +33,7 @@ const { createLocalSnippetElement } = createLocalSnippetHelper("select-box");
 
 const createSelectBoxHorizontalHandler = (ctx: ComponentHandlerDeps) =>
   defineComponentHandler<SelectBoxHorizontalProperties>(
-    metadata.componentDeprecatedSelectBox.key,
+    metadata.componentSelectBoxItemHorizontal.key,
     (node) => {
       const { componentProperties: props } = node;
 
@@ -105,7 +114,7 @@ const createSelectBoxHorizontalHandler = (ctx: ComponentHandlerDeps) =>
 
 const createSelectBoxVerticalHandler = (ctx: ComponentHandlerDeps) =>
   defineComponentHandler<SelectBoxVerticalProperties>(
-    metadata.componentDeprecatedSelectBox.key,
+    metadata.componentSelectBoxItemVertical.key,
     (node) => {
       const { componentProperties: props } = node;
 
@@ -189,7 +198,7 @@ export const createSelectBoxGroupHandler = (ctx: ComponentHandlerDeps) => {
   const verticalHandler = createSelectBoxVerticalHandler(ctx);
 
   return defineComponentHandler<SelectBoxGroupProperties>(
-    metadata.componentDeprecatedSelectBoxGroup.key,
+    metadata.componentSelectBoxGroup.key,
     (node, traverse) => {
       const props = node.componentProperties;
 
@@ -241,6 +250,84 @@ export const createSelectBoxGroupHandler = (ctx: ComponentHandlerDeps) => {
       ];
 
       return createLocalSnippetElement(tag, commonProps, children, { comment });
+    },
+  );
+};
+
+export const createSelectBoxGroupFieldHandler = (ctx: ComponentHandlerDeps) => {
+  const fieldHeaderHandler = createFieldHeaderHandler(ctx);
+  const fieldFooterHandler = createFieldFooterHandler(ctx);
+  const selectBoxGroupHandler = createSelectBoxGroupHandler(ctx);
+
+  return defineComponentHandler<SelectBoxGroupFieldProperties>(
+    metadata.templateSelectBoxField.key,
+    (node, traverse) => {
+      const { componentProperties: props } = node;
+
+      const [group] = findAllInstances<SelectBoxGroupProperties>({
+        node,
+        key: selectBoxGroupHandler.key,
+      });
+
+      const [fieldHeader] = findAllInstances<FieldHeaderProperties>({
+        node,
+        key: metadata.componentFieldHeader.key,
+      });
+      const [fieldFooter] = findAllInstances<FieldFooterProperties>({
+        node,
+        key: metadata.componentFieldFooter.key,
+      });
+
+      const __headerProps =
+        props["Show Header#40606:8"] && fieldHeader
+          ? (fieldHeaderHandler.transform(fieldHeader, traverse).props as FieldHeaderProps)
+          : {};
+      const __footerProps =
+        props["Show Footer#40606:9"] && fieldFooter
+          ? (fieldFooterHandler.transform(fieldFooter, traverse).props as FieldFooterProps)
+          : {};
+
+      const groupResult = selectBoxGroupHandler.transform(group, traverse);
+
+      const { headerProps, footerProps } = match(
+        groupResult.tag as "RadioSelectBoxRoot" | "CheckSelectBoxGroup" | "UnknownSelectBoxGroup",
+      )
+        .with("RadioSelectBoxRoot", () => {
+          const { required: _required, ...headerProps } = __headerProps;
+          const { maxGraphemeCount: _maxGraphemeCount, ...footerProps } = __footerProps;
+
+          return { headerProps, footerProps };
+        })
+        .with("CheckSelectBoxGroup", () => {
+          const { required: _required, ...headerProps } = __headerProps;
+          const {
+            maxGraphemeCount: _maxGraphemeCount,
+            invalid: _invalid,
+            ...footerProps
+          } = __footerProps;
+
+          return { headerProps, footerProps };
+        })
+        .with("UnknownSelectBoxGroup", () => {
+          const { required: _required, ...headerProps } = __headerProps;
+          const {
+            maxGraphemeCount: _maxGraphemeCount,
+            invalid: _invalid,
+            ...footerProps
+          } = __footerProps;
+
+          return { headerProps, footerProps };
+        })
+        .exhaustive();
+
+      return {
+        ...groupResult,
+        props: {
+          ...groupResult.props,
+          ...headerProps,
+          ...footerProps,
+        },
+      };
     },
   );
 };

--- a/packages/figma/src/codegen/targets/react/component/handlers/select-box.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/select-box.ts
@@ -240,7 +240,7 @@ export const createSelectBoxGroupHandler = (ctx: ComponentHandlerDeps) => {
             defaultValue:
               "Title#28452:21" in selectedSelectBoxProperties
                 ? selectedSelectBoxProperties["Title#28452:21"].value
-                : selectedSelectBoxProperties["Title#58766:114"],
+                : selectedSelectBoxProperties["Title#58766:114"].value,
           }),
       };
 
@@ -279,11 +279,11 @@ export const createSelectBoxGroupFieldHandler = (ctx: ComponentHandlerDeps) => {
       });
 
       const __headerProps =
-        props["Show Header#40606:8"] && fieldHeader
+        props["Show Header#40606:8"].value && fieldHeader
           ? (fieldHeaderHandler.transform(fieldHeader, traverse).props as FieldHeaderProps)
           : {};
       const __footerProps =
-        props["Show Footer#40606:9"] && fieldFooter
+        props["Show Footer#40606:9"].value && fieldFooter
           ? (fieldFooterHandler.transform(fieldFooter, traverse).props as FieldFooterProps)
           : {};
 

--- a/packages/figma/src/codegen/targets/react/component/handlers/select-box.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/select-box.ts
@@ -1,6 +1,7 @@
 import type {
   SelectBoxGroupProperties,
   SelectBoxHorizontalProperties,
+  SelectBoxPrefixIconProperties,
   SelectBoxVerticalProperties,
 } from "@/codegen/component-properties";
 import { defineComponentHandler } from "@/codegen/core";
@@ -46,8 +47,7 @@ const createSelectBoxHorizontalHandler = (ctx: ComponentHandlerDeps) =>
         if (props["Has Prefix#28452:85"].value === false) return null;
 
         for (const key of PREFIX_KEYS) {
-          // TODO: list item처럼 instance swap이 열려야 함
-          const [found] = findAllInstances<{} | {}>({ node, key });
+          const [found] = findAllInstances<SelectBoxPrefixIconProperties | {}>({ node, key });
 
           if (found) return found;
         }
@@ -58,10 +58,8 @@ const createSelectBoxHorizontalHandler = (ctx: ComponentHandlerDeps) =>
       const prefixIcon = (() => {
         if (!prefixNode) return undefined;
 
-        // TODO: handle
-        if ("somekey" in prefixNode.componentProperties) {
-          // @ts-expect-error
-          return ctx.iconHandler.transform(prefixNode.componentProperties["somekey"]);
+        if ("Icon#2475:0" in prefixNode.componentProperties) {
+          return ctx.iconHandler.transform(prefixNode.componentProperties["Icon#2475:0"]);
         }
 
         // React Select Box only supports icon for now
@@ -130,8 +128,7 @@ const createSelectBoxVerticalHandler = (ctx: ComponentHandlerDeps) =>
         if (props["Has Prefix#58766:115"].value === false) return null;
 
         for (const key of PREFIX_KEYS) {
-          // TODO: list item처럼 instance swap이 열려야 함
-          const [found] = findAllInstances<{} | {}>({ node, key });
+          const [found] = findAllInstances<SelectBoxPrefixIconProperties | {}>({ node, key });
 
           if (found) return found;
         }
@@ -142,10 +139,8 @@ const createSelectBoxVerticalHandler = (ctx: ComponentHandlerDeps) =>
       const prefixIcon = (() => {
         if (!prefixNode) return undefined;
 
-        // TODO: handle
-        if ("somekey" in prefixNode.componentProperties) {
-          // @ts-expect-error
-          return ctx.iconHandler.transform(prefixNode.componentProperties["somekey"]);
+        if ("Icon#2475:0" in prefixNode.componentProperties) {
+          return ctx.iconHandler.transform(prefixNode.componentProperties["Icon#2475:0"]);
         }
 
         // React Select Box only supports icon for now

--- a/packages/figma/src/codegen/targets/react/component/handlers/select-box.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/select-box.ts
@@ -271,11 +271,11 @@ export const createSelectBoxGroupFieldHandler = (ctx: ComponentHandlerDeps) => {
 
       const [fieldHeader] = findAllInstances<FieldHeaderProperties>({
         node,
-        key: metadata.componentFieldHeader.key,
+        key: fieldHeaderHandler.key,
       });
       const [fieldFooter] = findAllInstances<FieldFooterProperties>({
         node,
-        key: metadata.componentFieldFooter.key,
+        key: fieldFooterHandler.key,
       });
 
       const __headerProps =

--- a/packages/figma/src/codegen/targets/react/component/handlers/select-box.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/select-box.ts
@@ -1,0 +1,251 @@
+import type {
+  SelectBoxGroupProperties,
+  SelectBoxHorizontalProperties,
+  SelectBoxVerticalProperties,
+} from "@/codegen/component-properties";
+import { defineComponentHandler } from "@/codegen/core";
+import * as metadata from "@/entities/data/__generated__/component-sets";
+import * as components from "@/entities/data/__generated__/components";
+import { findAllInstances } from "@/utils/figma-node";
+import { match } from "ts-pattern";
+import { createLocalSnippetHelper, createSeedReactElement } from "../../element-factories";
+import type { ComponentHandlerDeps } from "../deps.interface";
+
+const PREFIX_KEYS = [
+  components.componentSelectBoxItemPrefixIcon.key,
+  components.componentSelectBoxItemPrefixAvatar.key,
+  components.componentSelectBoxItemPrefixImage.key,
+  components.componentSelectBoxItemPrefixBadge.key,
+  components.componentSelectBoxItemPrefixCustom.key,
+];
+
+const { createLocalSnippetElement } = createLocalSnippetHelper("select-box");
+
+const createSelectBoxHorizontalHandler = (ctx: ComponentHandlerDeps) =>
+  defineComponentHandler<SelectBoxHorizontalProperties>(
+    metadata.componentDeprecatedSelectBox.key,
+    (node) => {
+      const { componentProperties: props } = node;
+
+      const { tag, suffix } = match(props.Control.value)
+        .with("Checkmark", () => ({
+          tag: "CheckSelectBox" as const,
+          suffix: createLocalSnippetElement("CheckSelectBoxCheckmark"),
+        }))
+        .with("Radiomark", () => ({
+          tag: "RadioSelectBoxItem" as const,
+          suffix: createLocalSnippetElement("RadioSelectBoxRadiomark"),
+        }))
+        .with("None", () => ({
+          tag: "UnknownSelectBox" as const,
+          suffix: undefined,
+        }))
+        .exhaustive();
+
+      const prefixNode = (() => {
+        if (props["Has Prefix#28452:85"].value === false) return null;
+
+        for (const key of PREFIX_KEYS) {
+          // TODO: list item처럼 instance swap이 열려야 함
+          const [found] = findAllInstances<{} | {}>({ node, key });
+
+          if (found) return found;
+        }
+
+        return null;
+      })();
+
+      const prefixIcon = (() => {
+        if (!prefixNode) return undefined;
+
+        // TODO: handle
+        if ("somekey" in prefixNode.componentProperties) {
+          // @ts-expect-error
+          return ctx.iconHandler.transform(prefixNode.componentProperties["somekey"]);
+        }
+
+        // React Select Box only supports icon for now
+        // return undefined if not icon
+
+        return undefined;
+      })();
+
+      const commonProps = {
+        // layout: "horizontal",
+
+        ...(prefixIcon && { prefixIcon }),
+
+        label: props["Title#28452:21"].value,
+
+        ...(props["Show Description#28469:1"].value && {
+          description: props["Description#56540:0"].value,
+        }),
+
+        ...(suffix && { suffix }),
+
+        ...(props["Show Custom Content#56903:0"].value && {
+          footer: createSeedReactElement("Box", undefined, "Footer Placeholder"),
+        }),
+
+        ...(tag === "RadioSelectBoxItem" && {
+          value: props["Title#28452:21"].value,
+        }),
+
+        ...(tag === "CheckSelectBox" &&
+          props.Selected.value === "True" && {
+            defaultChecked: true,
+          }),
+
+        ...(props.State.value === "Disabled" && {
+          disabled: true,
+        }),
+      };
+
+      return createLocalSnippetElement(tag, commonProps, undefined);
+    },
+  );
+
+const createSelectBoxVerticalHandler = (ctx: ComponentHandlerDeps) =>
+  defineComponentHandler<SelectBoxVerticalProperties>(
+    metadata.componentDeprecatedSelectBox.key,
+    (node) => {
+      const { componentProperties: props } = node;
+
+      const { tag, suffix } = match(props.Control.value)
+        .with("Checkmark", () => ({
+          tag: "CheckSelectBox" as const,
+          suffix: createLocalSnippetElement("CheckSelectBoxCheckmark"),
+        }))
+        .with("Radiomark", () => ({
+          tag: "RadioSelectBoxItem" as const,
+          suffix: createLocalSnippetElement("RadioSelectBoxRadiomark"),
+        }))
+        .with("None", () => ({
+          tag: "UnknownSelectBox" as const,
+          suffix: undefined,
+        }))
+        .exhaustive();
+
+      const prefixNode = (() => {
+        if (props["Has Prefix#58766:115"].value === false) return null;
+
+        for (const key of PREFIX_KEYS) {
+          // TODO: list item처럼 instance swap이 열려야 함
+          const [found] = findAllInstances<{} | {}>({ node, key });
+
+          if (found) return found;
+        }
+
+        return null;
+      })();
+
+      const prefixIcon = (() => {
+        if (!prefixNode) return undefined;
+
+        // TODO: handle
+        if ("somekey" in prefixNode.componentProperties) {
+          // @ts-expect-error
+          return ctx.iconHandler.transform(prefixNode.componentProperties["somekey"]);
+        }
+
+        // React Select Box only supports icon for now
+        // return undefined if not icon
+
+        return undefined;
+      })();
+
+      const commonProps = {
+        // layout: "vertical",
+
+        ...(prefixIcon && { prefixIcon }),
+
+        label: props["Title#58766:114"].value,
+
+        ...(props["Show Description#58766:117"].value && {
+          description: props["Description#58766:118"].value,
+        }),
+
+        ...(suffix && { suffix }),
+
+        ...(props["Show Custom Content#58766:119"].value && {
+          footer: createSeedReactElement("Box", undefined, "Footer Placeholder"),
+        }),
+
+        ...(tag === "RadioSelectBoxItem" && {
+          value: props["Title#58766:114"].value,
+        }),
+
+        ...(tag === "CheckSelectBox" &&
+          props.Selected.value === "True" && {
+            defaultChecked: true,
+          }),
+
+        ...(props.State.value === "Disabled" && {
+          disabled: true,
+        }),
+      };
+
+      return createLocalSnippetElement(tag, commonProps, undefined);
+    },
+  );
+
+export const createSelectBoxGroupHandler = (ctx: ComponentHandlerDeps) => {
+  const horizontalHandler = createSelectBoxHorizontalHandler(ctx);
+  const verticalHandler = createSelectBoxVerticalHandler(ctx);
+
+  return defineComponentHandler<SelectBoxGroupProperties>(
+    metadata.componentDeprecatedSelectBoxGroup.key,
+    (node, traverse) => {
+      const props = node.componentProperties;
+
+      const horizontalBoxes = findAllInstances<SelectBoxHorizontalProperties>({
+        node,
+        key: horizontalHandler.key,
+      });
+
+      const verticalBoxes = findAllInstances<SelectBoxVerticalProperties>({
+        node,
+        key: verticalHandler.key,
+      });
+
+      const boxes = [...horizontalBoxes, ...verticalBoxes];
+
+      const selectedSelectBox = boxes.find(
+        (selectBox) => selectBox.componentProperties.Selected.value === "True",
+      );
+
+      const { tag, comment } = match([
+        boxes.every((box) => box.componentProperties.Control.value === "Radiomark"),
+        boxes.every((box) => box.componentProperties.Control.value === "Checkmark"),
+      ])
+        .with([true, false], () => ({ tag: "RadioSelectBoxRoot" as const, comment: undefined }))
+        .with([false, true], () => ({ tag: "CheckSelectBoxGroup" as const, comment: undefined }))
+        .otherwise(() => ({
+          tag: "UnknownSelectBoxGroup" as const,
+          comment:
+            "모든 SelectBox의 Control 프로퍼티가 동일하지 않거나 None이 포함되어 있기 때문에 코드에서 어떻게 사용될지 파악할 수 없습니다. 모든 children 요소들을 CheckSelectBox 또는 RadioSelectBoxItem으로 변경하고 CheckSelectBoxGroup 또는 RadioSelectBoxRoot로 묶어 사용하세요.",
+        }));
+
+      const selectedSelectBoxProperties = selectedSelectBox?.componentProperties;
+
+      const commonProps = {
+        columns: Number(props.Column.value[0]),
+
+        ...(selectedSelectBoxProperties &&
+          tag === "RadioSelectBoxRoot" && {
+            defaultValue:
+              "Title#28452:21" in selectedSelectBoxProperties
+                ? selectedSelectBoxProperties["Title#28452:21"].value
+                : selectedSelectBoxProperties["Title#58766:114"],
+          }),
+      };
+
+      const children = [
+        ...horizontalBoxes.map((box) => horizontalHandler.transform(box, traverse)),
+        ...verticalBoxes.map((box) => verticalHandler.transform(box, traverse)),
+      ];
+
+      return createLocalSnippetElement(tag, commonProps, children, { comment });
+    },
+  );
+};

--- a/packages/figma/src/codegen/targets/react/component/handlers/slider.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/slider.ts
@@ -42,15 +42,15 @@ export const createSliderFieldHandler = (ctx: ComponentHandlerDeps) => {
 
       const [slider] = findAllInstances<SliderProperties>({
         node,
-        key: metadata.componentSlider.key,
+        key: sliderHandler.key,
       });
       const [fieldHeader] = findAllInstances<FieldHeaderProperties>({
         node,
-        key: metadata.componentFieldHeader.key,
+        key: fieldHeaderHandler.key,
       });
       const [fieldFooter] = findAllInstances<FieldFooterProperties>({
         node,
-        key: metadata.componentFieldFooter.key,
+        key: fieldFooterHandler.key,
       });
 
       const sliderProps = sliderHandler.transform(slider, traverse).props;

--- a/packages/figma/src/codegen/targets/react/component/handlers/slider.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/slider.ts
@@ -46,11 +46,11 @@ export const createSliderFieldHandler = (ctx: ComponentHandlerDeps) => {
       });
       const [fieldHeader] = findAllInstances<FieldHeaderProperties>({
         node,
-        key: metadata.privateComponentFieldHeader.key,
+        key: metadata.componentFieldHeader.key,
       });
       const [fieldFooter] = findAllInstances<FieldFooterProperties>({
         node,
-        key: metadata.privateComponentFieldFooter.key,
+        key: metadata.componentFieldFooter.key,
       });
 
       const sliderProps = sliderHandler.transform(slider, traverse).props;

--- a/packages/figma/src/codegen/targets/react/component/handlers/slider.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/slider.ts
@@ -56,11 +56,11 @@ export const createSliderFieldHandler = (ctx: ComponentHandlerDeps) => {
       const sliderProps = sliderHandler.transform(slider, traverse).props;
 
       // maxGraphemeCount and required can't be props of Slider
-      const { required: __required, ...headerProps } =
+      const { required: _required, ...headerProps } =
         props["Show Header#40606:8"].value && fieldHeader
           ? (fieldHeaderHandler.transform(fieldHeader, traverse).props as FieldHeaderProps)
           : {};
-      const { maxGraphemeCount: __maxGraphemeCount, ...footerProps } =
+      const { maxGraphemeCount: _maxGraphemeCount, ...footerProps } =
         props["Show Footer#40606:9"].value && fieldFooter
           ? (fieldFooterHandler.transform(fieldFooter, traverse).props as FieldFooterProps)
           : {};

--- a/packages/figma/src/codegen/targets/react/component/handlers/tabs.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/tabs.ts
@@ -33,7 +33,7 @@ export const createTabsHandler = (_ctx: ComponentHandlerDeps) => {
       .with("Line", () => {
         const [wrapper] = findAllInstances<TabsLineWrapperProperties>({
           node,
-          key: metadata.privateComponentTabsLine.key,
+          key: lineHandler.key,
         });
 
         if (!wrapper) throw new Error("Line Tab wrapper not found");
@@ -43,7 +43,7 @@ export const createTabsHandler = (_ctx: ComponentHandlerDeps) => {
       .with("Chip", () => {
         const [wrapper] = findAllInstances<TabsChipWrapperProperties>({
           node,
-          key: metadata.privateComponentTabsChip.key,
+          key: chipHandler.key,
         });
 
         if (!wrapper) throw new Error("Chip Tab wrapper not found");
@@ -90,7 +90,7 @@ const createLineTabsHandler = (_ctx: ComponentHandlerDeps) => {
         .with("Hug", () => {
           const nodes = findAllInstances<TabsLineTriggerHugProperties>({
             node,
-            key: metadata.privateComponentTabItemLineHug.key,
+            key: hugHandler.key,
           });
 
           return {
@@ -105,7 +105,7 @@ const createLineTabsHandler = (_ctx: ComponentHandlerDeps) => {
         .with("Fill", () => {
           const nodes = findAllInstances<TabsLineTriggerFillProperties>({
             node,
-            key: metadata.privateComponentTabItemLineFill.key,
+            key: fillHandler.key,
           });
 
           return {
@@ -212,7 +212,7 @@ const createChipTabsHandler = (_ctx: ComponentHandlerDeps) => {
 
       const nodes = findAllInstances<ChipTabsTriggerProperties>({
         node,
-        key: metadata.privateComponentTabItemChip.key,
+        key: triggerHandler.key,
       });
 
       const triggers = nodes.map((node) => {

--- a/packages/figma/src/codegen/targets/react/component/handlers/tag-group.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/tag-group.ts
@@ -64,7 +64,7 @@ export const createTagGroupHandler = (ctx: ComponentHandlerDeps) => {
   );
 };
 
-export const createTagGroupItemHandler = (ctx: ComponentHandlerDeps) =>
+const createTagGroupItemHandler = (ctx: ComponentHandlerDeps) =>
   defineComponentHandler<TagGroupItemProperties>(
     metadata.privateComponentItemTag.key,
     ({ componentProperties: props }) => {

--- a/packages/figma/src/codegen/targets/react/component/handlers/tag-group.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/tag-group.ts
@@ -17,7 +17,7 @@ export const createTagGroupHandler = (ctx: ComponentHandlerDeps) => {
     (node, traverse) => {
       const itemNodes = findAllInstances<TagGroupItemProperties>({
         node,
-        key: metadata.privateComponentItemTag.key,
+        key: itemHandler.key,
       });
 
       const items = itemNodes.map((itemNode) =>

--- a/packages/figma/src/codegen/targets/react/component/handlers/text-field.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/text-field.ts
@@ -37,20 +37,20 @@ export const createTextInputFieldHandler = (ctx: ComponentHandlerDeps) => {
 
       const [textInputOutline] = findAllInstances<TextInputOutlineProperties>({
         node,
-        key: metadata.privateComponentTextInput.key,
+        key: metadata.componentTextInput.key,
       });
       const [textInputUnderline] = findAllInstances<TextInputUnderlineProperties>({
         node,
-        key: metadata.privateComponentUnderlineTextInput.key,
+        key: metadata.componentUnderlineTextInput.key,
       });
 
       const [fieldHeader] = findAllInstances<FieldHeaderProperties>({
         node,
-        key: metadata.privateComponentFieldHeader.key,
+        key: metadata.componentFieldHeader.key,
       });
       const [fieldFooter] = findAllInstances<FieldFooterProperties>({
         node,
-        key: metadata.privateComponentFieldFooter.key,
+        key: metadata.componentFieldFooter.key,
       });
 
       const fieldProps = {
@@ -193,15 +193,15 @@ export const createTextareaFieldHandler = (ctx: ComponentHandlerDeps) => {
     (node, traverse) => {
       const [textarea] = findAllInstances<TextareaProperties>({
         node,
-        key: metadata.privateComponentTextarea.key,
+        key: metadata.componentTextarea.key,
       });
       const [fieldHeader] = findAllInstances<FieldHeaderProperties>({
         node,
-        key: metadata.privateComponentFieldHeader.key,
+        key: metadata.componentFieldHeader.key,
       });
       const [fieldFooter] = findAllInstances<FieldFooterProperties>({
         node,
-        key: metadata.privateComponentFieldFooter.key,
+        key: metadata.componentFieldFooter.key,
       });
 
       const fieldProps = {

--- a/packages/figma/src/codegen/targets/react/component/handlers/text-field.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/text-field.ts
@@ -46,11 +46,11 @@ export const createTextInputFieldHandler = (ctx: ComponentHandlerDeps) => {
 
       const [fieldHeader] = findAllInstances<FieldHeaderProperties>({
         node,
-        key: metadata.componentFieldHeader.key,
+        key: fieldHeaderHandler.key,
       });
       const [fieldFooter] = findAllInstances<FieldFooterProperties>({
         node,
-        key: metadata.componentFieldFooter.key,
+        key: fieldFooterHandler.key,
       });
 
       const fieldProps = {
@@ -197,11 +197,11 @@ export const createTextareaFieldHandler = (ctx: ComponentHandlerDeps) => {
       });
       const [fieldHeader] = findAllInstances<FieldHeaderProperties>({
         node,
-        key: metadata.componentFieldHeader.key,
+        key: fieldHeaderHandler.key,
       });
       const [fieldFooter] = findAllInstances<FieldFooterProperties>({
         node,
-        key: metadata.componentFieldFooter.key,
+        key: fieldFooterHandler.key,
       });
 
       const fieldProps = {

--- a/packages/figma/src/entities/data/__generated__/component-sets/index.d.ts
+++ b/packages/figma/src/entities/data/__generated__/component-sets/index.d.ts
@@ -170,37 +170,6 @@ export declare const privateTemplateChipGroup: {
   }
 };
 
-export declare const privateComponentFieldFooter: {
-  "name": "privateComponentFieldFooter",
-  "key": "a2e73c375b787756a11e84c5915f8251c621ee3a",
-  "componentPropertyDefinitions": {
-    "Text#2770:0": {
-      "type": "TEXT"
-    },
-    "Has Prefix#2778:13": {
-      "type": "BOOLEAN"
-    },
-    "Error Text#32821:0": {
-      "type": "TEXT"
-    },
-    "Type": {
-      "type": "VARIANT",
-      "variantOptions": [
-        "Description",
-        "Description With Character Count",
-        "Character Count"
-      ]
-    },
-    "Error": {
-      "type": "VARIANT",
-      "variantOptions": [
-        "true",
-        "false"
-      ]
-    }
-  }
-};
-
 export declare const privateComponentFieldFooterCharacterCount: {
   "name": "privateComponentFieldFooterCharacterCount",
   "key": "73f1a9275275c87b563e879e6948318523faf8e4",
@@ -217,29 +186,6 @@ export declare const privateComponentFieldFooterCharacterCount: {
         "Null",
         "Has Value",
         "Error"
-      ]
-    }
-  }
-};
-
-export declare const privateComponentFieldHeader: {
-  "name": "privateComponentFieldHeader",
-  "key": "8371fe9083cb9bebfb4ee51b0791bfb00a799dd6",
-  "componentPropertyDefinitions": {
-    "Label#34796:0": {
-      "type": "TEXT"
-    },
-    "Has Indicator#34796:1": {
-      "type": "BOOLEAN"
-    },
-    "Has Suffix#34796:2": {
-      "type": "BOOLEAN"
-    },
-    "Weight": {
-      "type": "VARIANT",
-      "variantOptions": [
-        "Medium",
-        "Bold"
       ]
     }
   }
@@ -272,30 +218,6 @@ export declare const privateComponentFieldHeaderSuffix: {
         "Ghost Button",
         "Icon",
         "Custom"
-      ]
-    }
-  }
-};
-
-export declare const privateComponentInputButton: {
-  "name": "privateComponentInputButton",
-  "key": "1220e63a59a31b50eefe5c4ec1a4e516ba70b07b",
-  "componentPropertyDefinitions": {
-    "Has Prefix#32514:10": {
-      "type": "BOOLEAN"
-    },
-    "Has Suffix#32865:68": {
-      "type": "BOOLEAN"
-    },
-    "State": {
-      "type": "VARIANT",
-      "variantOptions": [
-        "Enabled",
-        "Error",
-        "Disabled",
-        "Read Only",
-        "Pressed",
-        "Error Pressed"
       ]
     }
   }
@@ -929,34 +851,6 @@ export declare const privateComponentTabsLine: {
   }
 };
 
-export declare const privateComponentTextInput: {
-  "name": "privateComponentTextInput",
-  "key": "1f3e7bd2f1d39a76e304188b5a8b800d7c87aff2",
-  "componentPropertyDefinitions": {
-    "Has Prefix#32514:10": {
-      "type": "BOOLEAN"
-    },
-    "Loading Text#32734:0": {
-      "type": "TEXT"
-    },
-    "Has Suffix#32865:68": {
-      "type": "BOOLEAN"
-    },
-    "State": {
-      "type": "VARIANT",
-      "variantOptions": [
-        "Enabled",
-        "Focused",
-        "Error",
-        "Error Focused",
-        "Disabled",
-        "Read Only",
-        "AI Loading (Figma Only)"
-      ]
-    }
-  }
-};
-
 export declare const privateComponentTextInputCardNumberInput: {
   "name": "privateComponentTextInputCardNumberInput",
   "key": "60888e1eba691721f0ec6a41df43c1c075e5beac",
@@ -1112,32 +1006,6 @@ export declare const privateComponentTextInputSuffix: {
         "Icon",
         "Icon Button (Ghost Button)",
         "Custom"
-      ]
-    }
-  }
-};
-
-export declare const privateComponentTextarea: {
-  "name": "privateComponentTextarea",
-  "key": "e20ec5b725e0fdbaca728cecdc72b0c485728b4d",
-  "componentPropertyDefinitions": {
-    "Auto Size (Figma Only)": {
-      "type": "VARIANT",
-      "variantOptions": [
-        "true",
-        "false"
-      ]
-    },
-    "State": {
-      "type": "VARIANT",
-      "variantOptions": [
-        "Enabled",
-        "Focused",
-        "Error",
-        "Error Focused",
-        "Disabled",
-        "Read Only",
-        "AI Loading (Figma Only)"
       ]
     }
   }
@@ -1303,31 +1171,6 @@ export declare const privateComponentTopNavigationTitleRight: {
         "Count",
         "Manner Temp Badge",
         "Custom"
-      ]
-    }
-  }
-};
-
-export declare const privateComponentUnderlineTextInput: {
-  "name": "privateComponentUnderlineTextInput",
-  "key": "004c8591153865af3fe3efb9c552cd280b9fd31d",
-  "componentPropertyDefinitions": {
-    "Has Prefix#34125:0": {
-      "type": "BOOLEAN"
-    },
-    "Has Suffix#34125:8": {
-      "type": "BOOLEAN"
-    },
-    "State": {
-      "type": "VARIANT",
-      "variantOptions": [
-        "Enabled",
-        "Focused",
-        "Error",
-        "Error Focused",
-        "Disabled",
-        "Read Only",
-        "AI Loading (Figma Only)"
       ]
     }
   }
@@ -2399,8 +2242,8 @@ export declare const componentCheckbox: {
   }
 };
 
-export declare const templateCheckboxGroupField: {
-  "name": "templateCheckboxGroupField",
+export declare const templateCheckboxField: {
+  "name": "templateCheckboxField",
   "key": "214dd0fc8a3c5bc1e0c90cce29936f1ec6a26c3c",
   "componentPropertyDefinitions": {
     "Show Header#40606:8": {
@@ -3226,8 +3069,8 @@ export declare const componentRadio: {
   }
 };
 
-export declare const templateRadioGroupField: {
-  "name": "templateRadioGroupField",
+export declare const templateRadioField: {
+  "name": "templateRadioField",
   "key": "a3f159c223e3a0888fc48098c1580793297f82e9",
   "componentPropertyDefinitions": {
     "Show Header#40606:8": {
@@ -3464,6 +3307,28 @@ export declare const componentSegmentedControl: {
         "2",
         "3",
         "4"
+      ]
+    }
+  }
+};
+
+export declare const templateSelectBoxField: {
+  "name": "templateSelectBoxField",
+  "key": "cddac54129eed15830319d1e30480f42ea80d4d3",
+  "componentPropertyDefinitions": {
+    "Show Header#40606:8": {
+      "type": "BOOLEAN"
+    },
+    "Show Footer#40606:9": {
+      "type": "BOOLEAN"
+    },
+    "State": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "Enabled",
+        "Error",
+        "Disabled",
+        "Read Only"
       ]
     }
   }
@@ -3941,6 +3806,163 @@ export declare const componentUserSelectionFigmaOnly: {
       "variantOptions": [
         "iOS",
         "Android"
+      ]
+    }
+  }
+};
+
+export declare const componentFieldFooter: {
+  "name": "componentFieldFooter",
+  "key": "a2e73c375b787756a11e84c5915f8251c621ee3a",
+  "componentPropertyDefinitions": {
+    "Text#2770:0": {
+      "type": "TEXT"
+    },
+    "Has Prefix#2778:13": {
+      "type": "BOOLEAN"
+    },
+    "Error Text#32821:0": {
+      "type": "TEXT"
+    },
+    "Type": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "Description",
+        "Description With Character Count",
+        "Character Count"
+      ]
+    },
+    "Error": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "true",
+        "false"
+      ]
+    }
+  }
+};
+
+export declare const componentFieldHeader: {
+  "name": "componentFieldHeader",
+  "key": "8371fe9083cb9bebfb4ee51b0791bfb00a799dd6",
+  "componentPropertyDefinitions": {
+    "Label#34796:0": {
+      "type": "TEXT"
+    },
+    "Has Indicator#34796:1": {
+      "type": "BOOLEAN"
+    },
+    "Has Suffix#34796:2": {
+      "type": "BOOLEAN"
+    },
+    "Weight": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "Medium",
+        "Bold"
+      ]
+    }
+  }
+};
+
+export declare const componentInputButton: {
+  "name": "componentInputButton",
+  "key": "1220e63a59a31b50eefe5c4ec1a4e516ba70b07b",
+  "componentPropertyDefinitions": {
+    "Has Prefix#32514:10": {
+      "type": "BOOLEAN"
+    },
+    "Has Suffix#32865:68": {
+      "type": "BOOLEAN"
+    },
+    "State": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "Enabled",
+        "Error",
+        "Disabled",
+        "Read Only",
+        "Pressed",
+        "Error Pressed"
+      ]
+    }
+  }
+};
+
+export declare const componentTextInput: {
+  "name": "componentTextInput",
+  "key": "1f3e7bd2f1d39a76e304188b5a8b800d7c87aff2",
+  "componentPropertyDefinitions": {
+    "Has Prefix#32514:10": {
+      "type": "BOOLEAN"
+    },
+    "Loading Text#32734:0": {
+      "type": "TEXT"
+    },
+    "Has Suffix#32865:68": {
+      "type": "BOOLEAN"
+    },
+    "State": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "Enabled",
+        "Focused",
+        "Error",
+        "Error Focused",
+        "Disabled",
+        "Read Only",
+        "AI Loading (Figma Only)"
+      ]
+    }
+  }
+};
+
+export declare const componentTextarea: {
+  "name": "componentTextarea",
+  "key": "e20ec5b725e0fdbaca728cecdc72b0c485728b4d",
+  "componentPropertyDefinitions": {
+    "Auto Size (Figma Only)": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "true",
+        "false"
+      ]
+    },
+    "State": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "Enabled",
+        "Focused",
+        "Error",
+        "Error Focused",
+        "Disabled",
+        "Read Only",
+        "AI Loading (Figma Only)"
+      ]
+    }
+  }
+};
+
+export declare const componentUnderlineTextInput: {
+  "name": "componentUnderlineTextInput",
+  "key": "004c8591153865af3fe3efb9c552cd280b9fd31d",
+  "componentPropertyDefinitions": {
+    "Has Prefix#34125:0": {
+      "type": "BOOLEAN"
+    },
+    "Has Suffix#34125:8": {
+      "type": "BOOLEAN"
+    },
+    "State": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "Enabled",
+        "Focused",
+        "Error",
+        "Error Focused",
+        "Disabled",
+        "Read Only",
+        "AI Loading (Figma Only)"
       ]
     }
   }

--- a/packages/figma/src/entities/data/__generated__/component-sets/index.d.ts
+++ b/packages/figma/src/entities/data/__generated__/component-sets/index.d.ts
@@ -680,6 +680,22 @@ export declare const privateComponentSegmentedControlItem: {
   }
 };
 
+export declare const privateComponentSelectBoxItemCheckmark: {
+  "name": "privateComponentSelectBoxItemCheckmark",
+  "key": "2d91bde3c21bc38b2b07d8e1b87a03116e96555d",
+  "componentPropertyDefinitions": {
+    "State": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "Enabled",
+        "Pressed",
+        "Selected",
+        "Disabled"
+      ]
+    }
+  }
+};
+
 export declare const privateComponentSliderItemHandles: {
   "name": "privateComponentSliderItemHandles",
   "key": "950b33735d6dda594436c876386b921908dedf64",

--- a/packages/figma/src/entities/data/__generated__/component-sets/index.mjs
+++ b/packages/figma/src/entities/data/__generated__/component-sets/index.mjs
@@ -170,37 +170,6 @@ export const privateTemplateChipGroup = {
   }
 };
 
-export const privateComponentFieldFooter = {
-  "name": "privateComponentFieldFooter",
-  "key": "a2e73c375b787756a11e84c5915f8251c621ee3a",
-  "componentPropertyDefinitions": {
-    "Text#2770:0": {
-      "type": "TEXT"
-    },
-    "Has Prefix#2778:13": {
-      "type": "BOOLEAN"
-    },
-    "Error Text#32821:0": {
-      "type": "TEXT"
-    },
-    "Type": {
-      "type": "VARIANT",
-      "variantOptions": [
-        "Description",
-        "Description With Character Count",
-        "Character Count"
-      ]
-    },
-    "Error": {
-      "type": "VARIANT",
-      "variantOptions": [
-        "true",
-        "false"
-      ]
-    }
-  }
-};
-
 export const privateComponentFieldFooterCharacterCount = {
   "name": "privateComponentFieldFooterCharacterCount",
   "key": "73f1a9275275c87b563e879e6948318523faf8e4",
@@ -217,29 +186,6 @@ export const privateComponentFieldFooterCharacterCount = {
         "Null",
         "Has Value",
         "Error"
-      ]
-    }
-  }
-};
-
-export const privateComponentFieldHeader = {
-  "name": "privateComponentFieldHeader",
-  "key": "8371fe9083cb9bebfb4ee51b0791bfb00a799dd6",
-  "componentPropertyDefinitions": {
-    "Label#34796:0": {
-      "type": "TEXT"
-    },
-    "Has Indicator#34796:1": {
-      "type": "BOOLEAN"
-    },
-    "Has Suffix#34796:2": {
-      "type": "BOOLEAN"
-    },
-    "Weight": {
-      "type": "VARIANT",
-      "variantOptions": [
-        "Medium",
-        "Bold"
       ]
     }
   }
@@ -272,30 +218,6 @@ export const privateComponentFieldHeaderSuffix = {
         "Ghost Button",
         "Icon",
         "Custom"
-      ]
-    }
-  }
-};
-
-export const privateComponentInputButton = {
-  "name": "privateComponentInputButton",
-  "key": "1220e63a59a31b50eefe5c4ec1a4e516ba70b07b",
-  "componentPropertyDefinitions": {
-    "Has Prefix#32514:10": {
-      "type": "BOOLEAN"
-    },
-    "Has Suffix#32865:68": {
-      "type": "BOOLEAN"
-    },
-    "State": {
-      "type": "VARIANT",
-      "variantOptions": [
-        "Enabled",
-        "Error",
-        "Disabled",
-        "Read Only",
-        "Pressed",
-        "Error Pressed"
       ]
     }
   }
@@ -929,34 +851,6 @@ export const privateComponentTabsLine = {
   }
 };
 
-export const privateComponentTextInput = {
-  "name": "privateComponentTextInput",
-  "key": "1f3e7bd2f1d39a76e304188b5a8b800d7c87aff2",
-  "componentPropertyDefinitions": {
-    "Has Prefix#32514:10": {
-      "type": "BOOLEAN"
-    },
-    "Loading Text#32734:0": {
-      "type": "TEXT"
-    },
-    "Has Suffix#32865:68": {
-      "type": "BOOLEAN"
-    },
-    "State": {
-      "type": "VARIANT",
-      "variantOptions": [
-        "Enabled",
-        "Focused",
-        "Error",
-        "Error Focused",
-        "Disabled",
-        "Read Only",
-        "AI Loading (Figma Only)"
-      ]
-    }
-  }
-};
-
 export const privateComponentTextInputCardNumberInput = {
   "name": "privateComponentTextInputCardNumberInput",
   "key": "60888e1eba691721f0ec6a41df43c1c075e5beac",
@@ -1112,32 +1006,6 @@ export const privateComponentTextInputSuffix = {
         "Icon",
         "Icon Button (Ghost Button)",
         "Custom"
-      ]
-    }
-  }
-};
-
-export const privateComponentTextarea = {
-  "name": "privateComponentTextarea",
-  "key": "e20ec5b725e0fdbaca728cecdc72b0c485728b4d",
-  "componentPropertyDefinitions": {
-    "Auto Size (Figma Only)": {
-      "type": "VARIANT",
-      "variantOptions": [
-        "true",
-        "false"
-      ]
-    },
-    "State": {
-      "type": "VARIANT",
-      "variantOptions": [
-        "Enabled",
-        "Focused",
-        "Error",
-        "Error Focused",
-        "Disabled",
-        "Read Only",
-        "AI Loading (Figma Only)"
       ]
     }
   }
@@ -1303,31 +1171,6 @@ export const privateComponentTopNavigationTitleRight = {
         "Count",
         "Manner Temp Badge",
         "Custom"
-      ]
-    }
-  }
-};
-
-export const privateComponentUnderlineTextInput = {
-  "name": "privateComponentUnderlineTextInput",
-  "key": "004c8591153865af3fe3efb9c552cd280b9fd31d",
-  "componentPropertyDefinitions": {
-    "Has Prefix#34125:0": {
-      "type": "BOOLEAN"
-    },
-    "Has Suffix#34125:8": {
-      "type": "BOOLEAN"
-    },
-    "State": {
-      "type": "VARIANT",
-      "variantOptions": [
-        "Enabled",
-        "Focused",
-        "Error",
-        "Error Focused",
-        "Disabled",
-        "Read Only",
-        "AI Loading (Figma Only)"
       ]
     }
   }
@@ -2399,8 +2242,8 @@ export const componentCheckbox = {
   }
 };
 
-export const templateCheckboxGroupField = {
-  "name": "templateCheckboxGroupField",
+export const templateCheckboxField = {
+  "name": "templateCheckboxField",
   "key": "214dd0fc8a3c5bc1e0c90cce29936f1ec6a26c3c",
   "componentPropertyDefinitions": {
     "Show Header#40606:8": {
@@ -3226,8 +3069,8 @@ export const componentRadio = {
   }
 };
 
-export const templateRadioGroupField = {
-  "name": "templateRadioGroupField",
+export const templateRadioField = {
+  "name": "templateRadioField",
   "key": "a3f159c223e3a0888fc48098c1580793297f82e9",
   "componentPropertyDefinitions": {
     "Show Header#40606:8": {
@@ -3464,6 +3307,28 @@ export const componentSegmentedControl = {
         "2",
         "3",
         "4"
+      ]
+    }
+  }
+};
+
+export const templateSelectBoxField = {
+  "name": "templateSelectBoxField",
+  "key": "cddac54129eed15830319d1e30480f42ea80d4d3",
+  "componentPropertyDefinitions": {
+    "Show Header#40606:8": {
+      "type": "BOOLEAN"
+    },
+    "Show Footer#40606:9": {
+      "type": "BOOLEAN"
+    },
+    "State": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "Enabled",
+        "Error",
+        "Disabled",
+        "Read Only"
       ]
     }
   }
@@ -3941,6 +3806,163 @@ export const componentUserSelectionFigmaOnly = {
       "variantOptions": [
         "iOS",
         "Android"
+      ]
+    }
+  }
+};
+
+export const componentFieldFooter = {
+  "name": "componentFieldFooter",
+  "key": "a2e73c375b787756a11e84c5915f8251c621ee3a",
+  "componentPropertyDefinitions": {
+    "Text#2770:0": {
+      "type": "TEXT"
+    },
+    "Has Prefix#2778:13": {
+      "type": "BOOLEAN"
+    },
+    "Error Text#32821:0": {
+      "type": "TEXT"
+    },
+    "Type": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "Description",
+        "Description With Character Count",
+        "Character Count"
+      ]
+    },
+    "Error": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "true",
+        "false"
+      ]
+    }
+  }
+};
+
+export const componentFieldHeader = {
+  "name": "componentFieldHeader",
+  "key": "8371fe9083cb9bebfb4ee51b0791bfb00a799dd6",
+  "componentPropertyDefinitions": {
+    "Label#34796:0": {
+      "type": "TEXT"
+    },
+    "Has Indicator#34796:1": {
+      "type": "BOOLEAN"
+    },
+    "Has Suffix#34796:2": {
+      "type": "BOOLEAN"
+    },
+    "Weight": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "Medium",
+        "Bold"
+      ]
+    }
+  }
+};
+
+export const componentInputButton = {
+  "name": "componentInputButton",
+  "key": "1220e63a59a31b50eefe5c4ec1a4e516ba70b07b",
+  "componentPropertyDefinitions": {
+    "Has Prefix#32514:10": {
+      "type": "BOOLEAN"
+    },
+    "Has Suffix#32865:68": {
+      "type": "BOOLEAN"
+    },
+    "State": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "Enabled",
+        "Error",
+        "Disabled",
+        "Read Only",
+        "Pressed",
+        "Error Pressed"
+      ]
+    }
+  }
+};
+
+export const componentTextInput = {
+  "name": "componentTextInput",
+  "key": "1f3e7bd2f1d39a76e304188b5a8b800d7c87aff2",
+  "componentPropertyDefinitions": {
+    "Has Prefix#32514:10": {
+      "type": "BOOLEAN"
+    },
+    "Loading Text#32734:0": {
+      "type": "TEXT"
+    },
+    "Has Suffix#32865:68": {
+      "type": "BOOLEAN"
+    },
+    "State": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "Enabled",
+        "Focused",
+        "Error",
+        "Error Focused",
+        "Disabled",
+        "Read Only",
+        "AI Loading (Figma Only)"
+      ]
+    }
+  }
+};
+
+export const componentTextarea = {
+  "name": "componentTextarea",
+  "key": "e20ec5b725e0fdbaca728cecdc72b0c485728b4d",
+  "componentPropertyDefinitions": {
+    "Auto Size (Figma Only)": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "true",
+        "false"
+      ]
+    },
+    "State": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "Enabled",
+        "Focused",
+        "Error",
+        "Error Focused",
+        "Disabled",
+        "Read Only",
+        "AI Loading (Figma Only)"
+      ]
+    }
+  }
+};
+
+export const componentUnderlineTextInput = {
+  "name": "componentUnderlineTextInput",
+  "key": "004c8591153865af3fe3efb9c552cd280b9fd31d",
+  "componentPropertyDefinitions": {
+    "Has Prefix#34125:0": {
+      "type": "BOOLEAN"
+    },
+    "Has Suffix#34125:8": {
+      "type": "BOOLEAN"
+    },
+    "State": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "Enabled",
+        "Focused",
+        "Error",
+        "Error Focused",
+        "Disabled",
+        "Read Only",
+        "AI Loading (Figma Only)"
       ]
     }
   }

--- a/packages/figma/src/entities/data/__generated__/component-sets/index.mjs
+++ b/packages/figma/src/entities/data/__generated__/component-sets/index.mjs
@@ -680,6 +680,22 @@ export const privateComponentSegmentedControlItem = {
   }
 };
 
+export const privateComponentSelectBoxItemCheckmark = {
+  "name": "privateComponentSelectBoxItemCheckmark",
+  "key": "2d91bde3c21bc38b2b07d8e1b87a03116e96555d",
+  "componentPropertyDefinitions": {
+    "State": {
+      "type": "VARIANT",
+      "variantOptions": [
+        "Enabled",
+        "Pressed",
+        "Selected",
+        "Disabled"
+      ]
+    }
+  }
+};
+
 export const privateComponentSliderItemHandles = {
   "name": "privateComponentSliderItemHandles",
   "key": "950b33735d6dda594436c876386b921908dedf64",

--- a/packages/figma/src/entities/data/__generated__/components/index.d.ts
+++ b/packages/figma/src/entities/data/__generated__/components/index.d.ts
@@ -1,3 +1,28 @@
+export declare const privateTemplateAddressPickerField: {
+  "name": "privateTemplateAddressPickerField",
+  "key": "4af06df28eca43fe2be5fe5ba5e6019587de9fac"
+};
+
+export declare const privateTemplateDatePickerField: {
+  "name": "privateTemplateDatePickerField",
+  "key": "c161d1326a1087258e4f762aa3c378c098308d98"
+};
+
+export declare const privateTemplateSelectField: {
+  "name": "privateTemplateSelectField",
+  "key": "a2138764f60a9b5a35e22ff40bc6cd701c660260"
+};
+
+export declare const privateTemplateTimePickerField: {
+  "name": "privateTemplateTimePickerField",
+  "key": "e38df17cf1e0f96e09774b015739dfde30d46115"
+};
+
+export declare const privateComponentBottomSheetContentsPlaceholder: {
+  "name": "privateComponentBottomSheetContentsPlaceholder",
+  "key": "e68b006d572300d3c987776192c8ab387fa45e05"
+};
+
 export declare const privateComponentField: {
   "name": "privateComponentField",
   "key": "96f0d114c3ec7826b22531502f05e82404835df4",
@@ -12,6 +37,21 @@ export declare const privateComponentField: {
       "type": "BOOLEAN"
     }
   }
+};
+
+export declare const privateComponentSelectBoxItemCustomContent: {
+  "name": "privateComponentSelectBoxItemCustomContent",
+  "key": "b327f8f0f74f9af3fded3f22fa4a64a08ed8d7cb"
+};
+
+export declare const privateComponentSliderItemHandleSliderItemValueIndicator: {
+  "name": "privateComponentSliderItemHandleSliderItemValueIndicator",
+  "key": "cfe6acde9d78c5020d2c84a0fdbd54f75277d231"
+};
+
+export declare const privateComponentSliderItemTrack: {
+  "name": "privateComponentSliderItemTrack",
+  "key": "dd6ea9f90ca6cabfb2f215155b77877adfaafdc9"
 };
 
 export declare const privateComponentTopNavigationLeftIconButton: {
@@ -34,6 +74,46 @@ export declare const templateFilterBar: {
   }
 };
 
+export declare const componentIcon: {
+  "name": "componentIcon",
+  "key": "4a6fdb3425a44a8bc1fe1502d830fa6e82decef7"
+};
+
+export declare const templateInformationList: {
+  "name": "templateInformationList",
+  "key": "ea1ff4070a5ef4ada5974dc7030e8f9a1b759cdb"
+};
+
+export declare const componentFigmaOnly: {
+  "name": "componentFigmaOnly",
+  "key": "a790da2ff1fb6f761abf202034920c1504b8f8f1"
+};
+
+export declare const componentBottomSheetContentsAgreement: {
+  "name": "componentBottomSheetContentsAgreement",
+  "key": "9d530235407646750ce8298b2815093dffcbbd83"
+};
+
+export declare const componentBottomSheetContentsFilter: {
+  "name": "componentBottomSheetContentsFilter",
+  "key": "9b50b222edac142fcce609da87250d7778e45ec4"
+};
+
+export declare const componentBottomSheetContentsImage: {
+  "name": "componentBottomSheetContentsImage",
+  "key": "b0b3e0f267ee67e93d6af524ce9d45764027507c"
+};
+
+export declare const componentBottomSheetContentsRange: {
+  "name": "componentBottomSheetContentsRange",
+  "key": "0e8d8770bacfb2567a054e9c2159fe5dad6a21ba"
+};
+
+export declare const componentBottomSheetContentsSorting: {
+  "name": "componentBottomSheetContentsSorting",
+  "key": "61f7b8ff0a1a374a10bb1a6a7a31f379863f2ac8"
+};
+
 export declare const componentChipSuffixIcon: {
   "name": "componentChipSuffixIcon",
   "key": "2f79e3c5a78315c854d7bd4499d142cfcc94548f",
@@ -42,6 +122,16 @@ export declare const componentChipSuffixIcon: {
       "type": "INSTANCE_SWAP"
     }
   }
+};
+
+export declare const componentImageFrameBadge: {
+  "name": "componentImageFrameBadge",
+  "key": "6a1feb47139040d6f7522528f7c91bf4fe7bcc84"
+};
+
+export declare const componentImageFrameCustom: {
+  "name": "componentImageFrameCustom",
+  "key": "60900f1f80431faf16f78e0570848d4656076990"
 };
 
 export declare const componentImageFrameIcon: {
@@ -64,6 +154,41 @@ export declare const componentImageFrameOverlayIndicator: {
   }
 };
 
+export declare const componentListItemDetailCustom: {
+  "name": "componentListItemDetailCustom",
+  "key": "d56900622b320739b5ce9dc9b12af1bcd1f6eeb4"
+};
+
+export declare const componentListItemDetailSubText_42a: {
+  "name": "componentListItemDetailSubText",
+  "key": "42ae9274fba94cb3b02c4e64b6584e5d03b73835"
+};
+
+export declare const componentListItemDetailSubText_07e: {
+  "name": "componentListItemDetailSubText",
+  "key": "07ea4a584c3fc5862e842efb5a151aff0059ee76"
+};
+
+export declare const componentListItemDetailTagGroup: {
+  "name": "componentListItemDetailTagGroup",
+  "key": "8e4743cce1ff6ac9e85269de6ce0ecff0ade06cb"
+};
+
+export declare const componentListItemPrefixAvatar: {
+  "name": "componentListItemPrefixAvatar",
+  "key": "27e33754113178be97e07195528c4ea020b3d3b7"
+};
+
+export declare const componentListItemPrefixCheckbox: {
+  "name": "componentListItemPrefixCheckbox",
+  "key": "563275de82ea1282cece0c35c0cd8d1625bc3a9d"
+};
+
+export declare const componentListItemPrefixCustom: {
+  "name": "componentListItemPrefixCustom",
+  "key": "b8059f5e0f85e0745fc61ff70f04571177c2cdfc"
+};
+
 export declare const componentListItemPrefixIcon: {
   "name": "componentListItemPrefixIcon",
   "key": "6c03690f1ce9f6c8b2fcdf4a7c57784f6cca12b9",
@@ -72,6 +197,21 @@ export declare const componentListItemPrefixIcon: {
       "type": "INSTANCE_SWAP"
     }
   }
+};
+
+export declare const componentListItemPrefixImage: {
+  "name": "componentListItemPrefixImage",
+  "key": "d06216ff143a960844799c0b8f9212628f78c69d"
+};
+
+export declare const componentListItemPrefixRadiomark: {
+  "name": "componentListItemPrefixRadiomark",
+  "key": "51f7c0917ebc559d81e63d0639cb632a792f40de"
+};
+
+export declare const componentListItemSuffixCheckbox: {
+  "name": "componentListItemSuffixCheckbox",
+  "key": "385ba8d607029e15e0d38ab415f783016488b185"
 };
 
 export declare const componentListItemSuffixChevron: {
@@ -97,6 +237,11 @@ export declare const componentListItemSuffixChevronWithText: {
   }
 };
 
+export declare const componentListItemSuffixCustom: {
+  "name": "componentListItemSuffixCustom",
+  "key": "26b86c9f8965d38aa5a1181a5cdc89fa487988d1"
+};
+
 export declare const componentListItemSuffixIcon: {
   "name": "componentListItemSuffixIcon",
   "key": "b7582e74a4bae29df8bc3f81368e528701a75855",
@@ -107,6 +252,16 @@ export declare const componentListItemSuffixIcon: {
   }
 };
 
+export declare const componentListItemSuffixRadiomark: {
+  "name": "componentListItemSuffixRadiomark",
+  "key": "09871d64c5c30407da586fb34425c2e83e147c81"
+};
+
+export declare const componentListItemSuffixSwitch: {
+  "name": "componentListItemSuffixSwitch",
+  "key": "0c26bd64e117e168b06eea69be903e4be762a728"
+};
+
 export declare const componentPageBannerSuffixAction: {
   "name": "componentPageBannerSuffixAction",
   "key": "1bbd6fff9a32b4211bbe3eeb09fde4e12e87caed",
@@ -115,4 +270,104 @@ export declare const componentPageBannerSuffixAction: {
       "type": "TEXT"
     }
   }
+};
+
+export declare const componentPageBannerSuffixCustom: {
+  "name": "componentPageBannerSuffixCustom",
+  "key": "40f2b4754bf16fa268941d03499dea575baa7e26"
+};
+
+export declare const componentPageBannerSuffixDismiss: {
+  "name": "componentPageBannerSuffixDismiss",
+  "key": "7bdf687e01996f3582b4056954fcb65f0bc67b2f"
+};
+
+export declare const componentPageBannerSuffixChevron: {
+  "name": "componentPageBannerSuffixChevron",
+  "key": "6f570f3b2b50649b0fd81190ebb42604ae3aa3a5"
+};
+
+export declare const componentResultSectionAssetTown: {
+  "name": "componentResultSectionAssetTown",
+  "key": "fb790e6aac3dea61df651faeb68078835c3e59ab"
+};
+
+export declare const componentResultSectionBridgeLottie: {
+  "name": "componentResultSectionBridgeLottie",
+  "key": "340c0c7a24b5a4c215b9e699d7af44578939485d"
+};
+
+export declare const componentResultSectionCompleteLottie: {
+  "name": "componentResultSectionCompleteLottie",
+  "key": "8c337e54aa38b7eb1eec9281c4934c5f0f87124c"
+};
+
+export declare const componentResultSectionCustom: {
+  "name": "componentResultSectionCustom",
+  "key": "c99bcc071b3ec4243ecdc1502545f427250a7286"
+};
+
+export declare const componentResultSectionFailLottie: {
+  "name": "componentResultSectionFailLottie",
+  "key": "ebace2f76203529076734076af40fbd04146b724"
+};
+
+export declare const componentResultSectionIconEmptyChat: {
+  "name": "componentResultSectionIconEmptyChat",
+  "key": "ed86a05df0ddeea4a84008ace70f750f5d1e46c9"
+};
+
+export declare const componentResultSectionIconEmptyList: {
+  "name": "componentResultSectionIconEmptyList",
+  "key": "99daf8fa5e0eed82c2dab35963f3a8e2f55968a3"
+};
+
+export declare const componentResultSectionIconEmptyPeople: {
+  "name": "componentResultSectionIconEmptyPeople",
+  "key": "18623f2ffffe641d3f9876189699839f27d279ac"
+};
+
+export declare const componentResultSectionIconEmptySearch: {
+  "name": "componentResultSectionIconEmptySearch",
+  "key": "4aa9c04ae49806098872f7c856b1925843ca7f4c"
+};
+
+export declare const componentSelectBoxSuffixCustom: {
+  "name": "componentSelectBoxSuffixCustom",
+  "key": "2ba92fc0cd161281686bf04767e8f2322c8a17f4"
+};
+
+export declare const componentSelectBoxItemPrefixAvatar: {
+  "name": "componentSelectBoxItemPrefixAvatar",
+  "key": "3d1ea583297f35880d9ec588326d9b82608565cc"
+};
+
+export declare const componentSelectBoxItemPrefixBadge: {
+  "name": "componentSelectBoxItemPrefixBadge",
+  "key": "d8c60ae70dee3a35795d83a9fd68282c0a90b554"
+};
+
+export declare const componentSelectBoxItemPrefixCustom: {
+  "name": "componentSelectBoxItemPrefixCustom",
+  "key": "8129b7b7804c8b22cf67d42df2383c1f5152298e"
+};
+
+export declare const componentSelectBoxItemPrefixIcon: {
+  "name": "componentSelectBoxItemPrefixIcon",
+  "key": "7184053a74eef18503170d08a1bdb74d37cbb65f"
+};
+
+export declare const componentSelectBoxItemPrefixImage: {
+  "name": "componentSelectBoxItemPrefixImage",
+  "key": "d4a3d2da63f6da1552f5d8f947105390248c9018"
+};
+
+export declare const componentSelectBoxItemSuffixCheck: {
+  "name": "componentSelectBoxItemSuffixCheck",
+  "key": "7b4bdf92e6852f0ecf85c1f6e0350ffaf674a172"
+};
+
+export declare const componentSelectBoxItemSuffixRadiomark: {
+  "name": "componentSelectBoxItemSuffixRadiomark",
+  "key": "cfb712b12fe2805b5594f8c143147c8aa3de490e"
 };

--- a/packages/figma/src/entities/data/__generated__/components/index.d.ts
+++ b/packages/figma/src/entities/data/__generated__/components/index.d.ts
@@ -354,7 +354,12 @@ export declare const componentSelectBoxItemPrefixCustom: {
 
 export declare const componentSelectBoxItemPrefixIcon: {
   "name": "componentSelectBoxItemPrefixIcon",
-  "key": "7184053a74eef18503170d08a1bdb74d37cbb65f"
+  "key": "7184053a74eef18503170d08a1bdb74d37cbb65f",
+  "componentPropertyDefinitions": {
+    "Icon#2475:0": {
+      "type": "INSTANCE_SWAP"
+    }
+  }
 };
 
 export declare const componentSelectBoxItemPrefixImage: {

--- a/packages/figma/src/entities/data/__generated__/components/index.mjs
+++ b/packages/figma/src/entities/data/__generated__/components/index.mjs
@@ -354,7 +354,12 @@ export const componentSelectBoxItemPrefixCustom = {
 
 export const componentSelectBoxItemPrefixIcon = {
   "name": "componentSelectBoxItemPrefixIcon",
-  "key": "7184053a74eef18503170d08a1bdb74d37cbb65f"
+  "key": "7184053a74eef18503170d08a1bdb74d37cbb65f",
+  "componentPropertyDefinitions": {
+    "Icon#2475:0": {
+      "type": "INSTANCE_SWAP"
+    }
+  }
 };
 
 export const componentSelectBoxItemPrefixImage = {

--- a/packages/figma/src/entities/data/__generated__/components/index.mjs
+++ b/packages/figma/src/entities/data/__generated__/components/index.mjs
@@ -1,3 +1,28 @@
+export const privateTemplateAddressPickerField = {
+  "name": "privateTemplateAddressPickerField",
+  "key": "4af06df28eca43fe2be5fe5ba5e6019587de9fac"
+};
+
+export const privateTemplateDatePickerField = {
+  "name": "privateTemplateDatePickerField",
+  "key": "c161d1326a1087258e4f762aa3c378c098308d98"
+};
+
+export const privateTemplateSelectField = {
+  "name": "privateTemplateSelectField",
+  "key": "a2138764f60a9b5a35e22ff40bc6cd701c660260"
+};
+
+export const privateTemplateTimePickerField = {
+  "name": "privateTemplateTimePickerField",
+  "key": "e38df17cf1e0f96e09774b015739dfde30d46115"
+};
+
+export const privateComponentBottomSheetContentsPlaceholder = {
+  "name": "privateComponentBottomSheetContentsPlaceholder",
+  "key": "e68b006d572300d3c987776192c8ab387fa45e05"
+};
+
 export const privateComponentField = {
   "name": "privateComponentField",
   "key": "96f0d114c3ec7826b22531502f05e82404835df4",
@@ -12,6 +37,21 @@ export const privateComponentField = {
       "type": "BOOLEAN"
     }
   }
+};
+
+export const privateComponentSelectBoxItemCustomContent = {
+  "name": "privateComponentSelectBoxItemCustomContent",
+  "key": "b327f8f0f74f9af3fded3f22fa4a64a08ed8d7cb"
+};
+
+export const privateComponentSliderItemHandleSliderItemValueIndicator = {
+  "name": "privateComponentSliderItemHandleSliderItemValueIndicator",
+  "key": "cfe6acde9d78c5020d2c84a0fdbd54f75277d231"
+};
+
+export const privateComponentSliderItemTrack = {
+  "name": "privateComponentSliderItemTrack",
+  "key": "dd6ea9f90ca6cabfb2f215155b77877adfaafdc9"
 };
 
 export const privateComponentTopNavigationLeftIconButton = {
@@ -34,6 +74,46 @@ export const templateFilterBar = {
   }
 };
 
+export const componentIcon = {
+  "name": "componentIcon",
+  "key": "4a6fdb3425a44a8bc1fe1502d830fa6e82decef7"
+};
+
+export const templateInformationList = {
+  "name": "templateInformationList",
+  "key": "ea1ff4070a5ef4ada5974dc7030e8f9a1b759cdb"
+};
+
+export const componentFigmaOnly = {
+  "name": "componentFigmaOnly",
+  "key": "a790da2ff1fb6f761abf202034920c1504b8f8f1"
+};
+
+export const componentBottomSheetContentsAgreement = {
+  "name": "componentBottomSheetContentsAgreement",
+  "key": "9d530235407646750ce8298b2815093dffcbbd83"
+};
+
+export const componentBottomSheetContentsFilter = {
+  "name": "componentBottomSheetContentsFilter",
+  "key": "9b50b222edac142fcce609da87250d7778e45ec4"
+};
+
+export const componentBottomSheetContentsImage = {
+  "name": "componentBottomSheetContentsImage",
+  "key": "b0b3e0f267ee67e93d6af524ce9d45764027507c"
+};
+
+export const componentBottomSheetContentsRange = {
+  "name": "componentBottomSheetContentsRange",
+  "key": "0e8d8770bacfb2567a054e9c2159fe5dad6a21ba"
+};
+
+export const componentBottomSheetContentsSorting = {
+  "name": "componentBottomSheetContentsSorting",
+  "key": "61f7b8ff0a1a374a10bb1a6a7a31f379863f2ac8"
+};
+
 export const componentChipSuffixIcon = {
   "name": "componentChipSuffixIcon",
   "key": "2f79e3c5a78315c854d7bd4499d142cfcc94548f",
@@ -42,6 +122,16 @@ export const componentChipSuffixIcon = {
       "type": "INSTANCE_SWAP"
     }
   }
+};
+
+export const componentImageFrameBadge = {
+  "name": "componentImageFrameBadge",
+  "key": "6a1feb47139040d6f7522528f7c91bf4fe7bcc84"
+};
+
+export const componentImageFrameCustom = {
+  "name": "componentImageFrameCustom",
+  "key": "60900f1f80431faf16f78e0570848d4656076990"
 };
 
 export const componentImageFrameIcon = {
@@ -64,6 +154,41 @@ export const componentImageFrameOverlayIndicator = {
   }
 };
 
+export const componentListItemDetailCustom = {
+  "name": "componentListItemDetailCustom",
+  "key": "d56900622b320739b5ce9dc9b12af1bcd1f6eeb4"
+};
+
+export const componentListItemDetailSubText_42a = {
+  "name": "componentListItemDetailSubText",
+  "key": "42ae9274fba94cb3b02c4e64b6584e5d03b73835"
+};
+
+export const componentListItemDetailSubText_07e = {
+  "name": "componentListItemDetailSubText",
+  "key": "07ea4a584c3fc5862e842efb5a151aff0059ee76"
+};
+
+export const componentListItemDetailTagGroup = {
+  "name": "componentListItemDetailTagGroup",
+  "key": "8e4743cce1ff6ac9e85269de6ce0ecff0ade06cb"
+};
+
+export const componentListItemPrefixAvatar = {
+  "name": "componentListItemPrefixAvatar",
+  "key": "27e33754113178be97e07195528c4ea020b3d3b7"
+};
+
+export const componentListItemPrefixCheckbox = {
+  "name": "componentListItemPrefixCheckbox",
+  "key": "563275de82ea1282cece0c35c0cd8d1625bc3a9d"
+};
+
+export const componentListItemPrefixCustom = {
+  "name": "componentListItemPrefixCustom",
+  "key": "b8059f5e0f85e0745fc61ff70f04571177c2cdfc"
+};
+
 export const componentListItemPrefixIcon = {
   "name": "componentListItemPrefixIcon",
   "key": "6c03690f1ce9f6c8b2fcdf4a7c57784f6cca12b9",
@@ -72,6 +197,21 @@ export const componentListItemPrefixIcon = {
       "type": "INSTANCE_SWAP"
     }
   }
+};
+
+export const componentListItemPrefixImage = {
+  "name": "componentListItemPrefixImage",
+  "key": "d06216ff143a960844799c0b8f9212628f78c69d"
+};
+
+export const componentListItemPrefixRadiomark = {
+  "name": "componentListItemPrefixRadiomark",
+  "key": "51f7c0917ebc559d81e63d0639cb632a792f40de"
+};
+
+export const componentListItemSuffixCheckbox = {
+  "name": "componentListItemSuffixCheckbox",
+  "key": "385ba8d607029e15e0d38ab415f783016488b185"
 };
 
 export const componentListItemSuffixChevron = {
@@ -97,6 +237,11 @@ export const componentListItemSuffixChevronWithText = {
   }
 };
 
+export const componentListItemSuffixCustom = {
+  "name": "componentListItemSuffixCustom",
+  "key": "26b86c9f8965d38aa5a1181a5cdc89fa487988d1"
+};
+
 export const componentListItemSuffixIcon = {
   "name": "componentListItemSuffixIcon",
   "key": "b7582e74a4bae29df8bc3f81368e528701a75855",
@@ -107,6 +252,16 @@ export const componentListItemSuffixIcon = {
   }
 };
 
+export const componentListItemSuffixRadiomark = {
+  "name": "componentListItemSuffixRadiomark",
+  "key": "09871d64c5c30407da586fb34425c2e83e147c81"
+};
+
+export const componentListItemSuffixSwitch = {
+  "name": "componentListItemSuffixSwitch",
+  "key": "0c26bd64e117e168b06eea69be903e4be762a728"
+};
+
 export const componentPageBannerSuffixAction = {
   "name": "componentPageBannerSuffixAction",
   "key": "1bbd6fff9a32b4211bbe3eeb09fde4e12e87caed",
@@ -115,4 +270,104 @@ export const componentPageBannerSuffixAction = {
       "type": "TEXT"
     }
   }
+};
+
+export const componentPageBannerSuffixCustom = {
+  "name": "componentPageBannerSuffixCustom",
+  "key": "40f2b4754bf16fa268941d03499dea575baa7e26"
+};
+
+export const componentPageBannerSuffixDismiss = {
+  "name": "componentPageBannerSuffixDismiss",
+  "key": "7bdf687e01996f3582b4056954fcb65f0bc67b2f"
+};
+
+export const componentPageBannerSuffixChevron = {
+  "name": "componentPageBannerSuffixChevron",
+  "key": "6f570f3b2b50649b0fd81190ebb42604ae3aa3a5"
+};
+
+export const componentResultSectionAssetTown = {
+  "name": "componentResultSectionAssetTown",
+  "key": "fb790e6aac3dea61df651faeb68078835c3e59ab"
+};
+
+export const componentResultSectionBridgeLottie = {
+  "name": "componentResultSectionBridgeLottie",
+  "key": "340c0c7a24b5a4c215b9e699d7af44578939485d"
+};
+
+export const componentResultSectionCompleteLottie = {
+  "name": "componentResultSectionCompleteLottie",
+  "key": "8c337e54aa38b7eb1eec9281c4934c5f0f87124c"
+};
+
+export const componentResultSectionCustom = {
+  "name": "componentResultSectionCustom",
+  "key": "c99bcc071b3ec4243ecdc1502545f427250a7286"
+};
+
+export const componentResultSectionFailLottie = {
+  "name": "componentResultSectionFailLottie",
+  "key": "ebace2f76203529076734076af40fbd04146b724"
+};
+
+export const componentResultSectionIconEmptyChat = {
+  "name": "componentResultSectionIconEmptyChat",
+  "key": "ed86a05df0ddeea4a84008ace70f750f5d1e46c9"
+};
+
+export const componentResultSectionIconEmptyList = {
+  "name": "componentResultSectionIconEmptyList",
+  "key": "99daf8fa5e0eed82c2dab35963f3a8e2f55968a3"
+};
+
+export const componentResultSectionIconEmptyPeople = {
+  "name": "componentResultSectionIconEmptyPeople",
+  "key": "18623f2ffffe641d3f9876189699839f27d279ac"
+};
+
+export const componentResultSectionIconEmptySearch = {
+  "name": "componentResultSectionIconEmptySearch",
+  "key": "4aa9c04ae49806098872f7c856b1925843ca7f4c"
+};
+
+export const componentSelectBoxSuffixCustom = {
+  "name": "componentSelectBoxSuffixCustom",
+  "key": "2ba92fc0cd161281686bf04767e8f2322c8a17f4"
+};
+
+export const componentSelectBoxItemPrefixAvatar = {
+  "name": "componentSelectBoxItemPrefixAvatar",
+  "key": "3d1ea583297f35880d9ec588326d9b82608565cc"
+};
+
+export const componentSelectBoxItemPrefixBadge = {
+  "name": "componentSelectBoxItemPrefixBadge",
+  "key": "d8c60ae70dee3a35795d83a9fd68282c0a90b554"
+};
+
+export const componentSelectBoxItemPrefixCustom = {
+  "name": "componentSelectBoxItemPrefixCustom",
+  "key": "8129b7b7804c8b22cf67d42df2383c1f5152298e"
+};
+
+export const componentSelectBoxItemPrefixIcon = {
+  "name": "componentSelectBoxItemPrefixIcon",
+  "key": "7184053a74eef18503170d08a1bdb74d37cbb65f"
+};
+
+export const componentSelectBoxItemPrefixImage = {
+  "name": "componentSelectBoxItemPrefixImage",
+  "key": "d4a3d2da63f6da1552f5d8f947105390248c9018"
+};
+
+export const componentSelectBoxItemSuffixCheck = {
+  "name": "componentSelectBoxItemSuffixCheck",
+  "key": "7b4bdf92e6852f0ecf85c1f6e0350ffaf674a172"
+};
+
+export const componentSelectBoxItemSuffixRadiomark = {
+  "name": "componentSelectBoxItemSuffixRadiomark",
+  "key": "cfb712b12fe2805b5594f8c143147c8aa3de490e"
 };


### PR DESCRIPTION
## Summary
- Figma에서 추출한 generated keys를 사용하도록 component handler들 리팩토링
- SelectBox handler 신규 구현
- CheckboxGroup & RadioGroup handler 구현 개선

## Test plan
- [ ] Figma extractor 실행 테스트
- [ ] 생성된 코드 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 체크박스 그룹, 라디오 그룹, 선택상자 그룹 및 필드 수준 렌더링 지원 추가
  * 선택상자의 수평/수직 변형과 관련된 새 속성 타입 공개

* **버그 수정**
  * 하단 시트·필드 등 컴포넌트 키 참조 방식 개선
  * 컴포넌트 세트 필터링 정확성 향상 (중복/집합 관련 제외 처리 개선)

* **개선 사항**
  * 생성된 인덱스 파일의 중복 식별 및 해소 로직 추가
  * 하드코딩된 상수를 동적 키/생성 데이터로 대체
<!-- end of auto-generated comment: release notes by coderabbit.ai -->