### PR TITLE
test(drawer): add useDrawer interaction and lifecycle coverage

### DIFF
--- a/packages/react-headless/drawer/src/useDrawer.test.tsx
+++ b/packages/react-headless/drawer/src/useDrawer.test.tsx
@@ -1,0 +1,341 @@
+import { act, fireEvent, render } from "@testing-library/react";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  jest,
+  mock,
+  spyOn,
+} from "bun:test";
+import * as React from "react";
+import { DRAG_CLASS, TRANSITIONS } from "./constants";
+import { useDrawer, type UseDrawerProps } from "./useDrawer";
+
+interface DrawerHarnessProps extends UseDrawerProps {
+  initialCloseButtonVisible?: boolean;
+  onApi?: (api: ReturnType<typeof useDrawer>) => void;
+}
+
+function DrawerHarness({
+  initialCloseButtonVisible = false,
+  onApi,
+  ...props
+}: DrawerHarnessProps) {
+  const api = useDrawer(props);
+  const [showCloseButton, setShowCloseButton] = React.useState(initialCloseButtonVisible);
+
+  React.useEffect(() => {
+    onApi?.(api);
+  }, [api, onApi]);
+
+  return (
+    <div>
+      <button data-testid="set-open" onClick={() => api.setIsOpen(true)}>
+        set open
+      </button>
+      <button
+        data-testid="set-close"
+        onClick={() =>
+          api.setIsOpen(false, { reason: "closeButton", event: new MouseEvent("click") })
+        }
+      >
+        set close
+      </button>
+      <button
+        data-testid="close-drawer"
+        onClick={() =>
+          api.closeDrawer(false, { reason: "escapeKeyDown", event: new KeyboardEvent("keydown") })
+        }
+      >
+        close drawer
+      </button>
+      <button
+        data-testid="set-second-snap"
+        onClick={() => api.setActiveSnapPoint(api.snapPoints?.[1] ?? null)}
+      >
+        set second snap
+      </button>
+      <button
+        data-testid="toggle-close-button"
+        onClick={() => setShowCloseButton((visible) => !visible)}
+      >
+        toggle close button
+      </button>
+
+      {showCloseButton ? <button data-testid="close-button" ref={api.closeButtonRef} /> : null}
+
+      <div data-testid="is-open">{String(api.isOpen)}</div>
+      <div data-testid="is-dragging">{String(api.isDragging)}</div>
+      <div data-testid="active-snap-point">{String(api.activeSnapPoint)}</div>
+      <div data-testid="has-animation-done">{String(api.hasAnimationDone)}</div>
+      <div data-testid="should-overlay-animate">{String(api.shouldOverlayAnimate)}</div>
+      <div data-testid="is-close-button-rendered">{String(api.isCloseButtonRendered)}</div>
+
+      <div
+        data-testid="drawer"
+        role="dialog"
+        ref={api.drawerRef}
+        onPointerDown={api.onPress}
+        onPointerMove={api.onDrag}
+        onPointerUp={api.onRelease}
+      />
+      <div data-testid="overlay" ref={api.overlayRef} />
+    </div>
+  );
+}
+
+function mockRect(element: HTMLElement, size = 100) {
+  return spyOn(element, "getBoundingClientRect").mockReturnValue({
+    x: 0,
+    y: 0,
+    width: size,
+    height: size,
+    top: 0,
+    left: 0,
+    right: size,
+    bottom: size,
+    toJSON: () => {},
+  });
+}
+
+describe("useDrawer", () => {
+  const originalSetPointerCapture = window.HTMLElement.prototype.setPointerCapture;
+
+  beforeAll(() => {
+    window.HTMLElement.prototype.setPointerCapture = mock(() => {});
+  });
+
+  afterAll(() => {
+    window.HTMLElement.prototype.setPointerCapture = originalSetPointerCapture;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    document.body.style.pointerEvents = "";
+  });
+
+  it("tracks close button mount state via closeButtonRef", () => {
+    const { getByTestId } = render(<DrawerHarness />);
+
+    expect(getByTestId("is-close-button-rendered")).toHaveTextContent("false");
+
+    fireEvent.click(getByTestId("toggle-close-button"));
+    expect(getByTestId("is-close-button-rendered")).toHaveTextContent("true");
+
+    fireEvent.click(getByTestId("toggle-close-button"));
+    expect(getByTestId("is-close-button-rendered")).toHaveTextContent("false");
+  });
+
+  it("calls close lifecycle callbacks with details when closeDrawer is invoked", () => {
+    jest.useFakeTimers();
+
+    const onOpenChange = mock(() => {});
+    const onAnimationEnd = mock(() => {});
+    const onClose = mock(() => {});
+    const { getByTestId } = render(
+      <DrawerHarness
+        defaultOpen
+        onOpenChange={onOpenChange}
+        onAnimationEnd={onAnimationEnd}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(getByTestId("close-drawer"));
+
+    expect(getByTestId("is-open")).toHaveTextContent("false");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ reason: "escapeKeyDown" }),
+    );
+    expect(document.body.style.pointerEvents).toBe("auto");
+
+    act(() => {
+      jest.advanceTimersByTime(TRANSITIONS.EXIT_DURATION * 1000);
+    });
+    expect(onAnimationEnd).toHaveBeenCalledWith(false);
+  });
+
+  it("does not start drag when dismissible is false and snapPoints are not provided", () => {
+    const { getByTestId } = render(<DrawerHarness defaultOpen dismissible={false} direction="left" />);
+    const drawer = getByTestId("drawer");
+
+    fireEvent.pointerDown(drawer, {
+      pointerId: 1,
+      pageX: 100,
+      pageY: 0,
+      clientX: 100,
+      clientY: 0,
+      pointerType: "mouse",
+    });
+    fireEvent.pointerMove(drawer, {
+      pointerId: 1,
+      pageX: 80,
+      pageY: 0,
+      clientX: 80,
+      clientY: 0,
+      pointerType: "mouse",
+    });
+
+    expect(getByTestId("is-dragging")).toHaveTextContent("false");
+    expect(drawer.classList.contains(DRAG_CLASS)).toBe(false);
+  });
+
+  it("starts drag when snapPoints exist even if dismissible is false", () => {
+    const { getByTestId } = render(
+      <DrawerHarness
+        defaultOpen
+        dismissible={false}
+        direction="left"
+        snapPoints={["100px", "300px"]}
+      />,
+    );
+    const drawer = getByTestId("drawer");
+    const rectSpy = mockRect(drawer, 100);
+
+    fireEvent.pointerDown(drawer, {
+      pointerId: 1,
+      pageX: 100,
+      pageY: 0,
+      clientX: 100,
+      clientY: 0,
+      pointerType: "mouse",
+    });
+
+    expect(getByTestId("is-dragging")).toHaveTextContent("true");
+
+    rectSpy.mockRestore();
+  });
+
+  it("updates transform and calls onDrag with percentage while dragging", () => {
+    const onDrag = mock(() => {});
+    let api: ReturnType<typeof useDrawer> | null = null;
+    const { getByTestId } = render(
+      <DrawerHarness
+        defaultOpen
+        direction="left"
+        onDrag={onDrag}
+        onApi={(latestApi) => {
+          api = latestApi;
+        }}
+      />,
+    );
+    const drawer = getByTestId("drawer");
+    const rectSpy = mockRect(drawer, 100);
+
+    if (!api) {
+      throw new Error("Drawer api is not available");
+    }
+
+    const createPointerEvent = (target: HTMLElement, pageX: number, pageY: number) =>
+      ({
+        target,
+        currentTarget: target,
+        pointerId: 1,
+        pageX,
+        pageY,
+        nativeEvent: new PointerEvent("pointermove"),
+      }) as unknown as React.PointerEvent<HTMLDivElement>;
+
+    act(() => {
+      api?.onPress(createPointerEvent(drawer, 100, 0));
+    });
+    drawer.style.transform = "matrix(1, 0, 0, 1, 0, 0)";
+    act(() => {
+      api?.onDrag(createPointerEvent(drawer, 80, 0));
+    });
+
+    expect(getByTestId("is-dragging")).toHaveTextContent("true");
+    expect(drawer.classList.contains(DRAG_CLASS)).toBe(true);
+    expect(drawer.style.transform).toBe("translate3d(-20px, 0, 0)");
+    expect(onDrag).toHaveBeenCalledWith(expect.anything(), 0.2);
+
+    rectSpy.mockRestore();
+  });
+
+  it("resets drawer and reports open=true on release when swiping toward the open direction", () => {
+    const onRelease = mock(() => {});
+    const { getByTestId } = render(
+      <DrawerHarness defaultOpen direction="right" onRelease={onRelease} />,
+    );
+    const drawer = getByTestId("drawer");
+    const rectSpy = mockRect(drawer, 100);
+
+    fireEvent.pointerDown(drawer, {
+      pointerId: 1,
+      pageX: 100,
+      pageY: 0,
+      clientX: 100,
+      clientY: 0,
+      pointerType: "mouse",
+    });
+    drawer.style.transform = "matrix(1, 0, 0, 1, 10, 0)";
+    fireEvent.pointerUp(drawer, {
+      pointerId: 1,
+      pageX: 80,
+      pageY: 0,
+      clientX: 80,
+      clientY: 0,
+      pointerType: "mouse",
+    });
+
+    expect(getByTestId("is-dragging")).toHaveTextContent("false");
+    expect(drawer.style.transform).toBe("translate3d(0, 0, 0)");
+    expect(onRelease).toHaveBeenCalledWith(expect.anything(), true);
+
+    rectSpy.mockRestore();
+  });
+
+  it("resets active snap point to the first snap point after close animation", () => {
+    jest.useFakeTimers();
+
+    const { getByTestId } = render(
+      <DrawerHarness defaultOpen snapPoints={["100px", "300px"]} />,
+    );
+
+    fireEvent.click(getByTestId("set-second-snap"));
+    expect(getByTestId("active-snap-point")).toHaveTextContent("300px");
+
+    fireEvent.click(getByTestId("close-drawer"));
+    act(() => {
+      jest.advanceTimersByTime(TRANSITIONS.EXIT_DURATION * 1000);
+    });
+
+    expect(getByTestId("active-snap-point")).toHaveTextContent("100px");
+  });
+
+  it("updates hasAnimationDone by open state and transition duration", () => {
+    jest.useFakeTimers();
+
+    const { getByTestId } = render(<DrawerHarness defaultOpen />);
+
+    expect(getByTestId("has-animation-done")).toHaveTextContent("false");
+
+    act(() => {
+      jest.advanceTimersByTime(TRANSITIONS.ENTER_DURATION * 1000);
+    });
+    expect(getByTestId("has-animation-done")).toHaveTextContent("true");
+
+    fireEvent.click(getByTestId("set-close"));
+    expect(getByTestId("has-animation-done")).toHaveTextContent("false");
+  });
+
+  it("enables overlay animation only during initial open when fadeFromIndex is 0", () => {
+    jest.useFakeTimers();
+
+    const { getByTestId } = render(
+      <DrawerHarness defaultOpen snapPoints={["100px", "300px"]} fadeFromIndex={0} />,
+    );
+
+    expect(getByTestId("should-overlay-animate")).toHaveTextContent("true");
+
+    act(() => {
+      jest.advanceTimersByTime(TRANSITIONS.ENTER_DURATION * 1000);
+    });
+    expect(getByTestId("should-overlay-animate")).toHaveTextContent("false");
+  });
+});

