### PR TITLE
chore(ci): unify Cloudflare Pages workflow names and split stackflow-spa alpha/prod

### DIFF
--- a/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
@@ -18,6 +18,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}

--- a/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
@@ -1,14 +1,15 @@
 on:
   push:
     branches:
-      - main
-      - dev # V3 deployment; remove this when V3 is stable
+      - "**"
+      - "!main"
+      - "!dev" # V3 deployment; remove this when V3 is stable
     paths:
       - "docs/**"
       - "packages/css/**"
       - "packages/react/**"
       - "packages/stackflow/**"
-      - ".github/workflows/docs-deploy-production-pages.yml"
+      - ".github/workflows/deploy-seed-design-docs-alpha-pages.yml"
   workflow_dispatch:
     inputs:
       skip-figma-cache:
@@ -17,20 +18,16 @@ on:
         type: boolean
         default: false
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
   FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
 
-name: Deploy seed-design-v3 docs (Production)
+name: deploy-seed-design-docs-alpha-pages
 
 jobs:
   deploy:
-    name: Deploy Seed Design V3 Docs
+    name: deploy-seed-design-docs-alpha-pages
     runs-on: ubuntu-latest
 
     steps:
@@ -72,7 +69,7 @@ jobs:
         run: |
           bun run build
 
-      - name: Deploy docs at Cloudflare Pages in `seed-design-v3` project (Production)
+      - name: Deploy docs at Cloudflare Pages in `seed-design-v3` project (Alpha)
         run: |
           CLOUDFLARE_ACCOUNT_ID=${{ secrets.CF_ACCOUNT_ID }} \
           CLOUDFLARE_API_TOKEN=${{ secrets.CF_API_TOKEN }} \

--- a/.github/workflows/deploy-seed-design-docs-prod-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-prod-pages.yml
@@ -1,15 +1,14 @@
 on:
   push:
     branches:
-      - "**"
-      - "!main"
-      - "!dev" # V3 deployment; remove this when V3 is stable
+      - main
+      - dev # V3 deployment; remove this when V3 is stable
     paths:
       - "docs/**"
       - "packages/css/**"
       - "packages/react/**"
       - "packages/stackflow/**"
-      - ".github/workflows/docs-deploy-alpha-pages.yml"
+      - ".github/workflows/deploy-seed-design-docs-prod-pages.yml"
   workflow_dispatch:
     inputs:
       skip-figma-cache:
@@ -18,16 +17,20 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
   FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
 
-name: Deploy seed-design-v3 docs (Alpha)
+name: deploy-seed-design-docs-prod-pages
 
 jobs:
   deploy:
-    name: Deploy Seed Design V3 Docs
+    name: deploy-seed-design-docs-prod-pages
     runs-on: ubuntu-latest
 
     steps:
@@ -69,7 +72,7 @@ jobs:
         run: |
           bun run build
 
-      - name: Deploy docs at Cloudflare Pages in `seed-design-v3` project (Alpha)
+      - name: Deploy docs at Cloudflare Pages in `seed-design-v3` project (Production)
         run: |
           CLOUDFLARE_ACCOUNT_ID=${{ secrets.CF_ACCOUNT_ID }} \
           CLOUDFLARE_API_TOKEN=${{ secrets.CF_API_TOKEN }} \

--- a/.github/workflows/deploy-seed-design-docs-prod-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-prod-pages.yml
@@ -17,6 +17,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy-seed-design-stackflow-spa-alpha-pages.yml
+++ b/.github/workflows/deploy-seed-design-stackflow-spa-alpha-pages.yml
@@ -13,6 +13,9 @@ on:
       - ".github/workflows/deploy-seed-design-stackflow-spa-alpha-pages.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/deploy-seed-design-stackflow-spa-alpha-pages.yml
+++ b/.github/workflows/deploy-seed-design-stackflow-spa-alpha-pages.yml
@@ -2,23 +2,25 @@ on:
   push:
     branches:
       - "**"
