### PR TITLE
fix(docs): icon bottom section update background color to use 'bg-fd-background'

### DIFF
--- a/docs/components/iconography/icon-bottom-infomation.tsx
+++ b/docs/components/iconography/icon-bottom-infomation.tsx
@@ -40,7 +40,7 @@ export const IconBottomInfomation = () => {
   );
 
   return (
-    <div className="flex justify-between fixed bottom-0 min-h-28 left-0 right-0 border-t border-gray-200 p-4 z-30 bg-fd-background">
+    <div className="flex justify-between fixed bottom-0 min-h-28 left-0 right-0 border-t border-fd-border p-4 z-30 bg-fd-background">
       <div className="flex flex-col justify-center gap-2">
         <div className="flex gap-4 items-end">
           <div

--- a/docs/components/iconography/icon-bottom-infomation.tsx
+++ b/docs/components/iconography/icon-bottom-infomation.tsx
@@ -40,7 +40,7 @@ export const IconBottomInfomation = () => {
   );
 
   return (
-    <div className="flex justify-between fixed bottom-0 min-h-28 left-0 right-0 border-t border-gray-200 p-4 z-30 bg-gray-50">
+    <div className="flex justify-between fixed bottom-0 min-h-28 left-0 right-0 border-t border-gray-200 p-4 z-30 bg-fd-background">
       <div className="flex flex-col justify-center gap-2">
         <div className="flex gap-4 items-end">
           <div

--- a/docs/components/iconography/icon-grid.tsx
+++ b/docs/components/iconography/icon-grid.tsx
@@ -51,6 +51,8 @@ const IconItem = ({
         selected: isSelected,
       })}
       data-metadatas={metadataString}
+      aria-label={iconName}
+      aria-pressed={isSelected}
     >
       <IconComponent />
     </button>

--- a/docs/components/iconography/icon-grid.tsx
+++ b/docs/components/iconography/icon-grid.tsx
@@ -31,8 +31,8 @@ const IconItem = ({
     {
       variants: {
         selected: {
-          true: "bg-seed-bg-brand-weak hover:bg-seed-bg-brand-weak-pressed border-seed-stroke-brand",
-          false: "bg-seed-bg-layer-default hover:bg-seed-bg-layer-default-pressed",
+          true: "bg-bg-brand-weak hover:bg-bg-brand-weak-pressed border-stroke-brand",
+          false: "bg-bg-layer-default hover:bg-bg-layer-default-pressed",
         },
         critical: {
           true: "border-seed-stroke-critical border-[1px] bg-seed-bg-critical-weak",
@@ -43,7 +43,8 @@ const IconItem = ({
   );
 
   return (
-    <div
+    <button
+      type="button"
       onClick={() => onSelect(iconName)}
       className={iconComponentVariants({
         critical: isCritical,
@@ -52,7 +53,7 @@ const IconItem = ({
       data-metadatas={metadataString}
     >
       <IconComponent />
-    </div>
+    </button>
   );
 };
 


### PR DESCRIPTION
https://seed-design.io/docs/foundation/iconography/library?icon=icon_a_uppercase_square_line
-  icon bottom section 의 bg color 가 gray-500 으로 고정되어서 다크모드 대응 되지 않는 버그를 해결해요.
- 잘못 들어간 tailwind css 클래스네임을 수정해요 (bg-seed-bg-brand-weak -> bg-bg-brand-weak)


## as-is

<img width="2992" height="1790" alt="image" src="https://github.com/user-attachments/assets/c77dd308-0613-41b1-a460-9e824125e8bf" />

## to- be

<img width="2984" height="1768" alt="image" src="https://github.com/user-attachments/assets/45321830-5095-409d-98f0-e8a48d2cc12e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 아이콘 그리드 항목이 버튼으로 전환되어 키보드 및 보조기술 접근성이 개선되었습니다(선택 상태 표시 및 레이블 추가).

* **Style**
  * 아이콘 컴포넌트의 배경 및 선택/비선택 상태 스타일 토큰이 갱신되어 시각적 표현이 업데이트되었습니다.
  * 하단 아이콘 정보 영역의 배경 및 테두리 색상 조정으로 UI가 미세하게 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->