### PR TITLE
fix(rootage): clarify ambiguous descriptions in component specs

### DIFF
--- a/docs/public/rootage/components/action-button.json
+++ b/docs/public/rootage/components/action-button.json
@@ -71,7 +71,7 @@
               "type": "dimension"
             }
           },
-          "description": "Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다."
+          "description": "layout=iconOnly에서 사용되는 아이콘 슬롯입니다."
         },
         "prefixIcon": {
           "properties": {
@@ -82,7 +82,7 @@
               "type": "dimension"
             }
           },
-          "description": "주로 액션의 의미를 보조합니다."
+          "description": "주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다."
         },
         "suffixIcon": {
           "properties": {
@@ -93,7 +93,7 @@
               "type": "dimension"
             }
           },
-          "description": "Chevron처럼 동작을 보조하는 역할입니다."
+          "description": "Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다."
         },
         "progressCircle": {
           "properties": {
@@ -128,13 +128,13 @@
               "description": "삭제나 초기화처럼 되돌릴 수 없는 중요한 작업에 사용합니다."
             },
             "neutralOutline": {
-              "description": "Solid 타입과 함께 사용할 수 없으며, Brand Outline과 조합하여 사용하는 것을 권장합니다."
+              "description": "variant=brandSolid, neutralSolid, criticalSolid와 함께 사용할 수 없으며, variant=brandOutline과 조합하여 사용하는 것을 권장합니다."
             },
             "brandOutline": {
-              "description": "Solid 타입과 함께 사용할 수 없으며, Neutral Outline과 조합하여 사용하는 것을 권장합니다."
+              "description": "variant=brandSolid, neutralSolid, criticalSolid와 함께 사용할 수 없으며, variant=neutralOutline과 조합하여 사용하는 것을 권장합니다."
             },
             "ghost": {
-              "description": "배경 없이 텍스트와 아이콘만 표시됩니다."
+              "description": "배경 없이 텍스트와 아이콘만 표시됩니다. 모두 동일한 색상을 사용하는 조건에서 icon, prefix icon, suffix icon, label에 정의된 color를 변경할 수 있으며, label의 fontWeight를 `$font-weight.regular` 또는 `$font-weight.medium`으로 변경하여 주목도를 조절할 수 있습니다."
             }
           },
           "defaultValue": "brandSolid"
@@ -162,7 +162,7 @@
               "description": "텍스트와 함께 아이콘을 표시할 수 있습니다."
             },
             "iconOnly": {
-              "description": "아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 사용하는 것을 권장합니다."
+              "description": "아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 접근성 레이블과 함께 사용하는 것을 권장합니다."
             }
           },
           "defaultValue": "withText"

--- a/docs/public/rootage/components/callout.json
+++ b/docs/public/rootage/components/callout.json
@@ -92,7 +92,7 @@
               "type": "color"
             }
           },
-          "description": "Container가 모두 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다."
+          "description": "root가 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다."
         },
         "suffixIcon": {
           "properties": {

--- a/docs/public/rootage/components/contextual-floating-button.json
+++ b/docs/public/rootage/components/contextual-floating-button.json
@@ -111,10 +111,10 @@
         "layout": {
           "values": {
             "withText": {
-              "description": "라벨과 아이콘을 함께 표시합니다."
+              "description": "label과 prefixIcon을 함께 표시합니다."
             },
             "iconOnly": {
-              "description": "아이콘만 표시합니다. 접근성을 위해 aria-label을 제공해야 합니다."
+              "description": "icon만 표시합니다. 아이콘만으로 의미를 전달하기 때문에 접근성 레이블과 함께 사용해야 합니다."
             }
           },
           "defaultValue": "withText"

--- a/docs/public/rootage/components/input-button.json
+++ b/docs/public/rootage/components/input-button.json
@@ -40,7 +40,7 @@
             },
             "strokeDuration": {
               "type": "duration",
-              "description": "1px stroke 위에 2px stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다."
+              "description": "enabled 상태의 stroke 위에 invalid 상태의 stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다."
             },
             "strokeTimingFunction": {
               "type": "cubicBezier"

--- a/docs/public/rootage/components/select-box.json
+++ b/docs/public/rootage/components/select-box.json
@@ -31,7 +31,7 @@
             },
             "strokeDuration": {
               "type": "duration",
-              "description": "1px stroke 위에 2px stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다."
+              "description": "enabled 상태의 stroke 위에 selected 상태의 stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다."
             },
             "strokeTimingFunction": {
               "type": "cubicBezier"

--- a/docs/public/rootage/components/slider.json
+++ b/docs/public/rootage/components/slider.json
@@ -108,7 +108,7 @@
               "type": "cubicBezier"
             }
           },
-          "description": "arrow width + paddingX * 2만큼의 최소 너비를 가집니다."
+          "description": "arrow width + (valueIndicatorRoot paddingX * 2)만큼의 최소 너비를 가집니다."
         },
         "valueIndicatorArrow": {
           "properties": {

--- a/docs/public/rootage/components/text-input.json
+++ b/docs/public/rootage/components/text-input.json
@@ -40,7 +40,7 @@
             },
             "strokeDuration": {
               "type": "duration",
-              "description": "1px stroke 위에 2px stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다."
+              "description": "enabled 상태의 stroke 위에 focused/invalid 상태의 stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다."
             },
             "strokeTimingFunction": {
               "type": "cubicBezier"

--- a/packages/css/vars/component/action-button.d.ts
+++ b/packages/css/vars/component/action-button.d.ts
@@ -21,15 +21,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-palette-static-white)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-palette-static-white)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-palette-static-white)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-palette-static-white)"
       },
