### PR TITLE
feat(dialog, drawer): add onOpenChange details with reason and event

### DIFF
--- a/.changeset/busy-goats-count.md
+++ b/.changeset/busy-goats-count.md
@@ -1,0 +1,8 @@
+---
+"@seed-design/react-use-controllable-state": major
+"@seed-design/react-dialog": patch
+"@seed-design/react-drawer": patch
+"@seed-design/react": patch
+---
+
+`AlertDialogRoot` 및 `BottomSheetRoot`의 `onOpenChange` 두 번째 인자로 `details`를 제공합니다. `details.reason`과 `details.event`를 사용할 수 있습니다.

--- a/.changeset/busy-goats-count.md
+++ b/.changeset/busy-goats-count.md
@@ -5,6 +5,6 @@
 "@seed-design/react": patch
 ---
 
-`AlertDialogRoot` 및 `BottomSheetRoot`의 `onOpenChange` 두 번째 인자로 `details`를 제공합니다. `details.reason`과 `details.event`를 사용할 수 있습니다.
+`AlertDialogRoot`, `MenuSheetRoot` 및 `BottomSheetRoot`의 `onOpenChange` 두 번째 인자로 `details`를 제공합니다. `details.reason`과 `details.event`를 사용할 수 있습니다.
 
 `DialogAction`을 `DialogPrimitive.CloseButton`으로 교체합니다. `AlertDialogAction` `onClick` 핸들러에서 `event.preventDefault()`를 호출하여 닫기 동작을 방지할 수 있습니다. [(예제)](https://seed-design.io/react/components/alert-dialog#prevent-close)

--- a/.changeset/busy-goats-count.md
+++ b/.changeset/busy-goats-count.md
@@ -6,3 +6,5 @@
 ---
 
 `AlertDialogRoot` 및 `BottomSheetRoot`의 `onOpenChange` 두 번째 인자로 `details`를 제공합니다. `details.reason`과 `details.event`를 사용할 수 있습니다.
+
+`DialogAction`을 `DialogPrimitive.CloseButton`으로 교체합니다. `AlertDialogAction` `onClick` 핸들러에서 `event.preventDefault()`를 호출하여 닫기 동작을 방지할 수 있습니다. [(예제)](https://seed-design.io/react/components/alert-dialog#prevent-close)

--- a/bun.lock
+++ b/bun.lock
@@ -569,9 +569,9 @@
         "@radix-ui/react-compose-refs": "^1.1.2",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-use-callback-ref": "^1.1.0",
-        "@radix-ui/react-use-controllable-state": "^1.2.2",
         "@seed-design/dom-utils": "1.0.0",
         "@seed-design/react-primitive": "1.0.0",
+        "@seed-design/react-use-controllable-state": "0.0.0",
       },
       "devDependencies": {
         "@types/react": "^19.1.6",

--- a/bun.lock
+++ b/bun.lock
@@ -936,6 +936,23 @@
         "react-dom": ">=18.0.0",
       },
     },
