### PR TITLE
fix(react): align PullToRefresh.Root ref type with HTMLDivElement

### DIFF
--- a/.changeset/old-feet-relate.md
+++ b/.changeset/old-feet-relate.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react": patch
+---
+
+PullToRefresh.Root의 ref 타입을 실제 렌더링 요소인 HTMLDivElement로 수정해 잘못된 SVG ref 타입 요구를 해결했습니다.

--- a/packages/react/src/components/PullToRefresh/PullToRefresh.tsx
+++ b/packages/react/src/components/PullToRefresh/PullToRefresh.tsx
@@ -11,7 +11,7 @@ export interface PullToRefreshRootProps
   extends PullToRefreshVariantProps,
     PullToRefreshPrimitive.RootProps {}
 
-export const PullToRefreshRoot = withProvider<SVGSVGElement, PullToRefreshRootProps>(
+export const PullToRefreshRoot = withProvider<HTMLDivElement, PullToRefreshRootProps>(
   PullToRefreshPrimitive.Root,
   "root",
 );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * PullToRefresh 컴포넌트의 루트 참조 타입을 수정했습니다. SVG 요소 타입에서 실제 렌더링되는 HTML 요소 타입으로 변경되어 타입 정확성과 안정성이 개선됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->