### PR TITLE
feat(mcp): add exports for programmatic usage

### DIFF
--- a/.changeset/legal-falcons-fall.md
+++ b/.changeset/legal-falcons-fall.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/mcp": patch
+---
+
+MCP를 Node.js 프로젝트에서 직접 구성할 수 있도록 `registerTools`를 비롯한 export를 추가합니다.

--- a/packages/mcp/.gitignore
+++ b/packages/mcp/.gitignore
@@ -1,2 +1,3 @@
 .env
 /bin/
+/dist/

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -12,12 +12,19 @@
   "sideEffects": false,
   "files": [
     "bin",
+    "dist",
     "src",
     "package.json"
   ],
   "bin": "./bin/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "scripts": {
-    "clean": "rm -rf lib",
+    "clean": "rm -rf dist bin",
     "build": "bunchee",
     "lint:publish": "bun publint"
   },

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,4 @@
+export { registerTools } from "./tools";
+export { createFigmaRestClient, parseFigmaUrl } from "./figma-rest-client";
+export type { FigmaRestClient } from "./figma-rest-client";
+export type { ToolMode } from "./tools-helpers";


### PR DESCRIPTION
## Summary
- `exports` 필드 추가로 ES module import 지원
- `src/index.ts` 생성하여 `registerTools`, `createFigmaRestClient`, `parseFigmaUrl` export
- `.gitignore`에 `/dist/` 추가
- `clean` 스크립트가 `dist`와 `bin` 모두 삭제하도록 수정

HTTP MCP 서버에서 직접 import하여 사용 가능:
```typescript
import { registerTools, createFigmaRestClient } from "@seed-design/mcp";

const restClient = createFigmaRestClient(process.env.FIGMA_PERSONAL_ACCESS_TOKEN);
registerTools(server, null, restClient, null, "rest");
```

## Test plan
- [x] `bun run build` 정상 동작 확인
- [ ] HTTP MCP 서버에서 import 테스트

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * MCP 패키지의 공개 API가 통합 및 확대되었습니다. registerTools, createFigmaRestClient, parseFigmaUrl 함수와 FigmaRestClient, ToolMode 타입이 중앙 내보내기 지점에서 제공됩니다.

* **기타**
  * 빌드 결과물 무시 설정 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->