### PR TITLE
feat(figma): skip codegen for Figma-only OS component instances

### DIFF
--- a/packages/figma/src/codegen/core/codegen.ts
+++ b/packages/figma/src/codegen/core/codegen.ts
@@ -23,6 +23,7 @@ export interface CodeGeneratorDeps {
   vectorTransformer: ElementTransformer<NormalizedVectorNode>;
   booleanOperationTransformer: ElementTransformer<NormalizedBooleanOperationNode>;
   shouldInferAutoLayout: boolean;
+  skipComponentKeys?: Set<string>;
 }
 
 export interface CodeGenerator {
@@ -41,9 +42,26 @@ export function createCodeGenerator({
   vectorTransformer,
   booleanOperationTransformer,
   shouldInferAutoLayout,
+  skipComponentKeys,
 }: CodeGeneratorDeps): CodeGenerator {
+  function isSkippedInstance(node: NormalizedSceneNode): boolean {
+    if (!skipComponentKeys || skipComponentKeys.size === 0) return false;
+    if (node.type !== "INSTANCE") return false;
+
+    const { componentKey, componentSetKey } = node;
+
+    return (
+      skipComponentKeys.has(componentKey) ||
+      (!!componentSetKey && skipComponentKeys.has(componentSetKey))
+    );
+  }
+
   function traverse(node: NormalizedSceneNode): ElementNode | undefined {
     if ("visible" in node && !node.visible) {
+      return;
+    }
+
+    if (isSkippedInstance(node)) {
       return;
     }
 
@@ -74,6 +92,10 @@ export function createCodeGenerator({
   }
 
   function generateCode(node: NormalizedSceneNode, options: { shouldPrintSource: boolean }) {
+    if (isSkippedInstance(node)) {
+      return { imports: "", jsx: "// This component is intentionally excluded from codegen" };
+     }
+
     const jsxTree = generateJsxTree(node);
 
     if (!jsxTree) {

--- a/packages/figma/src/codegen/skip-components.ts
+++ b/packages/figma/src/codegen/skip-components.ts
@@ -1,0 +1,7 @@
+import * as metadata from "../entities/data/__generated__/component-sets";
+
+export const SKIP_COMPONENT_KEYS: Set<string> = new Set([
+  metadata.componentOsBottomIndicatorFigmaOnly.key,
+  metadata.componentOsKeyboardFigmaOnly.key,
+  metadata.componentOsStatusBarFigmaOnly.key,
+]);

--- a/packages/figma/src/codegen/targets/figma/pipeline.ts
+++ b/packages/figma/src/codegen/targets/figma/pipeline.ts
@@ -1,6 +1,7 @@
 import { createCodeGenerator, createValueResolver } from "@/codegen/core";
 import type { CodeGenerator } from "@/codegen/core/codegen";
 import { styleService, variableService } from "@/codegen/default-services";
+import { SKIP_COMPONENT_KEYS } from "@/codegen/skip-components";
 import { componentRepository } from "@/entities";
 import { createFrameTransformer } from "./frame";
 import { createInstanceTransformer } from "./instance";
@@ -98,6 +99,7 @@ export function createPipeline(options: CreatePipelineConfig = {}): CodeGenerato
     vectorTransformer,
     booleanOperationTransformer,
     shouldInferAutoLayout,
+    skipComponentKeys: SKIP_COMPONENT_KEYS,
   });
 
   return codegenTransformer;

--- a/packages/figma/src/codegen/targets/react/pipeline.ts
+++ b/packages/figma/src/codegen/targets/react/pipeline.ts
@@ -1,5 +1,6 @@
 import { createCodeGenerator, createValueResolver } from "@/codegen/core";
 import { iconService, styleService, variableService } from "@/codegen/default-services";
+import { SKIP_COMPONENT_KEYS } from "@/codegen/skip-components";
 import {
   type UnboundComponentHandler,
   bindComponentHandler,
@@ -125,6 +126,7 @@ export function createPipeline(options: CreatePipelineConfig = {}) {
     vectorTransformer,
     booleanOperationTransformer,
     shouldInferAutoLayout,
+    skipComponentKeys: SKIP_COMPONENT_KEYS,
   });
 
   return codeGenerator;


### PR DESCRIPTION
## Summary
- Figma 전용 OS 컴포넌트(Status Bar, Keyboard, Bottom Indicator)를 코드 생성에서 제외하는 메커니즘 추가
- `SKIP_COMPONENT_KEYS` 세트에 등록된 컴포넌트 키를 `traverse`/`generateCode` 단계에서 스킵
- Figma, React 양쪽 파이프라인에 모두 적용

## Test plan
- [ ] Figma codegen에서 OS Status Bar, Keyboard, Bottom Indicator 인스턴스가 코드에 포함되지 않는지 확인
- [ ] 기존 컴포넌트 codegen이 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 코드 생성 파이프라인에 컴포넌트 스킵 기능 추가
  * 특정 컴포넌트 인스턴스를 코드 생성 과정에서 제외 가능
  * OS 관련 세 개의 컴포넌트가 기본적으로 제외되도록 구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->