### PR TITLE
feat(figma-v3-migration): migrate thumbnail to image frame

### DIFF
--- a/tools/figma-v3-migration/src/main/mapping/index.ts
+++ b/tools/figma-v3-migration/src/main/mapping/index.ts
@@ -38,6 +38,7 @@ import {
 import { dividerMapping, dividerNavMapping } from "./divider";
 import { actionSheetMapping, actionSheetV2BetaMapping } from "./action-sheet";
 import { squareBadgeMapping, pillBadgeMapping } from "./badges";
+import { thumbnailMapping, thumbnailRatioMapping } from "./thumbnail";
 
 export default [
   squareBadgeMapping,
@@ -83,4 +84,6 @@ export default [
   underlinedTextFieldMapping,
   multilineTextFieldMapping,
   outlineTextFieldMapping,
+  thumbnailMapping,
+  thumbnailRatioMapping,
 ] as const;

--- a/tools/figma-v3-migration/src/main/mapping/thumbnail.ts
+++ b/tools/figma-v3-migration/src/main/mapping/thumbnail.ts
@@ -1,0 +1,37 @@
+import type { ComponentMapping, NewComponentProperties } from "./types";
+
+export const thumbnailMapping: ComponentMapping<"Thumbnail", "Image Frame"> = {
+  oldComponent: "Thumbnail",
+  newComponent: "Image Frame",
+  variantMap: {
+    "Size:40": "Size:42",
+    "Size:48": "Size:48",
+    "Size:64": "Size:64",
+    "Size:72": "Size:80",
+    "Size:92": "Size:96",
+    "Size:108": "Size:120",
+    "Size:120": "Size:120",
+    "Size:140": "Size:120",
+    "Size:Full Width": "Size:120",
+  },
+  calculateProperties() {
+    const newProperties: NewComponentProperties<"Image Frame"> = {};
+    return newProperties;
+  },
+};
+
+export const thumbnailRatioMapping: ComponentMapping<"Thumbnail Ratio", "Image Frame"> = {
+  oldComponent: "Thumbnail Ratio",
+  newComponent: "Image Frame",
+  variantMap: {
+    "Aspect Ratio:1:1": "Ratio:1:1",
+    "Aspect Ratio:4:3": "Ratio:4:3",
+    "Aspect Ratio:16:9": "Ratio:16:9",
+    "Aspect Ratio:2:1": "Ratio:2:1",
+    "Aspect Ratio:2:3": "Ratio:2:3",
+  },
+  calculateProperties() {
+    const newProperties: NewComponentProperties<"Image Frame"> = {};
+    return newProperties;
+  },
+};

--- a/tools/figma-v3-migration/src/main/services/swap-component.ts
+++ b/tools/figma-v3-migration/src/main/services/swap-component.ts
@@ -24,6 +24,35 @@ export type ComponentInstances = {
   [newComponentName: string]: CapturedInstance[];
 };
 
+function findFirstImagePaintNode(node: SceneNode): SceneNode | null {
+  if ("fills" in node && node.fills !== figma.mixed) {
+    const fills = node.fills;
+    if (fills.some((paint) => paint.type === "IMAGE")) {
+      return node;
+    }
+  }
+
+  if ("children" in node) {
+    for (const child of node.children) {
+      const found = findFirstImagePaintNode(child);
+      if (found) return found;
+    }
+  }
+
+  return null;
+}
+
+function getImagePaints(node: SceneNode): Paint[] | null {
+  const imageNode = findFirstImagePaintNode(node);
+  if (!imageNode || !("fills" in imageNode)) return null;
+
+  const fills = imageNode.fills;
+  if (fills === figma.mixed) return null;
+  if (!fills.some((paint) => paint.type === "IMAGE")) return null;
+
+  return fills.map((paint) => ({ ...paint }));
+}
+
 // 컴포넌트의 구조를 캡처
 function captureInstances(
   node: SceneNode,
@@ -220,6 +249,8 @@ export async function swapComponent(
     }
 
     const capturedInstances = captureInstances(oldInstance, mapping.childrenMappings ?? []);
+    const oldImagePaints =
+      mapping.newComponent === "Image Frame" ? getImagePaints(oldInstance) : null;
 
     // 새 컴포넌트 정보 찾기
     const newComponentInfo = Object.values(newComponents).find(
@@ -336,6 +367,13 @@ export async function swapComponent(
     // 컴포넌트 교체 및 프로퍼티 적용
     oldInstance.swapComponent(newComponent);
     oldInstance.setProperties(newProperties);
+
+    if (oldImagePaints) {
+      const newImageNode = findFirstImagePaintNode(oldInstance);
+      if (newImageNode && "fills" in newImageNode && newImageNode.fills !== figma.mixed) {
+        newImageNode.fills = oldImagePaints;
+      }
+    }
 
     const childrenMappings = mapping.childrenMappings;
     if (childrenMappings) {


### PR DESCRIPTION
## 배경

V2 Thumbnail 컴포넌트를 V3 Image Frame으로 마이그레이션할 때 Variant와 이미지 콘텐츠가 유지되지 않아 수동 보정이 필요했습니다.

## 변경사항

- `Thumbnail`/`Thumbnail Ratio` -> `Image Frame` 매핑을 추가했습니다.
- V2 size/aspect ratio 값을 V3 size/ratio variant로 변환하도록 매핑했습니다.
- 컴포넌트 스왑 시 기존 IMAGE paint를 찾아 새 Image Frame 노드에 복사해 이미지가 유지되도록 처리했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 썸네일 및 비율 썸네일 컴포넌트를 Image Frame으로 마이그레이션하는 기능 추가
  * 컴포넌트 교체 시 이미지 속성 자동 보존 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->