### PR TITLE
feat(figma): implement ImageFrame handler

### DIFF
--- a/.changeset/figma.md
+++ b/.changeset/figma.md
@@ -4,5 +4,6 @@
 
 Figma Codegen 관련 개선 사항을 적용합니다.
 
+- Image Frame 컴포넌트의 React Codegen을 지원합니다.
 - OS 상단바 등 불필요한 UI 요소를 codegen 대상에서 제외합니다.
 - 너비가 Fill로 설정된 Action Button이 `flexGrow`를 갖도록 개선합니다.

--- a/packages/figma/src/codegen/component-properties.ts
+++ b/packages/figma/src/codegen/component-properties.ts
@@ -110,6 +110,22 @@ export type HelpBubbleProperties = InferComponentDefinition<
   typeof sets.componentHelpBubble.componentPropertyDefinitions
 >;
 
+export type ImageFrameProperties = InferComponentDefinition<
+  typeof sets.componentImageFrame.componentPropertyDefinitions
+>;
+
+export type ImageFrameIconProperties = InferComponentDefinition<
+  typeof components.componentImageFrameIcon.componentPropertyDefinitions
+>;
+
+export type ImageFrameOverlayIndicatorProperties = InferComponentDefinition<
+  typeof components.componentImageFrameOverlayIndicator.componentPropertyDefinitions
+>;
+
+export type ImageFrameReactionButtonProperties = InferComponentDefinition<
+  typeof sets.componentImageFrameReactionButton.componentPropertyDefinitions
+>;
+
 export type PageBannerProperties = InferComponentDefinition<
   typeof sets.componentPageBanner.componentPropertyDefinitions
 >;