@@ -50,15 +50,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       }
@@ -80,15 +80,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-neutral-inverted)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-neutral-inverted)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-neutral-inverted)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-neutral-inverted)"
       },
@@ -109,15 +109,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       }
@@ -139,15 +139,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-neutral)"
       },
@@ -168,15 +168,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       }
@@ -198,15 +198,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-palette-static-white)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-palette-static-white)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-palette-static-white)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-palette-static-white)"
       },
@@ -227,15 +227,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       }
@@ -247,7 +247,7 @@ export declare const vars: {
     }
   },
   /**
-   * Solid 타입과 함께 사용할 수 없으며, Brand Outline과 조합하여 사용하는 것을 권장합니다.
+   * variant=brandSolid, neutralSolid, criticalSolid와 함께 사용할 수 없으며, variant=brandOutline과 조합하여 사용하는 것을 권장합니다.
    */
   "variantNeutralOutline": {
     "enabled": {
@@ -259,15 +259,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-neutral)"
       },
@@ -289,15 +289,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       }
@@ -309,7 +309,7 @@ export declare const vars: {
     }
   },
   /**
-   * Solid 타입과 함께 사용할 수 없으며, Neutral Outline과 조합하여 사용하는 것을 권장합니다.
+   * variant=brandSolid, neutralSolid, criticalSolid와 함께 사용할 수 없으며, variant=neutralOutline과 조합하여 사용하는 것을 권장합니다.
    */
   "variantBrandOutline": {
     "enabled": {
@@ -321,15 +321,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-brand)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-brand)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-brand)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-brand)"
       },
@@ -351,15 +351,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       }
@@ -371,7 +371,7 @@ export declare const vars: {
     }
   },
   /**
-   * 배경 없이 텍스트와 아이콘만 표시됩니다.
+   * 배경 없이 텍스트와 아이콘만 표시됩니다. 모두 동일한 색상을 사용하는 조건에서 icon, prefix icon, suffix icon, label에 정의된 color를 변경할 수 있으며, label의 fontWeight를 `$font-weight.regular` 또는 `$font-weight.medium`으로 변경하여 주목도를 조절할 수 있습니다.
    */
   "variantGhost": {
     "enabled": {
@@ -381,15 +381,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-neutral)"
       },
@@ -410,15 +410,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       }
@@ -455,11 +455,11 @@ export declare const vars: {
         "paddingX": "var(--seed-dimension-x3_5)",
         "paddingY": "var(--seed-dimension-x1_5)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "size": "var(--seed-dimension-x3_5)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "size": "var(--seed-dimension-x3_5)"
       },
