### PR TITLE
docs: add fallback example

### DIFF
--- a/docs/content/react/components/image-frame.mdx
+++ b/docs/content/react/components/image-frame.mdx
@@ -16,6 +16,7 @@ description: 사용자가 업로드한 이미지를 표시하기 위한 컴포�
 
 ```tsx
 import { ImageFrame } from "@seed-design/react";
+import { IdentityPlaceholder } from "seed-design/ui/identity-placeholder";
 ```
 
 ```tsx
@@ -25,7 +26,7 @@ import { ImageFrame } from "@seed-design/react";
   stroke
   src="..."
   alt="..."
-  fallback={<Skeleton />}
+  fallback={<IdentityPlaceholder />}
 />
 ```
 
@@ -72,6 +73,19 @@ import { ImageFrame } from "@seed-design/react";
   ```json doc-gen:file
   {
     "file": "examples/react/image-frame/stroke.tsx",
+    "codeblock": true
+  }
+  ```
+</ComponentExample>
+
+### Fallback
+
+이미지 로딩이 실패하거나 `src`가 없을 때 `fallback` prop으로 대체 UI를 표시할 수 있습니다. `IdentityPlaceholder`를 함께 사용하면 사용자 이미지 영역을 일관된 형태로 보여줄 수 있습니다.
+
+<ComponentExample name="react/image-frame/fallback">
+  ```json doc-gen:file
+  {
+    "file": "examples/react/image-frame/fallback.tsx",
     "codeblock": true
   }
   ```

--- a/docs/examples/react/image-frame/fallback.tsx
+++ b/docs/examples/react/image-frame/fallback.tsx
@@ -1,0 +1,23 @@
+import { Flex, VStack, Text, ImageFrame } from "@seed-design/react";
+import { IdentityPlaceholder } from "seed-design/ui/identity-placeholder";
+
+export default function ImageFrameFallbackExample() {
+  return (
+    <Flex gap="x4" wrap="wrap" align="flex-end">
+      <VStack gap="x2" alignItems="center">
+        <ImageFrame
+          ratio={1}
+          borderRadius="r2"
+          stroke
+          src="https://example.com/invalid-image.jpg"
+          alt="이미지 로딩 실패 예시"
+          fallback={<IdentityPlaceholder />}
+          style={{ width: 120 }}
+        />
+        <Text color="palette.gray700" textStyle="t1Regular">
+          Identity Placeholder fallback
+        </Text>
+      </VStack>
+    </Flex>
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서

* **Documentation**
  * ImageFrame 컴포넌트의 Fallback 사용 방법에 대한 문서가 추가되었습니다.
  * IdentityPlaceholder를 Fallback으로 활용하는 예제가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->