### PR TITLE
docs: add llms.txt quick action to docs pages

### DIFF
--- a/docs/app/ai-integration/[[...slug]]/page.tsx
+++ b/docs/app/ai-integration/[[...slug]]/page.tsx
@@ -1,8 +1,10 @@
+import { getGitHubSourceUrl } from "@/app/_llms/config";
 import { aiIntegrationSource } from "@/app/source";
-import type { Metadata } from "next";
-import { DocsPage, DocsBody, DocsTitle, DocsDescription } from "fumadocs-ui/page";
-import { notFound } from "next/navigation";
+import { LLMCopyButton, LLMPageLinkButton, ViewOptions } from "@/components/page-actions";
 import { mdxComponents } from "@/components/mdx-components";
+import { DocsPage, DocsBody, DocsTitle, DocsDescription } from "fumadocs-ui/page";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 
 export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
   const params = await props.params;
@@ -10,11 +12,21 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
   if (!page) notFound();
 
   const { body: MDX, toc, lastModified } = await page.data.load();
+  const slugsWithExt = page.slugs.map((s, i) => (i === page.slugs.length - 1 ? `${s}.txt` : s));
+  const markdownUrl = `/llms/ai-integration/${slugsWithExt.join("/")}`;
 
   return (
     <DocsPage toc={toc} full={page.data.full} lastUpdate={lastModified}>
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
+      <div className="flex flex-row gap-2 items-center mb-3 justify-end">
+        <LLMCopyButton markdownUrl={markdownUrl} />
+        <LLMPageLinkButton markdownUrl={markdownUrl} />
+        <ViewOptions
+          markdownUrl={markdownUrl}
+          githubUrl={getGitHubSourceUrl("ai-integration", page.path)}
+        />
+      </div>
       <DocsBody className="prose-p:break-keep prose-p:text-pretty prose-headings:text-balance">
         <MDX components={mdxComponents} />
       </DocsBody>

--- a/docs/app/ai-integration/[[...slug]]/page.tsx
+++ b/docs/app/ai-integration/[[...slug]]/page.tsx
@@ -1,6 +1,6 @@
 import { getGitHubSourceUrl } from "@/app/_llms/config";
 import { aiIntegrationSource } from "@/app/source";
-import { LLMCopyButton, LLMPageLinkButton, ViewOptions } from "@/components/page-actions";
+import { LLMOptions, ViewOptions } from "@/components/page-actions";
 import { mdxComponents } from "@/components/mdx-components";
 import { DocsPage, DocsBody, DocsTitle, DocsDescription } from "fumadocs-ui/page";
 import type { Metadata } from "next";
@@ -20,8 +20,7 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <div className="flex flex-row gap-2 items-center mb-3 justify-end">
-        <LLMCopyButton markdownUrl={markdownUrl} />
-        <LLMPageLinkButton markdownUrl={markdownUrl} />
+        <LLMOptions markdownUrl={markdownUrl} />
         <ViewOptions
           markdownUrl={markdownUrl}
           githubUrl={getGitHubSourceUrl("ai-integration", page.path)}

--- a/docs/app/breeze/[[...slug]]/page.tsx
+++ b/docs/app/breeze/[[...slug]]/page.tsx
@@ -1,8 +1,10 @@
+import { getGitHubSourceUrl } from "@/app/_llms/config";
 import { breezeSource } from "@/app/source";
-import type { Metadata } from "next";
-import { DocsPage, DocsBody, DocsTitle, DocsDescription } from "fumadocs-ui/page";
-import { notFound } from "next/navigation";
+import { LLMCopyButton, LLMPageLinkButton, ViewOptions } from "@/components/page-actions";
 import { mdxComponents } from "@/components/mdx-components";
+import { DocsPage, DocsBody, DocsTitle, DocsDescription } from "fumadocs-ui/page";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 
 export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
   const params = await props.params;
@@ -10,11 +12,18 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
   if (!page) notFound();
 
   const { body: MDX, toc, lastModified } = await page.data.load();
+  const slugsWithExt = page.slugs.map((s, i) => (i === page.slugs.length - 1 ? `${s}.txt` : s));
+  const markdownUrl = `/llms/breeze/${slugsWithExt.join("/")}`;
 
   return (
     <DocsPage toc={toc} full={page.data.full} lastUpdate={lastModified}>
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
+      <div className="flex flex-row gap-2 items-center mb-3 justify-end">
+        <LLMCopyButton markdownUrl={markdownUrl} />
+        <LLMPageLinkButton markdownUrl={markdownUrl} />
+        <ViewOptions markdownUrl={markdownUrl} githubUrl={getGitHubSourceUrl("breeze", page.path)} />
+      </div>
       <DocsBody className="prose-p:break-keep prose-p:text-pretty prose-headings:text-balance">
         <MDX components={mdxComponents} />
       </DocsBody>

--- a/docs/app/breeze/[[...slug]]/page.tsx
+++ b/docs/app/breeze/[[...slug]]/page.tsx
@@ -1,6 +1,6 @@
 import { getGitHubSourceUrl } from "@/app/_llms/config";
 import { breezeSource } from "@/app/source";
-import { LLMCopyButton, LLMPageLinkButton, ViewOptions } from "@/components/page-actions";
+import { LLMOptions, ViewOptions } from "@/components/page-actions";
 import { mdxComponents } from "@/components/mdx-components";
 import { DocsPage, DocsBody, DocsTitle, DocsDescription } from "fumadocs-ui/page";
 import type { Metadata } from "next";
@@ -20,8 +20,7 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <div className="flex flex-row gap-2 items-center mb-3 justify-end">
-        <LLMCopyButton markdownUrl={markdownUrl} />
-        <LLMPageLinkButton markdownUrl={markdownUrl} />
+        <LLMOptions markdownUrl={markdownUrl} />
         <ViewOptions markdownUrl={markdownUrl} githubUrl={getGitHubSourceUrl("breeze", page.path)} />
       </div>
       <DocsBody className="prose-p:break-keep prose-p:text-pretty prose-headings:text-balance">

--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -1,4 +1,6 @@
+import { getGitHubSourceUrl } from "@/app/_llms/config";
 import { docsSource } from "@/app/source";
+import { LLMCopyButton, LLMPageLinkButton, ViewOptions } from "@/components/page-actions";
 import { mdxComponents } from "@/components/mdx-components";
 import { getComponentStatus } from "@/components/rootage";
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/page";
@@ -25,10 +27,18 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
   ) : (
     <span>{page.data.description}</span>
   );
+  const slugsWithExt = page.slugs.map((s, i) => (i === page.slugs.length - 1 ? `${s}.txt` : s));
+  const markdownUrl = `/llms/docs/${slugsWithExt.join("/")}`;
+
   return (
     <DocsPage toc={toc} full={page.data.full} lastUpdate={lastModified}>
       <DocsTitle>{displayTitle}</DocsTitle>
       <DocsDescription>{displayDescription}</DocsDescription>
+      <div className="flex flex-row gap-2 items-center mb-3 justify-end">
+        <LLMCopyButton markdownUrl={markdownUrl} />
+        <LLMPageLinkButton markdownUrl={markdownUrl} />
+        <ViewOptions markdownUrl={markdownUrl} githubUrl={getGitHubSourceUrl("docs", page.path)} />
+      </div>
       <DocsBody className="prose-p:break-keep prose-p:text-pretty prose-headings:text-balance">
         <MDX components={mdxComponents} />
       </DocsBody>

--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -1,6 +1,6 @@
 import { getGitHubSourceUrl } from "@/app/_llms/config";
 import { docsSource } from "@/app/source";
-import { LLMCopyButton, LLMPageLinkButton, ViewOptions } from "@/components/page-actions";
+import { LLMOptions, ViewOptions } from "@/components/page-actions";
 import { mdxComponents } from "@/components/mdx-components";
 import { getComponentStatus } from "@/components/rootage";
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/page";
@@ -35,8 +35,7 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
       <DocsTitle>{displayTitle}</DocsTitle>
       <DocsDescription>{displayDescription}</DocsDescription>
       <div className="flex flex-row gap-2 items-center mb-3 justify-end">
-        <LLMCopyButton markdownUrl={markdownUrl} />
-        <LLMPageLinkButton markdownUrl={markdownUrl} />
+        <LLMOptions markdownUrl={markdownUrl} />
         <ViewOptions markdownUrl={markdownUrl} githubUrl={getGitHubSourceUrl("docs", page.path)} />
       </div>
       <DocsBody className="prose-p:break-keep prose-p:text-pretty prose-headings:text-balance">

--- a/docs/app/lynx/[[...slug]]/page.tsx
+++ b/docs/app/lynx/[[...slug]]/page.tsx
@@ -1,8 +1,10 @@
+import { getGitHubSourceUrl } from "@/app/_llms/config";
 import { lynxSource } from "@/app/source";
-import type { Metadata } from "next";
-import { DocsPage, DocsBody, DocsTitle, DocsDescription } from "fumadocs-ui/page";
-import { notFound } from "next/navigation";
+import { LLMCopyButton, LLMPageLinkButton, ViewOptions } from "@/components/page-actions";
 import { mdxComponents } from "@/components/mdx-components";
+import { DocsPage, DocsBody, DocsTitle, DocsDescription } from "fumadocs-ui/page";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 
 export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
   const params = await props.params;
@@ -10,11 +12,18 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
   if (!page) notFound();
 
   const { body: MDX, toc, lastModified } = await page.data.load();
+  const slugsWithExt = page.slugs.map((s, i) => (i === page.slugs.length - 1 ? `${s}.txt` : s));
+  const markdownUrl = `/llms/lynx/${slugsWithExt.join("/")}`;
 
   return (
     <DocsPage toc={toc} full={page.data.full} lastUpdate={lastModified}>
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
+      <div className="flex flex-row gap-2 items-center mb-3 justify-end">
+        <LLMCopyButton markdownUrl={markdownUrl} />
+        <LLMPageLinkButton markdownUrl={markdownUrl} />
+        <ViewOptions markdownUrl={markdownUrl} githubUrl={getGitHubSourceUrl("lynx", page.path)} />
+      </div>
       <DocsBody className="prose-p:break-keep prose-p:text-pretty prose-headings:text-balance">
         <MDX components={mdxComponents} />
       </DocsBody>

--- a/docs/app/lynx/[[...slug]]/page.tsx
+++ b/docs/app/lynx/[[...slug]]/page.tsx
@@ -1,6 +1,6 @@
 import { getGitHubSourceUrl } from "@/app/_llms/config";
 import { lynxSource } from "@/app/source";
-import { LLMCopyButton, LLMPageLinkButton, ViewOptions } from "@/components/page-actions";
+import { LLMOptions, ViewOptions } from "@/components/page-actions";
 import { mdxComponents } from "@/components/mdx-components";
 import { DocsPage, DocsBody, DocsTitle, DocsDescription } from "fumadocs-ui/page";
 import type { Metadata } from "next";
@@ -20,8 +20,7 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <div className="flex flex-row gap-2 items-center mb-3 justify-end">
-        <LLMCopyButton markdownUrl={markdownUrl} />
-        <LLMPageLinkButton markdownUrl={markdownUrl} />
+        <LLMOptions markdownUrl={markdownUrl} />
         <ViewOptions markdownUrl={markdownUrl} githubUrl={getGitHubSourceUrl("lynx", page.path)} />
       </div>
       <DocsBody className="prose-p:break-keep prose-p:text-pretty prose-headings:text-balance">

--- a/docs/app/react/[[...slug]]/page.tsx
+++ b/docs/app/react/[[...slug]]/page.tsx
@@ -1,7 +1,7 @@
 import { getGitHubSourceUrl } from "@/app/_llms/config";
 import { reactSource } from "@/app/source";
 import { mdxComponents } from "@/components/mdx-components";
-import { LLMCopyButton, ViewOptions } from "@/components/page-actions";
+import { LLMCopyButton, LLMPageLinkButton, ViewOptions } from "@/components/page-actions";
 import { getComponentStatus } from "@/components/rootage";
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/page";
 import type { Metadata } from "next";
@@ -43,6 +43,7 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
       <DocsDescription>{displayDescription}</DocsDescription>
       <div className="flex flex-row gap-2 items-center mb-3 justify-end">
         <LLMCopyButton markdownUrl={markdownUrl} />
+        <LLMPageLinkButton markdownUrl={markdownUrl} />
         <ViewOptions markdownUrl={markdownUrl} githubUrl={getGitHubSourceUrl("react", page.path)} />
       </div>
       <DocsBody className="prose-p:break-keep prose-p:text-pretty prose-headings:text-balance">

--- a/docs/app/react/[[...slug]]/page.tsx
+++ b/docs/app/react/[[...slug]]/page.tsx
@@ -1,7 +1,7 @@
 import { getGitHubSourceUrl } from "@/app/_llms/config";
 import { reactSource } from "@/app/source";
 import { mdxComponents } from "@/components/mdx-components";
-import { LLMCopyButton, LLMPageLinkButton, ViewOptions } from "@/components/page-actions";
+import { LLMOptions, ViewOptions } from "@/components/page-actions";
 import { getComponentStatus } from "@/components/rootage";
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/page";
 import type { Metadata } from "next";
@@ -42,8 +42,7 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
       <DocsTitle>{displayTitle}</DocsTitle>
       <DocsDescription>{displayDescription}</DocsDescription>
       <div className="flex flex-row gap-2 items-center mb-3 justify-end">
-        <LLMCopyButton markdownUrl={markdownUrl} />
-        <LLMPageLinkButton markdownUrl={markdownUrl} />
+        <LLMOptions markdownUrl={markdownUrl} />
         <ViewOptions markdownUrl={markdownUrl} githubUrl={getGitHubSourceUrl("react", page.path)} />
       </div>
       <DocsBody className="prose-p:break-keep prose-p:text-pretty prose-headings:text-balance">

--- a/docs/components/page-actions.tsx
+++ b/docs/components/page-actions.tsx
@@ -62,6 +62,31 @@ export function LLMCopyButton({
   );
 }
 
+export function LLMPageLinkButton({
+  /**
+   * A URL to the raw Markdown/MDX content of page
+   */
+  markdownUrl,
+}: {
+  markdownUrl: string;
+}) {
+  return (
+    <a
+      href={markdownUrl}
+      rel="noreferrer noopener"
+      target="_blank"
+      className={buttonVariants({
+        color: "secondary",
+        size: "sm",
+        className: "gap-2 [&_svg]:size-3.5 [&_svg]:text-fd-muted-foreground",
+      })}
+    >
+      <IconArrowUpRightLine />
+      llms.txt 열기
+    </a>
+  );
+}
+
 const optionVariants = cva(
   "text-sm p-2 rounded-lg inline-flex items-center gap-2 hover:text-fd-accent-foreground hover:bg-fd-accent [&_svg]:size-4",
 );

--- a/docs/components/page-actions.tsx
+++ b/docs/components/page-actions.tsx
@@ -2,9 +2,9 @@
 
 import {
   IconArrowUpRightLine,
-  IconCheckmarkLine,
   IconChevronDownLine,
-  IconDocumentLine,
+  IconSparkle2Line,
+  IconSquare2StackedLine,
 } from "@karrotmarket/react-monochrome-icon";
 import { useMemo, useState } from "react";
 import { useCopyButton } from "fumadocs-ui/utils/use-copy-button";
@@ -14,16 +14,20 @@ import { cva } from "class-variance-authority";
 
 const cache = new Map<string, string>();
 
-export function LLMCopyButton({
+const optionVariants = cva(
+  "text-sm p-2 rounded-lg inline-flex items-center gap-2 hover:text-fd-accent-foreground hover:bg-fd-accent [&_svg]:size-4",
+);
+
+export function LLMOptions({
   /**
-   * A URL to fetch the raw Markdown/MDX content of page
+   * A URL to the raw Markdown/MDX content of page
    */
   markdownUrl,
 }: {
   markdownUrl: string;
 }) {
   const [isLoading, setLoading] = useState(false);
-  const [checked, onClick] = useCopyButton(async () => {
+  const [, onCopyClick] = useCopyButton(async () => {
     const cached = cache.get(markdownUrl);
     if (cached) return navigator.clipboard.writeText(cached);
 
@@ -46,50 +50,41 @@ export function LLMCopyButton({
   });
 
   return (
-    <button
-      type="button"
-      disabled={isLoading}
-      className={buttonVariants({
-        color: "secondary",
-        size: "sm",
-        className: "gap-2 [&_svg]:size-3.5 [&_svg]:text-fd-muted-foreground",
-      })}
-      onClick={onClick}
-    >
-      {checked ? <IconCheckmarkLine /> : <IconDocumentLine />}
-      마크다운 복사
-    </button>
+    <Popover>
+      <PopoverTrigger
+        className={buttonVariants({
+          color: "secondary",
+          size: "sm",
+          className: "gap-2 items-end",
+        })}
+      >
+        <IconSparkle2Line className="size-3.5 text-fd-muted-foreground" />
+        LLMs.txt
+        <IconChevronDownLine className="size-3.5 text-fd-muted-foreground" />
+      </PopoverTrigger>
+      <PopoverContent className="flex flex-col overflow-auto">
+        <button
+          type="button"
+          disabled={isLoading}
+          className={optionVariants()}
+          onClick={onCopyClick}
+        >
+          <IconSquare2StackedLine />
+          복사하기
+        </button>
+        <a
+          href={markdownUrl}
+          rel="noreferrer noopener"
+          target="_blank"
+          className={optionVariants()}
+        >
+          <IconArrowUpRightLine />
+          열기
+        </a>
+      </PopoverContent>
+    </Popover>
   );
 }
-
-export function LLMPageLinkButton({
-  /**
-   * A URL to the raw Markdown/MDX content of page
-   */
-  markdownUrl,
-}: {
-  markdownUrl: string;
-}) {
-  return (
-    <a
-      href={markdownUrl}
-      rel="noreferrer noopener"
-      target="_blank"
-      className={buttonVariants({
-        color: "secondary",
-        size: "sm",
-        className: "gap-2 [&_svg]:size-3.5 [&_svg]:text-fd-muted-foreground",
-      })}
-    >
-      <IconArrowUpRightLine />
-      llms.txt 열기
-    </a>
-  );
-}
-
-const optionVariants = cva(
-  "text-sm p-2 rounded-lg inline-flex items-center gap-2 hover:text-fd-accent-foreground hover:bg-fd-accent [&_svg]:size-4",
-);
 
 export function ViewOptions({
   markdownUrl,

--- a/docs/components/page-actions.tsx
+++ b/docs/components/page-actions.tsx
@@ -7,6 +7,7 @@ import {
   IconSquare2StackedLine,
 } from "@karrotmarket/react-monochrome-icon";
 import { useMemo, useState } from "react";
+import { Snackbar, SnackbarProvider, useSnackbarAdapter } from "seed-design/ui/snackbar";
 import { useCopyButton } from "fumadocs-ui/utils/use-copy-button";
 import { buttonVariants } from "fumadocs-ui/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "fumadocs-ui/components/ui/popover";
@@ -26,10 +27,32 @@ export function LLMOptions({
 }: {
   markdownUrl: string;
 }) {
+  return (
+    <SnackbarProvider>
+      <LLMOptionsContent markdownUrl={markdownUrl} />
+    </SnackbarProvider>
+  );
+}
+
+function LLMOptionsContent({
+  markdownUrl,
+}: {
+  markdownUrl: string;
+}) {
+  const [open, setOpen] = useState(false);
   const [isLoading, setLoading] = useState(false);
+  const adapter = useSnackbarAdapter();
   const [, onCopyClick] = useCopyButton(async () => {
     const cached = cache.get(markdownUrl);
-    if (cached) return navigator.clipboard.writeText(cached);
+    if (cached) {
+      await navigator.clipboard.writeText(cached);
+      adapter.create({
+        timeout: 2000,
+        onClose: () => {},
+        render: () => <Snackbar message="복사되었습니다" />,
+      });
+      return;
+    }
 
     setLoading(true);
 
@@ -44,13 +67,24 @@ export function LLMOptions({
           }),
         }),
       ]);
+      adapter.create({
+        timeout: 2000,
+        onClose: () => {},
+        render: () => <Snackbar message="복사되었습니다" />,
+      });
     } finally {
       setLoading(false);
+      setOpen(false);
     }
   });
 
+  const handleCopyClick = () => {
+    setOpen(false);
+    void onCopyClick();
+  };
+
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger
         className={buttonVariants({
           color: "secondary",
@@ -67,7 +101,7 @@ export function LLMOptions({
           type="button"
           disabled={isLoading}
           className={optionVariants()}
-          onClick={onCopyClick}
+          onClick={handleCopyClick}
         >
           <IconSquare2StackedLine />
           복사하기
@@ -77,6 +111,7 @@ export function LLMOptions({
           rel="noreferrer noopener"
           target="_blank"
           className={optionVariants()}
+          onClick={() => setOpen(false)}
         >
           <IconArrowUpRightLine />
           열기

--- a/docs/components/page-actions.tsx
+++ b/docs/components/page-actions.tsx
@@ -78,9 +78,9 @@ function LLMOptionsContent({
     }
   });
 
-  const handleCopyClick = () => {
+  const handleCopyClick = (event: Parameters<typeof onCopyClick>[0]) => {
     setOpen(false);
-    void onCopyClick();
+    void onCopyClick(event);
   };
 
   return (


### PR DESCRIPTION

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 문서 페이지에 페이지 액션 바 추가 - 내용 복사, 링크 열기, 보기 옵션 버튼 포함
  * 새로운 링크 열기 버튼 컴포넌트 추가

* **Improvements**
  * Deprecated 문서 페이지 제목에 표시 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 문서 페이지 헤더에 LLM 옵션 및 보기 옵션 컨트롤 추가(오른쪽 정렬)
  * LLM 옵션이 단일 버튼에서 드롭다운으로 확장되어 "복사하기" 및 "열기" 제공
  * 보기 옵션에 문서의 GitHub 소스 링크 통합

* **스타일**
  * 페이지 작업 UI 재설계(드롭다운 트리거 및 아이콘 업데이트)
  * 복사 완료 시 즉시 표시되는 스낵바 알림 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->