@@ -471,7 +471,7 @@ export declare const vars: {
   },
   /**
    * - `size=xsmall`: 작은 공간에서 효율적으로 사용할 수 있는 Pill 형태로 제공됩니다.
-   * - `layout=iconOnly`: 아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 사용하는 것을 권장합니다.
+   * - `layout=iconOnly`: 아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 접근성 레이블과 함께 사용하는 것을 권장합니다.
    */
   "sizeXsmallLayoutIconOnly": {
     "enabled": {
@@ -480,7 +480,7 @@ export declare const vars: {
         "paddingX": "var(--seed-dimension-x1_5)",
         "paddingY": "var(--seed-dimension-x1_5)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "size": "var(--seed-dimension-x3_5)"
       }
@@ -512,11 +512,11 @@ export declare const vars: {
         "paddingX": "var(--seed-dimension-x3_5)",
         "paddingY": "var(--seed-dimension-x2)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "size": "var(--seed-dimension-x3_5)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "size": "var(--seed-dimension-x3_5)"
       },
@@ -528,7 +528,7 @@ export declare const vars: {
   },
   /**
    * - `size=small`: 화면 중앙에서 범용적으로 사용됩니다.
-   * - `layout=iconOnly`: 아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 사용하는 것을 권장합니다.
+   * - `layout=iconOnly`: 아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 접근성 레이블과 함께 사용하는 것을 권장합니다.
    */
   "sizeSmallLayoutIconOnly": {
     "enabled": {
@@ -537,7 +537,7 @@ export declare const vars: {
         "paddingX": "var(--seed-dimension-x2)",
         "paddingY": "var(--seed-dimension-x2)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "size": "var(--seed-dimension-x4)"
       }
@@ -569,11 +569,11 @@ export declare const vars: {
         "paddingX": "var(--seed-dimension-x4)",
         "paddingY": "var(--seed-dimension-x2_5)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "size": "var(--seed-dimension-x4)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "size": "var(--seed-dimension-x4)"
       },
@@ -585,7 +585,7 @@ export declare const vars: {
   },
   /**
    * - `size=medium`: 화면 중앙에서 범용적으로 사용됩니다.
-   * - `layout=iconOnly`: 아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 사용하는 것을 권장합니다.
+   * - `layout=iconOnly`: 아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 접근성 레이블과 함께 사용하는 것을 권장합니다.
    */
   "sizeMediumLayoutIconOnly": {
     "enabled": {
@@ -594,7 +594,7 @@ export declare const vars: {
         "paddingX": "var(--seed-dimension-x2_5)",
         "paddingY": "var(--seed-dimension-x2_5)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "size": "18px"
       }
@@ -626,11 +626,11 @@ export declare const vars: {
         "paddingX": "var(--seed-dimension-x5)",
         "paddingY": "var(--seed-dimension-x3_5)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "size": "22px"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "size": "22px"
       },
@@ -642,7 +642,7 @@ export declare const vars: {
   },
   /**
    * - `size=large`: 주로 CTA 역할로 사용됩니다.
-   * - `layout=iconOnly`: 아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 사용하는 것을 권장합니다.
+   * - `layout=iconOnly`: 아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 접근성 레이블과 함께 사용하는 것을 권장합니다.
    */
   "sizeLargeLayoutIconOnly": {
     "enabled": {
@@ -651,7 +651,7 @@ export declare const vars: {
         "paddingX": "var(--seed-dimension-x3_5)",
         "paddingY": "var(--seed-dimension-x3_5)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "size": "22px"
       }

--- a/packages/css/vars/component/callout.d.ts
+++ b/packages/css/vars/component/callout.d.ts
@@ -22,7 +22,7 @@ export declare const vars: {
         "lineHeight": "var(--seed-line-height-t4)",
         "fontWeight": "var(--seed-font-weight-regular)"
       },
-      /** Container가 모두 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
+      /** root가 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
       "link": {
         "fontSize": "var(--seed-font-size-t4)",
         "lineHeight": "var(--seed-line-height-t4)",
@@ -52,7 +52,7 @@ export declare const vars: {
       "description": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** Container가 모두 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
+      /** root가 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
       "link": {
         "color": "var(--seed-color-fg-neutral)"
       },
@@ -84,7 +84,7 @@ export declare const vars: {
       "description": {
         "color": "var(--seed-color-fg-informative-contrast)"
       },
-      /** Container가 모두 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
+      /** root가 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
       "link": {
         "color": "var(--seed-color-fg-informative-contrast)"
       },
@@ -116,7 +116,7 @@ export declare const vars: {
       "description": {
         "color": "var(--seed-color-fg-positive-contrast)"
       },
-      /** Container가 모두 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
+      /** root가 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
       "link": {
         "color": "var(--seed-color-fg-positive-contrast)"
       },
@@ -148,7 +148,7 @@ export declare const vars: {
       "description": {
         "color": "var(--seed-color-fg-warning-contrast)"
       },
-      /** Container가 모두 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
+      /** root가 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
       "link": {
         "color": "var(--seed-color-fg-warning-contrast)"
       },
@@ -180,7 +180,7 @@ export declare const vars: {
       "description": {
         "color": "var(--seed-color-fg-critical-contrast)"
       },
-      /** Container가 모두 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
+      /** root가 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
       "link": {
         "color": "var(--seed-color-fg-critical-contrast)"
       },
@@ -212,7 +212,7 @@ export declare const vars: {
       "description": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** Container가 모두 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
+      /** root가 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
       "link": {
         "color": "var(--seed-color-fg-neutral)"
       },

--- a/packages/css/vars/component/contextual-floating-button.d.ts
+++ b/packages/css/vars/component/contextual-floating-button.d.ts
@@ -108,7 +108,7 @@ export declare const vars: {
     }
   },
   /**
-   * 라벨과 아이콘을 함께 표시합니다.
+   * label과 prefixIcon을 함께 표시합니다.
    */
   "layoutWithText": {
     "enabled": {
@@ -129,7 +129,7 @@ export declare const vars: {
     }
   },
   /**
-   * 아이콘만 표시합니다. 접근성을 위해 aria-label을 제공해야 합니다.
+   * icon만 표시합니다. 아이콘만으로 의미를 전달하기 때문에 접근성 레이블과 함께 사용해야 합니다.
    */
   "layoutIconOnly": {
     "enabled": {

--- a/packages/css/vars/component/input-button.d.ts
+++ b/packages/css/vars/component/input-button.d.ts
@@ -11,7 +11,7 @@ export declare const vars: {
         "color": "var(--seed-color-bg-transparent)",
         "colorDuration": "var(--seed-duration-color-transition)",
         "colorTimingFunction": "var(--seed-timing-function-easing)",
-        /** 1px stroke 위에 2px stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다. */
+        /** enabled 상태의 stroke 위에 invalid 상태의 stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다. */
         "strokeDuration": "0.1s",
         "strokeTimingFunction": "var(--seed-timing-function-easing)"
       },

--- a/packages/css/vars/component/select-box.d.ts
+++ b/packages/css/vars/component/select-box.d.ts
@@ -8,7 +8,7 @@ export declare const vars: {
         "strokeWidth": "1px",
         "colorDuration": "var(--seed-duration-color-transition)",
         "colorTimingFunction": "var(--seed-timing-function-easing)",
-        /** 1px stroke 위에 2px stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다. */
+        /** enabled 상태의 stroke 위에 selected 상태의 stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다. */
         "strokeDuration": "0.1s",
         "strokeTimingFunction": "var(--seed-timing-function-easing)"
       },

--- a/packages/css/vars/component/slider.d.ts
+++ b/packages/css/vars/component/slider.d.ts
@@ -23,7 +23,7 @@ export declare const vars: {
         "cornerRadius": "var(--seed-radius-full)",
         "color": "var(--seed-color-bg-neutral-inverted)"
       },
-      /** arrow width + paddingX * 2만큼의 최소 너비를 가집니다. */
+      /** arrow width + (valueIndicatorRoot paddingX * 2)만큼의 최소 너비를 가집니다. */
       "valueIndicatorRoot": {
         "color": "var(--seed-color-bg-neutral-inverted)",
         "cornerRadius": "var(--seed-radius-r1_5)",

--- a/packages/css/vars/component/text-input.d.ts
+++ b/packages/css/vars/component/text-input.d.ts
@@ -3,7 +3,7 @@ export declare const vars: {
     "enabled": {
       "root": {
         "strokeColor": "var(--seed-color-stroke-neutral-weak)",
-        /** 1px stroke 위에 2px stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다. */
+        /** enabled 상태의 stroke 위에 focused/invalid 상태의 stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다. */
         "strokeDuration": "0.1s",
         "strokeTimingFunction": "var(--seed-timing-function-easing)"
       },

--- a/packages/qvism-preset/src/vars/component/action-button.d.ts
+++ b/packages/qvism-preset/src/vars/component/action-button.d.ts
@@ -21,15 +21,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-palette-static-white)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-palette-static-white)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-palette-static-white)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-palette-static-white)"
       },
@@ -50,15 +50,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       }
@@ -80,15 +80,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-neutral-inverted)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-neutral-inverted)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-neutral-inverted)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-neutral-inverted)"
       },
@@ -109,15 +109,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       }
@@ -139,15 +139,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-neutral)"
       },
