### PR TITLE
fix(snackbar): only pause on keyboard focus using :focus-visible

### DIFF
--- a/.changeset/huge-clouds-design.md
+++ b/.changeset/huge-clouds-design.md
@@ -2,4 +2,4 @@
 "@seed-design/react-snackbar": patch
 ---
 
-Snackbar 타이머가 멈추는 기준을 `focus`에서 `focus-within || focus-visible`로 수정하여 `pauseOnInteraction={true}`인 경우 Snackbar가 닫히지 않는 문제를 수정합니다.
+Snackbar 타이머가 멈추는 기준을 `focus`에서 `focus-visible`로 수정하여 `pauseOnInteraction={true}`인 경우 Snackbar가 닫히지 않는 문제를 수정합니다.

--- a/.changeset/huge-clouds-design.md
+++ b/.changeset/huge-clouds-design.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react-snackbar": patch
+---
+
+Snackbar 타이머가 멈추는 기준을 `focus`에서 `focus-within || focus-visible`로 수정하여 `pauseOnInteraction={true}`인 경우 Snackbar가 닫히지 않는 문제를 수정합니다.

--- a/bun.lock
+++ b/bun.lock
@@ -834,6 +834,7 @@
         "@radix-ui/react-compose-refs": "^1.1.2",
         "@seed-design/dom-utils": "1.0.0",
         "@seed-design/react-primitive": "1.0.0",
+        "@seed-design/react-supports": "0.0.1",
       },
       "devDependencies": {
         "@types/react": "^19.1.6",

--- a/packages/react-headless/snackbar/package.json
+++ b/packages/react-headless/snackbar/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "@radix-ui/react-compose-refs": "^1.1.2",
     "@seed-design/dom-utils": "1.0.0",
-    "@seed-design/react-primitive": "1.0.0"
+    "@seed-design/react-primitive": "1.0.0",
+    "@seed-design/react-supports": "0.0.1"
   },
   "devDependencies": {
     "@types/react": "^19.1.6",

--- a/packages/react-headless/snackbar/src/useSnackbar.ts
+++ b/packages/react-headless/snackbar/src/useSnackbar.ts
@@ -1,4 +1,5 @@
 import { ariaAttr, buttonProps, dataAttr, elementProps } from "@seed-design/dom-utils";
+import { useSupports } from "@seed-design/react-supports";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSafeOffset } from "./useSafeOffset";
 
@@ -145,6 +146,7 @@ export function useSnackbar(props: UseSnackbarProps) {
   const { state, currentSnackbar, visible, queue, visibleDuration, events } =
     useSnackbarState(props);
   const { overlapTracker, regionRef, regionStyle, safeOffset } = useSafeOffset();
+  const isFocusVisibleSupported = useSupports("selector(:focus-visible)");
 
   return useMemo(
     () => ({
@@ -189,8 +191,17 @@ export function useSnackbar(props: UseSnackbarProps) {
           "--snackbar-remove-delay": `${currentSnackbar?.removeDelay ?? 0}ms`,
           "--snackbar-duration": `${visibleDuration}ms`,
         } as React.CSSProperties,
-        onFocus() {
-          events.pause();
+        onFocus(event) {
+          // if :focus-visible not supported, do not pause on focus
+          if (!isFocusVisibleSupported) return;
+
+          // only pause if focus is visible (focused using keyboard) || action label has focus
+          if (
+            event.target.matches(":focus-visible") ||
+            event.currentTarget.matches(":focus-within")
+          ) {
+            events.pause();
+          }
         },
         onBlur() {
           events.resume();
@@ -221,6 +232,7 @@ export function useSnackbar(props: UseSnackbarProps) {
       regionStyle,
       overlapTracker,
       regionRef,
+      isFocusVisibleSupported,
     ],
   );
 }

--- a/packages/react-headless/snackbar/src/useSnackbar.ts
+++ b/packages/react-headless/snackbar/src/useSnackbar.ts
@@ -196,10 +196,7 @@ export function useSnackbar(props: UseSnackbarProps) {
           if (!isFocusVisibleSupported) return;
 
           // only pause if focus is visible (focused using keyboard) || action label has focus
-          if (
-            event.target.matches(":focus-visible") ||
-            event.currentTarget.matches(":focus-within")
-          ) {
+          if (event.target.matches(":focus-visible")) {
             events.pause();
           }
         },


### PR DESCRIPTION
## Summary
- 마우스 클릭/탭 시에도 `onFocus`가 발생하여 스낵바 타이머가 멈추는 문제 수정
- `:focus-visible`을 사용하여 키보드 포커스만 감지하도록 변경
- `:focus-visible` 미지원 브라우저에서는 안전하게 pause하지 않음 (스낵바가 닫히지 않는 버그 방지)

## Changes
- `useSupports("selector(:focus-visible)")`로 브라우저 지원 여부 확인
- `onFocus` 핸들러에서 `event.target.matches(":focus-visible")` 체크
- `@seed-design/react-supports` dependency 추가

## Test plan
- [ ] 마우스로 스낵바 클릭 시 타이머가 계속 진행되는지 확인
- [ ] 키보드 Tab으로 스낵바 포커스 시 타이머가 멈추는지 확인
- [ ] 포커스 해제 시 타이머가 재개되는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * Snackbar에서 pauseOnInteraction 활성화 시 의도치 않게 닫히던 문제를 수정했습니다. 포커스 감지 로직을 개선해 :focus-visible을 지원하는 브라우저에서는 키보드 포커스에만 타이머가 일시정지되며, 지원하지 않는 환경에서는 기존 동작을 유지해 일관된 사용자 경험을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->