### PR TITLE
feat(cli): internalize init fallback and improve error diagnostics

### DIFF
--- a/.changeset/four-queens-brush.md
+++ b/.changeset/four-queens-brush.md
@@ -1,0 +1,6 @@
+---
+"@seed-design/cli": patch
+---
+
+Improve CLI failure diagnostics, add `--verbose` troubleshooting output, and run internal config initialization when `seed-design.json` is missing.
+Also update `@clack/prompts` to v1 and keep `init --default` as a compatibility alias for `--yes`.

--- a/.changeset/four-queens-brush.md
+++ b/.changeset/four-queens-brush.md
@@ -2,6 +2,6 @@
 "@seed-design/cli": patch
 ---
 
-CLI 실패 원인 표시를 개선하고 `--verbose` 상세 진단 출력을 추가합니다.
-`seed-design.json`이 없을 때 외부 명령 실행 대신 내부 초기화 로직으로 설정 파일을 생성합니다.
-또한 `@clack/prompts`를 v1으로 업데이트하고 `init --default`를 `--yes` 호환 alias로 유지합니다.
+- CLI 실패 원인 표시를 개선하고 `--verbose` 상세 진단 출력을 추가합니다.
+- `seed-design.json`이 없을 때 외부 명령 실행 대신 내부 초기화 로직으로 설정 파일을 생성합니다.
+- 또한 `@clack/prompts`를 v1으로 업데이트하고 `init --default`를 `--yes` 호환 alias로 유지합니다.

--- a/.changeset/four-queens-brush.md
+++ b/.changeset/four-queens-brush.md
@@ -2,5 +2,6 @@
 "@seed-design/cli": patch
 ---
 
-Improve CLI failure diagnostics, add `--verbose` troubleshooting output, and run internal config initialization when `seed-design.json` is missing.
-Also update `@clack/prompts` to v1 and keep `init --default` as a compatibility alias for `--yes`.
+CLI 실패 원인 표시를 개선하고 `--verbose` 상세 진단 출력을 추가합니다.
+`seed-design.json`이 없을 때 외부 명령 실행 대신 내부 초기화 로직으로 설정 파일을 생성합니다.
+또한 `@clack/prompts`를 v1으로 업데이트하고 `init --default`를 `--yes` 호환 alias로 유지합니다.

--- a/bun.lock
+++ b/bun.lock
@@ -291,7 +291,7 @@
         "@babel/core": "^7.26.10",
         "@babel/parser": "^7.27.0",
         "@babel/plugin-transform-typescript": "^7.27.0",
-        "@clack/prompts": "^0.11.0",
+        "@clack/prompts": "^1.0.0",
         "@npmcli/disparity-colors": "^3.0.1",
         "cac": "^6.7.14",
         "cosmiconfig": "^9.0.0",
@@ -1521,9 +1521,9 @@
 
     "@chromatic-com/storybook": ["@chromatic-com/storybook@4.1.3", "", { "dependencies": { "@neoconfetti/react": "^1.0.0", "chromatic": "^13.3.3", "filesize": "^10.0.12", "jsonfile": "^6.1.0", "strip-ansi": "^7.1.0" }, "peerDependencies": { "storybook": "^0.0.0-0 || ^9.0.0 || ^9.1.0-0 || ^9.2.0-0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0" } }, "sha512-hc0HO9GAV9pxqDE6fTVOV5KeLpTiCfV8Jrpk5ogKLiIgeq2C+NPjpt74YnrZTjiK8E19fYcMP+2WY9ZtX7zHmw=="],
 
-    "@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
+    "@clack/core": ["@clack/core@1.0.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-Orf9Ltr5NeiEuVJS8Rk2XTw3IxNC2Bic3ash7GgYeA8LJ/zmSNpSQ/m5UAhe03lA6KFgklzZ5KTHs4OAMA/SAQ=="],
 