@@ -168,15 +168,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       }
@@ -198,15 +198,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-palette-static-white)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-palette-static-white)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-palette-static-white)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-palette-static-white)"
       },
@@ -227,15 +227,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       }
@@ -247,7 +247,7 @@ export declare const vars: {
     }
   },
   /**
-   * Solid 타입과 함께 사용할 수 없으며, Brand Outline과 조합하여 사용하는 것을 권장합니다.
+   * variant=brandSolid, neutralSolid, criticalSolid와 함께 사용할 수 없으며, variant=brandOutline과 조합하여 사용하는 것을 권장합니다.
    */
   "variantNeutralOutline": {
     "enabled": {
@@ -259,15 +259,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-neutral)"
       },
@@ -289,15 +289,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       }
@@ -309,7 +309,7 @@ export declare const vars: {
     }
   },
   /**
-   * Solid 타입과 함께 사용할 수 없으며, Neutral Outline과 조합하여 사용하는 것을 권장합니다.
+   * variant=brandSolid, neutralSolid, criticalSolid와 함께 사용할 수 없으며, variant=neutralOutline과 조합하여 사용하는 것을 권장합니다.
    */
   "variantBrandOutline": {
     "enabled": {
@@ -321,15 +321,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-brand)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-brand)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-brand)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-brand)"
       },
