### PR TITLE
fix(docs): catch-all slug type error

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
         "estree-util-value-to-estree": "^3.4.0",
         "fumadocs-core": "^16.4.3",
         "fumadocs-docgen": "^3.0.0",
-        "fumadocs-mdx": "14.2.5",
+        "fumadocs-mdx": "14.2.6",
         "fumadocs-typescript": "^5.0.0",
         "fumadocs-ui": "15.8.5",
         "hast-util-to-estree": "^3.1.3",
@@ -3665,7 +3665,7 @@
 
     "fumadocs-docgen": ["fumadocs-docgen@3.0.3", "", { "dependencies": { "estree-util-to-js": "^2.0.0", "estree-util-value-to-estree": "^3.4.1", "npm-to-yarn": "^3.0.1", "oxc-transform": "^0.95.0", "unist-util-visit": "^5.0.0", "zod": "^4.1.12" }, "peerDependencies": { "fumadocs-core": "^15.7.2 || ^16.0.0" } }, "sha512-FrGhl2qfGEE5w3iijgaRTVHWQpMOFkS83CF4NciZPhh8taXerkJXuCZdmkwkxtksi+HUdni3QDoV5z3SaTBnZw=="],
 
-    "fumadocs-mdx": ["fumadocs-mdx@14.2.5", "", { "dependencies": { "@mdx-js/mdx": "^3.1.1", "@standard-schema/spec": "^1.1.0", "chokidar": "^5.0.0", "esbuild": "^0.27.2", "estree-util-value-to-estree": "^3.5.0", "js-yaml": "^4.1.1", "mdast-util-to-markdown": "^2.1.2", "picocolors": "^1.1.1", "picomatch": "^4.0.3", "remark-mdx": "^3.1.1", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.3", "zod": "^4.3.5" }, "peerDependencies": { "@fumadocs/mdx-remote": "^1.4.0", "@types/react": "*", "fumadocs-core": "^15.0.0 || ^16.0.0", "next": "^15.3.0 || ^16.0.0", "react": "*", "vite": "6.x.x || 7.x.x" }, "optionalPeers": ["@fumadocs/mdx-remote", "@types/react", "next", "react", "vite"], "bin": { "fumadocs-mdx": "dist/bin.js" } }, "sha512-1WJeJ1Xago2lRq6GhTvTb+hxDtWUBr7lHi4YgHNBYSpWKsTfOor3UxgZV1UYBrd32cq4xHdtMK33LM67gA0eBA=="],
+    "fumadocs-mdx": ["fumadocs-mdx@14.2.6", "", { "dependencies": { "@mdx-js/mdx": "^3.1.1", "@standard-schema/spec": "^1.1.0", "chokidar": "^5.0.0", "esbuild": "^0.27.2", "estree-util-value-to-estree": "^3.5.0", "js-yaml": "^4.1.1", "mdast-util-to-markdown": "^2.1.2", "picocolors": "^1.1.1", "picomatch": "^4.0.3", "remark-mdx": "^3.1.1", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.3", "zod": "^4.3.5" }, "peerDependencies": { "@fumadocs/mdx-remote": "^1.4.0", "@types/react": "*", "fumadocs-core": "^15.0.0 || ^16.0.0", "next": "^15.3.0 || ^16.0.0", "react": "*", "vite": "6.x.x || 7.x.x" }, "optionalPeers": ["@fumadocs/mdx-remote", "@types/react", "next", "react", "vite"], "bin": { "fumadocs-mdx": "dist/bin.js" } }, "sha512-T8i5IllZ6OGaZ3/4Wwjl1zovvypSsr6Cco9ZACvoABLqpqTQ2TDfrW1nBt1o9YUKyfzkwDnjKdrnrq/nDexfcg=="],
 
     "fumadocs-typescript": ["fumadocs-typescript@5.0.1", "", { "dependencies": { "estree-util-value-to-estree": "^3.5.0", "hast-util-to-estree": "^3.1.3", "hast-util-to-jsx-runtime": "^2.3.6", "remark": "^15.0.1", "remark-rehype": "^11.1.2", "tinyglobby": "^0.2.15", "ts-morph": "^27.0.2", "unist-util-visit": "^5.0.0" }, "peerDependencies": { "@types/react": "*", "fumadocs-core": "^15.7.0 || ^16.0.0", "fumadocs-ui": "^15.7.0 || ^16.0.0", "react": "*", "typescript": "*" }, "optionalPeers": ["@types/react", "fumadocs-ui"] }, "sha512-7WuisFYObFydP1JwhBaPJwq89LFii7jGSrUJXZDoT3A6jbxQQyww7jolL4zriENoyQFdpOMSSRv9kCZQu5wh8g=="],
 

--- a/docs/app/ai-integration/[[...slug]]/page.tsx
+++ b/docs/app/ai-integration/[[...slug]]/page.tsx
@@ -6,7 +6,7 @@ import { mdxComponents } from "@/components/mdx-components";
 
 export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
   const params = await props.params;
-  const page = aiIntegrationSource.getPage(params.slug);
+  const page = aiIntegrationSource.getPage(params.slug ?? []);
   if (!page) notFound();
 
   const { body: MDX, toc, lastModified } = await page.data.load();
@@ -30,7 +30,7 @@ export async function generateMetadata(props: {
   params: Promise<{ slug?: string[] }>;
 }): Promise<Metadata> {
   const params = await props.params;
-  const page = aiIntegrationSource.getPage(params.slug);
+  const page = aiIntegrationSource.getPage(params.slug ?? []);
   if (!page) notFound();
 
   return {

--- a/docs/app/breeze/[[...slug]]/page.tsx
+++ b/docs/app/breeze/[[...slug]]/page.tsx
@@ -6,7 +6,7 @@ import { mdxComponents } from "@/components/mdx-components";
 
 export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
   const params = await props.params;
-  const page = breezeSource.getPage(params.slug);
+  const page = breezeSource.getPage(params.slug ?? []);
   if (!page) notFound();
 
   const { body: MDX, toc, lastModified } = await page.data.load();
@@ -30,7 +30,7 @@ export async function generateMetadata(props: {
   params: Promise<{ slug?: string[] }>;
 }): Promise<Metadata> {
   const params = await props.params;
-  const page = breezeSource.getPage(params.slug);
+  const page = breezeSource.getPage(params.slug ?? []);
   if (!page) notFound();
 
   return {

--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -44,7 +44,7 @@ export async function generateMetadata(props: {
   params: Promise<{ slug?: string[] }>;
 }): Promise<Metadata> {
   const params = await props.params;
-  const page = docsSource.getPage(params.slug);
+  const page = docsSource.getPage(params.slug ?? []);
   if (!page) notFound();
 
   const loadedData = await page.data.load();

--- a/docs/app/lynx/[[...slug]]/page.tsx
+++ b/docs/app/lynx/[[...slug]]/page.tsx
@@ -6,7 +6,7 @@ import { mdxComponents } from "@/components/mdx-components";
 
 export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
   const params = await props.params;
-  const page = lynxSource.getPage(params.slug);
+  const page = lynxSource.getPage(params.slug ?? []);
   if (!page) notFound();
 
   const { body: MDX, toc, lastModified } = await page.data.load();
@@ -30,7 +30,7 @@ export async function generateMetadata(props: {
   params: Promise<{ slug?: string[] }>;
 }): Promise<Metadata> {
   const params = await props.params;
-  const page = lynxSource.getPage(params.slug);
+  const page = lynxSource.getPage(params.slug ?? []);
   if (!page) notFound();
 
   return {

--- a/docs/package.json
+++ b/docs/package.json
@@ -48,7 +48,7 @@
     "estree-util-value-to-estree": "^3.4.0",
     "fumadocs-core": "^16.4.3",
     "fumadocs-docgen": "^3.0.0",
-    "fumadocs-mdx": "14.2.5",
+    "fumadocs-mdx": "14.2.6",
     "fumadocs-typescript": "^5.0.0",
     "fumadocs-ui": "15.8.5",
     "hast-util-to-estree": "^3.1.3",


### PR DESCRIPTION
## 배경

CI에서 docs 빌드 중 `[[...slug]]` 라우트의 타입 추론이 불안정해 `page.data.load()` 오류가 발생했습니다. 함께 `fumadocs-mdx` 버전을 14.2.6으로 올려 생성 파이프라인을 최신화했습니다.

## 변경사항

- `docs/app/ai-integration/[[...slug]]/page.tsx`에서 `getPage(params.slug ?? [])`로 수정
- 동일 패턴을 `docs/app/breeze/[[...slug]]/page.tsx`, `docs/app/lynx/[[...slug]]/page.tsx`, `docs/app/docs/[[...slug]]/page.tsx`에도 반영
- `docs/package.json`의 `fumadocs-mdx`를 `14.2.5 -> 14.2.6`으로 업데이트
- `bun.lock` 갱신

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 다양한 페이지 레이아웃에서 슬러그 매개변수 처리 개선
  * 메타데이터 생성 및 페이지 조회 시 매개변수 안정성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->