-    "@clack/prompts": ["@clack/prompts@0.11.0", "", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw=="],
+    "@clack/prompts": ["@clack/prompts@1.0.0", "", { "dependencies": { "@clack/core": "1.0.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-rWPXg9UaCFqErJVQ+MecOaWsozjaxol4yjnmYcGNipAWzdaWa2x+VJmKfGq7L0APwBohQOYdHC+9RO4qRXej+A=="],
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.0", "", { "dependencies": { "mime": "^3.0.0" } }, "sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA=="],
 

--- a/docs/content/react/getting-started/cli/commands.mdx
+++ b/docs/content/react/getting-started/cli/commands.mdx
@@ -10,6 +10,7 @@ description: "@seed-design/cli 명령어를 안내해요."
 - 항목 추가 시 필요한 npm 패키지 의존성은 자동으로 설치돼요.
 - 기존 파일과 내용이 다르면 기본적으로 `덮어쓰기 / 백업 후 교체 / 건너뛰기`를 선택할 수 있어요.
 - `--on-diff` 옵션을 주면 충돌 처리 방식을 미리 고정할 수 있어요.
+- 실패 원인을 자세히 확인하려면 `--verbose` 옵션을 사용할 수 있어요.
 
 ## init
 
@@ -59,6 +60,8 @@ npx @seed-design/cli@latest init
 |------|------|
 | `-c, --cwd <cwd>` | 작업 디렉토리. 기본값은 현재 디렉토리 |
 | `-y, --yes` | 질문 없이 기본값으로 `seed-design.json` 생성 |
+| `--default` | Deprecated. `--yes`와 동일하게 기본값으로 생성 |
+| `--verbose` | 실패 시 stack trace 등 상세 오류 정보 출력 |
 | `-h, --help` | 도움말 출력 |
 
 ```package-install
@@ -113,6 +116,7 @@ npx @seed-design/cli@latest add ui:action-button ui:alert-dialog
 | `-u, --baseUrl <baseUrl>` | 레지스트리 base URL |
 | `--on-diff <mode>` | 파일 충돌 처리 방식 지정 (`overwrite` 또는 `backup`) |
 | `-a, --all` | **Deprecated**. 현재는 에러를 출력하고 `add-all` 사용을 안내 |
+| `--verbose` | 실패 시 stack trace 등 상세 오류 정보 출력 |
 | `-h, --help` | 도움말 출력 |
 
 ### baseUrl 사용하기
@@ -175,4 +179,5 @@ npx @seed-design/cli@latest add-all ui --include-deprecated # ui 레지스트리
 | `-c, --cwd <cwd>` | 작업 디렉토리. 기본값은 현재 디렉토리 |
 | `-u, --baseUrl <baseUrl>` | 레지스트리 base URL |
 | `--on-diff <mode>` | 파일 충돌 처리 방식 지정 (`overwrite` 또는 `backup`) |
+| `--verbose` | 실패 시 stack trace 등 상세 오류 정보 출력 |
 | `-h, --help` | 도움말 출력 |

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -1,0 +1,20 @@
+## 디렉토리 개요
+
+`packages/cli`는 `@seed-design/cli` 패키지의 소스와 빌드 설정을 관리하며, `seed-design init/add/add-all` 명령을 제공한다. 사용자 문서는 `docs/content/react/getting-started/cli/`와 동기화하고, 기술 상세는 이 폴더의 `TECH.md`를 우선 참고한다.
+
+## 파일 작성 컨벤션
+
+- 명령어 구현은 `src/commands/*.ts`, 공통 로직은 `src/utils/*.ts`, 검증 스키마는 `src/schema.ts`에 둔다.
+- 엔트리포인트는 `src/index.ts` 단일 파일을 유지하고, 빌드 결과물(`bin/`)은 생성물로 취급한다.
+- CLI 옵션/동작 변경 시 아래 문서를 함께 갱신한다.
+  - `docs/content/react/getting-started/cli/commands.mdx`
+  - `docs/content/react/getting-started/cli/configuration.mdx`
+- 배포 가능한 변경은 `.changeset/*.md`를 함께 추가한다.
+
+## 코드 작성 컨벤션
+
+- `cac` 기반으로 명령을 정의하고, 사용자 대상 메시지는 한국어 톤을 유지한다.
+- 예외 처리는 `src/utils/error.ts`의 `CliError`/`CliCancelError`를 사용해 공통 포맷으로 출력한다.
+- `process.exit`는 명령어 계층(`src/commands`)에서만 사용하고, `src/utils`에서는 에러를 throw 한다.
+- `seed-design.json` 미존재 시 외부 프로세스 실행 대신 내부 init 로직(`src/utils/init-config.ts`)으로 생성한다.
+- verbose 디버깅은 글로벌 `--verbose` 옵션을 기준으로 동작시킨다.

--- a/packages/cli/TECH.md
+++ b/packages/cli/TECH.md
@@ -1,15 +1,12 @@
-# @seed-design/cli - 기술 상세
+# @seed-design/cli TECH
 
 ## 개요
 
-| 항목 | 내용 |
-|------|------|
-| 패키지 | `@seed-design/cli` |
-| 런타임 | Node.js >= 18 |
-| 언어 | TypeScript (ESM) |
-| CLI 프레임워크 | `cac` |
-| 프롬프트 | `@clack/prompts` v1 |
-| 번들러 | `esbuild` (`build.mjs`, `dev.mjs`) |
+- 패키지: `@seed-design/cli`
+- 런타임: Node.js >= 18
+- 언어/모듈: TypeScript, ESM
+- 핵심 의존성: `cac`, `@clack/prompts@1`, `cosmiconfig`, `zod`, `execa`
+- 빌드: `esbuild` (`build.mjs`, `dev.mjs`)
 
 ## 아키텍처
 
@@ -20,66 +17,55 @@ src/index.ts
   └─ commands/add-all.ts
 
 src/utils/*
-  ├─ get-config.ts (seed-design.json 로드/자동 생성)
-  ├─ fetch.ts (registry 조회)
-  ├─ write.ts (snippet 파일 반영)
-  ├─ install.ts (의존성 설치)
-  ├─ analytics.ts (telemetry 전송)
-  └─ error.ts (공통 에러 포맷)
+  ├─ get-config.ts / init-config.ts
+  ├─ fetch.ts / write.ts / resolve-dependencies.ts / install.ts
+  ├─ analytics.ts
+  └─ error.ts
 ```
 
-## 핵심 동작
+## 기술적 결정
 
-### 1. 설정 파일 로딩/자동 생성
+### 1) 설정 파일 부트스트랩을 내부 로직으로 처리
 
-- 설정 로더: `src/utils/get-config.ts`
-- 탐색 대상: `seed-design.json` (cosmiconfig)
-- 파일이 없으면 사용자 확인 후 기본 설정으로 내부 생성한다.
-  - 기본값: `rsc=false`, `tsx=true`, `path="./seed-design"`, `telemetry=true`
-- 기존처럼 외부 프로세스(`seed-design init` execa)를 호출하지 않는다.
+- 파일: `src/utils/get-config.ts`, `src/utils/init-config.ts`
+- `seed-design.json`이 없을 때 외부 명령(`seed-design init`)을 `execa`로 재호출하지 않는다.
+- 사용자 확인 후 기본값(`rsc=false`, `tsx=true`, `path="./seed-design"`, `telemetry=true`)으로 내부 생성한다.
 
-### 2. 에러 처리 정책
+### 2) 에러 처리 책임 분리
 
-- 공통 에러 유틸: `src/utils/error.ts`
-  - `CliError`: 사용자 메시지/힌트/세부정보를 포함한 실패
-  - `CliCancelError`: 사용자 취소 흐름
-- 기본 출력: 실패 메시지 + 원인 + 해결 힌트
-- `--verbose` 출력: stack trace 포함
-- 원칙: 유틸은 throw, 명령어에서만 `process.exit` 처리
+- 파일: `src/utils/error.ts`, `src/commands/*.ts`
+- 유틸 레이어는 에러를 `throw`만 하고 종료하지 않는다.
+- 커맨드 레이어만 `process.exit(0/1)`을 결정한다.
+- 기본 실패 출력은 `실패 메시지 + 원인 + 힌트`, `--verbose`에서 stack trace를 추가 출력한다.
 
-### 3. 명령어 흐름
+### 3) 명령 성공 경로에서 telemetry는 비핵심(Non-blocking)
 
-- `init`
-  - 인터랙티브 질문 또는 `--yes`/`--default`로 기본값 생성
-- `add`
-  - registry 조회 → 항목 선택/검증 → snippet 반영 → npm 의존성 설치
-- `add-all`
-  - registry 단위 일괄 선택/검증 → snippet 반영 → npm 의존성 설치
+- 파일: `src/utils/analytics.ts`, `src/commands/*.ts`
+- `init`, `add`, `add-all` 이벤트를 전송한다.
+- telemetry 실패는 명령 성공/실패 판정에 영향을 주지 않는다(실패는 무시 또는 verbose 로그).
 
-### 4. Telemetry
+### 4) telemetry opt-out 우선순위 고정
 
-- 구현: `src/utils/analytics.ts`
-- 이벤트: `init`, `add`, `add-all`
-- 비활성화 우선순위
+- 파일: `src/utils/analytics.ts`
+- 우선순위:
   1. `DISABLE_TELEMETRY=true`
   2. `SEED_DISABLE_TELEMETRY=true`
   3. `seed-design.json`의 `telemetry=false`
 
-## 개발 스크립트
+## 패키지 로컬 스크립트
 
 | 스크립트 | 설명 |
-|---------|------|
+|---|---|
 | `bun dev` | dev 번들 (`NODE_ENV=dev`) |
 | `bun build` | prod 번들 (`bin/index.mjs`) |
-| `bun test` | CLI 테스트 실행 |
 | `bun lint:publish` | publint 검사 |
 
-## 환경 변수
+## 주요 환경 변수
 
-| 변수 | 설명 | 기본 |
-|------|------|------|
-| `NODE_ENV` | telemetry 출력 모드 전환 (`dev`/`prod`) | `prod` |
-| `POSTHOG_API_KEY` | PostHog API 키 | 선택 |
-| `POSTHOG_HOST` | PostHog 호스트 URL | 선택 |
-| `DISABLE_TELEMETRY` | telemetry 비활성화 | `false` |
-| `SEED_DISABLE_TELEMETRY` | telemetry 비활성화(대체 키) | `false` |
+| 변수 | 설명 |
+|---|---|
+| `NODE_ENV` | dev/prod 분기 (`build.mjs`, `dev.mjs`에서 주입) |
+| `POSTHOG_API_KEY` | telemetry 전송 API 키 |
+| `POSTHOG_HOST` | telemetry 전송 호스트 |
+| `DISABLE_TELEMETRY` | telemetry 비활성화 |
+| `SEED_DISABLE_TELEMETRY` | telemetry 비활성화(대체 키) |

--- a/packages/cli/TECH.md
+++ b/packages/cli/TECH.md
@@ -19,7 +19,7 @@ src/index.ts
   ├─ commands/add.ts
   └─ commands/add-all.ts
 
-commands/*
+src/utils/*
   ├─ get-config.ts (seed-design.json 로드/자동 생성)
   ├─ fetch.ts (registry 조회)
   ├─ write.ts (snippet 파일 반영)

--- a/packages/cli/TECH.md
+++ b/packages/cli/TECH.md
@@ -1,0 +1,85 @@
+# @seed-design/cli - 기술 상세
+
+## 개요
+
+| 항목 | 내용 |
+|------|------|
+| 패키지 | `@seed-design/cli` |
+| 런타임 | Node.js >= 18 |
+| 언어 | TypeScript (ESM) |
+| CLI 프레임워크 | `cac` |
+| 프롬프트 | `@clack/prompts` v1 |
+| 번들러 | `esbuild` (`build.mjs`, `dev.mjs`) |
+
+## 아키텍처
+
+```text
+src/index.ts
+  ├─ commands/init.ts
+  ├─ commands/add.ts
+  └─ commands/add-all.ts
+
+commands/*
+  ├─ get-config.ts (seed-design.json 로드/자동 생성)
+  ├─ fetch.ts (registry 조회)
+  ├─ write.ts (snippet 파일 반영)
+  ├─ install.ts (의존성 설치)
+  ├─ analytics.ts (telemetry 전송)
+  └─ error.ts (공통 에러 포맷)
+```
+
+## 핵심 동작
+
+### 1. 설정 파일 로딩/자동 생성
+
+- 설정 로더: `src/utils/get-config.ts`
+- 탐색 대상: `seed-design.json` (cosmiconfig)
+- 파일이 없으면 사용자 확인 후 기본 설정으로 내부 생성한다.
+  - 기본값: `rsc=false`, `tsx=true`, `path="./seed-design"`, `telemetry=true`
+- 기존처럼 외부 프로세스(`seed-design init` execa)를 호출하지 않는다.
+
+### 2. 에러 처리 정책
+
+- 공통 에러 유틸: `src/utils/error.ts`
+  - `CliError`: 사용자 메시지/힌트/세부정보를 포함한 실패
+  - `CliCancelError`: 사용자 취소 흐름
+- 기본 출력: 실패 메시지 + 원인 + 해결 힌트
+- `--verbose` 출력: stack trace 포함
+- 원칙: 유틸은 throw, 명령어에서만 `process.exit` 처리
+
+### 3. 명령어 흐름
+
+- `init`
+  - 인터랙티브 질문 또는 `--yes`/`--default`로 기본값 생성
+- `add`
+  - registry 조회 → 항목 선택/검증 → snippet 반영 → npm 의존성 설치
+- `add-all`
+  - registry 단위 일괄 선택/검증 → snippet 반영 → npm 의존성 설치
+
+### 4. Telemetry
+
+- 구현: `src/utils/analytics.ts`
+- 이벤트: `init`, `add`, `add-all`
+- 비활성화 우선순위
+  1. `DISABLE_TELEMETRY=true`
+  2. `SEED_DISABLE_TELEMETRY=true`
+  3. `seed-design.json`의 `telemetry=false`
+
+## 개발 스크립트
+
+| 스크립트 | 설명 |
+|---------|------|
+| `bun dev` | dev 번들 (`NODE_ENV=dev`) |
+| `bun build` | prod 번들 (`bin/index.mjs`) |
+| `bun test` | CLI 테스트 실행 |
+| `bun lint:publish` | publint 검사 |
+
+## 환경 변수
+
+| 변수 | 설명 | 기본 |
+|------|------|------|
+| `NODE_ENV` | telemetry 출력 모드 전환 (`dev`/`prod`) | `prod` |
+| `POSTHOG_API_KEY` | PostHog API 키 | 선택 |
+| `POSTHOG_HOST` | PostHog 호스트 URL | 선택 |
+| `DISABLE_TELEMETRY` | telemetry 비활성화 | `false` |
+| `SEED_DISABLE_TELEMETRY` | telemetry 비활성화(대체 키) | `false` |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "@babel/core": "^7.26.10",
     "@babel/parser": "^7.27.0",
     "@babel/plugin-transform-typescript": "^7.27.0",
-    "@clack/prompts": "^0.11.0",
+    "@clack/prompts": "^1.0.0",
     "@npmcli/disparity-colors": "^3.0.1",
     "cac": "^6.7.14",
     "cosmiconfig": "^9.0.0",

--- a/packages/cli/src/AGENTS.md
+++ b/packages/cli/src/AGENTS.md
@@ -1,0 +1,17 @@
+## 디렉토리 개요
+
+`packages/cli/src`는 CLI 실행 엔트리, 명령어 구현, 공통 유틸, 테스트를 포함한다. 상위 규칙은 `packages/cli/AGENTS.md`를 따르고, 이 문서는 `src` 내부 구조 전용 컨벤션만 정의한다.
+
+## 파일 작성 컨벤션
+
+- `commands/`: 사용자가 직접 호출하는 커맨드 액션(`init`, `add`, `add-all`)
+- `utils/`: 명령 간 공유 로직(설정, fetch, write, install, analytics, error)
+- `tests/`: 독립 단위 테스트
+- 파일명은 역할 중심 소문자 kebab-case를 유지하고, barrel file은 만들지 않는다.
+
+## 코드 작성 컨벤션
+
+- 명령어 파일에서 사용자 입출력(`@clack/prompts`)과 종료 코드(`process.exit`)를 최종 처리한다.
+- 유틸 파일은 사이드이펙트 종료 대신 예외를 throw하고, 명령어 계층에서 공통 핸들러로 변환한다.
+- 사용자 취소는 `CliCancelError`, 오류는 `CliError`로 구분한다.
+- 옵션 검증은 zod schema를 명령어 파일 상단에 정의하고 `safeParse/parse`로 검증한다.

--- a/packages/cli/src/commands/add-all.ts
+++ b/packages/cli/src/commands/add-all.ts
@@ -69,13 +69,21 @@ export const addAllCommand = (cli: CAC) => {
         const { start, stop } = p.spinner();
         start("Registry를 가져오고 있어요...");
 
-        const publicRegistries = await Promise.all(
-          (await fetchAvailableRegistries({ baseUrl })).map(async ({ id }) =>
-            fetchRegistry({ baseUrl, registryId: id }),
-          ),
-        );
+        const publicRegistries = await (async () => {
+          try {
+            const registries = await Promise.all(
+              (await fetchAvailableRegistries({ baseUrl })).map(async ({ id }) =>
+                fetchRegistry({ baseUrl, registryId: id }),
+              ),
+            );
+            stop("Registry를 가져왔어요.");
 
-        stop("Registry를 가져왔어요.");
+            return registries;
+          } catch (error) {
+            stop("Registry를 가져오지 못했어요.");
+            throw error;
+          }
+        })();
 
         const selectedRegistryIds: string[] = await (async () => {
           if (options.all) {
@@ -91,7 +99,6 @@ export const addAllCommand = (cli: CAC) => {
             for (const registryId of options.registryIds) {
               if (!availableIds.includes(registryId)) {
                 throw new CliError({
-                  code: "REGISTRY_NOT_FOUND",
                   message: `레지스트리 '${registryId}'를 찾을 수 없어요.`,
                   details: [`사용 가능한 레지스트리: ${availableIds.join(", ")}`],
                 });
@@ -228,6 +235,7 @@ export const addAllCommand = (cli: CAC) => {
           defaultHint: "`--verbose` 옵션으로 상세 오류를 확인해보세요.",
           verbose,
         });
+        process.exit(1);
       }
     });
 };

--- a/packages/cli/src/commands/add-all.ts
+++ b/packages/cli/src/commands/add-all.ts
@@ -110,11 +110,18 @@ export const addAllCommand = (cli: CAC) => {
             options: publicRegistries
               .filter(({ hideFromCLICatalog }) => !hideFromCLICatalog)
               .sort((a, b) => b.items.length - a.items.length)
-              .map((registry) => ({
-                label: registry.id,
-                value: registry.id,
-                hint: `${registry.items.length}개 항목 (${registry.items[0].id} 등)`,
-              })),
+              .map((registry) => {
+                const firstItemId = registry.items[0]?.id;
+                const hint = firstItemId
+                  ? `${registry.items.length}개 항목 (${firstItemId} 등)`
+                  : `${registry.items.length}개 항목 (항목 없음)`;
+
+                return {
+                  label: registry.id,
+                  value: registry.id,
+                  hint,
+                };
+              }),
           });
 
           if (p.isCancel(selected)) {
@@ -140,9 +147,10 @@ export const addAllCommand = (cli: CAC) => {
             .map((item) => `${registry.id}:${item.id}`),
         );
 
-        const deprecatedCount = selectedRegistries.flatMap((r) =>
-          r.items.filter((item) => item.deprecated).map(() => 1),
-        ).length;
+        const deprecatedCount = selectedRegistries.reduce(
+          (count, r) => count + r.items.filter((item) => item.deprecated).length,
+          0,
+        );
 
         if (!options.includeDeprecated && deprecatedCount > 0) {
           p.log.info(
@@ -193,16 +201,22 @@ export const addAllCommand = (cli: CAC) => {
 
         // add-all 성공 이벤트 추적
         const duration = Date.now() - startTime;
-        await analytics.track(options.cwd, {
-          event: "add-all",
-          properties: {
-            registries: selectedRegistryIds,
-            items_count: itemKeys.length,
-            include_deprecated: options.includeDeprecated || false,
-            dependencies_count: npmDependenciesToAdd.size,
-            duration_ms: duration,
-          },
-        });
+        try {
+          await analytics.track(options.cwd, {
+            event: "add-all",
+            properties: {
+              registries: selectedRegistryIds,
+              items_count: itemKeys.length,
+              include_deprecated: options.includeDeprecated || false,
+              dependencies_count: npmDependenciesToAdd.size,
+              duration_ms: duration,
+            },
+          });
+        } catch (telemetryError) {
+          if (verbose) {
+            console.error("[Telemetry] add-all tracking failed:", telemetryError);
+          }
+        }
       } catch (error) {
         if (isCliCancelError(error)) {
           p.outro(highlight(error.message));

--- a/packages/cli/src/commands/add-all.ts
+++ b/packages/cli/src/commands/add-all.ts
@@ -10,6 +10,13 @@ import type { CAC } from "cac";
 import { BASE_URL } from "../constants";
 import { analytics } from "../utils/analytics";
 import { highlight } from "../utils/color";
+import {
+  CliCancelError,
+  CliError,
+  handleCliError,
+  isCliCancelError,
+  isVerboseMode,
+} from "../utils/error";
 import { installDependencies } from "../utils/install";
 
 const addAllOptionsSchema = z.object({
@@ -43,131 +50,126 @@ export const addAllCommand = (cli: CAC) => {
     .example("seed-design add-all ui lib breeze")
     .action(async (registryIds, opts) => {
       const startTime = Date.now();
+      const verbose = isVerboseMode(opts);
       p.intro("seed-design add-all");
 
-      const {
-        success,
-        data: options,
-        error,
-      } = addAllOptionsSchema.safeParse({ registryIds, ...opts });
-
-      if (!success) {
-        p.log.error(`잘못된 옵션이에요: ${error?.message}`);
-
-        process.exit(1);
-      }
-
-      const cwd = options.cwd;
-      const baseUrl = options.baseUrl;
-      const config = await getConfig(cwd);
-      const rootPath = path.resolve(cwd, config.path);
-
-      const { start, stop } = p.spinner();
-
-      start("Registry를 가져오고 있어요...");
-
-      const publicRegistries = await Promise.all(
-        (await fetchAvailableRegistries({ baseUrl })).map(async ({ id }) =>
-          fetchRegistry({ baseUrl, registryId: id }),
-        ),
-      );
-
-      stop("Registry를 가져왔어요.");
-
-      const selectedRegistryIds: string[] = await (async () => {
-        if (options.all) {
-          const ids = publicRegistries.map((r) => r.id);
-          p.log.message(`모든 레지스트리의 모든 항목을 추가합니다: ${highlight(ids.join(", "))}`);
-
-          return ids;
+      try {
+        const parsed = addAllOptionsSchema.safeParse({ registryIds, ...opts });
+        if (!parsed.success) {
+          throw parsed.error;
         }
 
-        if (options.registryIds?.length) {
-          const availableIds = publicRegistries.map((r) => r.id);
+        const { data: options } = parsed;
 
-          for (const registryId of options.registryIds) {
-            if (!availableIds.includes(registryId)) {
-              p.log.error(`레지스트리 '${registryId}'를 찾을 수 없어요.`);
-              p.log.info(`사용 가능한 레지스트리: ${availableIds.join(", ")}`);
+        const cwd = options.cwd;
+        const baseUrl = options.baseUrl;
+        const config = await getConfig(cwd);
+        const rootPath = path.resolve(cwd, config.path);
 
-              process.exit(1);
-            }
+        const { start, stop } = p.spinner();
+        start("Registry를 가져오고 있어요...");
+
+        const publicRegistries = await Promise.all(
+          (await fetchAvailableRegistries({ baseUrl })).map(async ({ id }) =>
+            fetchRegistry({ baseUrl, registryId: id }),
+          ),
+        );
+
+        stop("Registry를 가져왔어요.");
+
+        const selectedRegistryIds: string[] = await (async () => {
+          if (options.all) {
+            const ids = publicRegistries.map((r) => r.id);
+            p.log.message(`모든 레지스트리의 모든 항목을 추가합니다: ${highlight(ids.join(", "))}`);
+
+            return ids;
           }
 
-          p.log.message(
-            `선택된 레지스트리의 모든 항목을 추가합니다: ${highlight(options.registryIds.join(", "))}`,
-          );
+          if (options.registryIds?.length) {
+            const availableIds = publicRegistries.map((r) => r.id);
 
-          return options.registryIds;
+            for (const registryId of options.registryIds) {
+              if (!availableIds.includes(registryId)) {
+                throw new CliError({
+                  code: "REGISTRY_NOT_FOUND",
+                  message: `레지스트리 '${registryId}'를 찾을 수 없어요.`,
+                  details: [`사용 가능한 레지스트리: ${availableIds.join(", ")}`],
+                });
+              }
+            }
+
+            p.log.message(
+              `선택된 레지스트리의 모든 항목을 추가합니다: ${highlight(options.registryIds.join(", "))}`,
+            );
+
+            return options.registryIds;
+          }
+
+          const selected = await p.multiselect({
+            message: "추가할 레지스트리를 선택해주세요 (스페이스 바로 여러 개 선택 가능)",
+            options: publicRegistries
+              .filter(({ hideFromCLICatalog }) => !hideFromCLICatalog)
+              .sort((a, b) => b.items.length - a.items.length)
+              .map((registry) => ({
+                label: registry.id,
+                value: registry.id,
+                hint: `${registry.items.length}개 항목 (${registry.items[0].id} 등)`,
+              })),
+          });
+
+          if (p.isCancel(selected)) {
+            throw new CliCancelError();
+          }
+
+          p.log.message(`선택된 레지스트리의 항목을 추가합니다: ${highlight(selected.join(", "))}`);
+
+          return selected;
+        })();
+
+        const selectedRegistries = publicRegistries.filter((r) =>
+          selectedRegistryIds.includes(r.id),
+        );
+
+        const itemKeys = selectedRegistries.flatMap((registry) =>
+          registry.items
+            .filter((item) => {
+              if (item.deprecated) return options.includeDeprecated;
+
+              return true;
+            })
+            .map((item) => `${registry.id}:${item.id}`),
+        );
+
+        const deprecatedCount = selectedRegistries.flatMap((r) =>
+          r.items.filter((item) => item.deprecated).map(() => 1),
+        ).length;
+
+        if (!options.includeDeprecated && deprecatedCount > 0) {
+          p.log.info(
+            `${deprecatedCount}개의 deprecated 항목은 제외되었어요. --include-deprecated 옵션을 사용하면 추가할 수 있어요.`,
+          );
         }
 
-        const selected = await p.multiselect({
-          message: "추가할 레지스트리를 선택해주세요 (스페이스 바로 여러 개 선택 가능)",
-          options: publicRegistries
-            .filter(({ hideFromCLICatalog }) => !hideFromCLICatalog)
-            .sort((a, b) => b.items.length - a.items.length)
-            .map((registry) => ({
-              label: registry.id,
-              value: registry.id,
-              hint: `${registry.items.length}개 항목 (${registry.items[0].id} 등)`,
-            })),
+        if (!itemKeys.length) {
+          throw new CliCancelError("추가할 항목이 없어요.");
+        }
+
+        p.log.message(`총 ${highlight(itemKeys.length.toString())}개의 항목을 추가합니다.`);
+
+        const { registryItemsToAdd, npmDependenciesToAdd } = resolveDependencies({
+          selectedItemKeys: itemKeys,
+          publicRegistries,
         });
 
-        if (p.isCancel(selected)) {
-          p.log.error("취소되었어요.");
-          process.exit(0);
-        }
+        await writeRegistryItemSnippets({
+          registryItemsToAdd,
+          rootPath,
+          cwd,
+          baseUrl,
+          config,
+          onDiff: options.onDiff,
+        });
 
-        p.log.message(`선택된 레지스트리의 항목을 추가합니다: ${highlight(selected.join(", "))}`);
-
-        return selected;
-      })();
-
-      const selectedRegistries = publicRegistries.filter((r) => selectedRegistryIds.includes(r.id));
-
-      const itemKeys = selectedRegistries.flatMap((registry) =>
-        registry.items
-          .filter((item) => {
-            if (item.deprecated) return options.includeDeprecated;
-
-            return true;
-          })
-          .map((item) => `${registry.id}:${item.id}`),
-      );
-
-      const deprecatedCount = selectedRegistries.flatMap((r) =>
-        r.items.filter((item) => item.deprecated).map(() => 1),
-      ).length;
-
-      if (!options.includeDeprecated && deprecatedCount > 0) {
-        p.log.info(
-          `${deprecatedCount}개의 deprecated 항목은 제외되었어요. --include-deprecated 옵션을 사용하면 추가할 수 있어요.`,
-        );
-      }
-
-      if (!itemKeys.length) {
-        p.log.error("추가할 항목이 없어요.");
-
-        process.exit(0);
-      }
-
-      p.log.message(`총 ${highlight(itemKeys.length.toString())}개의 항목을 추가합니다.`);
-
-      const { registryItemsToAdd, npmDependenciesToAdd } = resolveDependencies({
-        selectedItemKeys: itemKeys,
-        publicRegistries,
-      });
-
-      await writeRegistryItemSnippets({
-        registryItemsToAdd,
-        rootPath,
-        cwd,
-        baseUrl,
-        config,
-        onDiff: options.onDiff,
-      });
-
-      try {
         const { installed, filtered } = await installDependencies({
           cwd,
           deps: Array.from(npmDependenciesToAdd),
@@ -188,23 +190,30 @@ export const addAllCommand = (cli: CAC) => {
         }
 
         p.outro("완료했어요.");
-      } catch (error) {
-        p.log.error(`추가에 실패했어요. ${error}`);
-        p.outro(highlight("작업이 취소됐어요."));
-        process.exit(1);
-      }
 
-      // add-all 성공 이벤트 추적
-      const duration = Date.now() - startTime;
-      await analytics.track(options.cwd, {
-        event: "add-all",
-        properties: {
-          registries: selectedRegistryIds,
-          items_count: itemKeys.length,
-          include_deprecated: options.includeDeprecated || false,
-          dependencies_count: npmDependenciesToAdd.size,
-          duration_ms: duration,
-        },
-      });
+        // add-all 성공 이벤트 추적
+        const duration = Date.now() - startTime;
+        await analytics.track(options.cwd, {
+          event: "add-all",
+          properties: {
+            registries: selectedRegistryIds,
+            items_count: itemKeys.length,
+            include_deprecated: options.includeDeprecated || false,
+            dependencies_count: npmDependenciesToAdd.size,
+            duration_ms: duration,
+          },
+        });
+      } catch (error) {
+        if (isCliCancelError(error)) {
+          p.outro(highlight(error.message));
+          process.exit(0);
+        }
+
+        handleCliError(error, {
+          defaultMessage: "추가에 실패했어요.",
+          defaultHint: "`--verbose` 옵션으로 상세 오류를 확인해보세요.",
+          verbose,
+        });
+      }
     });
 };

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -87,7 +87,7 @@ export const addCommand = (cli: CAC) => {
         stop("Registry를 가져왔어요.");
 
         const selectedItemKeys: string[] = await (async () => {
-          if ((options.itemIds?.length ?? 0) > 0) {
+          if (options.itemIds?.length) {
             return options.itemIds ?? [];
           }
 
@@ -220,16 +220,22 @@ export const addCommand = (cli: CAC) => {
             ?.items.find((i) => i.id === itemId)?.deprecated;
         });
 
-        await analytics.track(options.cwd, {
-          event: "add",
-          properties: {
-            items_count: filteredItemKeys.length,
-            registries: Array.from(uniqueRegistries),
-            has_deprecated: hasDeprecated,
-            dependencies_count: npmDependenciesToAdd.size,
-            duration_ms: duration,
-          },
-        });
+        try {
+          await analytics.track(options.cwd, {
+            event: "add",
+            properties: {
+              items_count: filteredItemKeys.length,
+              registries: Array.from(uniqueRegistries),
+              has_deprecated: hasDeprecated,
+              dependencies_count: npmDependenciesToAdd.size,
+              duration_ms: duration,
+            },
+          });
+        } catch (telemetryError) {
+          if (verbose) {
+            console.error("[Telemetry] add tracking failed:", telemetryError);
+          }
+        }
       } catch (error) {
         if (isCliCancelError(error)) {
           p.outro(highlight(error.message));

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -11,6 +11,13 @@ import { BASE_URL } from "../constants";
 import { highlight } from "../utils/color";
 import { installDependencies } from "../utils/install";
 import { analytics } from "../utils/analytics";
+import {
+  CliCancelError,
+  CliError,
+  handleCliError,
+  isCliCancelError,
+  isVerboseMode,
+} from "../utils/error";
 
 const addOptionsSchema = z.object({
   itemIds: z.array(z.string()).optional(),
@@ -42,150 +49,146 @@ export const addCommand = (cli: CAC) => {
     .example("seed-design add ui:alert-dialog")
     .action(async (itemIds, opts) => {
       const startTime = Date.now();
+      const verbose = isVerboseMode(opts);
       p.intro("seed-design add");
 
-      const {
-        success,
-        data: { all, ...options },
-        error,
-      } = addOptionsSchema.safeParse({ itemIds, ...opts });
+      try {
+        const parsed = addOptionsSchema.safeParse({ itemIds, ...opts });
+        if (!parsed.success) {
+          throw parsed.error;
+        }
 
-      if (!success) {
-        p.log.error(`잘못된 옵션이에요: ${error?.message}`);
+        const {
+          data: { all, ...options },
+        } = parsed;
 
-        process.exit(1);
-      }
+        if (all) {
+          throw new CliError({
+            code: "DEPRECATED_OPTION",
+            message:
+              "`--all` 옵션은 더 이상 지원되지 않아요. 대신 `seed-design add-all` 명령어를 사용해주세요.",
+          });
+        }
 
-      if (all) {
-        p.log.error(
-          "`--all` 옵션은 더 이상 지원되지 않아요. 대신 `seed-design add-all` 명령어를 사용해주세요.",
+        const cwd = options.cwd;
+        const baseUrl = options.baseUrl;
+        const config = await getConfig(cwd);
+        const rootPath = path.resolve(cwd, config.path);
+
+        const { start, stop } = p.spinner();
+        start("Registry를 가져오고 있어요...");
+
+        const publicRegistries = await Promise.all(
+          (await fetchAvailableRegistries({ baseUrl })).map(async ({ id }) =>
+            fetchRegistry({ baseUrl, registryId: id }),
+          ),
         );
 
-        process.exit(1);
-      }
+        stop("Registry를 가져왔어요.");
 
-      const cwd = options.cwd;
-      const baseUrl = options.baseUrl;
-      const config = await getConfig(cwd);
-      const rootPath = path.resolve(cwd, config.path);
+        const selectedItemKeys: string[] = await (async () => {
+          if ((options.itemIds?.length ?? 0) > 0) {
+            return options.itemIds ?? [];
+          }
 
-      const { start, stop } = p.spinner();
+          const selected = await p.multiselect({
+            message: "추가할 항목을 선택해주세요 (스페이스 바로 여러 개 선택 가능)",
+            options: publicRegistries
+              .filter(({ hideFromCLICatalog }) => !hideFromCLICatalog)
+              .flatMap(({ id: registryId, items }) =>
+                items
+                  .filter(({ hideFromCLICatalog }) => !hideFromCLICatalog)
+                  .sort((a, b) => a.id.localeCompare(b.id))
+                  .map(({ id, description, deprecated }) => ({
+                    label: `${deprecated ? "(deprecated) " : ""}${highlight(registryId)}:${id}`,
+                    value: `${registryId}:${id}`,
+                    hint: description,
 
-      start("Registry를 가져오고 있어요...");
+                    // used for sorting
+                    deprecated,
+                    registryItemCount: items.length,
+                  })),
+              )
+              .sort((a, b) => {
+                if (a.deprecated !== b.deprecated) return a.deprecated ? 1 : -1;
 
-      const publicRegistries = await Promise.all(
-        (await fetchAvailableRegistries({ baseUrl })).map(async ({ id }) =>
-          fetchRegistry({ baseUrl, registryId: id }),
-        ),
-      );
-
-      stop("Registry를 가져왔어요.");
-
-      const selectedItemKeys: string[] = await (async () => {
-        if (options.itemIds.length > 0) return options.itemIds;
-
-        const selected = await p.multiselect({
-          message: "추가할 항목을 선택해주세요 (스페이스 바로 여러 개 선택 가능)",
-          options: publicRegistries
-            .filter(({ hideFromCLICatalog }) => !hideFromCLICatalog)
-            .flatMap(({ id: registryId, items }) =>
-              items
-                .filter(({ hideFromCLICatalog }) => !hideFromCLICatalog)
-                .sort((a, b) => a.id.localeCompare(b.id))
-                .map(({ id, description, deprecated }) => ({
-                  label: `${deprecated ? "(deprecated) " : ""}${highlight(registryId)}:${id}`,
-                  value: `${registryId}:${id}`,
-                  hint: description,
-
-                  // used for sorting
-                  deprecated,
-                  registryItemCount: items.length,
-                })),
-            )
-            .sort((a, b) => {
-              if (a.deprecated !== b.deprecated) return a.deprecated ? 1 : -1;
-
-              return b.registryItemCount - a.registryItemCount;
-            }),
-        });
-
-        if (p.isCancel(selected)) {
-          p.log.error("취소되었어요.");
-          process.exit(0);
-        }
-
-        return selected;
-      })();
-
-      if (!selectedItemKeys?.length) {
-        p.log.error("항목을 찾을 수 없어요.");
-
-        process.exit(0);
-      }
-
-      p.log.message(`선택된 항목: ${highlight(selectedItemKeys.join(", "))}`);
-
-      const filteredItemKeys: string[] = [];
-
-      for (const itemKey of selectedItemKeys) {
-        const [registryId, ...rest] = itemKey.split(":");
-        const itemId = rest.join(":");
-
-        if (!registryId || !itemId) {
-          p.log.error(
-            `${highlight(itemKey)}: 항목 이름이 잘못되었어요. ${highlight("ui:action-button")}과 같은 형식으로 입력해보세요.`,
-          );
-
-          process.exit(1);
-        }
-
-        const foundItem = publicRegistries
-          .find((r) => r.id === registryId)
-          ?.items.find((i) => i.id === itemId);
-
-        if (!foundItem) {
-          p.log.error(`${highlight(itemKey)}: 항목을 찾을 수 없어요.`);
-
-          process.exit(1);
-        }
-
-        if (foundItem.deprecated) {
-          const confirm = await p.confirm({
-            message: `${highlight(foundItem.id)}: deprecated 되었어요. 추가할까요?`,
-            initialValue: false,
+                return b.registryItemCount - a.registryItemCount;
+              }),
           });
 
-          if (confirm === false || p.isCancel(confirm)) {
-            p.log.info(`${highlight(foundItem.id)}: 추가하지 않을게요.`);
-
-            continue;
+          if (p.isCancel(selected)) {
+            throw new CliCancelError();
           }
+
+          return selected;
+        })();
+
+        if (!selectedItemKeys?.length) {
+          throw new CliCancelError("추가할 항목이 선택되지 않았어요.");
         }
 
-        filteredItemKeys.push(itemKey);
-      }
+        p.log.message(`선택된 항목: ${highlight(selectedItemKeys.join(", "))}`);
 
-      const { registryItemsToAdd, npmDependenciesToAdd } = resolveDependencies({
-        selectedItemKeys: filteredItemKeys,
-        publicRegistries,
-      });
+        const filteredItemKeys: string[] = [];
 
-      p.log.info(
-        `추가할 항목: ${highlight(registryItemsToAdd.map((r) => r.items.map((i) => `${r.registryId}:${i.id}`).join(", ")).join(", ") || "없음")}
+        for (const itemKey of selectedItemKeys) {
+          const [registryId, ...rest] = itemKey.split(":");
+          const itemId = rest.join(":");
+
+          if (!registryId || !itemId) {
+            throw new CliError({
+              code: "INVALID_ITEM_ID",
+              message: `${highlight(itemKey)}: 항목 이름이 잘못되었어요.`,
+              hint: `${highlight("ui:action-button")}과 같은 형식으로 입력해보세요.`,
+            });
+          }
+
+          const foundItem = publicRegistries
+            .find((r) => r.id === registryId)
+            ?.items.find((i) => i.id === itemId);
+
+          if (!foundItem) {
+            throw new CliError({
+              code: "ITEM_NOT_FOUND",
+              message: `${highlight(itemKey)}: 항목을 찾을 수 없어요.`,
+            });
+          }
+
+          if (foundItem.deprecated) {
+            const confirm = await p.confirm({
+              message: `${highlight(foundItem.id)}: deprecated 되었어요. 추가할까요?`,
+              initialValue: false,
+            });
+
+            if (confirm === false || p.isCancel(confirm)) {
+              p.log.info(`${highlight(foundItem.id)}: 추가하지 않을게요.`);
+              continue;
+            }
+          }
+
+          filteredItemKeys.push(itemKey);
+        }
+
+        const { registryItemsToAdd, npmDependenciesToAdd } = resolveDependencies({
+          selectedItemKeys: filteredItemKeys,
+          publicRegistries,
+        });
+
+        p.log.info(
+          `추가할 항목: ${highlight(registryItemsToAdd.map((r) => r.items.map((i) => `${r.registryId}:${i.id}`).join(", ")).join(", ") || "없음")}
 
 설치할 의존성: ${highlight(Array.from(npmDependenciesToAdd).join(", ") || "없음")}`,
-      );
+        );
 
-      await writeRegistryItemSnippets({
-        registryItemsToAdd,
-        rootPath,
-        cwd,
-        baseUrl,
-        config,
-        onDiff: options.onDiff,
-      });
+        await writeRegistryItemSnippets({
+          registryItemsToAdd,
+          rootPath,
+          cwd,
+          baseUrl,
+          config,
+          onDiff: options.onDiff,
+        });
 
-      try {
         const { installed, filtered } = await installDependencies({
           cwd,
           deps: Array.from(npmDependenciesToAdd),
@@ -205,31 +208,39 @@ export const addCommand = (cli: CAC) => {
           }
         }
         p.outro("완료했어요.");
+
+        // add 성공 이벤트 추적
+        const duration = Date.now() - startTime;
+        const uniqueRegistries = new Set(registryItemsToAdd.map((r) => r.registryId));
+        const hasDeprecated = selectedItemKeys.some((itemKey) => {
+          const [registryId, ...rest] = itemKey.split(":");
+          const itemId = rest.join(":");
+          return publicRegistries
+            .find((r) => r.id === registryId)
+            ?.items.find((i) => i.id === itemId)?.deprecated;
+        });
+
+        await analytics.track(options.cwd, {
+          event: "add",
+          properties: {
+            items_count: filteredItemKeys.length,
+            registries: Array.from(uniqueRegistries),
+            has_deprecated: hasDeprecated,
+            dependencies_count: npmDependenciesToAdd.size,
+            duration_ms: duration,
+          },
+        });
       } catch (error) {
-        p.log.error(`추가에 실패했어요. ${error}`);
-        p.outro(highlight("작업이 취소됐어요."));
-        process.exit(1);
+        if (isCliCancelError(error)) {
+          p.outro(highlight(error.message));
+          process.exit(0);
+        }
+
+        handleCliError(error, {
+          defaultMessage: "추가에 실패했어요.",
+          defaultHint: "`--verbose` 옵션으로 상세 오류를 확인해보세요.",
+          verbose,
+        });
       }
-
-      // add 성공 이벤트 추적
-      const duration = Date.now() - startTime;
-      const uniqueRegistries = new Set(registryItemsToAdd.map((r) => r.registryId));
-      const hasDeprecated = selectedItemKeys.some((itemKey) => {
-        const [registryId, ...rest] = itemKey.split(":");
-        const itemId = rest.join(":");
-        return publicRegistries.find((r) => r.id === registryId)?.items.find((i) => i.id === itemId)
-          ?.deprecated;
-      });
-
-      await analytics.track(options.cwd, {
-        event: "add",
-        properties: {
-          items_count: filteredItemKeys.length,
-          registries: Array.from(uniqueRegistries),
-          has_deprecated: hasDeprecated,
-          dependencies_count: npmDependenciesToAdd.size,
-          duration_ms: duration,
-        },
-      });
     });
 };

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -64,7 +64,6 @@ export const addCommand = (cli: CAC) => {
 
         if (all) {
           throw new CliError({
-            code: "DEPRECATED_OPTION",
             message:
               "`--all` 옵션은 더 이상 지원되지 않아요. 대신 `seed-design add-all` 명령어를 사용해주세요.",
           });
@@ -78,17 +77,25 @@ export const addCommand = (cli: CAC) => {
         const { start, stop } = p.spinner();
         start("Registry를 가져오고 있어요...");
 
-        const publicRegistries = await Promise.all(
-          (await fetchAvailableRegistries({ baseUrl })).map(async ({ id }) =>
-            fetchRegistry({ baseUrl, registryId: id }),
-          ),
-        );
+        const publicRegistries = await (async () => {
+          try {
+            const registries = await Promise.all(
+              (await fetchAvailableRegistries({ baseUrl })).map(async ({ id }) =>
+                fetchRegistry({ baseUrl, registryId: id }),
+              ),
+            );
+            stop("Registry를 가져왔어요.");
 
-        stop("Registry를 가져왔어요.");
+            return registries;
+          } catch (error) {
+            stop("Registry를 가져오지 못했어요.");
+            throw error;
+          }
+        })();
 
         const selectedItemKeys: string[] = await (async () => {
           if (options.itemIds?.length) {
-            return options.itemIds ?? [];
+            return options.itemIds;
           }
 
           const selected = await p.multiselect({
@@ -137,7 +144,6 @@ export const addCommand = (cli: CAC) => {
 
           if (!registryId || !itemId) {
             throw new CliError({
-              code: "INVALID_ITEM_ID",
               message: `${highlight(itemKey)}: 항목 이름이 잘못되었어요.`,
               hint: `${highlight("ui:action-button")}과 같은 형식으로 입력해보세요.`,
             });
@@ -149,7 +155,6 @@ export const addCommand = (cli: CAC) => {
 
           if (!foundItem) {
             throw new CliError({
-              code: "ITEM_NOT_FOUND",
               message: `${highlight(itemKey)}: 항목을 찾을 수 없어요.`,
             });
           }
@@ -160,7 +165,11 @@ export const addCommand = (cli: CAC) => {
               initialValue: false,
             });
 
-            if (confirm === false || p.isCancel(confirm)) {
+            if (p.isCancel(confirm)) {
+              throw new CliCancelError();
+            }
+
+            if (confirm === false) {
               p.log.info(`${highlight(foundItem.id)}: 추가하지 않을게요.`);
               continue;
             }
@@ -247,6 +256,7 @@ export const addCommand = (cli: CAC) => {
           defaultHint: "`--verbose` 옵션으로 상세 오류를 확인해보세요.",
           verbose,
         });
+        process.exit(1);
       }
     });
 };

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -30,27 +30,32 @@ export const initCommand = (cli: CAC) => {
       p.intro("seed-design.json 파일 생성");
 
       try {
-        const options = initOptionsSchema.parse(opts);
+        const parsed = initOptionsSchema.safeParse(opts);
+        if (!parsed.success) {
+          throw parsed.error;
+        }
+
+        const options = parsed.data;
         const isDefaultMode = options.yes || options.default;
         const config: Config = isDefaultMode ? DEFAULT_INIT_CONFIG : await promptInitConfig();
 
         const { start, stop } = p.spinner();
-        let spinnerStopped = false;
         start("seed-design.json 파일 생성중...");
-        let relativePath = "";
-        try {
-          ({ relativePath } = await writeInitConfigFile({
-            cwd: options.cwd,
-            config,
-          }));
+        const relativePath = await (async () => {
+          try {
+            const result = await writeInitConfigFile({
+              cwd: options.cwd,
+              config,
+            });
 
-          stop(`seed-design.json 파일이 ${highlight(relativePath)}에 생성됐어요.`);
-          spinnerStopped = true;
-        } finally {
-          if (!spinnerStopped) {
+            return result.relativePath;
+          } catch (error) {
             stop("seed-design.json 파일 생성이 중단됐어요.");
+            throw error;
           }
-        }
+        })();
+
+        stop(`seed-design.json 파일이 ${highlight(relativePath)}에 생성됐어요.`);
 
         p.log.info(highlight("seed-design add {component} 명령어로 컴포넌트를 추가해보세요!"));
         p.log.info(
@@ -99,6 +104,7 @@ export const initCommand = (cli: CAC) => {
           defaultHint: "`--verbose` 옵션으로 상세 오류를 확인해보세요.",
           verbose,
         });
+        process.exit(1);
       }
     });
 };

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,9 +1,9 @@
 import * as p from "@clack/prompts";
-import fs from "fs-extra";
-import path from "path";
 import { z } from "zod";
 import { analytics } from "../utils/analytics";
 import { highlight } from "../utils/color";
+import { handleCliError, isCliCancelError, isVerboseMode } from "../utils/error";
+import { DEFAULT_INIT_CONFIG, promptInitConfig, writeInitConfigFile } from "../utils/init-config";
 
 import type { Config } from "@/src/utils/get-config";
 
@@ -13,6 +13,7 @@ import dedent from "dedent";
 const initOptionsSchema = z.object({
   cwd: z.string(),
   yes: z.boolean().optional(),
+  default: z.boolean().optional(),
 });
 
 export const initCommand = (cli: CAC) => {
@@ -22,64 +23,25 @@ export const initCommand = (cli: CAC) => {
       default: process.cwd(),
     })
     .option("-y, --yes", "모든 질문에 대해 기본값으로 답변합니다.")
+    .option("--default", "Deprecated. --yes와 동일하게 기본값으로 생성합니다.")
     .action(async (opts) => {
       const startTime = Date.now();
+      const verbose = isVerboseMode(opts);
       p.intro("seed-design.json 파일 생성");
 
-      const options = initOptionsSchema.parse(opts);
-      const isYesOption = options.yes;
-      let config: Config = {
-        rsc: false,
-        tsx: true,
-        path: "./seed-design",
-        telemetry: true,
-      };
-
-      if (!isYesOption) {
-        const group = await p.group(
-          {
-            tsx: () =>
-              p.confirm({
-                message: `${highlight("TypeScript")}를 사용중이신가요?`,
-                initialValue: true,
-              }),
-            rsc: () =>
-              p.confirm({
-                message: `${highlight("React Server Components")}를 사용중이신가요?`,
-                initialValue: false,
-              }),
-            path: () =>
-              p.text({
-                message: `${highlight("seed-design 폴더")} 경로를 입력해주세요. (기본값은 프로젝트 루트에 생성됩니다.)`,
-                initialValue: "./seed-design",
-                defaultValue: "./seed-design",
-                placeholder: "./seed-design",
-              }),
-            telemetry: () =>
-              p.confirm({
-                message: `개선을 위해 ${highlight("익명 사용 데이터")}를 수집할까요?`,
-                initialValue: true,
-              }),
-          },
-          {
-            onCancel: () => {
-              p.cancel("작업이 취소됐어요.");
-              process.exit(0);
-            },
-          },
-        );
-
-        config = {
-          ...group,
-        };
-      }
-
       try {
+        const options = initOptionsSchema.parse(opts);
+        const isDefaultMode = options.yes || options.default;
+        const config: Config = isDefaultMode ? DEFAULT_INIT_CONFIG : await promptInitConfig();
+
         const { start, stop } = p.spinner();
         start("seed-design.json 파일 생성중...");
-        const targetPath = path.resolve(options.cwd, "seed-design.json");
-        await fs.writeFile(targetPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
-        const relativePath = path.relative(process.cwd(), targetPath);
+
+        const { relativePath } = await writeInitConfigFile({
+          cwd: options.cwd,
+          config,
+        });
+
         stop(`seed-design.json 파일이 ${highlight(relativePath)}에 생성됐어요.`);
 
         p.log.info(highlight("seed-design add {component} 명령어로 컴포넌트를 추가해보세요!"));
@@ -99,23 +61,30 @@ export const initCommand = (cli: CAC) => {
         );
 
         p.outro("작업이 완료됐어요.");
-      } catch (error) {
-        p.log.error(`seed-design.json 파일 생성에 실패했어요. ${error}`);
-        p.outro(highlight("작업이 취소됐어요."));
-        process.exit(1);
-      }
 
-      // init 성공 이벤트 추적
-      const duration = Date.now() - startTime;
-      await analytics.track(options.cwd, {
-        event: "init",
-        properties: {
-          tsx: config.tsx,
-          rsc: config.rsc,
-          telemetry: config.telemetry,
-          yes_option: isYesOption,
-          duration_ms: duration,
-        },
-      });
+        // init 성공 이벤트 추적
+        const duration = Date.now() - startTime;
+        await analytics.track(options.cwd, {
+          event: "init",
+          properties: {
+            tsx: config.tsx,
+            rsc: config.rsc,
+            telemetry: config.telemetry,
+            yes_option: isDefaultMode,
+            duration_ms: duration,
+          },
+        });
+      } catch (error) {
+        if (isCliCancelError(error)) {
+          p.outro(highlight(error.message));
+          process.exit(0);
+        }
+
+        handleCliError(error, {
+          defaultMessage: "seed-design.json 파일 생성에 실패했어요.",
+          defaultHint: "`--verbose` 옵션으로 상세 오류를 확인해보세요.",
+          verbose,
+        });
+      }
     });
 };

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -35,14 +35,22 @@ export const initCommand = (cli: CAC) => {
         const config: Config = isDefaultMode ? DEFAULT_INIT_CONFIG : await promptInitConfig();
 
         const { start, stop } = p.spinner();
+        let spinnerStopped = false;
         start("seed-design.json 파일 생성중...");
+        let relativePath = "";
+        try {
+          ({ relativePath } = await writeInitConfigFile({
+            cwd: options.cwd,
+            config,
+          }));
 
-        const { relativePath } = await writeInitConfigFile({
-          cwd: options.cwd,
-          config,
-        });
-
-        stop(`seed-design.json 파일이 ${highlight(relativePath)}에 생성됐어요.`);
+          stop(`seed-design.json 파일이 ${highlight(relativePath)}에 생성됐어요.`);
+          spinnerStopped = true;
+        } finally {
+          if (!spinnerStopped) {
+            stop("seed-design.json 파일 생성이 중단됐어요.");
+          }
+        }
 
         p.log.info(highlight("seed-design add {component} 명령어로 컴포넌트를 추가해보세요!"));
         p.log.info(
@@ -64,16 +72,22 @@ export const initCommand = (cli: CAC) => {
 
         // init 성공 이벤트 추적
         const duration = Date.now() - startTime;
-        await analytics.track(options.cwd, {
-          event: "init",
-          properties: {
-            tsx: config.tsx,
-            rsc: config.rsc,
-            telemetry: config.telemetry,
-            yes_option: isDefaultMode,
-            duration_ms: duration,
-          },
-        });
+        try {
+          await analytics.track(options.cwd, {
+            event: "init",
+            properties: {
+              tsx: config.tsx,
+              rsc: config.rsc,
+              telemetry: config.telemetry,
+              yes_option: isDefaultMode,
+              duration_ms: duration,
+            },
+          });
+        } catch (telemetryError) {
+          if (verbose) {
+            console.error("[Telemetry] init tracking failed:", telemetryError);
+          }
+        }
       } catch (error) {
         if (isCliCancelError(error)) {
           p.outro(highlight(error.message));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,8 @@ const CLI = cac(NAME);
 async function main() {
   const packageInfo = getPackageInfo();
 
+  CLI.option("--verbose", "오류 상세 정보를 출력합니다.");
+
   /* Commands */
   addCommand(CLI);
   addAllCommand(CLI);

--- a/packages/cli/src/utils/error.ts
+++ b/packages/cli/src/utils/error.ts
@@ -3,7 +3,6 @@ import { ZodError } from "zod";
 import { highlight } from "./color";
 
 interface CliErrorOptions {
-  code: string;
   message: string;
   hint?: string;
   details?: string[];
@@ -27,14 +26,12 @@ interface ExecaLikeError {
 }
 
 export class CliError extends Error {
-  code: string;
   hint?: string;
   details: string[];
 
-  constructor({ code, message, hint, details = [], cause }: CliErrorOptions) {
+  constructor({ message, hint, details = [], cause }: CliErrorOptions) {
     super(message, { cause });
     this.name = "CliError";
-    this.code = code;
     this.hint = hint;
     this.details = details;
   }
@@ -140,7 +137,7 @@ function toStack(error: unknown): string | undefined {
 export function handleCliError(
   error: unknown,
   { defaultMessage, defaultHint, verbose = false }: HandleCliErrorOptions,
-): never {
+): void {
   const normalized = normalizeError(error, defaultHint);
 
   p.log.error(defaultMessage);
@@ -160,5 +157,4 @@ export function handleCliError(
   }
 
   p.outro(highlight("작업에 실패했어요."));
-  process.exit(1);
 }

--- a/packages/cli/src/utils/error.ts
+++ b/packages/cli/src/utils/error.ts
@@ -30,15 +30,13 @@ export class CliError extends Error {
   code: string;
   hint?: string;
   details: string[];
-  cause?: unknown;
 
   constructor({ code, message, hint, details = [], cause }: CliErrorOptions) {
-    super(message);
+    super(message, { cause });
     this.name = "CliError";
     this.code = code;
     this.hint = hint;
     this.details = details;
-    this.cause = cause;
   }
 }
 
@@ -161,6 +159,6 @@ export function handleCliError(
     p.log.message(normalized.stack);
   }
 
-  p.outro(highlight("작업이 취소됐어요."));
+  p.outro(highlight("작업에 실패했어요."));
   process.exit(1);
 }

--- a/packages/cli/src/utils/error.ts
+++ b/packages/cli/src/utils/error.ts
@@ -1,0 +1,166 @@
+import * as p from "@clack/prompts";
+import { ZodError } from "zod";
+import { highlight } from "./color";
+
+interface CliErrorOptions {
+  code: string;
+  message: string;
+  hint?: string;
+  details?: string[];
+  cause?: unknown;
+}
+
+interface HandleCliErrorOptions {
+  defaultMessage: string;
+  defaultHint?: string;
+  verbose?: boolean;
+}
+
+interface ExecaLikeError {
+  command?: string;
+  escapedCommand?: string;
+  exitCode?: number;
+  shortMessage?: string;
+  stderr?: string;
+  stdout?: string;
+  stack?: string;
+}
+
+export class CliError extends Error {
+  code: string;
+  hint?: string;
+  details: string[];
+  cause?: unknown;
+
+  constructor({ code, message, hint, details = [], cause }: CliErrorOptions) {
+    super(message);
+    this.name = "CliError";
+    this.code = code;
+    this.hint = hint;
+    this.details = details;
+    this.cause = cause;
+  }
+}
+
+export class CliCancelError extends Error {
+  constructor(message = "작업이 취소됐어요.") {
+    super(message);
+    this.name = "CliCancelError";
+  }
+}
+
+export function isCliCancelError(error: unknown): error is CliCancelError {
+  return error instanceof CliCancelError;
+}
+
+export function isVerboseMode(options: unknown): boolean {
+  if (!options || typeof options !== "object") return false;
+  if (!("verbose" in options)) return false;
+
+  return options.verbose === true;
+}
+
+function normalizeError(
+  error: unknown,
+  defaultHint?: string,
+): {
+  reason: string;
+  hint?: string;
+  details: string[];
+  stack?: string;
+} {
+  if (error instanceof CliError) {
+    return {
+      reason: error.message,
+      hint: error.hint ?? defaultHint,
+      details: error.details,
+      stack: toStack(error.cause ?? error),
+    };
+  }
+
+  if (error instanceof ZodError) {
+    const issues = error.issues.map((issue) => {
+      const path = issue.path.join(".") || "(root)";
+      return `${path}: ${issue.message}`;
+    });
+
+    return {
+      reason: "입력값 또는 설정 파일 형식이 올바르지 않아요.",
+      hint: defaultHint,
+      details: issues,
+      stack: error.stack,
+    };
+  }
+
+  if (error instanceof Error) {
+    const execaLike = error as ExecaLikeError;
+    const details: string[] = [];
+
+    if (execaLike.escapedCommand || execaLike.command) {
+      details.push(`실행 명령어: ${execaLike.escapedCommand ?? execaLike.command}`);
+    }
+    if (typeof execaLike.exitCode === "number") {
+      details.push(`종료 코드: ${execaLike.exitCode}`);
+    }
+    if (execaLike.stderr?.trim()) {
+      details.push(`stderr: ${execaLike.stderr.trim()}`);
+    } else if (execaLike.stdout?.trim()) {
+      details.push(`stdout: ${execaLike.stdout.trim()}`);
+    }
+
+    return {
+      reason: execaLike.shortMessage ?? error.message,
+      hint: defaultHint,
+      details,
+      stack: error.stack,
+    };
+  }
+
+  if (typeof error === "string") {
+    return {
+      reason: error,
+      hint: defaultHint,
+      details: [],
+    };
+  }
+
+  return {
+    reason: "알 수 없는 오류가 발생했어요.",
+    hint: defaultHint,
+    details: [],
+  };
+}
+
+function toStack(error: unknown): string | undefined {
+  if (error instanceof Error) {
+    return error.stack;
+  }
+
+  return undefined;
+}
+
+export function handleCliError(
+  error: unknown,
+  { defaultMessage, defaultHint, verbose = false }: HandleCliErrorOptions,
+): never {
+  const normalized = normalizeError(error, defaultHint);
+
+  p.log.error(defaultMessage);
+  p.log.error(`원인: ${normalized.reason}`);
+
+  for (const detail of normalized.details) {
+    p.log.info(detail);
+  }
+
+  if (normalized.hint) {
+    p.log.info(`해결 힌트: ${normalized.hint}`);
+  }
+
+  if (verbose && normalized.stack) {
+    p.log.message(highlight("\n[verbose] stack trace"));
+    p.log.message(normalized.stack);
+  }
+
+  p.outro(highlight("작업이 취소됐어요."));
+  process.exit(1);
+}

--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -43,7 +43,6 @@ export async function getConfig(cwd: string): Promise<Config> {
     return configSchema.parse(DEFAULT_INIT_CONFIG);
   } catch (error) {
     throw new CliError({
-      code: "CONFIG_WRITE_FAILED",
       message: "seed-design.json 파일 생성에 실패했어요.",
       hint: "디렉토리 쓰기 권한과 경로를 확인한 뒤 다시 시도해보세요.",
       cause: error,
@@ -59,7 +58,6 @@ export async function getRawConfig(cwd: string): Promise<Config | null> {
     return configSchema.parse(configResult.config);
   } catch (error) {
     throw new CliError({
-      code: "CONFIG_INVALID",
       message: "seed-design.json 형식이 올바르지 않아요.",
       hint: "https://seed-design.com/react/getting-started/cli/configuration 문서를 참고해 주세요.",
       cause: error,

--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -1,9 +1,8 @@
 import * as p from "@clack/prompts";
 import { cosmiconfig } from "cosmiconfig";
-import { execa } from "execa";
 import { z } from "zod";
-import { highlight } from "./color";
-import { getPackageManager } from "./get-package-manager";
+import { CliCancelError, CliError } from "./error";
+import { DEFAULT_INIT_CONFIG, writeInitConfigFile } from "./init-config";
 
 const MODULE_NAME = "seed-design";
 
@@ -23,31 +22,47 @@ export const configSchema = z
 
 export type Config = z.infer<typeof configSchema>;
 
-export async function getConfig(cwd: string) {
+export async function getConfig(cwd: string): Promise<Config> {
   const config = await getRawConfig(cwd);
-  if (!config) return null;
+  if (config) return config;
 
-  return configSchema.parse(config);
+  p.log.error("프로젝트 루트 경로에 `seed-design.json` 파일이 없어요.");
+
+  const isConfirm = await p.confirm({ message: "seed-design.json 파일을 생성하시겠어요?" });
+
+  if (p.isCancel(isConfirm) || !isConfirm) {
+    throw new CliCancelError();
+  }
+
+  try {
+    await writeInitConfigFile({
+      cwd,
+      config: DEFAULT_INIT_CONFIG,
+    });
+    p.log.message("seed-design.json 파일이 생성됐어요.");
+    return configSchema.parse(DEFAULT_INIT_CONFIG);
+  } catch (error) {
+    throw new CliError({
+      code: "CONFIG_WRITE_FAILED",
+      message: "seed-design.json 파일 생성에 실패했어요.",
+      hint: "디렉토리 쓰기 권한과 경로를 확인한 뒤 다시 시도해보세요.",
+      cause: error,
+    });
+  }
 }
 
 export async function getRawConfig(cwd: string): Promise<Config | null> {
+  const configResult = await explorer.search(cwd);
+  if (!configResult || configResult.isEmpty) return null;
+
   try {
-    const configResult = await explorer.search(cwd);
     return configSchema.parse(configResult.config);
-  } catch {
-    p.log.error("프로젝트 루트 경로에 `seed-design.json` 파일이 없어요.");
-
-    const isConfirm = await p.confirm({ message: "seed-design.json 파일을 생성하시겠어요?" });
-
-    if (!isConfirm) {
-      p.outro(highlight("작업이 취소됐어요."));
-      process.exit(1);
-    }
-
-    const packageManager = await getPackageManager(cwd);
-
-    await execa(packageManager, ["seed-design", "init", "--default"], { cwd });
-
-    p.log.message("seed-design.json 파일이 생성됐어요.");
+  } catch (error) {
+    throw new CliError({
+      code: "CONFIG_INVALID",
+      message: "seed-design.json 형식이 올바르지 않아요.",
+      hint: "https://seed-design.com/react/getting-started/cli/configuration 문서를 참고해 주세요.",
+      cause: error,
+    });
   }
 }

--- a/packages/cli/src/utils/init-config.ts
+++ b/packages/cli/src/utils/init-config.ts
@@ -46,9 +46,7 @@ export async function promptInitConfig(): Promise<Config> {
     },
   );
 
-  return {
-    ...group,
-  };
+  return group;
 }
 
 export async function writeInitConfigFile({

--- a/packages/cli/src/utils/init-config.ts
+++ b/packages/cli/src/utils/init-config.ts
@@ -1,0 +1,69 @@
+import * as p from "@clack/prompts";
+import fs from "fs-extra";
+import path from "path";
+import { highlight } from "./color";
+import { CliCancelError } from "./error";
+
+import type { Config } from "./get-config";
+
+export const DEFAULT_INIT_CONFIG: Config = {
+  rsc: false,
+  tsx: true,
+  path: "./seed-design",
+  telemetry: true,
+};
+
+export async function promptInitConfig(): Promise<Config> {
+  const group = await p.group(
+    {
+      tsx: () =>
+        p.confirm({
+          message: `${highlight("TypeScript")}를 사용중이신가요?`,
+          initialValue: DEFAULT_INIT_CONFIG.tsx,
+        }),
+      rsc: () =>
+        p.confirm({
+          message: `${highlight("React Server Components")}를 사용중이신가요?`,
+          initialValue: DEFAULT_INIT_CONFIG.rsc,
+        }),
+      path: () =>
+        p.text({
+          message: `${highlight("seed-design 폴더")} 경로를 입력해주세요. (기본값은 프로젝트 루트에 생성됩니다.)`,
+          initialValue: DEFAULT_INIT_CONFIG.path,
+          defaultValue: DEFAULT_INIT_CONFIG.path,
+          placeholder: DEFAULT_INIT_CONFIG.path,
+        }),
+      telemetry: () =>
+        p.confirm({
+          message: `개선을 위해 ${highlight("익명 사용 데이터")}를 수집할까요?`,
+          initialValue: DEFAULT_INIT_CONFIG.telemetry,
+        }),
+    },
+    {
+      onCancel: () => {
+        throw new CliCancelError();
+      },
+    },
+  );
+
+  return {
+    ...group,
+  };
+}
+
+export async function writeInitConfigFile({
+  cwd,
+  config,
+}: {
+  cwd: string;
+  config: Config;
+}): Promise<{ relativePath: string; targetPath: string }> {
+  const targetPath = path.resolve(cwd, "seed-design.json");
+  await fs.writeFile(targetPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+  const relativePath = path.relative(process.cwd(), targetPath);
+
+  return {
+    relativePath,
+    targetPath,
+  };
+}

--- a/packages/cli/src/utils/install.ts
+++ b/packages/cli/src/utils/install.ts
@@ -1,5 +1,6 @@
 import * as p from "@clack/prompts";
 import { execa } from "execa";
+import { CliError } from "./error";
 import { getPackageManager } from "./get-package-manager";
 import { getPackageInfo } from "./get-package-info";
 
@@ -31,12 +32,18 @@ export async function installDependencies({ cwd, deps, dev = false }: InstallDep
   const isDev = dev ? "-D" : null;
   const addCommand = packageManager === "npm" ? "install" : "add";
   const command = [addCommand, isDev, ...depsToInstall].filter(Boolean);
+  const commandLabel = `${packageManager} ${command.join(" ")}`;
 
   try {
     await execa(packageManager, command, { cwd });
   } catch (error) {
-    console.error(`의존성 설치 실패: ${error}`);
-    process.exit(1);
+    throw new CliError({
+      code: "INSTALL_FAILED",
+      message: "의존성 설치에 실패했어요.",
+      hint: "네트워크 상태를 확인하고, 설치 명령어를 직접 실행해 상세 오류를 확인해보세요.",
+      details: [`실행 명령어: ${commandLabel}`],
+      cause: error,
+    });
   }
 
   stop("의존성 설치가 완료됐어요.");

--- a/packages/cli/src/utils/install.ts
+++ b/packages/cli/src/utils/install.ts
@@ -39,7 +39,6 @@ export async function installDependencies({ cwd, deps, dev = false }: InstallDep
   } catch (error) {
     stop("의존성 설치에 실패했어요.");
     throw new CliError({
-      code: "INSTALL_FAILED",
       message: "의존성 설치에 실패했어요.",
       hint: "네트워크 상태를 확인하고, 설치 명령어를 직접 실행해 상세 오류를 확인해보세요.",
       details: [`실행 명령어: ${commandLabel}`],

--- a/packages/cli/src/utils/install.ts
+++ b/packages/cli/src/utils/install.ts
@@ -37,6 +37,7 @@ export async function installDependencies({ cwd, deps, dev = false }: InstallDep
   try {
     await execa(packageManager, command, { cwd });
   } catch (error) {
+    stop("의존성 설치에 실패했어요.");
     throw new CliError({
       code: "INSTALL_FAILED",
       message: "의존성 설치에 실패했어요.",


### PR DESCRIPTION
## Summary
- internalize `seed-design.json` bootstrap in CLI when config is missing (remove external `execa` init invocation)
- add shared CLI error handling with clearer cause/hint output and `--verbose` stack trace support
- keep `init --default` as compatibility alias of `--yes`
- upgrade `@clack/prompts` to v1 and sync lockfile
- add CLI-local documentation (`packages/cli/AGENTS.md`, `packages/cli/TECH.md`, `packages/cli/src/AGENTS.md`)

## Main changes
- added `CliError`/`CliCancelError` + `handleCliError` in `packages/cli/src/utils/error.ts`
- added shared init-config helpers in `packages/cli/src/utils/init-config.ts`
- refactored `get-config` to create default config internally instead of spawning package manager command
- refactored `init`, `add`, `add-all` to use common failure handling and cancellation flow
- added global `--verbose` option in CLI entrypoint
- made install utility throw structured errors instead of exiting directly
- updated docs for `--verbose` and `--default` behavior

## Validation
### Passed
- `bun x biome check` (changed CLI files)
- `bun test packages/cli`
- `bun --filter @seed-design/cli build`

### Known pre-existing workspace issues
- `bun generate:all` fails in qvism-preset due to unresolved `@seed-design/rootage-core`
- `bun test:all` fails because multiple tests cannot resolve workspace modules such as `@seed-design/dom-utils`, `@seed-design/react-field`, and `@seed-design/react-primitive`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 전역 --verbose 옵션 추가로 명령 실패 시 상세 진단 출력 가능
  * seed-design.json이 없을 때 대화형/기본값으로 설정을 생성·저장하는 초기화 흐름 추가
  * init의 --default 옵션을 --yes와 동등한 호환 별칭으로 유지

* **Bug Fixes**
  * 오류·취소 처리 및 실패 진단 흐름을 일관되게 개선하여 사용자 피드백 강화

* **Documentation**
  * 명령/옵션 문서에 verbose 및 --default(구식) 안내 추가
  * CLI 기술·개발 가이드 및 소스 디렉터리 운영 문서 추가

* **Chores**
  * @clack/prompts 의존성 업데이트 (v1)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->