### PR TITLE
test(drawer): add useDrawer interaction and lifecycle coverage

### DIFF
--- a/packages/react-headless/drawer/src/useDrawer.test.tsx
+++ b/packages/react-headless/drawer/src/useDrawer.test.tsx
@@ -1,0 +1,341 @@
+import { act, fireEvent, render } from "@testing-library/react";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  jest,
+  mock,
+  spyOn,
+} from "bun:test";
+import * as React from "react";
+import { DRAG_CLASS, TRANSITIONS } from "./constants";
+import { useDrawer, type UseDrawerProps } from "./useDrawer";
+
+interface DrawerHarnessProps extends UseDrawerProps {
+  initialCloseButtonVisible?: boolean;
+  onApi?: (api: ReturnType<typeof useDrawer>) => void;
+}
+
+function DrawerHarness({
+  initialCloseButtonVisible = false,
+  onApi,
+  ...props
+}: DrawerHarnessProps) {
+  const api = useDrawer(props);
+  const [showCloseButton, setShowCloseButton] = React.useState(initialCloseButtonVisible);
+
+  React.useEffect(() => {
+    onApi?.(api);
+  }, [api, onApi]);
+
+  return (
+    <div>
+      <button data-testid="set-open" onClick={() => api.setIsOpen(true)}>
+        set open
+      </button>
+      <button
+        data-testid="set-close"
+        onClick={() =>
+          api.setIsOpen(false, { reason: "closeButton", event: new MouseEvent("click") })
+        }
+      >
+        set close
+      </button>
+      <button
+        data-testid="close-drawer"
+        onClick={() =>
+          api.closeDrawer(false, { reason: "escapeKeyDown", event: new KeyboardEvent("keydown") })
+        }
+      >
+        close drawer
+      </button>
+      <button
+        data-testid="set-second-snap"
+        onClick={() => api.setActiveSnapPoint(api.snapPoints?.[1] ?? null)}
+      >
+        set second snap
+      </button>
+      <button
+        data-testid="toggle-close-button"
+        onClick={() => setShowCloseButton((visible) => !visible)}
+      >
+        toggle close button
+      </button>
+
+      {showCloseButton ? <button data-testid="close-button" ref={api.closeButtonRef} /> : null}
+
+      <div data-testid="is-open">{String(api.isOpen)}</div>
+      <div data-testid="is-dragging">{String(api.isDragging)}</div>
+      <div data-testid="active-snap-point">{String(api.activeSnapPoint)}</div>
+      <div data-testid="has-animation-done">{String(api.hasAnimationDone)}</div>
+      <div data-testid="should-overlay-animate">{String(api.shouldOverlayAnimate)}</div>
+      <div data-testid="is-close-button-rendered">{String(api.isCloseButtonRendered)}</div>
+
+      <div
+        data-testid="drawer"
+        role="dialog"
+        ref={api.drawerRef}
+        onPointerDown={api.onPress}
+        onPointerMove={api.onDrag}
+        onPointerUp={api.onRelease}
+      />
+      <div data-testid="overlay" ref={api.overlayRef} />
+    </div>
+  );
+}
+
+function mockRect(element: HTMLElement, size = 100) {
+  return spyOn(element, "getBoundingClientRect").mockReturnValue({
+    x: 0,
+    y: 0,
+    width: size,
+    height: size,
+    top: 0,
+    left: 0,
+    right: size,
+    bottom: size,
+    toJSON: () => {},
+  });
+}
+
+describe("useDrawer", () => {
+  const originalSetPointerCapture = window.HTMLElement.prototype.setPointerCapture;
+
+  beforeAll(() => {
+    window.HTMLElement.prototype.setPointerCapture = mock(() => {});
+  });
+
+  afterAll(() => {
+    window.HTMLElement.prototype.setPointerCapture = originalSetPointerCapture;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    document.body.style.pointerEvents = "";
+  });
+
+  it("tracks close button mount state via closeButtonRef", () => {
+    const { getByTestId } = render(<DrawerHarness />);
+
+    expect(getByTestId("is-close-button-rendered")).toHaveTextContent("false");
+
+    fireEvent.click(getByTestId("toggle-close-button"));
+    expect(getByTestId("is-close-button-rendered")).toHaveTextContent("true");
+
+    fireEvent.click(getByTestId("toggle-close-button"));
+    expect(getByTestId("is-close-button-rendered")).toHaveTextContent("false");
+  });
+
+  it("calls close lifecycle callbacks with details when closeDrawer is invoked", () => {
+    jest.useFakeTimers();
+
+    const onOpenChange = mock(() => {});
+    const onAnimationEnd = mock(() => {});
+    const onClose = mock(() => {});
+    const { getByTestId } = render(
+      <DrawerHarness
+        defaultOpen
+        onOpenChange={onOpenChange}
+        onAnimationEnd={onAnimationEnd}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(getByTestId("close-drawer"));
+
+    expect(getByTestId("is-open")).toHaveTextContent("false");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ reason: "escapeKeyDown" }),
+    );
+    expect(document.body.style.pointerEvents).toBe("auto");
+
+    act(() => {
+      jest.advanceTimersByTime(TRANSITIONS.EXIT_DURATION * 1000);
+    });
+    expect(onAnimationEnd).toHaveBeenCalledWith(false);
+  });
+
+  it("does not start drag when dismissible is false and snapPoints are not provided", () => {
+    const { getByTestId } = render(<DrawerHarness defaultOpen dismissible={false} direction="left" />);
+    const drawer = getByTestId("drawer");
+
+    fireEvent.pointerDown(drawer, {
+      pointerId: 1,
+      pageX: 100,
+      pageY: 0,
+      clientX: 100,
+      clientY: 0,
+      pointerType: "mouse",
+    });
+    fireEvent.pointerMove(drawer, {
+      pointerId: 1,
+      pageX: 80,
+      pageY: 0,
+      clientX: 80,
+      clientY: 0,
+      pointerType: "mouse",
+    });
+
+    expect(getByTestId("is-dragging")).toHaveTextContent("false");
+    expect(drawer.classList.contains(DRAG_CLASS)).toBe(false);
+  });
+
+  it("starts drag when snapPoints exist even if dismissible is false", () => {
+    const { getByTestId } = render(
+      <DrawerHarness
+        defaultOpen
+        dismissible={false}
+        direction="left"
+        snapPoints={["100px", "300px"]}
+      />,
+    );
+    const drawer = getByTestId("drawer");
+    const rectSpy = mockRect(drawer, 100);
+
+    fireEvent.pointerDown(drawer, {
+      pointerId: 1,
+      pageX: 100,
+      pageY: 0,
+      clientX: 100,
+      clientY: 0,
+      pointerType: "mouse",
+    });
+
+    expect(getByTestId("is-dragging")).toHaveTextContent("true");
+
+    rectSpy.mockRestore();
+  });
+
+  it("updates transform and calls onDrag with percentage while dragging", () => {
+    const onDrag = mock(() => {});
+    let api: ReturnType<typeof useDrawer> | null = null;
+    const { getByTestId } = render(
+      <DrawerHarness
+        defaultOpen
+        direction="left"
+        onDrag={onDrag}
+        onApi={(latestApi) => {
+          api = latestApi;
+        }}
+      />,
+    );
+    const drawer = getByTestId("drawer");
+    const rectSpy = mockRect(drawer, 100);
+
+    if (!api) {
+      throw new Error("Drawer api is not available");
+    }
+
+    const createPointerEvent = (target: HTMLElement, pageX: number, pageY: number) =>
+      ({
+        target,
+        currentTarget: target,
+        pointerId: 1,
+        pageX,
+        pageY,
+        nativeEvent: new PointerEvent("pointermove"),
+      }) as unknown as React.PointerEvent<HTMLDivElement>;
+
+    act(() => {
+      api?.onPress(createPointerEvent(drawer, 100, 0));
+    });
+    drawer.style.transform = "matrix(1, 0, 0, 1, 0, 0)";
+    act(() => {
+      api?.onDrag(createPointerEvent(drawer, 80, 0));
+    });
+
+    expect(getByTestId("is-dragging")).toHaveTextContent("true");
+    expect(drawer.classList.contains(DRAG_CLASS)).toBe(true);
+    expect(drawer.style.transform).toBe("translate3d(-20px, 0, 0)");
+    expect(onDrag).toHaveBeenCalledWith(expect.anything(), 0.2);
+
+    rectSpy.mockRestore();
+  });
+
+  it("resets drawer and reports open=true on release when swiping toward the open direction", () => {
+    const onRelease = mock(() => {});
+    const { getByTestId } = render(
+      <DrawerHarness defaultOpen direction="right" onRelease={onRelease} />,
+    );
+    const drawer = getByTestId("drawer");
+    const rectSpy = mockRect(drawer, 100);
+
+    fireEvent.pointerDown(drawer, {
+      pointerId: 1,
+      pageX: 100,
+      pageY: 0,
+      clientX: 100,
+      clientY: 0,
+      pointerType: "mouse",
+    });
+    drawer.style.transform = "matrix(1, 0, 0, 1, 10, 0)";
+    fireEvent.pointerUp(drawer, {
+      pointerId: 1,
+      pageX: 80,
+      pageY: 0,
+      clientX: 80,
+      clientY: 0,
+      pointerType: "mouse",
+    });
+
+    expect(getByTestId("is-dragging")).toHaveTextContent("false");
+    expect(drawer.style.transform).toBe("translate3d(0, 0, 0)");
+    expect(onRelease).toHaveBeenCalledWith(expect.anything(), true);
+
+    rectSpy.mockRestore();
+  });
+
+  it("resets active snap point to the first snap point after close animation", () => {
+    jest.useFakeTimers();
+
+    const { getByTestId } = render(
+      <DrawerHarness defaultOpen snapPoints={["100px", "300px"]} />,
+    );
+
+    fireEvent.click(getByTestId("set-second-snap"));
+    expect(getByTestId("active-snap-point")).toHaveTextContent("300px");
+
+    fireEvent.click(getByTestId("close-drawer"));
+    act(() => {
+      jest.advanceTimersByTime(TRANSITIONS.EXIT_DURATION * 1000);
+    });
+
+    expect(getByTestId("active-snap-point")).toHaveTextContent("100px");
+  });
+
+  it("updates hasAnimationDone by open state and transition duration", () => {
+    jest.useFakeTimers();
+
+    const { getByTestId } = render(<DrawerHarness defaultOpen />);
+
+    expect(getByTestId("has-animation-done")).toHaveTextContent("false");
+
+    act(() => {
+      jest.advanceTimersByTime(TRANSITIONS.ENTER_DURATION * 1000);
+    });
+    expect(getByTestId("has-animation-done")).toHaveTextContent("true");
+
+    fireEvent.click(getByTestId("set-close"));
+    expect(getByTestId("has-animation-done")).toHaveTextContent("false");
+  });
+
+  it("enables overlay animation only during initial open when fadeFromIndex is 0", () => {
+    jest.useFakeTimers();
+
+    const { getByTestId } = render(
+      <DrawerHarness defaultOpen snapPoints={["100px", "300px"]} fadeFromIndex={0} />,
+    );
+
+    expect(getByTestId("should-overlay-animate")).toHaveTextContent("true");
+
+    act(() => {
+      jest.advanceTimersByTime(TRANSITIONS.ENTER_DURATION * 1000);
+    });
+    expect(getByTestId("should-overlay-animate")).toHaveTextContent("false");
+  });
+});


### PR DESCRIPTION
핵심 커버리지(9개 케이스):

- closeButtonRef 렌더 상태 동기화
- closeDrawer 호출 시 onOpenChange/onClose/onAnimationEnd 및 detail reason 검증
- dismissible=false + snapPoints 유무에 따른 드래그 허용/차단
- 드래그 중 transform 계산과 onDrag(percentage) 호출
- release 시 reset 동작과 onRelease(..., true) 검증
- close 이후 snap point 초기화
- hasAnimationDone 전이
- fadeFromIndex=0일 때 shouldOverlayAnimate 타이밍


## Summary
- add a dedicated useDrawer test harness to verify hook behavior in realistic interactions
- cover drag gating behavior (dismissible + snapPoints) and transform/percentage updates during drag
- cover close lifecycle callbacks/details, animation state timing, and snap point reset after close

## Testing
- bun test packages/react-headless/drawer/src/useDrawer.test.tsx
- bun headless:test
- bun generate:all
- bun test:all