### PR TITLE
fix(drawer): properly restore height after keyboard collapses on android

### DIFF
--- a/.changeset/eleven-pants-drop.md
+++ b/.changeset/eleven-pants-drop.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react-drawer": patch
+---
+
+Android 환경에서 온스크린 키보드가 닫힐 때 Drawer(Bottom Sheet) 높이가 정상적으로 복원되지 않는 문제를 수정합니다.

--- a/packages/react-headless/drawer/src/browser.ts
+++ b/packages/react-headless/drawer/src/browser.ts
@@ -30,6 +30,13 @@ export function isIOS(): boolean | undefined {
   return isIPhone() || isIPad();
 }
 
+export function isAndroid(): boolean | undefined {
+  if (typeof window === "undefined" || typeof navigator === "undefined") return false;
+
+  return /Android/.test(navigator.userAgent);
+}
+
+// TODO: use userAgent instead?
 export function testPlatform(re: RegExp): boolean | undefined {
   return typeof window !== "undefined" && window.navigator != null
     ? re.test(window.navigator.platform)

--- a/packages/react-headless/drawer/src/useDrawer.ts
+++ b/packages/react-headless/drawer/src/useDrawer.ts
@@ -606,7 +606,7 @@ export function useDrawer(props: UseDrawerProps) {
           } else {
             drawerRef.current.style.height = `${Math.max(newDrawerHeight, visualViewportHeight - offsetFromTop)}px`;
           }
-        } else if (!isMobileFirefox()) {
+        } else if (!isMobileFirefox() && !isAndroid()) {
           drawerRef.current.style.height = `${initialDrawerHeight.current}px`;
         }
 

--- a/packages/react-headless/drawer/src/useDrawer.ts
+++ b/packages/react-headless/drawer/src/useDrawer.ts
@@ -1,7 +1,7 @@
 import { useControllableState } from "@seed-design/react-use-controllable-state";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { isIOS, isMobileFirefox } from "./browser";
+import { isAndroid, isIOS, isMobileFirefox } from "./browser";
 import {
   CLOSE_THRESHOLD,
   DRAG_CLASS,


### PR DESCRIPTION
Related: https://github.com/emilkowalski/vaul/issues/538, https://github.com/emilkowalski/vaul/issues/539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * Android에서 드로어의 시각적 뷰포트 조정 시 높이 복원 동작을 개선해 흔들림과 불안정성을 줄였습니다.
  * 모바일 브라우저(예: 모바일 파이어폭스 및 Android)에서 높이 초기화 처리를 건너뛰어 보다 일관된 동작을 제공합니다.
  * 플랫폼 정보가 없을 때도 높이 복원 로직이 안전하게 동작하도록 안정성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->