### PR TITLE
fix(react-headless/image): prevent lazy loading deadlock with hidden attribute

### DIFF
--- a/.changeset/eight-lemons-admire.md
+++ b/.changeset/eight-lemons-admire.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react-image": patch
+---
+
+`Image.Content` (`ImageFrame` 및 `AvatarImage`)에 `loading="lazy"` 사용 시 이미지 로드가 시작되지 않는 문제를 수정합니다.

--- a/packages/react-headless/image/src/Image.tsx
+++ b/packages/react-headless/image/src/Image.tsx
@@ -4,7 +4,7 @@ import { composeRefs } from "@radix-ui/react-compose-refs";
 import { useLayoutEffect } from "@radix-ui/react-use-layout-effect";
 import { mergeProps } from "@seed-design/dom-utils";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";
-import * as React from "react";
+import type * as React from "react";
 import { forwardRef } from "react";
 import { useImage, type UseImageProps } from "./useImage";
 import { ImageProvider, useImageContext } from "./useImageContext";
@@ -43,7 +43,12 @@ export const ImageContent = forwardRef<HTMLImageElement, ImageContentProps>((pro
   return (
     <Primitive.img
       ref={composeRefs(refs.image, ref)}
-      {...mergeProps(contentProps, otherProps)}
+      {...mergeProps(contentProps, otherProps, {
+        // if loading is lazy, we should not hide the image even if it's not loaded yet,
+        // because the browser should be able to check if it's in the viewport.
+        // TODO: it should be better than this; why doesn't useImage properly handle this case?
+        hidden: otherProps.loading === "lazy" ? false : contentProps.hidden,
+      })}
       onLoad={(e) => {
         handleLoad();
         onLoad?.(e);


### PR DESCRIPTION
## Summary

- `ImageContent`에서 `loading="lazy"` 사용 시, `useImage` 훅의 `hidden: !isLoaded` 속성이 브라우저의 lazy loading 메커니즘과 데드락을 발생시키는 문제 수정
- `hidden`이면 브라우저가 이미지를 로드하지 않고, 로드하지 않으면 `hidden`이 풀리지 않는 chicken-and-egg 문제
- `loading="lazy"`일 때 `hidden`을 `false`로 override하여 브라우저가 viewport intersection을 감지할 수 있도록 함

## Test plan

- [ ] `loading="lazy"`인 `ImageFrame`이 viewport 진입 시 정상 로드되는지 확인
- [ ] `loading="eager"` (기본값) 동작이 변경되지 않았는지 확인
- [ ] fallback (Skeleton)이 로드 완료 후 정상적으로 사라지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 지연 로딩(loading="lazy")된 이미지가 로드되지 않거나 로드 중 숨겨지는 문제를 해결했습니다. 관련 이미지 컴포넌트들이 지연 로딩 시에도 브라우저에 의해 정상적으로 표시되고 로드가 시작됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->