--- a/packages/figma/src/codegen/targets/react/component/handlers/image-frame.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/image-frame.ts
@@ -147,7 +147,9 @@ export const createImageFrameHandler = (ctx: ComponentHandlerDeps) => {
 
         ...(node.layoutGrow === 1
           ? { flexGrow: true }
-          : { width: ctx.valueResolver.getFormattedValue.width(node) }),
+          : node.layoutAlign === "STRETCH"
+            ? { alignSelf: "stretch" }
+            : { width: ctx.valueResolver.getFormattedValue.width(node) }),
       };
 
       return createSeedReactElement(

--- a/packages/figma/src/codegen/targets/react/component/handlers/image-frame.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/image-frame.ts
@@ -5,10 +5,10 @@ import type {
   ImageFrameProperties,
   ImageFrameReactionButtonProperties,
 } from "@/codegen/component-properties";
-import { defineComponentHandler, type ElementNode } from "@/codegen/core";
+import { defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
 import * as components from "@/entities/data/__generated__/components";
-import { findAllInstances } from "@/utils/figma-node";
+import { findAllInstances, findOne } from "@/utils/figma-node";
 import { createSeedReactElement } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
 import { createBadgeHandler } from "@/codegen/targets/react/component/handlers/badge";
@@ -16,125 +16,96 @@ import { createBadgeHandler } from "@/codegen/targets/react/component/handlers/b
 const CORNER_CONFIGS = [
   {
     showKey: "ㄴ Left Top#58686:165",
-    swapKey: "Left Top#58686:0",
     placement: "top-start",
   },
   {
     showKey: "ㄴ Right Top#58686:198",
-    swapKey: "Right Top#58686:66",
     placement: "top-end",
   },
   {
     showKey: "ㄴ Left Bottom#58686:231",
-    swapKey: "Left Bottom#58686:99",
     placement: "bottom-start",
   },
   {
     showKey: "ㄴ Right Bottom#58686:264",
-    swapKey: "Right Bottom#58686:132",
     placement: "bottom-end",
   },
 ] as const satisfies ReadonlyArray<{
   showKey: keyof ImageFrameProperties;
-  swapKey: keyof ImageFrameProperties;
   placement: string;
 }>;
 
-function formatRatio(ratioStr: string): string {
+function formatRatio(ratioStr: `${number}:${number}`): string {
   const [w, h] = ratioStr.split(":");
 
   return `${w} / ${h}`;
 }
 
-const createImageFrameBadgeHandler = (ctx: ComponentHandlerDeps) => {
+export const createImageFrameBadgeHandler = (ctx: ComponentHandlerDeps) => {
   const badgeHandler = createBadgeHandler(ctx);
 
-  return defineComponentHandler<BadgeProperties>(
-    components.componentImageFrameBadge.key,
-    (node, traverse) => {
-      const [badge] = findAllInstances<BadgeProperties>({
-        node,
-        key: badgeHandler.key,
+  return defineComponentHandler<{}>(components.componentImageFrameBadge.key, (node, traverse) => {
+    const [badge] = findAllInstances<BadgeProperties>({
+      node,
+      key: badgeHandler.key,
+    });
+
+    if (!badge) throw new Error("Badge component not found within ImageFrameBadge");
+
+    return { ...badgeHandler.transform(badge, traverse), tag: "ImageFrameBadge" };
+  });
+};
+
+export const createImageFrameReactionButtonHandler = (_ctx: ComponentHandlerDeps) => {
+  return defineComponentHandler<ImageFrameReactionButtonProperties>(
+    metadata.componentImageFrameReactionButton.key,
+    ({ componentProperties: props }) => {
+      return createSeedReactElement("ImageFrameReactionButton", {
+        ...(props.Selected.value === "True" && { defaultPressed: true }),
       });
+    },
+  );
+};
 
-      if (!badge) throw new Error("Badge component not found within ImageFrameBadge");
+export const createImageFrameOverlayIndicatorHandler = (_ctx: ComponentHandlerDeps) => {
+  return defineComponentHandler<ImageFrameOverlayIndicatorProperties>(
+    components.componentImageFrameOverlayIndicator.key,
+    ({ componentProperties: props }) => {
+      return createSeedReactElement("ImageFrameIndicator", undefined, props["Text#58708:0"].value);
+    },
+  );
+};
 
-      const { tag, ...rest } = badgeHandler.transform(badge, traverse);
-
-      return {
-        ...createSeedReactElement("ImageFrameBadge", { tag }),
-        ...rest,
-      };
+export const createImageFrameIconHandler = (ctx: ComponentHandlerDeps) => {
+  return defineComponentHandler<ImageFrameIconProperties>(
+    components.componentImageFrameIcon.key,
+    ({ componentProperties: props }) => {
+      return createSeedReactElement("ImageFrameIcon", {
+        svg: ctx.iconHandler.transform(props["Icon#58686:297"]),
+      });
     },
   );
 };
 
 export const createImageFrameHandler = (ctx: ComponentHandlerDeps) => {
-  const imageFrameBadgeHandler = createImageFrameBadgeHandler(ctx);
-
   return defineComponentHandler<ImageFrameProperties>(
     metadata.componentImageFrame.key,
     (node, traverse) => {
       const props = node.componentProperties;
 
-      const contentMap = new Map<string, ElementNode>([
-        ...findAllInstances<BadgeProperties>({
-          node,
-          key: components.componentImageFrameBadge.key,
-        }).map(
-          (badge) =>
-            [badge.componentKey, imageFrameBadgeHandler.transform(badge, traverse)] as const,
-        ),
-        ...findAllInstances<ImageFrameIconProperties>({
-          node,
-          key: components.componentImageFrameIcon.key,
-        }).map(
-          (icon) =>
-            [
-              icon.componentKey,
-              createSeedReactElement("ImageFrameIcon", {
-                svg: ctx.iconHandler.transform(icon.componentProperties["Icon#58686:297"]),
-              }),
-            ] as const,
-        ),
-        ...findAllInstances<ImageFrameOverlayIndicatorProperties>({
-          node,
-          key: components.componentImageFrameOverlayIndicator.key,
-        }).map(
-          (indicator) =>
-            [
-              indicator.componentKey,
-              createSeedReactElement(
-                "ImageFrameIndicator",
-                undefined,
-                indicator.componentProperties["Text#58708:0"].value,
-              ),
-            ] as const,
-        ),
-        ...findAllInstances<ImageFrameReactionButtonProperties>({
-          node,
-          key: metadata.componentImageFrameReactionButton.key,
-        }).map(
-          (rb) =>
-            [
-              rb.componentKey,
-              createSeedReactElement("ImageFrameReactionButton", {
-                ...(rb.componentProperties.Selected.value === "True" && {
-                  defaultPressed: true,
-                }),
-              }),
-            ] as const,
-        ),
-      ]);
+      const floaters = [];
+      for (const { showKey, placement } of CORNER_CONFIGS) {
+        if (!props[showKey].value) continue;
 
-      const floaters = CORNER_CONFIGS.flatMap(({ showKey, swapKey, placement }) => {
-        if (!props[showKey].value) return [];
+        const slotName = showKey.split("#")[0];
+        const slotNode = findOne(node, (n) => "name" in n && n.name === slotName);
+        if (!slotNode) continue;
 
-        const content = contentMap.get(props[swapKey].componentKey);
-        if (!content) return [];
+        const child = traverse(slotNode);
+        if (!child) continue;
 
-        return [createSeedReactElement("ImageFrameFloater", { placement }, content)];
-      });
+        floaters.push(createSeedReactElement("ImageFrameFloater", { placement }, child));
+      }
 
       const commonProps = {
         src: `https://placehold.co/${node.absoluteBoundingBox?.width ?? 100}x${node.absoluteBoundingBox?.height ?? 100}`,

--- a/packages/figma/src/codegen/targets/react/component/handlers/image-frame.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/image-frame.ts
@@ -1,0 +1,161 @@
+import type {
+  BadgeProperties,
+  ImageFrameIconProperties,
+  ImageFrameOverlayIndicatorProperties,
+  ImageFrameProperties,
+  ImageFrameReactionButtonProperties,
+} from "@/codegen/component-properties";
+import { defineComponentHandler, type ElementNode } from "@/codegen/core";
+import * as metadata from "@/entities/data/__generated__/component-sets";
+import * as components from "@/entities/data/__generated__/components";
+import { findAllInstances } from "@/utils/figma-node";
+import { createSeedReactElement } from "../../element-factories";
+import type { ComponentHandlerDeps } from "../deps.interface";
+import { createBadgeHandler } from "@/codegen/targets/react/component/handlers/badge";
+
+const CORNER_CONFIGS = [
+  {
+    showKey: "ㄴ Left Top#58686:165",
+    swapKey: "Left Top#58686:0",
+    placement: "top-start",
+  },
+  {
+    showKey: "ㄴ Right Top#58686:198",
+    swapKey: "Right Top#58686:66",
+    placement: "top-end",
+  },
+  {
+    showKey: "ㄴ Left Bottom#58686:231",
+    swapKey: "Left Bottom#58686:99",
+    placement: "bottom-start",
+  },
+  {
+    showKey: "ㄴ Right Bottom#58686:264",
+    swapKey: "Right Bottom#58686:132",
+    placement: "bottom-end",
+  },
+] as const satisfies ReadonlyArray<{
+  showKey: keyof ImageFrameProperties;
+  swapKey: keyof ImageFrameProperties;
+  placement: string;
+}>;
+
+function formatRatio(ratioStr: string): string {
+  const [w, h] = ratioStr.split(":");
+
+  return `${w} / ${h}`;
+}
+
+const createImageFrameBadgeHandler = (ctx: ComponentHandlerDeps) => {
+  const badgeHandler = createBadgeHandler(ctx);
+
+  return defineComponentHandler<BadgeProperties>(
+    components.componentImageFrameBadge.key,
+    (node, traverse) => {
+      const [badge] = findAllInstances<BadgeProperties>({
+        node,
+        key: badgeHandler.key,
+      });
+
+      if (!badge) throw new Error("Badge component not found within ImageFrameBadge");
+
+      const { tag, ...rest } = badgeHandler.transform(badge, traverse);
+
+      return {
+        ...createSeedReactElement("ImageFrameBadge", { tag }),
+        ...rest,
+      };
+    },
+  );
+};
+
+export const createImageFrameHandler = (ctx: ComponentHandlerDeps) => {
+  const imageFrameBadgeHandler = createImageFrameBadgeHandler(ctx);
+
+  return defineComponentHandler<ImageFrameProperties>(
+    metadata.componentImageFrame.key,
+    (node, traverse) => {
+      const props = node.componentProperties;
+
+      const contentMap = new Map<string, ElementNode>([
+        ...findAllInstances<BadgeProperties>({
+          node,
+          key: components.componentImageFrameBadge.key,
+        }).map(
+          (badge) =>
+            [badge.componentKey, imageFrameBadgeHandler.transform(badge, traverse)] as const,
+        ),
+        ...findAllInstances<ImageFrameIconProperties>({
+          node,
+          key: components.componentImageFrameIcon.key,
+        }).map(
+          (icon) =>
+            [
+              icon.componentKey,
+              createSeedReactElement("ImageFrameIcon", {
+                svg: ctx.iconHandler.transform(icon.componentProperties["Icon#58686:297"]),
+              }),
+            ] as const,
+        ),
+        ...findAllInstances<ImageFrameOverlayIndicatorProperties>({
+          node,
+          key: components.componentImageFrameOverlayIndicator.key,
+        }).map(
+          (indicator) =>
+            [
+              indicator.componentKey,
+              createSeedReactElement(
+                "ImageFrameIndicator",
+                undefined,
+                indicator.componentProperties["Text#58708:0"].value,
+              ),
+            ] as const,
+        ),
+        ...findAllInstances<ImageFrameReactionButtonProperties>({
+          node,
+          key: metadata.componentImageFrameReactionButton.key,
+        }).map(
+          (rb) =>
+            [
+              rb.componentKey,
+              createSeedReactElement("ImageFrameReactionButton", {
+                ...(rb.componentProperties.Selected.value === "True" && {
+                  defaultPressed: true,
+                }),
+              }),
+            ] as const,
+        ),
+      ]);
+
+      const floaters = CORNER_CONFIGS.flatMap(({ showKey, swapKey, placement }) => {
+        if (!props[showKey].value) return [];
+
+        const content = contentMap.get(props[swapKey].componentKey);
+        if (!content) return [];
+
+        return [createSeedReactElement("ImageFrameFloater", { placement }, content)];
+      });
+
+      const commonProps = {
+        src: `https://placehold.co/${node.absoluteBoundingBox?.width ?? 100}x${node.absoluteBoundingBox?.height ?? 100}`,
+        alt: "",
+        ratio: formatRatio(props.Ratio.value),
+
+        ...(props.Rounded.value === "True" && {
+          borderRadius: ctx.valueResolver.getFormattedValue.topLeftRadius(node),
+        }),
+
+        ...(node.layoutGrow === 1
+          ? { flexGrow: true }
+          : { width: ctx.valueResolver.getFormattedValue.width(node) }),
+      };
+
+      return createSeedReactElement(
+        "ImageFrame",
+        commonProps,
+        props["Show Overlay#58686:33"].value && floaters.length > 0 ? floaters : undefined,
+        { comment: "alt 텍스트를 제공해야 합니다." },
+      );
+    },
+  );
+};

--- a/packages/figma/src/codegen/targets/react/component/handlers/index.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/index.ts
@@ -15,6 +15,7 @@ export * from "./field-button";
 export * from "./floating-action-button";
 export * from "./help-bubble";
 export * from "./identity-placeholder";
+export * from "./image-frame";
 export * from "./legacy-select-box";
 export * from "./legacy-text-field";
 export * from "./list-header";

--- a/packages/figma/src/entities/data/__generated__/component-sets/index.d.ts
+++ b/packages/figma/src/entities/data/__generated__/component-sets/index.d.ts
@@ -2648,7 +2648,7 @@ export declare const componentImageFrame: {
         "80",
         "96",
         "120",
-        "\bFree"
+        "Free"
       ]
     },
     "Rounded": {


### PR DESCRIPTION
## Summary

- ImageFrame 컴포넌트의 Figma → React codegen 핸들러를 구현합니다.
- 4개 코너(top-start, top-end, bottom-start, bottom-end) 슬롯에 Badge, Icon, OverlayIndicator, ReactionButton을 배치하는 floater 시스템을 지원합니다.
- aspect ratio, rounded corners, flexible width 등 레이아웃 속성을 처리합니다.
- 생성 코드에 alt 텍스트 제공 안내 코멘트를 자동 삽입합니다.
- `componentImageFrame`의 `\bFree` 오타를 `Free`로 수정합니다.

## Changes

| File | Description |
|------|-------------|
| `packages/figma/src/codegen/targets/react/component/handlers/image-frame.ts` | ImageFrame 핸들러 신규 추가 |
| `packages/figma/src/codegen/component-properties.ts` | ImageFrame 관련 타입 정의 추가 |
| `packages/figma/src/codegen/targets/react/component/handlers/index.ts` | barrel export 추가 |
| `packages/figma/src/entities/data/__generated__/component-sets/index.d.ts` | `\bFree` 오타 수정 + EOF newline |
| `.changeset/figma.md` | changeset 항목 추가 |

## Test plan

- [ ] `bun packages:build` 로 빌드 성공 확인
- [ ] Figma에서 ImageFrame 컴포넌트 codegen 시 올바른 React 코드 생성 확인
- [ ] 각 코너 슬롯(Badge, Icon, Indicator, ReactionButton)이 정상 매핑되는지 확인
- [ ] Rounded / aspect ratio / flexGrow 등 레이아웃 속성이 올바르게 반영되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Image Frame 컴포넌트에 대한 React Codegen 지원이 추가되었습니다.
  * 이미지 프레임 생성 시 배지, 아이콘, 오버레이 인디케이터, 반응 버튼 등 자식 콘텐츠를 포함하여 생성됩니다.
  * 코너별 플로터(overlay) 배치, 비율 표기, 대체 텍스트(alt) 및 기본 플레이스홀더 처리를 지원합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->