+      - "!main"
+      - "!dev" # V3 deployment; remove this when V3 is stable
     paths:
       - "docs/**"
       - "examples/stackflow-spa/**"
       - "packages/css/**"
       - "packages/react/**"
       - "packages/stackflow/**"
-      - ".github/workflows/docs-deploy-qa-pages.yml"
+      - ".github/workflows/deploy-seed-design-stackflow-spa-alpha-pages.yml"
   workflow_dispatch:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-name: Deploy seed-design-v3 QA app
+name: deploy-seed-design-stackflow-spa-alpha-pages
 
 jobs:
   deploy:
-    name: Deploy Seed Design V3 QA app
+    name: deploy-seed-design-stackflow-spa-alpha-pages
     runs-on: ubuntu-latest
 
     steps:
@@ -34,13 +36,13 @@ jobs:
       - name: Build Packages
         run: bun packages:build
 
-      - name: Build QA app
+      - name: Build Stackflow SPA
         working-directory: ./examples/stackflow-spa
         run: |
           bun run build
 
-      - name: Deploy qa app at Cloudflare Pages in `seed-design-qa` project
+      - name: Deploy stackflow-spa at Cloudflare Pages in `seed-design-stackflow-spa` project (Alpha)
         run: |
           CLOUDFLARE_ACCOUNT_ID=${{ secrets.CF_ACCOUNT_ID }} \
           CLOUDFLARE_API_TOKEN=${{ secrets.CF_API_TOKEN }} \
-          bun wrangler pages deploy ./examples/stackflow-spa/dist --project-name=seed-design-qa --branch=${{ github.ref_name }}
+          bun wrangler pages deploy ./examples/stackflow-spa/dist --project-name=seed-design-stackflow-spa --branch=${{ github.ref_name }}

--- a/.github/workflows/deploy-seed-design-stackflow-spa-prod-pages.yml
+++ b/.github/workflows/deploy-seed-design-stackflow-spa-prod-pages.yml
@@ -12,6 +12,9 @@ on:
       - ".github/workflows/deploy-seed-design-stackflow-spa-prod-pages.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/deploy-seed-design-stackflow-spa-prod-pages.yml
+++ b/.github/workflows/deploy-seed-design-stackflow-spa-prod-pages.yml
@@ -5,20 +5,21 @@ on:
       - dev # V3 deployment; remove this when V3 is stable
     paths:
       - "docs/**"
+      - "examples/stackflow-spa/**"
       - "packages/css/**"
       - "packages/react/**"
       - "packages/stackflow/**"
-      - ".github/workflows/docs-deploy-storybook-production-pages.yml"
+      - ".github/workflows/deploy-seed-design-stackflow-spa-prod-pages.yml"
   workflow_dispatch:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-name: Deploy seed-design-v3 Storybook
+name: deploy-seed-design-stackflow-spa-prod-pages
 
 jobs:
   deploy:
-    name: Deploy seed-design-v3 Storybook
+    name: deploy-seed-design-stackflow-spa-prod-pages
     runs-on: ubuntu-latest
 
     steps:
@@ -34,12 +35,13 @@ jobs:
       - name: Build Packages
         run: bun packages:build
 
-      - name: Build Storybook
-        working-directory: ./docs
-        run: bun build-storybook
+      - name: Build Stackflow SPA
+        working-directory: ./examples/stackflow-spa
+        run: |
+          bun run build
 
-      - name: Deploy docs at Cloudflare Pages in `seed-design-v3-storybook` project (Production)
+      - name: Deploy stackflow-spa at Cloudflare Pages in `seed-design-stackflow-spa` project (Production)
         run: |
           CLOUDFLARE_ACCOUNT_ID=${{ secrets.CF_ACCOUNT_ID }} \
           CLOUDFLARE_API_TOKEN=${{ secrets.CF_API_TOKEN }} \
-          bun wrangler pages deploy ./docs/storybook-static --project-name=seed-design-v3-storybook --branch=${{ github.ref_name }}
+          bun wrangler pages deploy ./examples/stackflow-spa/dist --project-name=seed-design-stackflow-spa --branch=${{ github.ref_name }}