--- a/packages/react-headless/drawer/src/useDrawer.test.tsx
+++ b/packages/react-headless/drawer/src/useDrawer.test.tsx
@@ -34,7 +34,7 @@ function DrawerHarness({
   return (
     <div>
       <button data-testid="set-open" onClick={() => api.setIsOpen(true)}>
-        set open
+        열기 설정
       </button>
       <button
         data-testid="set-close"
@@ -42,7 +42,7 @@ function DrawerHarness({
           api.setIsOpen(false, { reason: "closeButton", event: new MouseEvent("click") })
         }
       >
-        set close
+        닫기 설정
       </button>
       <button
         data-testid="close-drawer"
@@ -50,19 +50,19 @@ function DrawerHarness({
           api.closeDrawer(false, { reason: "escapeKeyDown", event: new KeyboardEvent("keydown") })
         }
       >
-        close drawer
+        드로어 닫기
       </button>
       <button
         data-testid="set-second-snap"
         onClick={() => api.setActiveSnapPoint(api.snapPoints?.[1] ?? null)}
       >
-        set second snap
+        두 번째 스냅으로 이동
       </button>
       <button
         data-testid="toggle-close-button"
         onClick={() => setShowCloseButton((visible) => !visible)}
       >
-        toggle close button
+        닫기 버튼 토글
       </button>
 
       {showCloseButton ? <button data-testid="close-button" ref={api.closeButtonRef} /> : null}
@@ -117,7 +117,7 @@ describe("useDrawer", () => {
     document.body.style.pointerEvents = "";
   });
 
-  it("tracks close button mount state via closeButtonRef", () => {
+  it("closeButtonRef를 통해 닫기 버튼 마운트 상태를 추적한다", () => {
     const { getByTestId } = render(<DrawerHarness />);
 
     expect(getByTestId("is-close-button-rendered")).toHaveTextContent("false");
@@ -129,7 +129,7 @@ describe("useDrawer", () => {
     expect(getByTestId("is-close-button-rendered")).toHaveTextContent("false");
   });
 
-  it("calls close lifecycle callbacks with details when closeDrawer is invoked", () => {
+  it("closeDrawer 호출 시 상세 정보와 함께 닫힘 라이프사이클 콜백을 호출한다", () => {
     jest.useFakeTimers();
 
     const onOpenChange = mock(() => {});
@@ -160,7 +160,7 @@ describe("useDrawer", () => {
     expect(onAnimationEnd).toHaveBeenCalledWith(false);
   });
 
-  it("does not start drag when dismissible is false and snapPoints are not provided", () => {
+  it("dismissible이 false이고 snapPoints가 없으면 드래그를 시작하지 않는다", () => {
     const { getByTestId } = render(<DrawerHarness defaultOpen dismissible={false} direction="left" />);
     const drawer = getByTestId("drawer");
 
@@ -185,7 +185,7 @@ describe("useDrawer", () => {
     expect(drawer.classList.contains(DRAG_CLASS)).toBe(false);
   });
 
-  it("starts drag when snapPoints exist even if dismissible is false", () => {
+  it("dismissible이 false여도 snapPoints가 있으면 드래그를 시작한다", () => {
     const { getByTestId } = render(
       <DrawerHarness
         defaultOpen
@@ -211,7 +211,7 @@ describe("useDrawer", () => {
     rectSpy.mockRestore();
   });
 
-  it("updates transform and calls onDrag with percentage while dragging", () => {
+  it("드래그 중 transform을 갱신하고 onDrag를 비율과 함께 호출한다", () => {
     const onDrag = mock(() => {});
     let api: ReturnType<typeof useDrawer> | null = null;
     const { getByTestId } = render(
@@ -228,7 +228,7 @@ describe("useDrawer", () => {
     const rectSpy = mockRect(drawer, 100);
 
     if (!api) {
-      throw new Error("Drawer api is not available");
+      throw new Error("Drawer API를 사용할 수 없습니다.");
     }
 
     const createPointerEvent = (target: HTMLElement, pageX: number, pageY: number) =>
@@ -257,7 +257,7 @@ describe("useDrawer", () => {
     rectSpy.mockRestore();
   });
 
-  it("resets drawer and reports open=true on release when swiping toward the open direction", () => {
+  it("열리는 방향으로 스와이프 후 릴리즈하면 드로어를 리셋하고 open=true를 전달한다", () => {
     const onRelease = mock(() => {});
     const { getByTestId } = render(
       <DrawerHarness defaultOpen direction="right" onRelease={onRelease} />,
@@ -290,7 +290,7 @@ describe("useDrawer", () => {
     rectSpy.mockRestore();
   });
 
-  it("resets active snap point to the first snap point after close animation", () => {
+  it("닫힘 애니메이션 후 active snap point를 첫 번째 스냅 포인트로 되돌린다", () => {
     jest.useFakeTimers();
 
     const { getByTestId } = render(
@@ -308,7 +308,7 @@ describe("useDrawer", () => {
     expect(getByTestId("active-snap-point")).toHaveTextContent("100px");
   });
 
-  it("updates hasAnimationDone by open state and transition duration", () => {
+  it("open 상태와 transition 시간에 따라 hasAnimationDone을 갱신한다", () => {
     jest.useFakeTimers();
 
     const { getByTestId } = render(<DrawerHarness defaultOpen />);
@@ -324,7 +324,7 @@ describe("useDrawer", () => {
     expect(getByTestId("has-animation-done")).toHaveTextContent("false");
   });
 
-  it("enables overlay animation only during initial open when fadeFromIndex is 0", () => {
+  it("fadeFromIndex가 0이면 초기 열림 구간에서만 오버레이 애니메이션을 활성화한다", () => {
     jest.useFakeTimers();
 
     const { getByTestId } = render(


### PR DESCRIPTION
## Summary
- add a dedicated useDrawer test harness that exercises the hook through realistic interactions
- increase confidence for future behavior changes by covering drag/release lifecycle and timing-sensitive states

## Core Coverage
- close lifecycle: verifies onOpenChange details, onClose, body pointer-events reset, and delayed onAnimationEnd callback
- drag gating: verifies drag is blocked when dismissible is false without snap points, and allowed when snap points are configured
- drag behavior: verifies transform updates and onDrag percentage callback while dragging
- release behavior: verifies drawer reset path and onRelease(open=true) for non-closing swipe direction
- snap points: verifies active snap point resets to first snap point after close transition
- animation flags: verifies hasAnimationDone timing and shouldOverlayAnimate window when fadeFromIndex is 0
- close button ref: verifies closeButtonRef drives isCloseButtonRendered state correctly

## Testing
- bun test packages/react-headless/drawer/src/useDrawer.test.tsx
- bun headless:test
- bun generate:all
- bun test:all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **테스트**
  * useDrawer 관련 포괄적인 테스트 스위트가 추가되었습니다. 마운트 상태, 열림/닫힘 콜백과 애니메이션 종료, 해제/드래그 상호작용, 스냅 포인트 동작, 애니메이션 상태 전환, 오버레이 애니메이션 제어 및 포인터/타이머 기반 동작을 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->