+    "packages/react-headless/use-controllable-state": {
+      "name": "@seed-design/react-use-controllable-state",
+      "version": "0.0.0",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "^0.0.2",
+        "@radix-ui/react-use-layout-effect": "^1.1.1",
+      },
+      "devDependencies": {
+        "@types/react": "^19.1.6",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0",
+      },
+    },
     "packages/rootage": {
       "name": "@seed-design/rootage-artifacts",
       "version": "1.2.1",
@@ -2413,6 +2430,8 @@
     "@seed-design/react-text-field": ["@seed-design/react-text-field@workspace:packages/react-headless/text-field"],
 
     "@seed-design/react-toggle": ["@seed-design/react-toggle@workspace:packages/react-headless/toggle"],
+
+    "@seed-design/react-use-controllable-state": ["@seed-design/react-use-controllable-state@workspace:packages/react-headless/use-controllable-state"],
 
     "@seed-design/rootage-artifacts": ["@seed-design/rootage-artifacts@workspace:packages/rootage"],
 
@@ -5661,6 +5680,8 @@
     "@sanity/uuid/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
     "@seed-design/design-token/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
+
+    "@seed-design/docs/@types/node": ["@types/node@25.1.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA=="],
 
     "@seed-design/docs/zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -547,10 +547,10 @@
       "dependencies": {
         "@radix-ui/react-dismissable-layer": "^1.1.7",
         "@radix-ui/react-focus-scope": "^1.1.4",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-use-layout-effect": "^1.1.1",
         "@seed-design/dom-utils": "1.0.0",
         "@seed-design/react-primitive": "1.0.0",
+        "@seed-design/react-use-controllable-state": "0.0.0",
       },
       "devDependencies": {
         "@types/react": "^19.1.6",

--- a/docs/content/react/components/alert-dialog.mdx
+++ b/docs/content/react/components/alert-dialog.mdx
@@ -149,6 +149,45 @@ Trigger 외의 방식으로 AlertDialog를 열고 닫을 수 있습니다. 이 �
   ```
 </ComponentExample>
 
+### Prevent Close
+
+`AlertDialogAction`의 `onClick`에서 `e.preventDefault()`를 호출하면 다이얼로그가 닫히지 않습니다.
+
+<ComponentExample name="react/alert-dialog/prevent-close">
+  ```json doc-gen:file
+  {
+    "file": "examples/react/alert-dialog/prevent-close.tsx",
+    "codeblock": true
+  }
+  ```
+</ComponentExample>
+
+### `onOpenChange` Details
+
+`onOpenChange` 두 번째 인자로 `details`가 제공됩니다.
+
+#### `reason`
+
+**열릴 때** (`open: true`)
+
+- `"trigger"`: `AlertDialogTrigger` (`Dialog.Trigger`)로 열림
+
+**닫힐 때** (`open: false`)
+
+- `"closeButton"`: `AlertDialogAction`으로 닫힘
+- `"escapeKeyDown"`: <kbd>ESC</kbd> 키 사용
+- `"interactOutside"`: 외부 영역 클릭
+  - `AlertDialogRoot`는 기본적으로 `closeOnInteractOutside={false}`입니다. `interactOutside`는 이 옵션을 `true`로 설정한 경우에만 발생할 수 있습니다.
+
+<ComponentExample name="react/alert-dialog/open-change-reason">
+  ```json doc-gen:file
+  {
+    "file": "examples/react/alert-dialog/open-change-reason.tsx",
+    "codeblock": true
+  }
+  ```
+</ComponentExample>
+
 ### Portalled
 
 Portal은 기본적으로 `document.body`에 렌더링됩니다.

--- a/docs/content/react/components/bottom-sheet.mdx
+++ b/docs/content/react/components/bottom-sheet.mdx
@@ -105,6 +105,7 @@ Trigger 외의 방식으로 BottomSheet를 열고 닫을 수 있습니다. 이 �
 - `"escapeKeyDown"`: <kbd>ESC</kbd> 키 사용
 - `"interactOutside"`: 외부 영역 클릭
 - `"drag"`: 드래그로 닫힘
+- `"handleClickOnLastSnapPoint"`: 마지막 스냅 포인트에서 핸들 클릭으로 닫힘
 
 <ComponentExample name="react/bottom-sheet/open-change-reason">
   ```json doc-gen:file

--- a/docs/content/react/components/bottom-sheet.mdx
+++ b/docs/content/react/components/bottom-sheet.mdx
@@ -99,10 +99,6 @@ Trigger 외의 방식으로 BottomSheet를 열고 닫을 수 있습니다. 이 �
 
 #### `reason`
 
-**열릴 때** (`open: true`)
-
-- `"trigger"`: `BottomSheetTrigger` (`BottomSheet.Trigger`)로 열림
-
 **닫힐 때** (`open: false`)
 
 - `"closeButton"`: `BottomSheet.CloseButton`으로 닫힘

--- a/docs/content/react/components/bottom-sheet.mdx
+++ b/docs/content/react/components/bottom-sheet.mdx
@@ -93,6 +93,32 @@ Trigger 외의 방식으로 BottomSheet를 열고 닫을 수 있습니다. 이 �
   ```
 </ComponentExample>
 
+### `onOpenChange` Details
+
+`onOpenChange` 두 번째 인자로 `details`가 제공됩니다.
+
+#### `reason`
+
+**열릴 때** (`open: true`)
+
+- `"trigger"`: `BottomSheetTrigger` (`BottomSheet.Trigger`)로 열림
+
+**닫힐 때** (`open: false`)
+
+- `"closeButton"`: `BottomSheet.CloseButton`으로 닫힘
+- `"escapeKeyDown"`: <kbd>ESC</kbd> 키 사용
+- `"interactOutside"`: 외부 영역 클릭
+- `"drag"`: 드래그로 닫힘
+
+<ComponentExample name="react/bottom-sheet/open-change-reason">
+  ```json doc-gen:file
+  {
+    "file": "examples/react/bottom-sheet/open-change-reason.tsx",
+    "codeblock": true
+  }
+  ```
+</ComponentExample>
+
 ### Header Align
 
 `<BottomSheetRoot>`에 `headerAlign` prop을 설정하여 title과 description의 정렬을 설정할 수 있습니다.

--- a/docs/content/react/components/menu-sheet.mdx
+++ b/docs/content/react/components/menu-sheet.mdx
@@ -134,6 +134,31 @@ npx @seed-design/cli@latest add ui:menu-sheet
   ```
 </ComponentExample>
 
+### `onOpenChange` Details
+
+`onOpenChange` 두 번째 인자로 `details`가 제공됩니다.
+
+#### `reason`
+
+**열릴 때** (`open: true`)
+
+- `"trigger"`: `MenuSheetTrigger` (`MenuSheet.Trigger`)로 열림
+
+**닫힐 때** (`open: false`)
+
+- `"closeButton"`: `MenuSheet.CloseButton`으로 닫힘
+- `"escapeKeyDown"`: <kbd>ESC</kbd> 키 사용
+- `"interactOutside"`: 외부 영역 클릭
+
+<ComponentExample name="react/menu-sheet/open-change-reason">
+  ```json doc-gen:file
+  {
+    "file": "examples/react/menu-sheet/open-change-reason.tsx",
+    "codeblock": true
+  }
+  ```
+</ComponentExample>
+
 ### Skip Animation
 
 `skipAnimation` prop을 사용하여 MenuSheet의 enter/exit 애니메이션을 건너뛸 수 있습니다.

--- a/docs/examples/react/alert-dialog/open-change-reason.tsx
+++ b/docs/examples/react/alert-dialog/open-change-reason.tsx
@@ -18,7 +18,7 @@ export default function AlertDialogOnOpenChangeReason() {
   const [closeReason, setCloseReason] = useState<string | null>(null);
 
   return (
-    <VStack gap="x4" width="full" p="x4">
+    <VStack gap="x4" align="center">
       <AlertDialogRoot
         open={open}
         onOpenChange={(open, meta) => {

--- a/docs/examples/react/alert-dialog/open-change-reason.tsx
+++ b/docs/examples/react/alert-dialog/open-change-reason.tsx
@@ -1,0 +1,59 @@
+import { HStack, ResponsivePair, Text, VStack } from "@seed-design/react";
+import { useState } from "react";
+import { ActionButton } from "seed-design/ui/action-button";
+import {
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogRoot,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "seed-design/ui/alert-dialog";
+
+export default function AlertDialogOnOpenChangeReason() {
+  const [open, setOpen] = useState(false);
+  const [openReason, setOpenReason] = useState<string | null>(null);
+  const [closeReason, setCloseReason] = useState<string | null>(null);
+
+  return (
+    <VStack gap="x4" width="full" p="x4">
+      <AlertDialogRoot
+        open={open}
+        onOpenChange={(open, meta) => {
+          setOpen(open);
+
+          (open ? setOpenReason : setCloseReason)(meta?.reason ?? null);
+        }}
+      >
+        <AlertDialogTrigger asChild>
+          <ActionButton variant="neutralSolid">열기</ActionButton>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>알림</AlertDialogTitle>
+            <AlertDialogDescription>
+              ESC 키를 누르거나 버튼을 클릭하여 닫아보세요.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <ResponsivePair gap="x2">
+              <AlertDialogAction variant="neutralWeak">취소</AlertDialogAction>
+              <AlertDialogAction variant="neutralSolid">확인</AlertDialogAction>
+            </ResponsivePair>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialogRoot>
+
+      <HStack gap="x4">
+        <Text fontSize="t3" color="fg.neutralMuted">
+          마지막 열림 이유: {openReason ?? "-"}
+        </Text>
+        <Text fontSize="t3" color="fg.neutralMuted">
+          마지막 닫힘 이유: {closeReason ?? "-"}
+        </Text>
+      </HStack>
+    </VStack>
+  );
+}

--- a/docs/examples/react/alert-dialog/prevent-close.tsx
+++ b/docs/examples/react/alert-dialog/prevent-close.tsx
@@ -1,0 +1,57 @@
+import { Box, VStack } from "@seed-design/react";
+import { useState } from "react";
+import { ActionButton } from "seed-design/ui/action-button";
+import {
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogRoot,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "seed-design/ui/alert-dialog";
+import { Switch } from "seed-design/ui/switch";
+
+export default function AlertDialogPreventClose() {
+  const [preventClose, setPreventClose] = useState(true);
+
+  return (
+    <AlertDialogRoot>
+      <AlertDialogTrigger asChild>
+        <ActionButton variant="neutralSolid">열기</ActionButton>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>닫기 방지</AlertDialogTitle>
+          <AlertDialogDescription>
+            확인 버튼을 눌러도 다이얼로그가 닫히지 않도록 설정할 수 있습니다.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter asChild>
+          <VStack gap="x4">
+            <Box alignSelf="flex-start">
+              <Switch
+                size="16"
+                tone="neutral"
+                label="preventDefault 사용"
+                checked={preventClose}
+                onCheckedChange={setPreventClose}
+              />
+            </Box>
+            <AlertDialogAction
+              variant="neutralSolid"
+              onClick={(e) => {
+                if (preventClose) {
+                  e.preventDefault();
+                }
+              }}
+            >
+              확인
+            </AlertDialogAction>
+          </VStack>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialogRoot>
+  );
+}

--- a/docs/examples/react/bottom-sheet/open-change-reason.tsx
+++ b/docs/examples/react/bottom-sheet/open-change-reason.tsx
@@ -34,7 +34,7 @@ export default function BottomSheetOnOpenChangeReason() {
           <ActionButton variant="neutralSolid">열기</ActionButton>
         </BottomSheetTrigger>
         <BottomSheetContent title="알림" showHandle style={{ height: "100%", maxHeight: "97%" }}>
-          <BottomSheetBody minHeight="x16" paddingX="">
+          <BottomSheetBody minHeight="x16">
             <Text textStyle="t4Medium" color="fg.neutralMuted">
               ESC 키를 누르거나, 외부 영역을 클릭하거나, 아래로 스와이프하거나, 핸들을 탭하여 snap
               point를 순환해보세요.

--- a/docs/examples/react/bottom-sheet/open-change-reason.tsx
+++ b/docs/examples/react/bottom-sheet/open-change-reason.tsx
@@ -13,7 +13,6 @@ const snapPoints = ["200px", "400px", 1];
 export default function BottomSheetOnOpenChangeReason() {
   const [open, setOpen] = useState(false);
   const [snap, setSnap] = useState<number | string | null>(snapPoints[0]);
-  const [openReason, setOpenReason] = useState<string | null>(null);
   const [closeReason, setCloseReason] = useState<string | null>(null);
 
   return (
@@ -23,7 +22,9 @@ export default function BottomSheetOnOpenChangeReason() {
         onOpenChange={(open, details) => {
           setOpen(open);
 
-          (open ? setOpenReason : setCloseReason)(details?.reason ?? null);
+          if (open) return;
+
+          setCloseReason(details?.reason ?? null);
         }}
         snapPoints={snapPoints}
         activeSnapPoint={snap}
@@ -33,8 +34,8 @@ export default function BottomSheetOnOpenChangeReason() {
           <ActionButton variant="neutralSolid">열기</ActionButton>
         </BottomSheetTrigger>
         <BottomSheetContent title="알림" showHandle style={{ height: "100%", maxHeight: "97%" }}>
-          <BottomSheetBody minHeight="x16">
-            <Text fontSize="t3" color="fg.neutralMuted">
+          <BottomSheetBody minHeight="x16" paddingX="">
+            <Text textStyle="t4Medium" color="fg.neutralMuted">
               ESC 키를 누르거나, 외부 영역을 클릭하거나, 아래로 스와이프하거나, 핸들을 탭하여 snap
               point를 순환해보세요.
             </Text>
@@ -43,9 +44,6 @@ export default function BottomSheetOnOpenChangeReason() {
       </BottomSheetRoot>
 
       <HStack gap="x4">
-        <Text fontSize="t3" color="fg.neutralMuted">
-          마지막 열림 이유: {openReason ?? "-"}
-        </Text>
         <Text fontSize="t3" color="fg.neutralMuted">
           마지막 닫힘 이유: {closeReason ?? "-"}
         </Text>

--- a/docs/examples/react/bottom-sheet/open-change-reason.tsx
+++ b/docs/examples/react/bottom-sheet/open-change-reason.tsx
@@ -1,0 +1,55 @@
+import { HStack, Text, VStack } from "@seed-design/react";
+import { useState } from "react";
+import { ActionButton } from "seed-design/ui/action-button";
+import {
+  BottomSheetBody,
+  BottomSheetContent,
+  BottomSheetRoot,
+  BottomSheetTrigger,
+} from "seed-design/ui/bottom-sheet";
+
+const snapPoints = ["200px", "400px", 1];
+
+export default function BottomSheetOnOpenChangeReason() {
+  const [open, setOpen] = useState(false);
+  const [snap, setSnap] = useState<number | string | null>(snapPoints[0]);
+  const [openReason, setOpenReason] = useState<string | null>(null);
+  const [closeReason, setCloseReason] = useState<string | null>(null);
+
+  return (
+    <VStack gap="x4" align="center">
+      <BottomSheetRoot
+        open={open}
+        onOpenChange={(open, details) => {
+          setOpen(open);
+
+          (open ? setOpenReason : setCloseReason)(details?.reason ?? null);
+        }}
+        snapPoints={snapPoints}
+        activeSnapPoint={snap}
+        setActiveSnapPoint={setSnap}
+      >
+        <BottomSheetTrigger asChild>
+          <ActionButton variant="neutralSolid">열기</ActionButton>
+        </BottomSheetTrigger>
+        <BottomSheetContent title="알림" showHandle style={{ height: "100%", maxHeight: "97%" }}>
+          <BottomSheetBody minHeight="x16">
+            <Text fontSize="t3" color="fg.neutralMuted">
+              ESC 키를 누르거나, 외부 영역을 클릭하거나, 아래로 스와이프하거나, 핸들을 탭하여 snap
+              point를 순환해보세요.
+            </Text>
+          </BottomSheetBody>
+        </BottomSheetContent>
+      </BottomSheetRoot>
+
+      <HStack gap="x4">
+        <Text fontSize="t3" color="fg.neutralMuted">
+          마지막 열림 이유: {openReason ?? "-"}
+        </Text>
+        <Text fontSize="t3" color="fg.neutralMuted">
+          마지막 닫힘 이유: {closeReason ?? "-"}
+        </Text>
+      </HStack>
+    </VStack>
+  );
+}

--- a/docs/examples/react/menu-sheet/open-change-reason.tsx
+++ b/docs/examples/react/menu-sheet/open-change-reason.tsx
@@ -16,7 +16,7 @@ export default function MenuSheetOnOpenChangeReason() {
   const [closeReason, setCloseReason] = useState<string | null>(null);
 
   return (
-    <VStack gap="x4" width="full" p="x4">
+    <VStack gap="x4" align="center">
       <MenuSheetRoot
         open={open}
         onOpenChange={(open, meta) => {

--- a/docs/examples/react/menu-sheet/open-change-reason.tsx
+++ b/docs/examples/react/menu-sheet/open-change-reason.tsx
@@ -1,0 +1,50 @@
+import { IconEyeSlashLine } from "@karrotmarket/react-monochrome-icon";
+import { HStack, Text, VStack } from "@seed-design/react";
+import { useState } from "react";
+import { ActionButton } from "seed-design/ui/action-button";
+import {
+  MenuSheetContent,
+  MenuSheetGroup,
+  MenuSheetItem,
+  MenuSheetRoot,
+  MenuSheetTrigger,
+} from "seed-design/ui/menu-sheet";
+
+export default function MenuSheetOnOpenChangeReason() {
+  const [open, setOpen] = useState(false);
+  const [openReason, setOpenReason] = useState<string | null>(null);
+  const [closeReason, setCloseReason] = useState<string | null>(null);
+
+  return (
+    <VStack gap="x4" width="full" p="x4">
+      <MenuSheetRoot
+        open={open}
+        onOpenChange={(open, meta) => {
+          setOpen(open);
+
+          (open ? setOpenReason : setCloseReason)(meta?.reason ?? null);
+        }}
+      >
+        <MenuSheetTrigger asChild>
+          <ActionButton variant="neutralSolid">열기</ActionButton>
+        </MenuSheetTrigger>
+        <MenuSheetContent title="메뉴" aria-label="Menu Sheet">
+          <MenuSheetGroup>
+            <MenuSheetItem label="Action 1" prefixIcon={<IconEyeSlashLine />} />
+            <MenuSheetItem label="Action 2" prefixIcon={<IconEyeSlashLine />} />
+            <MenuSheetItem label="Action 3" prefixIcon={<IconEyeSlashLine />} />
+          </MenuSheetGroup>
+        </MenuSheetContent>
+      </MenuSheetRoot>
+
+      <HStack gap="x4">
+        <Text fontSize="t3" color="fg.neutralMuted">
+          마지막 열림 이유: {openReason ?? "-"}
+        </Text>
+        <Text fontSize="t3" color="fg.neutralMuted">
+          마지막 닫힘 이유: {closeReason ?? "-"}
+        </Text>
+      </HStack>
+    </VStack>
+  );
+}

--- a/packages/react-headless/dialog/package.json
+++ b/packages/react-headless/dialog/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@radix-ui/react-dismissable-layer": "^1.1.7",
     "@radix-ui/react-focus-scope": "^1.1.4",
-    "@radix-ui/react-use-controllable-state": "1.2.2",
+    "@seed-design/react-use-controllable-state": "0.0.0",
     "@radix-ui/react-use-layout-effect": "^1.1.1",
     "@seed-design/dom-utils": "1.0.0",
     "@seed-design/react-primitive": "1.0.0"

--- a/packages/react-headless/dialog/src/Dialog.tsx
+++ b/packages/react-headless/dialog/src/Dialog.tsx
@@ -61,19 +61,27 @@ export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>((pro
   return (
     <Presence present={api.open} unmountOnExit={api.unmountOnExit} lazyMount={api.lazyMount}>
       <FocusScope asChild loop trapped={api.open}>
+        {/* onDismiss = onEscapeKeyDown + onInteractOutside (= onFocusOutside + onPointerDownOutside) */}
         <DismissableLayer
           ref={ref}
-          onEscapeKeyDown={(e) => {
+          onEscapeKeyDown={(event) => {
             if (!api.closeOnEscape) {
-              e.preventDefault();
+              event.preventDefault();
+              return;
             }
+
+            api.setOpen(false, { reason: "escapeKeyDown", event });
           }}
-          onInteractOutside={(e) => {
+          // onInteractOutside = onFocusOutside + onPointerDownOutside
+          onInteractOutside={(event) => {
             if (!api.closeOnInteractOutside) {
-              e.preventDefault();
+              event.preventDefault();
+              return;
             }
+
+            api.setOpen(false, { reason: "interactOutside", event: event.detail.originalEvent });
           }}
-          onDismiss={() => api.setOpen(false)}
+          // onFocusOutside isn't needed because FocusScope traps the focus
           {...mergeProps(api.contentProps, props)}
         />
       </FocusScope>

--- a/packages/react-headless/dialog/src/Dialog.tsx
+++ b/packages/react-headless/dialog/src/Dialog.tsx
@@ -64,22 +64,22 @@ export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>((pro
         {/* onDismiss = onEscapeKeyDown + onInteractOutside (= onFocusOutside + onPointerDownOutside) */}
         <DismissableLayer
           ref={ref}
-          onEscapeKeyDown={(event) => {
+          onEscapeKeyDown={(e) => {
             if (!api.closeOnEscape) {
-              event.preventDefault();
+              e.preventDefault();
               return;
             }
 
-            api.setOpen(false, { reason: "escapeKeyDown", event });
+            api.setOpen(false, { reason: "escapeKeyDown", event: e });
           }}
           // onInteractOutside = onFocusOutside + onPointerDownOutside
-          onInteractOutside={(event) => {
+          onInteractOutside={(e) => {
             if (!api.closeOnInteractOutside) {
-              event.preventDefault();
+              e.preventDefault();
               return;
             }
 
-            api.setOpen(false, { reason: "interactOutside", event: event.detail.originalEvent });
+            api.setOpen(false, { reason: "interactOutside", event: e.detail.originalEvent });
           }}
           // onFocusOutside isn't needed because FocusScope traps the focus
           {...mergeProps(api.contentProps, props)}

--- a/packages/react-headless/dialog/src/useDialog.ts
+++ b/packages/react-headless/dialog/src/useDialog.ts
@@ -1,19 +1,39 @@
-import { useControllableState } from "@radix-ui/react-use-controllable-state";
+import { useControllableState } from "@seed-design/react-use-controllable-state";
 import { buttonProps, dataAttr, elementProps } from "@seed-design/dom-utils";
+import type React from "react";
 import { useId, useMemo } from "react";
+
+interface DialogReasonToEventMap {
+  trigger: React.MouseEvent<HTMLButtonElement>;
+  closeButton: React.MouseEvent<HTMLButtonElement>;
+  escapeKeyDown: KeyboardEvent;
+  interactOutside: PointerEvent | FocusEvent;
+}
+
+type DialogChangeDetails = {
+  [R in keyof DialogReasonToEventMap]: {
+    /** The reason for the dialog open state change. */
+    reason: R;
+    /** The native event that triggered the change. */
+    event?: DialogReasonToEventMap[R];
+  };
+}[keyof DialogReasonToEventMap];
 
 export interface UseDialogStateProps {
   open?: boolean;
 
   defaultOpen?: boolean;
 
-  onOpenChange?: (open: boolean) => void;
+  onOpenChange?: (open: boolean, details?: DialogChangeDetails) => void;
 }
 
 function useDialogState(props: UseDialogStateProps) {
-  const [open = false, onOpenChange] = useControllableState({
+  const [open = false, onOpenChange] = useControllableState<
+    boolean,
+    Parameters<NonNullable<UseDialogStateProps["onOpenChange"]>>[1]
+  >({
     prop: props.open,
-    defaultProp: props.defaultOpen,
+    defaultProp: props.defaultOpen ?? false,
     onChange: props.onOpenChange,
   });
 
@@ -82,9 +102,9 @@ export function useDialog(props: UseDialogProps = {}) {
         "aria-haspopup": "dialog",
         "aria-expanded": open,
         ...stateProps,
-        onClick: (e) => {
-          if (e.defaultPrevented) return;
-          onOpenChange(true);
+        onClick: (event) => {
+          if (event.defaultPrevented) return;
+          onOpenChange(true, { reason: "trigger", event });
         },
       }),
       positionerProps: elementProps({
@@ -113,9 +133,9 @@ export function useDialog(props: UseDialogProps = {}) {
       }),
       closeButtonProps: buttonProps({
         ...stateProps,
-        onClick: (e) => {
-          if (e.defaultPrevented) return;
-          onOpenChange(false);
+        onClick: (event) => {
+          if (event.defaultPrevented) return;
+          onOpenChange(false, { reason: "closeButton", event });
         },
       }),
     }),

--- a/packages/react-headless/dialog/src/useDialog.ts
+++ b/packages/react-headless/dialog/src/useDialog.ts
@@ -13,7 +13,7 @@ interface DialogReasonToDetailMap {
 type DialogChangeDetails = {
   [R in keyof DialogReasonToDetailMap]: {
     /** The reason for the dialog open state change. */
-    reason: R;
+    reason?: R;
   } & DialogReasonToDetailMap[R];
 }[keyof DialogReasonToDetailMap];
 

--- a/packages/react-headless/dialog/src/useDialog.ts
+++ b/packages/react-headless/dialog/src/useDialog.ts
@@ -102,9 +102,9 @@ export function useDialog(props: UseDialogProps = {}) {
         "aria-haspopup": "dialog",
         "aria-expanded": open,
         ...stateProps,
-        onClick: (event) => {
-          if (event.defaultPrevented) return;
-          onOpenChange(true, { reason: "trigger", event });
+        onClick: (e) => {
+          if (e.defaultPrevented) return;
+          onOpenChange(true, { reason: "trigger", event: e });
         },
       }),
       positionerProps: elementProps({
@@ -133,9 +133,9 @@ export function useDialog(props: UseDialogProps = {}) {
       }),
       closeButtonProps: buttonProps({
         ...stateProps,
-        onClick: (event) => {
-          if (event.defaultPrevented) return;
-          onOpenChange(false, { reason: "closeButton", event });
+        onClick: (e) => {
+          if (e.defaultPrevented) return;
+          onOpenChange(false, { reason: "closeButton", event: e });
         },
       }),
     }),

--- a/packages/react-headless/dialog/src/useDialog.ts
+++ b/packages/react-headless/dialog/src/useDialog.ts
@@ -3,21 +3,19 @@ import { buttonProps, dataAttr, elementProps } from "@seed-design/dom-utils";
 import type React from "react";
 import { useId, useMemo } from "react";
 
-interface DialogReasonToEventMap {
-  trigger: React.MouseEvent<HTMLButtonElement>;
-  closeButton: React.MouseEvent<HTMLButtonElement>;
-  escapeKeyDown: KeyboardEvent;
-  interactOutside: PointerEvent | FocusEvent;
+interface DialogReasonToDetailMap {
+  trigger: { event: React.MouseEvent<HTMLButtonElement> };
+  closeButton: { event: React.MouseEvent<HTMLButtonElement> };
+  escapeKeyDown: { event: KeyboardEvent };
+  interactOutside: { event: PointerEvent | FocusEvent };
 }
 
 type DialogChangeDetails = {
-  [R in keyof DialogReasonToEventMap]: {
+  [R in keyof DialogReasonToDetailMap]: {
     /** The reason for the dialog open state change. */
     reason: R;
-    /** The native event that triggered the change. */
-    event?: DialogReasonToEventMap[R];
-  };
-}[keyof DialogReasonToEventMap];
+  } & DialogReasonToDetailMap[R];
+}[keyof DialogReasonToDetailMap];
 
 export interface UseDialogStateProps {
   open?: boolean;

--- a/packages/react-headless/dialog/src/useDialog.ts
+++ b/packages/react-headless/dialog/src/useDialog.ts
@@ -1,11 +1,11 @@
 import { useControllableState } from "@seed-design/react-use-controllable-state";
 import { buttonProps, dataAttr, elementProps } from "@seed-design/dom-utils";
-import type React from "react";
 import { useId, useMemo } from "react";
 
 interface DialogReasonToDetailMap {
-  trigger: { event: React.MouseEvent<HTMLButtonElement> };
-  closeButton: { event: React.MouseEvent<HTMLButtonElement> };
+  // we might add synthetic events later if needed; currently we aim consistency; DismissableLayer gives us native events
+  trigger: { event: MouseEvent };
+  closeButton: { event: MouseEvent };
   escapeKeyDown: { event: KeyboardEvent };
   interactOutside: { event: PointerEvent | FocusEvent };
 }
@@ -102,7 +102,7 @@ export function useDialog(props: UseDialogProps = {}) {
         ...stateProps,
         onClick: (e) => {
           if (e.defaultPrevented) return;
-          onOpenChange(true, { reason: "trigger", event: e });
+          onOpenChange(true, { reason: "trigger", event: e.nativeEvent });
         },
       }),
       positionerProps: elementProps({
@@ -133,7 +133,7 @@ export function useDialog(props: UseDialogProps = {}) {
         ...stateProps,
         onClick: (e) => {
           if (e.defaultPrevented) return;
-          onOpenChange(false, { reason: "closeButton", event: e });
+          onOpenChange(false, { reason: "closeButton", event: e.nativeEvent });
         },
       }),
     }),

--- a/packages/react-headless/drawer/package.json
+++ b/packages/react-headless/drawer/package.json
@@ -30,7 +30,7 @@
     "@radix-ui/react-compose-refs": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-use-callback-ref": "^1.1.0",
-    "@radix-ui/react-use-controllable-state": "^1.2.2",
+    "@seed-design/react-use-controllable-state": "0.0.0",
     "@seed-design/dom-utils": "1.0.0",
     "@seed-design/react-primitive": "1.0.0"
   },

--- a/packages/react-headless/drawer/src/Drawer.tsx
+++ b/packages/react-headless/drawer/src/Drawer.tsx
@@ -260,18 +260,18 @@ export const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>((pro
           handleOnPointerUp(lastKnownPointerEventRef.current);
         }
       }}
-      onInteractOutside={(e) => {
+      onInteractOutside={(event) => {
         // Only close if event is not prevented (e.g., by onFocusOutside or onPointerDownOutside)
-        if (dismissible && closeOnInteractOutside && !e.defaultPrevented) {
-          closeDrawer();
+        if (dismissible && closeOnInteractOutside && !event.defaultPrevented) {
+          closeDrawer(false, { reason: "interactOutside", event: event.detail.originalEvent });
         }
-        props.onInteractOutside?.(e);
+        props.onInteractOutside?.(event);
       }}
-      onEscapeKeyDown={(e) => {
+      onEscapeKeyDown={(event) => {
         if (dismissible && closeOnEscape) {
-          closeDrawer();
+          closeDrawer(false, { reason: "escapeKeyDown", event });
         }
-        props.onEscapeKeyDown?.(e);
+        props.onEscapeKeyDown?.(event);
       }}
     />
   );
@@ -306,10 +306,10 @@ export const DrawerCloseButton = forwardRef<HTMLButtonElement, DrawerCloseButton
       <Primitive.button
         ref={composedRef}
         {...props}
-        onClick={(e) => {
-          props.onClick?.(e);
-          if (e.defaultPrevented) return;
-          setIsOpen(false);
+        onClick={(event) => {
+          props.onClick?.(event);
+          if (event.defaultPrevented) return;
+          setIsOpen(false, { reason: "closeButton", event });
         }}
       />
     );
@@ -342,18 +342,18 @@ export const DrawerHandle = forwardRef<HTMLDivElement, DrawerHandleProps>((props
   const closeTimeoutIdRef = useRef<number | null>(null);
   const shouldCancelInteractionRef = useRef(false);
 
-  function handleStartCycle() {
+  function handleStartCycle(event: React.MouseEvent<HTMLDivElement>) {
     // Stop if this is the second click of a double click
     if (shouldCancelInteractionRef.current) {
       handleCancelInteraction();
       return;
     }
     window.setTimeout(() => {
-      handleCycleSnapPoints();
+      handleCycleSnapPoints(event);
     }, DOUBLE_TAP_TIMEOUT);
   }
 
-  function handleCycleSnapPoints() {
+  function handleCycleSnapPoints(event: React.MouseEvent<HTMLDivElement>) {
     // Prevent accidental taps while resizing drawer
     if (isDragging || preventCycle || shouldCancelInteractionRef.current) {
       handleCancelInteraction();
@@ -364,7 +364,7 @@ export const DrawerHandle = forwardRef<HTMLDivElement, DrawerHandleProps>((props
 
     if (!snapPoints || snapPoints.length === 0) {
       if (!dismissible) {
-        closeDrawer();
+        closeDrawer(false, { reason: "handleClickOnLastSnapPoint", event });
       }
       return;
     }
@@ -372,7 +372,7 @@ export const DrawerHandle = forwardRef<HTMLDivElement, DrawerHandleProps>((props
     const isLastSnapPoint = activeSnapPoint === snapPoints[snapPoints.length - 1];
 
     if (isLastSnapPoint && dismissible) {
-      closeDrawer();
+      closeDrawer(false, { reason: "handleClickOnLastSnapPoint", event });
       return;
     }
 

--- a/packages/react-headless/drawer/src/Drawer.tsx
+++ b/packages/react-headless/drawer/src/Drawer.tsx
@@ -260,18 +260,18 @@ export const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>((pro
           handleOnPointerUp(lastKnownPointerEventRef.current);
         }
       }}
-      onInteractOutside={(event) => {
+      onInteractOutside={(e) => {
         // Only close if event is not prevented (e.g., by onFocusOutside or onPointerDownOutside)
-        if (dismissible && closeOnInteractOutside && !event.defaultPrevented) {
-          closeDrawer(false, { reason: "interactOutside", event: event.detail.originalEvent });
+        if (dismissible && closeOnInteractOutside && !e.defaultPrevented) {
+          closeDrawer(false, { reason: "interactOutside", event: e.detail.originalEvent });
         }
-        props.onInteractOutside?.(event);
+        props.onInteractOutside?.(e);
       }}
-      onEscapeKeyDown={(event) => {
+      onEscapeKeyDown={(e) => {
         if (dismissible && closeOnEscape) {
-          closeDrawer(false, { reason: "escapeKeyDown", event });
+          closeDrawer(false, { reason: "escapeKeyDown", event: e });
         }
-        props.onEscapeKeyDown?.(event);
+        props.onEscapeKeyDown?.(e);
       }}
     />
   );
@@ -306,10 +306,10 @@ export const DrawerCloseButton = forwardRef<HTMLButtonElement, DrawerCloseButton
       <Primitive.button
         ref={composedRef}
         {...props}
-        onClick={(event) => {
-          props.onClick?.(event);
-          if (event.defaultPrevented) return;
-          setIsOpen(false, { reason: "closeButton", event });
+        onClick={(e) => {
+          props.onClick?.(e);
+          if (e.defaultPrevented) return;
+          setIsOpen(false, { reason: "closeButton", event: e });
         }}
       />
     );

--- a/packages/react-headless/drawer/src/Drawer.tsx
+++ b/packages/react-headless/drawer/src/Drawer.tsx
@@ -309,7 +309,7 @@ export const DrawerCloseButton = forwardRef<HTMLButtonElement, DrawerCloseButton
         onClick={(e) => {
           props.onClick?.(e);
           if (e.defaultPrevented) return;
-          setIsOpen(false, { reason: "closeButton", event: e });
+          setIsOpen(false, { reason: "closeButton", event: e.nativeEvent });
         }}
       />
     );
@@ -364,7 +364,7 @@ export const DrawerHandle = forwardRef<HTMLDivElement, DrawerHandleProps>((props
 
     if (!snapPoints || snapPoints.length === 0) {
       if (!dismissible) {
-        closeDrawer(false, { reason: "handleClickOnLastSnapPoint", event });
+        closeDrawer(false, { reason: "handleClickOnLastSnapPoint", event: event.nativeEvent });
       }
       return;
     }
@@ -372,7 +372,7 @@ export const DrawerHandle = forwardRef<HTMLDivElement, DrawerHandleProps>((props
     const isLastSnapPoint = activeSnapPoint === snapPoints[snapPoints.length - 1];
 
     if (isLastSnapPoint && dismissible) {
-      closeDrawer(false, { reason: "handleClickOnLastSnapPoint", event });
+      closeDrawer(false, { reason: "handleClickOnLastSnapPoint", event: event.nativeEvent });
       return;
     }
 

--- a/packages/react-headless/drawer/src/use-snap-points.ts
+++ b/packages/react-headless/drawer/src/use-snap-points.ts
@@ -1,4 +1,4 @@
-import { useControllableState } from "@radix-ui/react-use-controllable-state";
+import { useControllableState } from "@seed-design/react-use-controllable-state";
 import React from "react";
 import { TRANSITIONS, VELOCITY_THRESHOLD } from "./constants";
 import { isVertical, set } from "./helpers";

--- a/packages/react-headless/drawer/src/use-snap-points.ts
+++ b/packages/react-headless/drawer/src/use-snap-points.ts
@@ -196,11 +196,16 @@ export function useSnapPoints({
     closeDrawer,
     velocity,
     dismissible,
+    event,
   }: {
     draggedDistance: number;
-    closeDrawer: () => void;
+    closeDrawer: (
+      fromWithin: boolean,
+      details: { reason: "drag"; event: React.PointerEvent<HTMLElement> },
+    ) => void;
     velocity: number;
     dismissible: boolean;
+    event: React.PointerEvent<HTMLElement>;
   }) {
     if (fadeFromIndex === undefined) return;
 
@@ -219,7 +224,7 @@ export function useSnapPoints({
     }
 
     if (!snapToSequentialPoint && velocity > 2 && !hasDraggedUp) {
-      if (dismissible) closeDrawer();
+      if (dismissible) closeDrawer(false, { reason: "drag", event });
       else snapToPoint(snapPointsOffset[0]); // snap to initial point
       return;
     }
@@ -247,7 +252,7 @@ export function useSnapPoints({
       }
 
       if (isFirst && dragDirection < 0 && dismissible) {
-        closeDrawer();
+        closeDrawer(false, { reason: "drag", event });
       }
 
       if (activeSnapPointIndex === null) return;

--- a/packages/react-headless/drawer/src/use-snap-points.ts
+++ b/packages/react-headless/drawer/src/use-snap-points.ts
@@ -199,13 +199,10 @@ export function useSnapPoints({
     event,
   }: {
     draggedDistance: number;
-    closeDrawer: (
-      fromWithin: boolean,
-      details: { reason: "drag"; event: React.PointerEvent<HTMLElement> },
-    ) => void;
+    closeDrawer: (fromWithin: boolean, details: { reason: "drag"; event: PointerEvent }) => void;
     velocity: number;
     dismissible: boolean;
-    event: React.PointerEvent<HTMLElement>;
+    event: PointerEvent;
   }) {
     if (fadeFromIndex === undefined) return;
 

--- a/packages/react-headless/drawer/src/useDrawer.ts
+++ b/packages/react-headless/drawer/src/useDrawer.ts
@@ -1,4 +1,5 @@
-import { useControllableState } from "@radix-ui/react-use-controllable-state";
+import { useControllableState } from "@seed-design/react-use-controllable-state";
+import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { isIOS, isMobileFirefox } from "./browser";
 import {
@@ -12,6 +13,22 @@ import {
 import { dampenValue, getTranslate, isInput, isVertical, reset, set } from "./helpers";
 import { usePositionFixed } from "./use-position-fixed";
 import { useSnapPoints } from "./use-snap-points";
+
+interface DrawerReasonToEventMap {
+  trigger: React.MouseEvent<HTMLButtonElement>;
+  closeButton: React.MouseEvent<HTMLButtonElement>;
+  escapeKeyDown: KeyboardEvent;
+  interactOutside: PointerEvent | FocusEvent;
+  drag: React.PointerEvent<HTMLElement>;
+  handleClickOnLastSnapPoint: React.MouseEvent<HTMLDivElement>;
+}
+
+type DrawerChangeDetails = {
+  [R in keyof DrawerReasonToEventMap]: {
+    reason: R;
+    event?: DrawerReasonToEventMap[R];
+  };
+}[keyof DrawerReasonToEventMap];
 
 export interface UseDrawerProps {
   activeSnapPoint?: number | string | null;
@@ -29,7 +46,7 @@ export interface UseDrawerProps {
    * @default true
    */
   noBodyStyles?: boolean;
-  onOpenChange?: (open: boolean) => void;
+  onOpenChange?: (open: boolean, details?: DrawerChangeDetails) => void;
   /**
    * Duration for which the drawer is not draggable after scrolling content inside of the drawer.
    * @default 500ms
@@ -149,11 +166,11 @@ export function useDrawer(props: UseDrawerProps) {
     closeOnEscape = true,
   } = props;
 
-  const [isOpen = false, setIsOpen] = useControllableState({
+  const [isOpen = false, setIsOpen] = useControllableState<boolean, DrawerChangeDetails>({
     defaultProp: defaultOpen,
     prop: openProp,
-    onChange: (o: boolean) => {
-      onOpenChange?.(o);
+    onChange: (o: boolean, details?: DrawerChangeDetails) => {
+      onOpenChange?.(o, details);
 
       if (!o && !nested) {
         restorePositionSetting();
@@ -425,12 +442,12 @@ export function useDrawer(props: UseDrawerProps) {
   }, [isDragging]);
 
   const closeDrawer = useCallback(
-    (fromWithin?: boolean) => {
+    (fromWithin?: boolean, details?: DrawerChangeDetails) => {
       cancelDrag();
       onClose?.();
 
       if (!fromWithin) {
-        setIsOpen(false);
+        setIsOpen(false, details);
       }
 
       if (fadeFromIndex !== undefined && fadeFromIndex > 0 && activeSnapPointIndex === 0) {
@@ -495,6 +512,7 @@ export function useDrawer(props: UseDrawerProps) {
         closeDrawer,
         velocity,
         dismissible,
+        event,
       });
       onReleaseProp?.(event, true);
       return;
@@ -507,7 +525,7 @@ export function useDrawer(props: UseDrawerProps) {
     }
 
     if (velocity > VELOCITY_THRESHOLD) {
-      closeDrawer();
+      closeDrawer(false, { reason: "drag", event });
       onReleaseProp?.(event, false);
       return;
     }
@@ -526,7 +544,7 @@ export function useDrawer(props: UseDrawerProps) {
       Math.abs(swipeAmount) >=
       (isHorizontalSwipe ? visibleDrawerWidth : visibleDrawerHeight) * closeThreshold
     ) {
-      closeDrawer();
+      closeDrawer(false, { reason: "drag", event });
       onReleaseProp?.(event, false);
       return;
     }

--- a/packages/react-headless/drawer/src/useDrawer.ts
+++ b/packages/react-headless/drawer/src/useDrawer.ts
@@ -25,7 +25,7 @@ interface DrawerReasonToDetailMap {
 
 type DrawerChangeDetails = {
   [R in keyof DrawerReasonToDetailMap]: {
-    reason: R;
+    reason?: R;
   } & DrawerReasonToDetailMap[R];
 }[keyof DrawerReasonToDetailMap];
 

--- a/packages/react-headless/drawer/src/useDrawer.ts
+++ b/packages/react-headless/drawer/src/useDrawer.ts
@@ -15,11 +15,12 @@ import { usePositionFixed } from "./use-position-fixed";
 import { useSnapPoints } from "./use-snap-points";
 
 interface DrawerReasonToDetailMap {
-  closeButton: { event: React.MouseEvent<HTMLButtonElement> };
+  // we might add synthetic events later if needed; currently we aim consistency; DismissableLayer gives us native events
+  closeButton: { event: MouseEvent };
   escapeKeyDown: { event: KeyboardEvent };
   interactOutside: { event: PointerEvent | FocusEvent };
-  drag: { event: React.PointerEvent<HTMLElement> };
-  handleClickOnLastSnapPoint: { event: React.MouseEvent<HTMLDivElement> };
+  drag: { event: PointerEvent };
+  handleClickOnLastSnapPoint: { event: MouseEvent };
 }
 
 type DrawerChangeDetails = {
@@ -510,7 +511,7 @@ export function useDrawer(props: UseDrawerProps) {
         closeDrawer,
         velocity,
         dismissible,
-        event,
+        event: event.nativeEvent,
       });
       onReleaseProp?.(event, true);
       return;
@@ -523,7 +524,7 @@ export function useDrawer(props: UseDrawerProps) {
     }
 
     if (velocity > VELOCITY_THRESHOLD) {
-      closeDrawer(false, { reason: "drag", event });
+      closeDrawer(false, { reason: "drag", event: event.nativeEvent });
       onReleaseProp?.(event, false);
       return;
     }
@@ -542,7 +543,7 @@ export function useDrawer(props: UseDrawerProps) {
       Math.abs(swipeAmount) >=
       (isHorizontalSwipe ? visibleDrawerWidth : visibleDrawerHeight) * closeThreshold
     ) {
-      closeDrawer(false, { reason: "drag", event });
+      closeDrawer(false, { reason: "drag", event: event.nativeEvent });
       onReleaseProp?.(event, false);
       return;
     }

--- a/packages/react-headless/drawer/src/useDrawer.ts
+++ b/packages/react-headless/drawer/src/useDrawer.ts
@@ -15,7 +15,6 @@ import { usePositionFixed } from "./use-position-fixed";
 import { useSnapPoints } from "./use-snap-points";
 
 interface DrawerReasonToEventMap {
-  trigger: React.MouseEvent<HTMLButtonElement>;
   closeButton: React.MouseEvent<HTMLButtonElement>;
   escapeKeyDown: KeyboardEvent;
   interactOutside: PointerEvent | FocusEvent;

--- a/packages/react-headless/drawer/src/useDrawer.ts
+++ b/packages/react-headless/drawer/src/useDrawer.ts
@@ -14,20 +14,19 @@ import { dampenValue, getTranslate, isInput, isVertical, reset, set } from "./he
 import { usePositionFixed } from "./use-position-fixed";
 import { useSnapPoints } from "./use-snap-points";
 
-interface DrawerReasonToEventMap {
-  closeButton: React.MouseEvent<HTMLButtonElement>;
-  escapeKeyDown: KeyboardEvent;
-  interactOutside: PointerEvent | FocusEvent;
-  drag: React.PointerEvent<HTMLElement>;
-  handleClickOnLastSnapPoint: React.MouseEvent<HTMLDivElement>;
+interface DrawerReasonToDetailMap {
+  closeButton: { event: React.MouseEvent<HTMLButtonElement> };
+  escapeKeyDown: { event: KeyboardEvent };
+  interactOutside: { event: PointerEvent | FocusEvent };
+  drag: { event: React.PointerEvent<HTMLElement> };
+  handleClickOnLastSnapPoint: { event: React.MouseEvent<HTMLDivElement> };
 }
 
 type DrawerChangeDetails = {
-  [R in keyof DrawerReasonToEventMap]: {
+  [R in keyof DrawerReasonToDetailMap]: {
     reason: R;
-    event?: DrawerReasonToEventMap[R];
-  };
-}[keyof DrawerReasonToEventMap];
+  } & DrawerReasonToDetailMap[R];
+}[keyof DrawerReasonToDetailMap];
 
 export interface UseDrawerProps {
   activeSnapPoint?: number | string | null;

--- a/packages/react-headless/use-controllable-state/package.json
+++ b/packages/react-headless/use-controllable-state/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@seed-design/react-use-controllable-state",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/daangn/seed-design.git",
+    "directory": "packages/react-headless/use-controllable-state"
+  },
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/index.js",
+      "require": "./lib/index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./lib/index.cjs",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "clean": "rm -rf lib",
+    "build": "bunchee",
+    "lint:publish": "bun publint"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.6",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@radix-ui/react-use-effect-event": "^0.0.2",
+    "@radix-ui/react-use-layout-effect": "^1.1.1"
+  }
+}

--- a/packages/react-headless/use-controllable-state/src/index.ts
+++ b/packages/react-headless/use-controllable-state/src/index.ts
@@ -1,0 +1,1 @@
+export { useControllableState } from "./useControllableState";

--- a/packages/react-headless/use-controllable-state/src/useControllableState.test.tsx
+++ b/packages/react-headless/use-controllable-state/src/useControllableState.test.tsx
@@ -21,7 +21,7 @@ describe("useControllableState", () => {
       it("should update the value when set internally", async () => {
         render(<ControlledComponent />);
         const checkbox = screen.getByRole("checkbox");
-        userEvent.click(checkbox);
+        await userEvent.click(checkbox);
         await waitFor(() => {
           expect(checkbox).toHaveAttribute("aria-checked", "true");
         });
@@ -31,7 +31,7 @@ describe("useControllableState", () => {
         render(<ControlledComponent defaultChecked />);
         const checkbox = screen.getByRole("checkbox");
         const clearButton = screen.getByText("Clear value");
-        userEvent.click(clearButton);
+        await userEvent.click(clearButton);
         await waitFor(() => {
           expect(checkbox).toHaveAttribute("aria-checked", "false");
         });
@@ -48,7 +48,7 @@ describe("useControllableState", () => {
       it("should update the value", async () => {
         render(<UncontrolledComponent defaultChecked />);
         const checkbox = screen.getByRole("checkbox");
-        userEvent.click(checkbox);
+        await userEvent.click(checkbox);
         await waitFor(() => {
           expect(checkbox).toHaveAttribute("aria-checked", "false");
         });
@@ -65,7 +65,7 @@ describe("useControllableState", () => {
         it("should warn", async () => {
           render(<UnstableComponent defaultChecked />);
           const clearButton = screen.getByText("Clear value");
-          userEvent.click(clearButton);
+          await userEvent.click(clearButton);
           await waitFor(() => {
             expect(consoleMock).toHaveBeenLastCalledWith(
               "Checkbox is changing from controlled to uncontrolled. Components should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled value for the lifetime of the component.",
@@ -78,7 +78,7 @@ describe("useControllableState", () => {
         it("should warn", async () => {
           render(<UnstableComponent />);
           const checkbox = screen.getByRole("checkbox");
-          userEvent.click(checkbox);
+          await userEvent.click(checkbox);
           await waitFor(() => {
             expect(consoleMock).toHaveBeenLastCalledWith(
               "Checkbox is changing from uncontrolled to controlled. Components should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled value for the lifetime of the component.",

--- a/packages/react-headless/use-controllable-state/src/useControllableState.test.tsx
+++ b/packages/react-headless/use-controllable-state/src/useControllableState.test.tsx
@@ -1,0 +1,143 @@
+import * as React from "react";
+import "@testing-library/jest-dom/vitest";
+import { screen, cleanup, render, waitFor } from "@testing-library/react";
+import { useControllableState } from "./useControllableState";
+import { afterEach, describe, it, expect, afterAll, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+
+describe("useControllableState", () => {
+  afterEach(cleanup);
+
+  // Tests ported from radix-ui/primitives (https://github.com/radix-ui/primitives)
+  // Used under the MIT License: https://opensource.org/licenses/MIT
+  describe("Radix UI Original Tests", () => {
+    describe("given a controlled value", () => {
+      it("should initially use the controlled value", () => {
+        render(<ControlledComponent />);
+        const checkbox = screen.getByRole("checkbox");
+        expect(checkbox).toHaveAttribute("aria-checked", "false");
+      });
+
+      it("should update the value when set internally", async () => {
+        render(<ControlledComponent />);
+        const checkbox = screen.getByRole("checkbox");
+        userEvent.click(checkbox);
+        await waitFor(() => {
+          expect(checkbox).toHaveAttribute("aria-checked", "true");
+        });
+      });
+
+      it("should update the value when set externally", async () => {
+        render(<ControlledComponent defaultChecked />);
+        const checkbox = screen.getByRole("checkbox");
+        const clearButton = screen.getByText("Clear value");
+        userEvent.click(clearButton);
+        await waitFor(() => {
+          expect(checkbox).toHaveAttribute("aria-checked", "false");
+        });
+      });
+    });
+
+    describe("given a default value", () => {
+      it("should initially use the default value", () => {
+        render(<UncontrolledComponent defaultChecked />);
+        const checkbox = screen.getByRole("checkbox");
+        expect(checkbox).toHaveAttribute("aria-checked", "true");
+      });
+
+      it("should update the value", async () => {
+        render(<UncontrolledComponent defaultChecked />);
+        const checkbox = screen.getByRole("checkbox");
+        userEvent.click(checkbox);
+        await waitFor(() => {
+          expect(checkbox).toHaveAttribute("aria-checked", "false");
+        });
+      });
+    });
+
+    describe("switching between controlled and uncontrolled", () => {
+      const consoleMock = vi.spyOn(console, "warn").mockImplementation(() => void 0);
+      afterAll(() => {
+        consoleMock.mockReset();
+      });
+
+      describe("controlled to uncontrolled", () => {
+        it("should warn", async () => {
+          render(<UnstableComponent defaultChecked />);
+          const clearButton = screen.getByText("Clear value");
+          userEvent.click(clearButton);
+          await waitFor(() => {
+            expect(consoleMock).toHaveBeenLastCalledWith(
+              "Checkbox is changing from controlled to uncontrolled. Components should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled value for the lifetime of the component.",
+            );
+          });
+        });
+      });
+
+      describe("uncontrolled to controlled", () => {
+        it("should warn", async () => {
+          render(<UnstableComponent />);
+          const checkbox = screen.getByRole("checkbox");
+          userEvent.click(checkbox);
+          await waitFor(() => {
+            expect(consoleMock).toHaveBeenLastCalledWith(
+              "Checkbox is changing from uncontrolled to controlled. Components should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled value for the lifetime of the component.",
+            );
+          });
+        });
+      });
+    });
+  });
+});
+
+function ControlledComponent({ defaultChecked }: { defaultChecked?: boolean }) {
+  const [checked, setChecked] = React.useState(defaultChecked ?? false);
+  return (
+    <div>
+      <Checkbox checked={checked} onChange={setChecked} />
+      <button type="button" onClick={() => setChecked(false)}>
+        Clear value
+      </button>
+    </div>
+  );
+}
+
+function UncontrolledComponent({ defaultChecked }: { defaultChecked?: boolean }) {
+  return <Checkbox defaultChecked={defaultChecked} />;
+}
+
+function UnstableComponent({ defaultChecked }: { defaultChecked?: boolean }) {
+  const [checked, setChecked] = React.useState(defaultChecked);
+  return (
+    <div>
+      <Checkbox checked={checked} onChange={setChecked} />
+      <button type="button" onClick={() => setChecked(undefined)}>
+        Clear value
+      </button>
+    </div>
+  );
+}
+
+function Checkbox(props: {
+  checked?: boolean;
+  defaultChecked?: boolean;
+  onChange?: (value: boolean) => void;
+}) {
+  const [checked, setChecked] = useControllableState({
+    defaultProp: props.defaultChecked ?? false,
+    prop: props.checked,
+    onChange: props.onChange,
+    caller: "Checkbox",
+  });
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: test
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={checked}
+      onKeyDown={(e) => void (e.key === "Enter" && e.preventDefault())}
+      onClick={() => setChecked((c) => !c)}
+    />
+  );
+}

--- a/packages/react-headless/use-controllable-state/src/useControllableState.test.tsx
+++ b/packages/react-headless/use-controllable-state/src/useControllableState.test.tsx
@@ -89,43 +89,43 @@ describe("useControllableState", () => {
     });
   });
 
-  describe("meta parameter", () => {
+  describe("details parameter", () => {
     describe("controlled mode", () => {
-      it("should pass meta to onChange", async () => {
+      it("should pass details to onChange", async () => {
         const onChange = vi.fn();
-        render(<ControlledToggleWithMeta onChange={onChange} />);
-        const button = screen.getByRole("button", { name: "toggle with meta" });
+        render(<ControlledToggleWithDetails onChange={onChange} />);
+        const button = screen.getByRole("button", { name: "toggle with details" });
         await userEvent.click(button);
         await waitFor(() => {
           expect(onChange).toHaveBeenCalledWith(true, "trigger");
         });
       });
 
-      it("should pass undefined meta when not provided", async () => {
+      it("should pass undefined details when not provided", async () => {
         const onChange = vi.fn();
-        render(<ControlledToggleWithMeta onChange={onChange} />);
-        const button = screen.getByRole("button", { name: "toggle without meta" });
+        render(<ControlledToggleWithDetails onChange={onChange} />);
+        const button = screen.getByRole("button", { name: "toggle without details" });
         await userEvent.click(button);
         await waitFor(() => {
           expect(onChange).toHaveBeenCalledWith(true, undefined);
         });
       });
 
-      it("should pass different meta on consecutive calls", async () => {
+      it("should pass different details on consecutive calls", async () => {
         const onChange = vi.fn();
-        render(<ControlledToggleWithMeta onChange={onChange} />);
-        const withMeta = screen.getByRole("button", { name: "toggle with meta" });
-        const withoutMeta = screen.getByRole("button", { name: "toggle without meta" });
+        render(<ControlledToggleWithDetails onChange={onChange} />);
+        const withDetails = screen.getByRole("button", { name: "toggle with details" });
+        const withoutDetails = screen.getByRole("button", { name: "toggle without details" });
         const close = screen.getByRole("button", { name: "close" });
         const withUpdater = screen.getByRole("button", { name: "toggle with updater" });
 
-        await userEvent.click(withMeta);
+        await userEvent.click(withDetails);
         await userEvent.click(close);
-        await userEvent.click(withoutMeta);
+        await userEvent.click(withoutDetails);
         await userEvent.click(withUpdater);
         await userEvent.click(withUpdater);
         await userEvent.click(close);
-        await userEvent.click(withMeta);
+        await userEvent.click(withDetails);
 
         await waitFor(() => {
           expect(onChange).toHaveBeenNthCalledWith(1, true, "trigger");
@@ -140,50 +140,50 @@ describe("useControllableState", () => {
 
       it("should not call onChange when value is the same", async () => {
         const onChange = vi.fn();
-        render(<ControlledToggleWithMeta onChange={onChange} defaultValue={true} />);
-        const withMeta = screen.getByRole("button", { name: "toggle with meta" });
-        await userEvent.click(withMeta);
-        await userEvent.click(withMeta);
+        render(<ControlledToggleWithDetails onChange={onChange} defaultValue={true} />);
+        const withDetails = screen.getByRole("button", { name: "toggle with details" });
+        await userEvent.click(withDetails);
+        await userEvent.click(withDetails);
         expect(onChange).toHaveBeenCalledTimes(0);
       });
     });
 
     describe("uncontrolled mode", () => {
-      it("should pass meta to onChange", async () => {
+      it("should pass details to onChange", async () => {
         const onChange = vi.fn();
-        render(<UncontrolledToggleWithMeta onChange={onChange} />);
-        const button = screen.getByRole("button", { name: "toggle with meta" });
+        render(<UncontrolledToggleWithDetails onChange={onChange} />);
+        const button = screen.getByRole("button", { name: "toggle with details" });
         await userEvent.click(button);
         await waitFor(() => {
           expect(onChange).toHaveBeenCalledWith(true, "trigger");
         });
       });
 
-      it("should pass undefined meta when not provided", async () => {
+      it("should pass undefined details when not provided", async () => {
         const onChange = vi.fn();
-        render(<UncontrolledToggleWithMeta onChange={onChange} />);
-        const button = screen.getByRole("button", { name: "toggle without meta" });
+        render(<UncontrolledToggleWithDetails onChange={onChange} />);
+        const button = screen.getByRole("button", { name: "toggle without details" });
         await userEvent.click(button);
         await waitFor(() => {
           expect(onChange).toHaveBeenCalledWith(true, undefined);
         });
       });
 
-      it("should pass different meta on consecutive calls", async () => {
+      it("should pass different details on consecutive calls", async () => {
         const onChange = vi.fn();
-        render(<UncontrolledToggleWithMeta onChange={onChange} />);
-        const withMeta = screen.getByRole("button", { name: "toggle with meta" });
-        const withoutMeta = screen.getByRole("button", { name: "toggle without meta" });
+        render(<UncontrolledToggleWithDetails onChange={onChange} />);
+        const withDetails = screen.getByRole("button", { name: "toggle with details" });
+        const withoutDetails = screen.getByRole("button", { name: "toggle without details" });
         const close = screen.getByRole("button", { name: "close" });
         const withUpdater = screen.getByRole("button", { name: "toggle with updater" });
 
-        await userEvent.click(withMeta);
+        await userEvent.click(withDetails);
         await userEvent.click(close);
-        await userEvent.click(withoutMeta);
+        await userEvent.click(withoutDetails);
         await userEvent.click(withUpdater);
         await userEvent.click(withUpdater);
         await userEvent.click(close);
-        await userEvent.click(withMeta);
+        await userEvent.click(withDetails);
 
         await waitFor(() => {
           expect(onChange).toHaveBeenNthCalledWith(1, true, "trigger");
@@ -199,46 +199,46 @@ describe("useControllableState", () => {
   });
 });
 
-// Test components for meta parameter tests
-function ControlledToggleWithMeta({
+// Test components for details parameter tests
+function ControlledToggleWithDetails({
   onChange,
   defaultValue = false,
 }: {
-  onChange: (value: boolean, meta?: string) => void;
+  onChange: (value: boolean, details?: string) => void;
   defaultValue?: boolean;
 }) {
   const [value, setValue] = React.useState(defaultValue);
-  const [, setValueWithMeta] = useControllableState<boolean, string>({
+  const [, setValueWithDetails] = useControllableState<boolean, string>({
     prop: value,
     defaultProp: false,
-    onChange: (newValue, meta) => {
+    onChange: (newValue, details) => {
       setValue(newValue);
-      onChange(newValue, meta);
+      onChange(newValue, details);
     },
   });
 
   return (
     <div>
-      <button type="button" onClick={() => setValueWithMeta(true, "trigger")}>
-        toggle with meta
+      <button type="button" onClick={() => setValueWithDetails(true, "trigger")}>
+        toggle with details
       </button>
-      <button type="button" onClick={() => setValueWithMeta(true)}>
-        toggle without meta
+      <button type="button" onClick={() => setValueWithDetails(true)}>
+        toggle without details
       </button>
-      <button type="button" onClick={() => setValueWithMeta(false, "closeButton")}>
+      <button type="button" onClick={() => setValueWithDetails(false, "closeButton")}>
         close
       </button>
-      <button type="button" onClick={() => setValueWithMeta((prev) => !prev, "updater")}>
+      <button type="button" onClick={() => setValueWithDetails((prev) => !prev, "updater")}>
         toggle with updater
       </button>
     </div>
   );
 }
 
-function UncontrolledToggleWithMeta({
+function UncontrolledToggleWithDetails({
   onChange,
 }: {
-  onChange: (value: boolean, meta?: string) => void;
+  onChange: (value: boolean, details?: string) => void;
 }) {
   const [, setValue] = useControllableState<boolean, string>({
     defaultProp: false,
@@ -248,10 +248,10 @@ function UncontrolledToggleWithMeta({
   return (
     <div>
       <button type="button" onClick={() => setValue(true, "trigger")}>
-        toggle with meta
+        toggle with details
       </button>
       <button type="button" onClick={() => setValue(true)}>
-        toggle without meta
+        toggle without details
       </button>
       <button type="button" onClick={() => setValue(false, "closeButton")}>
         close

--- a/packages/react-headless/use-controllable-state/src/useControllableState.test.tsx
+++ b/packages/react-headless/use-controllable-state/src/useControllableState.test.tsx
@@ -88,7 +88,180 @@ describe("useControllableState", () => {
       });
     });
   });
+
+  describe("meta parameter", () => {
+    describe("controlled mode", () => {
+      it("should pass meta to onChange", async () => {
+        const onChange = vi.fn();
+        render(<ControlledToggleWithMeta onChange={onChange} />);
+        const button = screen.getByRole("button", { name: "toggle with meta" });
+        await userEvent.click(button);
+        await waitFor(() => {
+          expect(onChange).toHaveBeenCalledWith(true, "trigger");
+        });
+      });
+
+      it("should pass undefined meta when not provided", async () => {
+        const onChange = vi.fn();
+        render(<ControlledToggleWithMeta onChange={onChange} />);
+        const button = screen.getByRole("button", { name: "toggle without meta" });
+        await userEvent.click(button);
+        await waitFor(() => {
+          expect(onChange).toHaveBeenCalledWith(true, undefined);
+        });
+      });
+
+      it("should pass different meta on consecutive calls", async () => {
+        const onChange = vi.fn();
+        render(<ControlledToggleWithMeta onChange={onChange} />);
+        const withMeta = screen.getByRole("button", { name: "toggle with meta" });
+        const withoutMeta = screen.getByRole("button", { name: "toggle without meta" });
+        const close = screen.getByRole("button", { name: "close" });
+        const withUpdater = screen.getByRole("button", { name: "toggle with updater" });
+
+        await userEvent.click(withMeta);
+        await userEvent.click(close);
+        await userEvent.click(withoutMeta);
+        await userEvent.click(withUpdater);
+        await userEvent.click(withUpdater);
+        await userEvent.click(close);
+        await userEvent.click(withMeta);
+
+        await waitFor(() => {
+          expect(onChange).toHaveBeenNthCalledWith(1, true, "trigger");
+          expect(onChange).toHaveBeenNthCalledWith(2, false, "closeButton");
+          expect(onChange).toHaveBeenNthCalledWith(3, true, undefined);
+          expect(onChange).toHaveBeenNthCalledWith(4, false, "updater");
+          expect(onChange).toHaveBeenNthCalledWith(5, true, "updater");
+          expect(onChange).toHaveBeenNthCalledWith(6, false, "closeButton");
+          expect(onChange).toHaveBeenNthCalledWith(7, true, "trigger");
+        });
+      });
+
+      it("should not call onChange when value is the same", async () => {
+        const onChange = vi.fn();
+        render(<ControlledToggleWithMeta onChange={onChange} defaultValue={true} />);
+        const withMeta = screen.getByRole("button", { name: "toggle with meta" });
+        await userEvent.click(withMeta);
+        await userEvent.click(withMeta);
+        expect(onChange).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe("uncontrolled mode", () => {
+      it("should pass meta to onChange", async () => {
+        const onChange = vi.fn();
+        render(<UncontrolledToggleWithMeta onChange={onChange} />);
+        const button = screen.getByRole("button", { name: "toggle with meta" });
+        await userEvent.click(button);
+        await waitFor(() => {
+          expect(onChange).toHaveBeenCalledWith(true, "trigger");
+        });
+      });
+
+      it("should pass undefined meta when not provided", async () => {
+        const onChange = vi.fn();
+        render(<UncontrolledToggleWithMeta onChange={onChange} />);
+        const button = screen.getByRole("button", { name: "toggle without meta" });
+        await userEvent.click(button);
+        await waitFor(() => {
+          expect(onChange).toHaveBeenCalledWith(true, undefined);
+        });
+      });
+
+      it("should pass different meta on consecutive calls", async () => {
+        const onChange = vi.fn();
+        render(<UncontrolledToggleWithMeta onChange={onChange} />);
+        const withMeta = screen.getByRole("button", { name: "toggle with meta" });
+        const withoutMeta = screen.getByRole("button", { name: "toggle without meta" });
+        const close = screen.getByRole("button", { name: "close" });
+        const withUpdater = screen.getByRole("button", { name: "toggle with updater" });
+
+        await userEvent.click(withMeta);
+        await userEvent.click(close);
+        await userEvent.click(withoutMeta);
+        await userEvent.click(withUpdater);
+        await userEvent.click(withUpdater);
+        await userEvent.click(close);
+        await userEvent.click(withMeta);
+
+        await waitFor(() => {
+          expect(onChange).toHaveBeenNthCalledWith(1, true, "trigger");
+          expect(onChange).toHaveBeenNthCalledWith(2, false, "closeButton");
+          expect(onChange).toHaveBeenNthCalledWith(3, true, undefined);
+          expect(onChange).toHaveBeenNthCalledWith(4, false, "updater");
+          expect(onChange).toHaveBeenNthCalledWith(5, true, "updater");
+          expect(onChange).toHaveBeenNthCalledWith(6, false, "closeButton");
+          expect(onChange).toHaveBeenNthCalledWith(7, true, "trigger");
+        });
+      });
+    });
+  });
 });
+
+// Test components for meta parameter tests
+function ControlledToggleWithMeta({
+  onChange,
+  defaultValue = false,
+}: {
+  onChange: (value: boolean, meta?: string) => void;
+  defaultValue?: boolean;
+}) {
+  const [value, setValue] = React.useState(defaultValue);
+  const [, setValueWithMeta] = useControllableState<boolean, string>({
+    prop: value,
+    defaultProp: false,
+    onChange: (newValue, meta) => {
+      setValue(newValue);
+      onChange(newValue, meta);
+    },
+  });
+
+  return (
+    <div>
+      <button type="button" onClick={() => setValueWithMeta(true, "trigger")}>
+        toggle with meta
+      </button>
+      <button type="button" onClick={() => setValueWithMeta(true)}>
+        toggle without meta
+      </button>
+      <button type="button" onClick={() => setValueWithMeta(false, "closeButton")}>
+        close
+      </button>
+      <button type="button" onClick={() => setValueWithMeta((prev) => !prev, "updater")}>
+        toggle with updater
+      </button>
+    </div>
+  );
+}
+
+function UncontrolledToggleWithMeta({
+  onChange,
+}: {
+  onChange: (value: boolean, meta?: string) => void;
+}) {
+  const [, setValue] = useControllableState<boolean, string>({
+    defaultProp: false,
+    onChange,
+  });
+
+  return (
+    <div>
+      <button type="button" onClick={() => setValue(true, "trigger")}>
+        toggle with meta
+      </button>
+      <button type="button" onClick={() => setValue(true)}>
+        toggle without meta
+      </button>
+      <button type="button" onClick={() => setValue(false, "closeButton")}>
+        close
+      </button>
+      <button type="button" onClick={() => setValue((prev) => !prev, "updater")}>
+        toggle with updater
+      </button>
+    </div>
+  );
+}
 
 function ControlledComponent({ defaultChecked }: { defaultChecked?: boolean }) {
   const [checked, setChecked] = React.useState(defaultChecked ?? false);

--- a/packages/react-headless/use-controllable-state/src/useControllableState.tsx
+++ b/packages/react-headless/use-controllable-state/src/useControllableState.tsx
@@ -1,0 +1,97 @@
+// This code includes portions derived from radix-ui/primitives (https://github.com/radix-ui/primitives)
+// Used under the MIT License: https://opensource.org/licenses/MIT
+
+import * as React from "react";
+import { useLayoutEffect } from "@radix-ui/react-use-layout-effect";
+
+// Prevent bundlers from trying to optimize the import
+const useInsertionEffect: typeof useLayoutEffect =
+  (React as any)[" useInsertionEffect ".trim().toString()] || useLayoutEffect;
+
+type ChangeHandler<T> = (state: T) => void;
+type SetStateFn<T> = React.Dispatch<React.SetStateAction<T>>;
+
+interface UseControllableStateParams<T> {
+  prop?: T | undefined;
+  defaultProp: T;
+  onChange?: ChangeHandler<T>;
+  caller?: string;
+}
+
+export function useControllableState<T>({
+  prop,
+  defaultProp,
+  onChange = () => {},
+  caller,
+}: UseControllableStateParams<T>): [T, SetStateFn<T>] {
+  const [uncontrolledProp, setUncontrolledProp, onChangeRef] = useUncontrolledState({
+    defaultProp,
+    onChange,
+  });
+  const isControlled = prop !== undefined;
+  const value = isControlled ? prop : uncontrolledProp;
+
+  if (process.env.NODE_ENV !== "production") {
+    // biome-ignore lint/correctness/useHookAtTopLevel: OK to disable conditionally calling hooks here because they will always run consistently in the same environment. Bundlers should be able to remove the code block entirely in production.
+    const isControlledRef = React.useRef(prop !== undefined);
+
+    // biome-ignore lint/correctness/useHookAtTopLevel: same
+    React.useEffect(() => {
+      const wasControlled = isControlledRef.current;
+      if (wasControlled !== isControlled) {
+        const from = wasControlled ? "controlled" : "uncontrolled";
+        const to = isControlled ? "controlled" : "uncontrolled";
+        console.warn(
+          `${caller} is changing from ${from} to ${to}. Components should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled value for the lifetime of the component.`,
+        );
+      }
+      isControlledRef.current = isControlled;
+    }, [isControlled, caller]);
+  }
+
+  const setValue = React.useCallback<SetStateFn<T>>(
+    (nextValue) => {
+      if (isControlled) {
+        const value = isFunction(nextValue) ? nextValue(prop) : nextValue;
+        if (value !== prop) {
+          onChangeRef.current?.(value);
+        }
+      } else {
+        setUncontrolledProp(nextValue);
+      }
+    },
+    [isControlled, prop, setUncontrolledProp, onChangeRef],
+  );
+
+  return [value, setValue];
+}
+
+function useUncontrolledState<T>({
+  defaultProp,
+  onChange,
+}: Omit<UseControllableStateParams<T>, "prop">): [
+  Value: T,
+  setValue: React.Dispatch<React.SetStateAction<T>>,
+  OnChangeRef: React.RefObject<ChangeHandler<T> | undefined>,
+] {
+  const [value, setValue] = React.useState(defaultProp);
+  const prevValueRef = React.useRef(value);
+
+  const onChangeRef = React.useRef(onChange);
+  useInsertionEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  React.useEffect(() => {
+    if (prevValueRef.current !== value) {
+      onChangeRef.current?.(value);
+      prevValueRef.current = value;
+    }
+  }, [value, prevValueRef]);
+
+  return [value, setValue, onChangeRef];
+}
+
+function isFunction(value: unknown): value is (...args: any[]) => any {
+  return typeof value === "function";
+}

--- a/packages/react-headless/use-controllable-state/src/useControllableState.tsx
+++ b/packages/react-headless/use-controllable-state/src/useControllableState.tsx
@@ -6,31 +6,33 @@ import { useLayoutEffect } from "@radix-ui/react-use-layout-effect";
 
 // Prevent bundlers from trying to optimize the import
 const useInsertionEffect: typeof useLayoutEffect =
+  // biome-ignore lint/suspicious/noExplicitAny: React internal API access
   (React as any)[" useInsertionEffect ".trim().toString()] || useLayoutEffect;
 
-type ChangeHandler<T> = (state: T) => void;
-type SetStateFn<T> = React.Dispatch<React.SetStateAction<T>>;
+export type ChangeHandler<T, M = undefined> = (state: T, meta?: M) => void;
+export type SetStateFn<T, M = undefined> = (value: T | ((prev: T) => T), meta?: M) => void;
 
-interface UseControllableStateParams<T> {
+export interface UseControllableStateParams<T, M = undefined> {
   prop?: T | undefined;
   defaultProp: T;
-  onChange?: ChangeHandler<T>;
+  onChange?: ChangeHandler<T, M>;
   caller?: string;
 }
 
-export function useControllableState<T>({
+export function useControllableState<T, M = undefined>({
   prop,
   defaultProp,
   onChange = () => {},
   caller,
-}: UseControllableStateParams<T>): [T, SetStateFn<T>] {
-  const [uncontrolledProp, setUncontrolledProp, onChangeRef] = useUncontrolledState({
+}: UseControllableStateParams<T, M>): [T, SetStateFn<T, M>] {
+  const [uncontrolledProp, setUncontrolledProp, onChangeRef, metaRef] = useUncontrolledState<T, M>({
     defaultProp,
     onChange,
   });
   const isControlled = prop !== undefined;
   const value = isControlled ? prop : uncontrolledProp;
 
+  // @ts-expect-error
   if (process.env.NODE_ENV !== "production") {
     // biome-ignore lint/correctness/useHookAtTopLevel: OK to disable conditionally calling hooks here because they will always run consistently in the same environment. Bundlers should be able to remove the code block entirely in production.
     const isControlledRef = React.useRef(prop !== undefined);
@@ -49,33 +51,36 @@ export function useControllableState<T>({
     }, [isControlled, caller]);
   }
 
-  const setValue = React.useCallback<SetStateFn<T>>(
-    (nextValue) => {
+  const setValue = React.useCallback<SetStateFn<T, M>>(
+    (nextValue, meta) => {
       if (isControlled) {
         const value = isFunction(nextValue) ? nextValue(prop) : nextValue;
         if (value !== prop) {
-          onChangeRef.current?.(value);
+          onChangeRef.current?.(value, meta);
         }
       } else {
+        metaRef.current = meta;
         setUncontrolledProp(nextValue);
       }
     },
-    [isControlled, prop, setUncontrolledProp, onChangeRef],
+    [isControlled, prop, setUncontrolledProp, onChangeRef, metaRef],
   );
 
   return [value, setValue];
 }
 
-function useUncontrolledState<T>({
+function useUncontrolledState<T, M = undefined>({
   defaultProp,
   onChange,
-}: Omit<UseControllableStateParams<T>, "prop">): [
-  Value: T,
+}: Omit<UseControllableStateParams<T, M>, "prop" | "caller">): [
+  value: T,
   setValue: React.Dispatch<React.SetStateAction<T>>,
-  OnChangeRef: React.RefObject<ChangeHandler<T> | undefined>,
+  onChangeRef: React.RefObject<ChangeHandler<T, M> | undefined>,
+  metaRef: React.RefObject<M | undefined>,
 ] {
   const [value, setValue] = React.useState(defaultProp);
   const prevValueRef = React.useRef(value);
+  const metaRef = React.useRef<M | undefined>(undefined);
 
   const onChangeRef = React.useRef(onChange);
   useInsertionEffect(() => {
@@ -84,14 +89,16 @@ function useUncontrolledState<T>({
 
   React.useEffect(() => {
     if (prevValueRef.current !== value) {
-      onChangeRef.current?.(value);
+      onChangeRef.current?.(value, metaRef.current);
       prevValueRef.current = value;
+      metaRef.current = undefined;
     }
-  }, [value, prevValueRef]);
+  }, [value]);
 
-  return [value, setValue, onChangeRef];
+  return [value, setValue, onChangeRef, metaRef];
 }
 
+// biome-ignore lint/suspicious/noExplicitAny: type guard utility
 function isFunction(value: unknown): value is (...args: any[]) => any {
   return typeof value === "function";
 }

--- a/packages/react-headless/use-controllable-state/src/useControllableState.tsx
+++ b/packages/react-headless/use-controllable-state/src/useControllableState.tsx
@@ -9,8 +9,8 @@ const useInsertionEffect: typeof useLayoutEffect =
   // biome-ignore lint/suspicious/noExplicitAny: React internal API access
   (React as any)[" useInsertionEffect ".trim().toString()] || useLayoutEffect;
 
-export type ChangeHandler<T, M = undefined> = (state: T, meta?: M) => void;
-export type SetStateFn<T, M = undefined> = (value: T | ((prev: T) => T), meta?: M) => void;
+export type ChangeHandler<T, M = undefined> = (state: T, details?: M) => void;
+export type SetStateFn<T, M = undefined> = (value: T | ((prev: T) => T), details?: M) => void;
 
 export interface UseControllableStateParams<T, M = undefined> {
   prop?: T | undefined;
@@ -25,7 +25,10 @@ export function useControllableState<T, M = undefined>({
   onChange = () => {},
   caller,
 }: UseControllableStateParams<T, M>): [T, SetStateFn<T, M>] {
-  const [uncontrolledProp, setUncontrolledProp, onChangeRef, metaRef] = useUncontrolledState<T, M>({
+  const [uncontrolledProp, setUncontrolledProp, onChangeRef, detailsRef] = useUncontrolledState<
+    T,
+    M
+  >({
     defaultProp,
     onChange,
   });
@@ -52,18 +55,18 @@ export function useControllableState<T, M = undefined>({
   }
 
   const setValue = React.useCallback<SetStateFn<T, M>>(
-    (nextValue, meta) => {
+    (nextValue, details) => {
       if (isControlled) {
         const value = isFunction(nextValue) ? nextValue(prop) : nextValue;
         if (value !== prop) {
-          onChangeRef.current?.(value, meta);
+          onChangeRef.current?.(value, details);
         }
       } else {
-        metaRef.current = meta;
+        detailsRef.current = details;
         setUncontrolledProp(nextValue);
       }
     },
-    [isControlled, prop, setUncontrolledProp, onChangeRef, metaRef],
+    [isControlled, prop, setUncontrolledProp, onChangeRef, detailsRef],
   );
 
   return [value, setValue];
@@ -76,11 +79,11 @@ function useUncontrolledState<T, M = undefined>({
   value: T,
   setValue: React.Dispatch<React.SetStateAction<T>>,
   onChangeRef: React.RefObject<ChangeHandler<T, M> | undefined>,
-  metaRef: React.RefObject<M | undefined>,
+  detailsRef: React.RefObject<M | undefined>,
 ] {
   const [value, setValue] = React.useState(defaultProp);
   const prevValueRef = React.useRef(value);
-  const metaRef = React.useRef<M | undefined>(undefined);
+  const detailsRef = React.useRef<M | undefined>(undefined);
 
   const onChangeRef = React.useRef(onChange);
   useInsertionEffect(() => {
@@ -89,13 +92,13 @@ function useUncontrolledState<T, M = undefined>({
 
   React.useEffect(() => {
     if (prevValueRef.current !== value) {
-      onChangeRef.current?.(value, metaRef.current);
+      onChangeRef.current?.(value, detailsRef.current);
       prevValueRef.current = value;
-      metaRef.current = undefined;
+      detailsRef.current = undefined;
     }
   }, [value]);
 
-  return [value, setValue, onChangeRef, metaRef];
+  return [value, setValue, onChangeRef, detailsRef];
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: type guard utility

--- a/packages/react-headless/use-controllable-state/tsconfig.json
+++ b/packages/react-headless/use-controllable-state/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.headless.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}

--- a/packages/react/src/components/Dialog/Dialog.tsx
+++ b/packages/react/src/components/Dialog/Dialog.tsx
@@ -1,7 +1,6 @@
 import { Dialog as DialogPrimitive, useDialogContext } from "@seed-design/react-dialog";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";
 import { dialog, type DialogVariantProps } from "@seed-design/css/recipes/dialog";
-import { forwardRef } from "react";
 import { createSlotRecipeContext } from "../../utils/createSlotRecipeContext";
 import { createWithStateProps } from "../../utils/createWithStateProps";
 
@@ -103,7 +102,4 @@ export interface DialogActionProps
   extends PrimitiveProps,
     React.HTMLAttributes<HTMLButtonElement> {}
 
-export const DialogAction = forwardRef<HTMLButtonElement, DialogActionProps>((props, ref) => {
-  const api = useDialogContext();
-  return <Primitive.button {...props} ref={ref} onClick={() => api.setOpen(false)} />;
-});
+export const DialogAction = DialogPrimitive.CloseButton;


### PR DESCRIPTION
## Summary

- Dialog와 Drawer의 `onOpenChange` 콜백에 `details` 객체를 추가하여 열림/닫힘 이유와 원본 이벤트를 제공합니다.
- `details.reason`: 상태 변경 이유
- `details.event`: 원본 네이티브 이벤트 (reason에 따라 타입이 narrowing됨)

## Changes

### `@seed-design/react-dialog` (headless)
- `DialogReasonToEventMap`으로 reason별 이벤트 타입 매핑
- `DialogChangeDetails` discriminated union 타입 추가
- `onOpenChange` 콜백에 details 전달
- reason: `"trigger"` | `"closeButton"` | `"escapeKeyDown"` | `"interactOutside"`

### `@seed-design/react-headless-drawer`
- `DrawerReasonToEventMap`으로 reason별 이벤트 타입 매핑
- `DrawerChangeDetails` discriminated union 타입 추가
- `onOpenChange` 콜백에 details 전달
- reason: `"closeButton"` | `"escapeKeyDown"` | `"interactOutside"` | `"drag"` | `"handleClickOnLastSnapPoint"`

### `@seed-design/react` (styled)
- `DialogAction`을 `DialogPrimitive.CloseButton`으로 단순화

### `@seed-design/react-use-controllable-state`
- `useControllableState`에 제네릭 meta 파라미터 지원 추가

### Documentation
- Dialog, BottomSheet, MenuSheet `onOpenChange` details 문서 및 예제 추가

## Test plan

- [ ] Dialog 열기/닫기 시 `onOpenChange`에 올바른 reason이 전달되는지 확인
- [ ] BottomSheet 열기/닫기 시 `onOpenChange`에 올바른 reason이 전달되는지 확인
- [ ] ESC 키, 외부 클릭, 드래그 등 다양한 닫기 방식에서 reason이 정확한지 확인
- [ ] TypeScript에서 reason 체크 시 event 타입이 narrowing되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * onOpenChange 콜백에 두 번째 인자로 상세한 reason 및 이벤트 컨텍스트 전달 지원(예: trigger, closeButton, escapeKeyDown, interactOutside, drag).

* **문서**
  * AlertDialog, MenuSheet, BottomSheet 등에서 onOpenChange 상세 이유와 예제(열기/닫기 이유 표시, prevent-close 데모) 추가/확장.

* **테스트**
  * 제어형 상태 훅에 대한 포괄적 테스트 스위트 추가.

* **기타**
  * Dialog 액션 단순화 및 닫기 동작 관련 일관성 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->