--- a/.github/workflows/deploy-seed-design-storybook-alpha-pages.yml
+++ b/.github/workflows/deploy-seed-design-storybook-alpha-pages.yml
@@ -12,6 +12,9 @@ on:
       - "packages/stackflow/**"
       - ".github/workflows/deploy-seed-design-storybook-alpha-pages.yml"
 
+permissions:
+  contents: read
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/deploy-seed-design-storybook-alpha-pages.yml
+++ b/.github/workflows/deploy-seed-design-storybook-alpha-pages.yml
@@ -10,16 +10,16 @@ on:
       - "packages/css/**"
       - "packages/react/**"
       - "packages/stackflow/**"
-      - ".github/workflows/docs-deploy-storybook-alpha-pages.yml"
+      - ".github/workflows/deploy-seed-design-storybook-alpha-pages.yml"
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-name: Deploy seed-design-v3 Storybook Alpha
+name: deploy-seed-design-storybook-alpha-pages
 
 jobs:
   deploy:
-    name: Deploy seed-design-v3 Storybook Alpha
+    name: deploy-seed-design-storybook-alpha-pages
     runs-on: ubuntu-latest
 
     steps:
@@ -39,8 +39,8 @@ jobs:
         working-directory: ./docs
         run: bun build-storybook
 
-      - name: Deploy docs at Cloudflare Pages in `seed-design-v3-storybook` project (Alpha)
+      - name: Deploy docs at Cloudflare Pages in `seed-design-storybook` project (Alpha)
         run: |
           CLOUDFLARE_ACCOUNT_ID=${{ secrets.CF_ACCOUNT_ID }} \
           CLOUDFLARE_API_TOKEN=${{ secrets.CF_API_TOKEN }} \
-          bun wrangler pages deploy ./docs/storybook-static --project-name=seed-design-v3-storybook --branch=${{ github.ref_name }}
+          bun wrangler pages deploy ./docs/storybook-static --project-name=seed-design-storybook --branch=${{ github.ref_name }}

--- a/.github/workflows/deploy-seed-design-storybook-prod-pages.yml
+++ b/.github/workflows/deploy-seed-design-storybook-prod-pages.yml
@@ -11,6 +11,9 @@ on:
       - ".github/workflows/deploy-seed-design-storybook-prod-pages.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/deploy-seed-design-storybook-prod-pages.yml
+++ b/.github/workflows/deploy-seed-design-storybook-prod-pages.yml
@@ -1,0 +1,45 @@
+on:
+  push:
+    branches:
+      - main
+      - dev # V3 deployment; remove this when V3 is stable
+    paths:
+      - "docs/**"
+      - "packages/css/**"
+      - "packages/react/**"
+      - "packages/stackflow/**"
+      - ".github/workflows/deploy-seed-design-storybook-prod-pages.yml"
+  workflow_dispatch:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+name: deploy-seed-design-storybook-prod-pages
+
+jobs:
+  deploy:
+    name: deploy-seed-design-storybook-prod-pages
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.8"
+
+      - name: Install Dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build Packages
+        run: bun packages:build
+
+      - name: Build Storybook
+        working-directory: ./docs
+        run: bun build-storybook
+
+      - name: Deploy docs at Cloudflare Pages in `seed-design-storybook` project (Production)
+        run: |
+          CLOUDFLARE_ACCOUNT_ID=${{ secrets.CF_ACCOUNT_ID }} \
+          CLOUDFLARE_API_TOKEN=${{ secrets.CF_API_TOKEN }} \
+          bun wrangler pages deploy ./docs/storybook-static --project-name=seed-design-storybook --branch=${{ github.ref_name }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 워크플로우 이름·작업명을 표준화하고 참조를 정리했습니다.
  * 워크플로우 트리거와 브랜치/경로 제외 규칙을 업데이트했습니다.
  * 권한 블록(contents: read)을 추가해 읽기 권한을 명시했습니다.
  * 배포 대상 프로젝트 및 명령을 조정했습니다.
  * Stackflow SPA의 프로덕션 배포 워크플로우를 새로 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->