### PR TITLE
fix(rootage): add missing strokeWidth and rename stroke to strokeColor in chip-tab

### DIFF
--- a/docs/public/rootage/components/chip-tab.json
+++ b/docs/public/rootage/components/chip-tab.json
@@ -32,8 +32,11 @@
             "color": {
               "type": "color"
             },
-            "stroke": {
+            "strokeColor": {
               "type": "color"
+            },
+            "strokeWidth": {
+              "type": "dimension"
             }
           }
         },
@@ -293,9 +296,16 @@
                   "type": "color",
                   "value": "$color.bg.transparent"
                 },
-                "stroke": {
+                "strokeColor": {
                   "type": "color",
                   "value": "$color.stroke.neutral-muted"
+                },
+                "strokeWidth": {
+                  "type": "dimension",
+                  "value": {
+                    "value": 1,
+                    "unit": "px"
+                  }
                 }
               },
               "label": {

--- a/packages/css/vars/component/chip-tab.d.ts
+++ b/packages/css/vars/component/chip-tab.d.ts
@@ -79,7 +79,8 @@ export declare const vars: {
     "enabled": {
       "root": {
         "color": "var(--seed-color-bg-transparent)",
-        "stroke": "var(--seed-color-stroke-neutral-muted)"
+        "strokeColor": "var(--seed-color-stroke-neutral-muted)",
+        "strokeWidth": "1px"
       },
       "label": {
         "color": "var(--seed-color-fg-neutral)"

--- a/packages/css/vars/component/chip-tab.mjs
+++ b/packages/css/vars/component/chip-tab.mjs
@@ -79,7 +79,8 @@ export const vars = {
     "enabled": {
       "root": {
         "color": "var(--seed-color-bg-transparent)",
-        "stroke": "var(--seed-color-stroke-neutral-muted)"
+        "strokeColor": "var(--seed-color-stroke-neutral-muted)",
+        "strokeWidth": "1px"
       },
       "label": {
         "color": "var(--seed-color-fg-neutral)"

--- a/packages/qvism-preset/src/recipes/chip-tabs.ts
+++ b/packages/qvism-preset/src/recipes/chip-tabs.ts
@@ -128,7 +128,8 @@ const chipTabs = defineSlotRecipe({
       neutralOutline: {
         trigger: {
           backgroundColor: triggerVars.variantNeutralOutline.enabled.root.color,
-          border: `1px solid ${triggerVars.variantNeutralOutline.enabled.root.stroke}`,
+          // TODO: replace 1px with triggerVars.variantNeutralOutline.enabled.root.strokeWidth
+          border: `1px solid ${triggerVars.variantNeutralOutline.enabled.root.strokeColor}`,
 
           color: triggerVars.variantNeutralOutline.enabled.label.color,
 

--- a/packages/qvism-preset/src/vars/component/chip-tab.d.ts
+++ b/packages/qvism-preset/src/vars/component/chip-tab.d.ts
@@ -79,7 +79,8 @@ export declare const vars: {
     "enabled": {
       "root": {
         "color": "var(--seed-color-bg-transparent)",
-        "stroke": "var(--seed-color-stroke-neutral-muted)"
+        "strokeColor": "var(--seed-color-stroke-neutral-muted)",
+        "strokeWidth": "1px"
       },
       "label": {
         "color": "var(--seed-color-fg-neutral)"

--- a/packages/qvism-preset/src/vars/component/chip-tab.mjs
+++ b/packages/qvism-preset/src/vars/component/chip-tab.mjs
@@ -79,7 +79,8 @@ export const vars = {
     "enabled": {
       "root": {
         "color": "var(--seed-color-bg-transparent)",
-        "stroke": "var(--seed-color-stroke-neutral-muted)"
+        "strokeColor": "var(--seed-color-stroke-neutral-muted)",
+        "strokeWidth": "1px"
       },
       "label": {
         "color": "var(--seed-color-fg-neutral)"

--- a/packages/rootage/components/chip-tab.yaml
+++ b/packages/rootage/components/chip-tab.yaml
@@ -22,8 +22,10 @@ data:
             type: dimension
           color:
             type: color
-          stroke:
+          strokeColor:
             type: color
+          strokeWidth:
+            type: dimension
       label:
         properties:
           fontSize:
@@ -85,7 +87,8 @@ data:
       enabled:
         root:
           color: $color.bg.transparent
-          stroke: $color.stroke.neutral-muted
+          strokeColor: $color.stroke.neutral-muted
+          strokeWidth: 1px
         label:
           color: $color.fg.neutral
       enabled,pressed:


### PR DESCRIPTION
## Summary
- `chip-tab` rootage 스키마에서 `stroke` 속성을 `strokeColor`로 rename하고, 누락된 `strokeWidth` 속성을 추가합니다.
- rootage YAML, 생성된 vars/타입 파일, recipe에 변경사항이 반영됩니다.

## Test plan
- [ ] `bun generate:all` 실행하여 생성물이 일치하는지 확인
- [ ] `bun test:all` 실행하여 기존 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 칩 탭 컴포넌트의 테두리 스타일이 개선되었습니다. 테두리 색상과 너비 속성이 더욱 명확하게 정의되어 디자인 토큰의 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->