### PR TITLE
feat(docs): add ReactVersionSwitcher and LatestVersionBanner

### DIFF
--- a/docs/app/layout.config.tsx
+++ b/docs/app/layout.config.tsx
@@ -5,7 +5,7 @@ import {
   reactSource,
   docsSource,
 } from "@/app/source";
-import { VersionSwitcher } from "@/components/version-switcher";
+import { VersionSwitcher } from "@/components/react-version-switcher";
 import { IconSparkle2, IconTree } from "@karrotmarket/react-multicolor-icon";
 import clsx from "clsx";
 import type { DocsLayoutProps } from "fumadocs-ui/layouts/notebook";

--- a/docs/app/layout.config.tsx
+++ b/docs/app/layout.config.tsx
@@ -123,12 +123,10 @@ export const docsOptions: DocsLayoutProps = {
 
 export const reactOptions: DocsLayoutProps = {
   ...baseOptions,
-  links: [
-    {
-      type: "custom",
-      children: <VersionSwitcher />,
-    },
-  ],
+  sidebar: {
+    ...baseOptions.sidebar,
+    banner: <VersionSwitcher />,
+  },
   tree: await reactSource.getTransformedReactPageTree(),
 };
 

--- a/docs/app/layout.config.tsx
+++ b/docs/app/layout.config.tsx
@@ -5,7 +5,7 @@ import {
   reactSource,
   docsSource,
 } from "@/app/source";
-import { VersionSwitcher } from "@/components/react-version-switcher";
+import { ReactVersionSwitcher } from "@/components/react-version-switcher";
 import { IconSparkle2, IconTree } from "@karrotmarket/react-multicolor-icon";
 import clsx from "clsx";
 import type { DocsLayoutProps } from "fumadocs-ui/layouts/notebook";
@@ -125,7 +125,7 @@ export const reactOptions: DocsLayoutProps = {
   ...baseOptions,
   sidebar: {
     ...baseOptions.sidebar,
-    banner: <VersionSwitcher />,
+    banner: <ReactVersionSwitcher />,
   },
   tree: await reactSource.getTransformedReactPageTree(),
 };

--- a/docs/app/layout.config.tsx
+++ b/docs/app/layout.config.tsx
@@ -17,6 +17,7 @@ function SidebarTabIconContainer({
 }: PropsWithChildren<{ className?: string }>) {
   return (
     <div
+      aria-hidden
       className={clsx(
         className,
         "[&_svg]:size-full rounded-lg size-full text-(--tab-color) max-md:bg-(--tab-color)/10 max-md:border max-md:p-1.5",
@@ -44,7 +45,7 @@ export const baseOptions: Omit<DocsLayoutProps, "tree"> = {
         url: "/docs",
         icon: (
           <SidebarTabIconContainer>
-            <img src="/logo.webp" alt="Seed Icons" className="size-full" />
+            <img src="/logo.webp" alt="" className="size-full" />
           </SidebarTabIconContainer>
         ),
       },
@@ -54,7 +55,7 @@ export const baseOptions: Omit<DocsLayoutProps, "tree"> = {
         url: "/react",
         icon: (
           <SidebarTabIconContainer>
-            <img src="/react.webp" alt="Seed Icons" className="size-full" />
+            <img src="/react.webp" alt="" className="size-full" />
           </SidebarTabIconContainer>
         ),
       },
@@ -64,7 +65,7 @@ export const baseOptions: Omit<DocsLayoutProps, "tree"> = {
         url: "/lynx",
         icon: (
           <SidebarTabIconContainer>
-            <img src="/lynx.svg" alt="Lynx" className="size-full" />
+            <img src="/lynx.svg" alt="" className="size-full" />
           </SidebarTabIconContainer>
         ),
       },

--- a/docs/app/layout.config.tsx
+++ b/docs/app/layout.config.tsx
@@ -36,12 +36,6 @@ function SidebarTabIconContainer({
  */
 export const baseOptions: Omit<DocsLayoutProps, "tree"> = {
   githubUrl: "https://github.com/daangn/seed-design",
-  links: [
-    {
-      type: "custom",
-      children: <VersionSwitcher />,
-    },
-  ],
   sidebar: {
     tabs: [
       {
@@ -128,6 +122,12 @@ export const docsOptions: DocsLayoutProps = {
 
 export const reactOptions: DocsLayoutProps = {
   ...baseOptions,
+  links: [
+    {
+      type: "custom",
+      children: <VersionSwitcher />,
+    },
+  ],
   tree: await reactSource.getTransformedReactPageTree(),
 };
 

--- a/docs/app/layout.config.tsx
+++ b/docs/app/layout.config.tsx
@@ -5,6 +5,7 @@ import {
   reactSource,
   docsSource,
 } from "@/app/source";
+import { VersionSwitcher } from "@/components/version-switcher";
 import { IconSparkle2, IconTree } from "@karrotmarket/react-multicolor-icon";
 import clsx from "clsx";
 import type { DocsLayoutProps } from "fumadocs-ui/layouts/notebook";
@@ -35,6 +36,12 @@ function SidebarTabIconContainer({
  */
 export const baseOptions: Omit<DocsLayoutProps, "tree"> = {
   githubUrl: "https://github.com/daangn/seed-design",
+  links: [
+    {
+      type: "custom",
+      children: <VersionSwitcher />,
+    },
+  ],
   sidebar: {
     tabs: [
       {

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -3,6 +3,7 @@ import "simple-reveal/index.css";
 import "./global.css";
 
 import GoogleAnalytics from "@/components/google-analytics";
+import { LatestVersionBanner } from "@/components/latest-version-banner";
 import { Inter } from "next/font/google";
 import type { ReactNode } from "react";
 import ThemeSync from "@/components/theme-sync";
@@ -27,6 +28,7 @@ export default function Layout({ children }: { children: ReactNode }) {
         <GoogleAnalytics GA_MEASUREMENT_ID="G-02SS22W02G" />
       </head>
       <body>
+        <LatestVersionBanner />
         <ThemeSync />
         {children}
       </body>

--- a/docs/components/component-card.tsx
+++ b/docs/components/component-card.tsx
@@ -36,7 +36,7 @@ export function ComponentCard({
         ) : (
           <Image
             src={coverImageSrc}
-            alt={`${title} anatomy`}
+            alt=""
             onError={setError}
             fill
             className="object-cover transition-transform group-hover:scale-105"

--- a/docs/components/latest-version-banner.tsx
+++ b/docs/components/latest-version-banner.tsx
@@ -7,16 +7,19 @@ export function LatestVersionBanner() {
   const [show, setShow] = useState(false);
 
   useEffect(() => {
-    setShow(window.location.hostname.includes("pages.dev"));
+    setShow(
+      window.location.hostname !== "seed-design.pages.dev" &&
+        window.location.hostname.endsWith("pages.dev"),
+    );
   }, []);
 
   if (!show) return null;
 
   return (
     <Banner id="latest-version">
-      더 최신 버전의 문서가 있습니다.{" "}
+      프리뷰 또는 이전 버전의 문서를 보고 있습니다.{" "}
       <a href="https://seed-design.io" className="font-medium underline">
-        최신 버전 보기 →
+        seed-design.io 방문 →
       </a>
     </Banner>
   );

--- a/docs/components/latest-version-banner.tsx
+++ b/docs/components/latest-version-banner.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Banner } from "fumadocs-ui/components/banner";
+
+export function LatestVersionBanner() {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    setShow(window.location.hostname.includes("pages.dev"));
+  }, []);
+
+  if (!show) return null;
+
+  return (
+    <Banner id="latest-version">
+      더 최신 버전의 문서가 있습니다.{" "}
+      <a href="https://seed-design.io" className="font-medium underline">
+        최신 버전 보기 →
+      </a>
+    </Banner>
+  );
+}

--- a/docs/components/latest-version-banner.tsx
+++ b/docs/components/latest-version-banner.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Banner } from "fumadocs-ui/components/banner";
+import { IconArrowRightFill } from "@karrotmarket/react-monochrome-icon";
 
 export function LatestVersionBanner() {
   const [show, setShow] = useState(false);
@@ -17,9 +18,12 @@ export function LatestVersionBanner() {
 
   return (
     <Banner id="latest-version">
-      프리뷰 또는 이전 버전의 문서를 보고 있습니다.{" "}
-      <a href="https://seed-design.io" className="font-medium underline">
-        seed-design.io 방문 →
+      프리뷰 또는 이전 버전의 문서를 보고 있습니다.
+      <a
+        href="https://seed-design.io"
+        className="ml-1 font-medium underline flex gap-0.5 items-center"
+      >
+        seed-design.io 방문 <IconArrowRightFill className="size-3.5" />
       </a>
     </Banner>
   );

--- a/docs/components/react-version-switcher.tsx
+++ b/docs/components/react-version-switcher.tsx
@@ -7,8 +7,9 @@ import { buttonVariants } from "fumadocs-ui/components/ui/button";
 import { cva } from "class-variance-authority";
 
 const VERSIONS = [
-  { label: "v1.1", url: "https://seed-design.io", current: true },
-  { label: "v1.0", url: "https://1-0.seed-design.pages.dev", current: false },
+  { label: "v1.2 (latest)", url: "https://seed-design.io/react", current: true },
+  { label: "v1.1", url: "https://1-1.seed-design.pages.dev/react", current: false },
+  { label: "v1.0", url: "https://1-0.seed-design.pages.dev/react", current: false },
 ] as const;
 
 const itemVariants = cva(

--- a/docs/components/react-version-switcher.tsx
+++ b/docs/components/react-version-switcher.tsx
@@ -1,15 +1,15 @@
 "use client";
 
 import { IconCheckmarkLine, IconChevronDownLine } from "@karrotmarket/react-monochrome-icon";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "fumadocs-ui/components/ui/popover";
 import { buttonVariants } from "fumadocs-ui/components/ui/button";
 import { cva } from "class-variance-authority";
 
 const VERSIONS = [
-  { label: "v1.2 (latest)", url: "https://seed-design.io/react", current: true },
-  { label: "v1.1", url: "https://1-1.seed-design.pages.dev/react", current: false },
-  { label: "v1.0", url: "https://1-0.seed-design.pages.dev/react", current: false },
+  { label: "v1.2 (latest)", url: "https://seed-design.io/react" },
+  { label: "v1.1", url: "https://1-1.seed-design.pages.dev/react" },
+  { label: "v1.0", url: "https://1-0.seed-design.pages.dev/react" },
 ] as const;
 
 const itemVariants = cva(
@@ -18,25 +18,31 @@ const itemVariants = cva(
 
 export function VersionSwitcher() {
   const [open, setOpen] = useState(false);
-  const current = VERSIONS.find((v) => v.current);
+  const [hostname, setHostname] = useState("");
+
+  useEffect(() => {
+    setHostname(window.location.hostname);
+  }, []);
+
+  const current = VERSIONS.find((v) => new URL(v.url).hostname === hostname) ?? VERSIONS[0];
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger>
-        <div
-          className={buttonVariants({
-            color: "secondary",
-            size: "sm",
-            className: "gap-1.5 text-xs justify-between",
-          })}
-        >
+      <PopoverTrigger
+        className={buttonVariants({
+          color: "secondary",
+          size: "sm",
+          className: "gap-1.5 text-xs",
+        })}
+      >
+        <div className="flex grow justify-between items-center">
           {current?.label}
           <IconChevronDownLine className="size-3.5 text-fd-muted-foreground" />
         </div>
       </PopoverTrigger>
       <PopoverContent className="flex flex-col overflow-auto">
         {VERSIONS.map((version) =>
-          version.current ? (
+          version === current ? (
             <div
               aria-current
               key={version.label}

--- a/docs/components/react-version-switcher.tsx
+++ b/docs/components/react-version-switcher.tsx
@@ -36,6 +36,7 @@ export function VersionSwitcher() {
         {VERSIONS.map((version) =>
           version.current ? (
             <div
+              aria-current
               key={version.label}
               className={itemVariants({
                 className: "text-fd-primary pointer-events-none justify-between",
@@ -46,6 +47,7 @@ export function VersionSwitcher() {
             </div>
           ) : (
             <a
+              target="_blank"
               key={version.label}
               href={version.url}
               className={itemVariants({ className: "justify-between" })}

--- a/docs/components/react-version-switcher.tsx
+++ b/docs/components/react-version-switcher.tsx
@@ -16,7 +16,7 @@ const itemVariants = cva(
   "text-sm p-2 rounded-lg inline-flex items-center gap-2 hover:text-fd-accent-foreground hover:bg-fd-accent [&_svg]:size-4",
 );
 
-export function VersionSwitcher() {
+export function ReactVersionSwitcher() {
   const [open, setOpen] = useState(false);
   const [hostname, setHostname] = useState("");
 

--- a/docs/components/react-version-switcher.tsx
+++ b/docs/components/react-version-switcher.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { IconCheckmarkLine, IconChevronDownLine } from "@karrotmarket/react-monochrome-icon";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "fumadocs-ui/components/ui/popover";
 import { buttonVariants } from "fumadocs-ui/components/ui/button";
 import { cva } from "class-variance-authority";
@@ -12,19 +12,17 @@ const VERSIONS = [
   { label: "v1.0", url: "https://1-0.seed-design.pages.dev/react" },
 ] as const satisfies ReadonlyArray<{ label: string; url: string }>;
 
+// NOTE: update CURRENT_VERSION when releasing a new version & keep in release branch
+const CURRENT_VERSION: (typeof VERSIONS)[number]["label"] = "v1.2 (latest)";
+
 const itemVariants = cva(
   "text-sm p-2 rounded-lg inline-flex items-center gap-2 hover:text-fd-accent-foreground hover:bg-fd-accent [&_svg]:size-4",
 );
 
 export function ReactVersionSwitcher() {
   const [open, setOpen] = useState(false);
-  const [hostname, setHostname] = useState("");
 
-  useEffect(() => {
-    setHostname(window.location.hostname);
-  }, []);
-
-  const current = VERSIONS.find((v) => new URL(v.url).hostname === hostname) ?? VERSIONS[0];
+  const current = VERSIONS.find((v) => v.label === CURRENT_VERSION) ?? VERSIONS[0];
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/docs/components/react-version-switcher.tsx
+++ b/docs/components/react-version-switcher.tsx
@@ -10,7 +10,7 @@ const VERSIONS = [
   { label: "v1.2 (latest)", url: "https://seed-design.io/react" },
   { label: "v1.1", url: "https://1-1.seed-design.pages.dev/react" },
   { label: "v1.0", url: "https://1-0.seed-design.pages.dev/react" },
-] as const;
+] as const satisfies ReadonlyArray<{ label: string; url: string }>;
 
 const itemVariants = cva(
   "text-sm p-2 rounded-lg inline-flex items-center gap-2 hover:text-fd-accent-foreground hover:bg-fd-accent [&_svg]:size-4",

--- a/docs/components/react-version-switcher.tsx
+++ b/docs/components/react-version-switcher.tsx
@@ -22,15 +22,17 @@ export function VersionSwitcher() {
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger
-        className={buttonVariants({
-          color: "secondary",
-          size: "sm",
-          className: "gap-1.5 text-xs tabular-nums",
-        })}
-      >
-        {current?.label}
-        <IconChevronDownLine className="size-3.5 text-fd-muted-foreground" />
+      <PopoverTrigger>
+        <div
+          className={buttonVariants({
+            color: "secondary",
+            size: "sm",
+            className: "gap-1.5 text-xs justify-between",
+          })}
+        >
+          {current?.label}
+          <IconChevronDownLine className="size-3.5 text-fd-muted-foreground" />
+        </div>
       </PopoverTrigger>
       <PopoverContent className="flex flex-col overflow-auto">
         {VERSIONS.map((version) =>

--- a/docs/components/version-switcher.tsx
+++ b/docs/components/version-switcher.tsx
@@ -6,7 +6,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "fumadocs-ui/components/
 import { buttonVariants } from "fumadocs-ui/components/ui/button";
 import { cva } from "class-variance-authority";
 
-const versions = [
+const VERSIONS = [
   { label: "v1.1", url: "https://seed-design.io", current: true },
   { label: "v1.0", url: "https://1-0.seed-design.pages.dev", current: false },
 ] as const;
@@ -17,7 +17,7 @@ const itemVariants = cva(
 
 export function VersionSwitcher() {
   const [open, setOpen] = useState(false);
-  const current = versions.find((v) => v.current);
+  const current = VERSIONS.find((v) => v.current);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -32,7 +32,7 @@ export function VersionSwitcher() {
         <IconChevronDownLine className="size-3.5 text-fd-muted-foreground" />
       </PopoverTrigger>
       <PopoverContent className="flex flex-col overflow-auto">
-        {versions.map((version) =>
+        {VERSIONS.map((version) =>
           version.current ? (
             <div
               key={version.label}

--- a/docs/components/version-switcher.tsx
+++ b/docs/components/version-switcher.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { IconCheckmarkLine, IconChevronDownLine } from "@karrotmarket/react-monochrome-icon";
+import { useState } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "fumadocs-ui/components/ui/popover";
+import { buttonVariants } from "fumadocs-ui/components/ui/button";
+import { cva } from "class-variance-authority";
+
+const versions = [
+  { label: "v1.1", url: "https://seed-design.io", current: true },
+  { label: "v1.0", url: "https://1-0.seed-design.pages.dev", current: false },
+] as const;
+
+const itemVariants = cva(
+  "text-sm p-2 rounded-lg inline-flex items-center gap-2 hover:text-fd-accent-foreground hover:bg-fd-accent [&_svg]:size-4",
+);
+
+export function VersionSwitcher() {
+  const [open, setOpen] = useState(false);
+  const current = versions.find((v) => v.current);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        className={buttonVariants({
+          color: "secondary",
+          size: "sm",
+          className: "gap-1.5 text-xs tabular-nums",
+        })}
+      >
+        {current?.label}
+        <IconChevronDownLine className="size-3.5 text-fd-muted-foreground" />
+      </PopoverTrigger>
+      <PopoverContent className="flex flex-col overflow-auto">
+        {versions.map((version) =>
+          version.current ? (
+            <div
+              key={version.label}
+              className={itemVariants({
+                className: "text-fd-primary pointer-events-none justify-between",
+              })}
+            >
+              {version.label}
+              <IconCheckmarkLine />
+            </div>
+          ) : (
+            <a
+              key={version.label}
+              href={version.url}
+              className={itemVariants({ className: "justify-between" })}
+              onClick={() => setOpen(false)}
+            >
+              {version.label}
+            </a>
+          ),
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}


### PR DESCRIPTION
## Summary
- React 문서 사이드바에 **VersionSwitcher** 추가 — v1.0, v1.1, v1.2(latest) 간 전환 가능
- `*.pages.dev` 프리뷰/이전 배포에서 `seed-design.io`로 안내하는 **LatestVersionBanner** 추가
- 장식용 이미지에 `alt=""`, 아이콘 컨테이너에 `aria-hidden` 적용 등 접근성 개선

## Test plan
- [ ] 로컬에서 `bun --filter @seed-design/docs dev` 실행 후 `/react` 섹션에서 VersionSwitcher 확인
- [ ] `pages.dev` 호스트네임에서 LatestVersionBanner가 표시되는지 확인
- [ ] `seed-design.io` (또는 `seed-design.pages.dev`)에서는 배너가 표시되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 리액트 문서에 버전 전환 드롭다운 추가
  * 문서 레이아웃의 상단 및 사이드바에 최신 버전 알림 배너 추가 (프리뷰/이전 버전 문서 표시 시 안내 및 링크 제공)

* **접근성 / UI**
  * 일부 탭 아이콘과 컴포넌트 카드 표지 이미지의 alt 속성 비우기
  * 사이드바 아이콘 래퍼에 aria-hidden 속성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->