@@ -351,15 +351,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       }
@@ -371,7 +371,7 @@ export declare const vars: {
     }
   },
   /**
-   * 배경 없이 텍스트와 아이콘만 표시됩니다.
+   * 배경 없이 텍스트와 아이콘만 표시됩니다. 모두 동일한 색상을 사용하는 조건에서 icon, prefix icon, suffix icon, label에 정의된 color를 변경할 수 있으며, label의 fontWeight를 `$font-weight.regular` 또는 `$font-weight.medium`으로 변경하여 주목도를 조절할 수 있습니다.
    */
   "variantGhost": {
     "enabled": {
@@ -381,15 +381,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-neutral)"
       },
@@ -410,15 +410,15 @@ export declare const vars: {
       "label": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "color": "var(--seed-color-fg-disabled)"
       }
@@ -455,11 +455,11 @@ export declare const vars: {
         "paddingX": "var(--seed-dimension-x3_5)",
         "paddingY": "var(--seed-dimension-x1_5)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "size": "var(--seed-dimension-x3_5)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "size": "var(--seed-dimension-x3_5)"
       },
@@ -471,7 +471,7 @@ export declare const vars: {
   },
   /**
    * - `size=xsmall`: 작은 공간에서 효율적으로 사용할 수 있는 Pill 형태로 제공됩니다.
-   * - `layout=iconOnly`: 아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 사용하는 것을 권장합니다.
+   * - `layout=iconOnly`: 아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 접근성 레이블과 함께 사용하는 것을 권장합니다.
    */
   "sizeXsmallLayoutIconOnly": {
     "enabled": {
@@ -480,7 +480,7 @@ export declare const vars: {
         "paddingX": "var(--seed-dimension-x1_5)",
         "paddingY": "var(--seed-dimension-x1_5)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "size": "var(--seed-dimension-x3_5)"
       }
@@ -512,11 +512,11 @@ export declare const vars: {
         "paddingX": "var(--seed-dimension-x3_5)",
         "paddingY": "var(--seed-dimension-x2)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "size": "var(--seed-dimension-x3_5)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "size": "var(--seed-dimension-x3_5)"
       },
@@ -528,7 +528,7 @@ export declare const vars: {
   },
   /**
    * - `size=small`: 화면 중앙에서 범용적으로 사용됩니다.
-   * - `layout=iconOnly`: 아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 사용하는 것을 권장합니다.
+   * - `layout=iconOnly`: 아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 접근성 레이블과 함께 사용하는 것을 권장합니다.
    */
   "sizeSmallLayoutIconOnly": {
     "enabled": {
@@ -537,7 +537,7 @@ export declare const vars: {
         "paddingX": "var(--seed-dimension-x2)",
         "paddingY": "var(--seed-dimension-x2)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "size": "var(--seed-dimension-x4)"
       }
@@ -569,11 +569,11 @@ export declare const vars: {
         "paddingX": "var(--seed-dimension-x4)",
         "paddingY": "var(--seed-dimension-x2_5)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "size": "var(--seed-dimension-x4)"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "size": "var(--seed-dimension-x4)"
       },
@@ -585,7 +585,7 @@ export declare const vars: {
   },
   /**
    * - `size=medium`: 화면 중앙에서 범용적으로 사용됩니다.
-   * - `layout=iconOnly`: 아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 사용하는 것을 권장합니다.
+   * - `layout=iconOnly`: 아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 접근성 레이블과 함께 사용하는 것을 권장합니다.
    */
   "sizeMediumLayoutIconOnly": {
     "enabled": {
@@ -594,7 +594,7 @@ export declare const vars: {
         "paddingX": "var(--seed-dimension-x2_5)",
         "paddingY": "var(--seed-dimension-x2_5)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "size": "18px"
       }
@@ -626,11 +626,11 @@ export declare const vars: {
         "paddingX": "var(--seed-dimension-x5)",
         "paddingY": "var(--seed-dimension-x3_5)"
       },
-      /** 주로 액션의 의미를 보조합니다. */
+      /** 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다. */
       "prefixIcon": {
         "size": "22px"
       },
-      /** Chevron처럼 동작을 보조하는 역할입니다. */
+      /** Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다. */
       "suffixIcon": {
         "size": "22px"
       },
@@ -642,7 +642,7 @@ export declare const vars: {
   },
   /**
    * - `size=large`: 주로 CTA 역할로 사용됩니다.
-   * - `layout=iconOnly`: 아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 사용하는 것을 권장합니다.
+   * - `layout=iconOnly`: 아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 접근성 레이블과 함께 사용하는 것을 권장합니다.
    */
   "sizeLargeLayoutIconOnly": {
     "enabled": {
@@ -651,7 +651,7 @@ export declare const vars: {
         "paddingX": "var(--seed-dimension-x3_5)",
         "paddingY": "var(--seed-dimension-x3_5)"
       },
-      /** Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다. */
+      /** layout=iconOnly에서 사용되는 아이콘 슬롯입니다. */
       "icon": {
         "size": "22px"
       }

--- a/packages/qvism-preset/src/vars/component/callout.d.ts
+++ b/packages/qvism-preset/src/vars/component/callout.d.ts
@@ -22,7 +22,7 @@ export declare const vars: {
         "lineHeight": "var(--seed-line-height-t4)",
         "fontWeight": "var(--seed-font-weight-regular)"
       },
-      /** Container가 모두 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
+      /** root가 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
       "link": {
         "fontSize": "var(--seed-font-size-t4)",
         "lineHeight": "var(--seed-line-height-t4)",
@@ -52,7 +52,7 @@ export declare const vars: {
       "description": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** Container가 모두 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
+      /** root가 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
       "link": {
         "color": "var(--seed-color-fg-neutral)"
       },
@@ -84,7 +84,7 @@ export declare const vars: {
       "description": {
         "color": "var(--seed-color-fg-informative-contrast)"
       },
-      /** Container가 모두 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
+      /** root가 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
       "link": {
         "color": "var(--seed-color-fg-informative-contrast)"
       },
@@ -116,7 +116,7 @@ export declare const vars: {
       "description": {
         "color": "var(--seed-color-fg-positive-contrast)"
       },
-      /** Container가 모두 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
+      /** root가 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
       "link": {
         "color": "var(--seed-color-fg-positive-contrast)"
       },
@@ -148,7 +148,7 @@ export declare const vars: {
       "description": {
         "color": "var(--seed-color-fg-warning-contrast)"
       },
-      /** Container가 모두 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
+      /** root가 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
       "link": {
         "color": "var(--seed-color-fg-warning-contrast)"
       },
@@ -180,7 +180,7 @@ export declare const vars: {
       "description": {
         "color": "var(--seed-color-fg-critical-contrast)"
       },
-      /** Container가 모두 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
+      /** root가 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
       "link": {
         "color": "var(--seed-color-fg-critical-contrast)"
       },
@@ -212,7 +212,7 @@ export declare const vars: {
       "description": {
         "color": "var(--seed-color-fg-neutral)"
       },
-      /** Container가 모두 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
+      /** root가 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다. */
       "link": {
         "color": "var(--seed-color-fg-neutral)"
       },

--- a/packages/qvism-preset/src/vars/component/contextual-floating-button.d.ts
+++ b/packages/qvism-preset/src/vars/component/contextual-floating-button.d.ts
@@ -108,7 +108,7 @@ export declare const vars: {
     }
   },
   /**
-   * 라벨과 아이콘을 함께 표시합니다.
+   * label과 prefixIcon을 함께 표시합니다.
    */
   "layoutWithText": {
     "enabled": {
@@ -129,7 +129,7 @@ export declare const vars: {
     }
   },
   /**
-   * 아이콘만 표시합니다. 접근성을 위해 aria-label을 제공해야 합니다.
+   * icon만 표시합니다. 아이콘만으로 의미를 전달하기 때문에 접근성 레이블과 함께 사용해야 합니다.
    */
   "layoutIconOnly": {
     "enabled": {

--- a/packages/qvism-preset/src/vars/component/input-button.d.ts
+++ b/packages/qvism-preset/src/vars/component/input-button.d.ts
@@ -11,7 +11,7 @@ export declare const vars: {
         "color": "var(--seed-color-bg-transparent)",
         "colorDuration": "var(--seed-duration-color-transition)",
         "colorTimingFunction": "var(--seed-timing-function-easing)",
-        /** 1px stroke 위에 2px stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다. */
+        /** enabled 상태의 stroke 위에 invalid 상태의 stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다. */
         "strokeDuration": "0.1s",
         "strokeTimingFunction": "var(--seed-timing-function-easing)"
       },

--- a/packages/qvism-preset/src/vars/component/select-box.d.ts
+++ b/packages/qvism-preset/src/vars/component/select-box.d.ts
@@ -8,7 +8,7 @@ export declare const vars: {
         "strokeWidth": "1px",
         "colorDuration": "var(--seed-duration-color-transition)",
         "colorTimingFunction": "var(--seed-timing-function-easing)",
-        /** 1px stroke 위에 2px stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다. */
+        /** enabled 상태의 stroke 위에 selected 상태의 stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다. */
         "strokeDuration": "0.1s",
         "strokeTimingFunction": "var(--seed-timing-function-easing)"
       },

--- a/packages/qvism-preset/src/vars/component/slider.d.ts
+++ b/packages/qvism-preset/src/vars/component/slider.d.ts
@@ -23,7 +23,7 @@ export declare const vars: {
         "cornerRadius": "var(--seed-radius-full)",
         "color": "var(--seed-color-bg-neutral-inverted)"
       },
-      /** arrow width + paddingX * 2만큼의 최소 너비를 가집니다. */
+      /** arrow width + (valueIndicatorRoot paddingX * 2)만큼의 최소 너비를 가집니다. */
       "valueIndicatorRoot": {
         "color": "var(--seed-color-bg-neutral-inverted)",
         "cornerRadius": "var(--seed-radius-r1_5)",

--- a/packages/qvism-preset/src/vars/component/text-input.d.ts
+++ b/packages/qvism-preset/src/vars/component/text-input.d.ts
@@ -3,7 +3,7 @@ export declare const vars: {
     "enabled": {
       "root": {
         "strokeColor": "var(--seed-color-stroke-neutral-weak)",
-        /** 1px stroke 위에 2px stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다. */
+        /** enabled 상태의 stroke 위에 focused/invalid 상태의 stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다. */
         "strokeDuration": "0.1s",
         "strokeTimingFunction": "var(--seed-timing-function-easing)"
       },

--- a/packages/rootage/components/action-button.yaml
+++ b/packages/rootage/components/action-button.yaml
@@ -41,21 +41,21 @@ data:
           lineHeight:
             type: dimension
       icon:
-        description: Icon Only 레이아웃에서 사용되는 아이콘 슬롯입니다.
+        description: layout=iconOnly에서 사용되는 아이콘 슬롯입니다.
         properties:
           color:
             type: color
           size:
             type: dimension
       prefixIcon:
-        description: 주로 액션의 의미를 보조합니다.
+        description: 주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다.
         properties:
           color:
             type: color
           size:
             type: dimension
       suffixIcon:
-        description: Chevron처럼 동작을 보조하는 역할입니다.
+        description: Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다.
         properties:
           color:
             type: color
@@ -83,11 +83,11 @@ data:
           criticalSolid:
             description: 삭제나 초기화처럼 되돌릴 수 없는 중요한 작업에 사용합니다.
           neutralOutline:
-            description: Solid 타입과 함께 사용할 수 없으며, Brand Outline과 조합하여 사용하는 것을 권장합니다.
+            description: variant=brandSolid, neutralSolid, criticalSolid와 함께 사용할 수 없으며, variant=brandOutline과 조합하여 사용하는 것을 권장합니다.
           brandOutline:
-            description: Solid 타입과 함께 사용할 수 없으며, Neutral Outline과 조합하여 사용하는 것을 권장합니다.
+            description: variant=brandSolid, neutralSolid, criticalSolid와 함께 사용할 수 없으며, variant=neutralOutline과 조합하여 사용하는 것을 권장합니다.
           ghost:
-            description: 배경 없이 텍스트와 아이콘만 표시됩니다.
+            description: 배경 없이 텍스트와 아이콘만 표시됩니다. 모두 동일한 색상을 사용하는 조건에서 icon, prefix icon, suffix icon, label에 정의된 color를 변경할 수 있으며, label의 fontWeight를 `$font-weight.regular` 또는 `$font-weight.medium`으로 변경하여 주목도를 조절할 수 있습니다.
       size:
         values:
           xsmall:
@@ -103,7 +103,7 @@ data:
           withText:
             description: 텍스트와 함께 아이콘을 표시할 수 있습니다.
           iconOnly:
-            description: 아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 사용하는 것을 권장합니다.
+            description: 아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 접근성 레이블과 함께 사용하는 것을 권장합니다.
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/callout.yaml
+++ b/packages/rootage/components/callout.yaml
@@ -50,7 +50,7 @@ data:
           color:
             type: color
       link:
-        description: Container가 모두 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다.
+        description: root가 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다.
         properties:
           fontSize:
             type: dimension

--- a/packages/rootage/components/contextual-floating-button.yaml
+++ b/packages/rootage/components/contextual-floating-button.yaml
@@ -70,9 +70,9 @@ data:
       layout:
         values:
           withText:
-            description: 라벨과 아이콘을 함께 표시합니다.
+            description: label과 prefixIcon을 함께 표시합니다.
           iconOnly:
-            description: 아이콘만 표시합니다. 접근성을 위해 aria-label을 제공해야 합니다.
+            description: icon만 표시합니다. 아이콘만으로 의미를 전달하기 때문에 접근성 레이블과 함께 사용해야 합니다.
   definitions:
     base:
       enabled:

--- a/packages/rootage/components/input-button.yaml
+++ b/packages/rootage/components/input-button.yaml
@@ -28,7 +28,7 @@ data:
             type: cubicBezier
           strokeDuration:
             type: duration
-            description: 1px stroke 위에 2px stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다.
+            description: enabled 상태의 stroke 위에 invalid 상태의 stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다.
           strokeTimingFunction:
             type: cubicBezier
       value:

--- a/packages/rootage/components/select-box.yaml
+++ b/packages/rootage/components/select-box.yaml
@@ -22,7 +22,7 @@ data:
             type: cubicBezier
           strokeDuration:
             type: duration
-            description: 1px stroke 위에 2px stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다.
+            description: enabled 상태의 stroke 위에 selected 상태의 stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다.
           strokeTimingFunction:
             type: cubicBezier
       trigger:

--- a/packages/rootage/components/slider.yaml
+++ b/packages/rootage/components/slider.yaml
@@ -41,7 +41,7 @@ data:
           color:
             type: color
       valueIndicatorRoot:
-        description: arrow width + paddingX * 2만큼의 최소 너비를 가집니다.
+        description: arrow width + (valueIndicatorRoot paddingX * 2)만큼의 최소 너비를 가집니다.
         properties:
           color:
             type: color

--- a/packages/rootage/components/text-input.yaml
+++ b/packages/rootage/components/text-input.yaml
@@ -28,7 +28,7 @@ data:
             type: color
           strokeDuration:
             type: duration
-            description: 1px stroke 위에 2px stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다.
+            description: enabled 상태의 stroke 위에 focused/invalid 상태의 stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다.
           strokeTimingFunction:
             type: cubicBezier
       value:


### PR DESCRIPTION
## Summary
- Rootage component YAML의 description 필드에서 비공식 용어를 실제 variant/slot 이름으로 대체
- "Solid 타입" → `variant=brandSolid, neutralSolid, criticalSolid`, "Brand Outline" → `variant=brandOutline` 등
- action-button, callout, contextual-floating-button, input-button, select-box, slider, text-input 대상

## Changes
| Component | Before | After |
|---|---|---|
| action-button | "Solid 타입", "Brand Outline" | `variant=brandSolid, neutralSolid, criticalSolid`, `variant=brandOutline` |
| action-button | "Icon Only 레이아웃" | `layout=iconOnly` |
| action-button | "배경 없이 텍스트와 아이콘만 표시됩니다." | + ghost variant 커스터마이징 가이드 추가 |
| callout | "Container" | `root` (slot 이름) |
| contextual-floating-button | "라벨과 아이콘" | `label`과 `prefixIcon` (slot 이름) |
| input-button, select-box, text-input | "1px stroke 위에 2px stroke" | 실제 state 이름 (enabled/invalid/selected/focused) |
| slider | "paddingX" | `valueIndicatorRoot paddingX` (slot 이름 명시) |

## Test plan
- [ ] `bun rootage:generate` 정상 실행 확인
- [ ] 생성된 JSON/d.ts 파일에 변경된 description 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 컴포넌트 사용 가이드 개선: 레이아웃 옵션, 슬롯 및 변형 간 상호작용 설명 명확화
  * 아이콘 전용 레이아웃 사용 시 접근성 레이블 적용 방법 안내 추가
  * 애니메이션 전환 시간 관련 설명 정확성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->