### PR TITLE
feat(segmented-control): stroke width/color rootage 에 업데이트

### DIFF
--- a/.changeset/curvy-mugs-work.md
+++ b/.changeset/curvy-mugs-work.md
@@ -1,0 +1,6 @@
+---
+"@seed-design/rootage-artifacts": patch
+"@seed-design/css": patch
+---
+
+Segemented Control Item rootage 에 stroke width,color 를 추가합니다.

--- a/docs/public/rootage/components/segmented-control-item.json
+++ b/docs/public/rootage/components/segmented-control-item.json
@@ -37,6 +37,12 @@
             },
             "colorTimingFunction": {
               "type": "cubicBezier"
+            },
+            "strokeWidth": {
+              "type": "dimension"
+            },
+            "strokeColor": {
+              "type": "color"
             }
           }
         },
@@ -151,6 +157,17 @@
                 "color": {
                   "type": "color",
                   "value": "$color.bg.neutral-weak-pressed"
+                },
+                "strokeWidth": {
+                  "type": "dimension",
+                  "value": {
+                    "value": 1,
+                    "unit": "px"
+                  }
+                },
+                "strokeColor": {
+                  "type": "color",
+                  "value": "$color.stroke.neutral-muted"
                 }
               }
             }

--- a/packages/css/vars/component/segmented-control-item.d.ts
+++ b/packages/css/vars/component/segmented-control-item.d.ts
@@ -22,7 +22,9 @@ export declare const vars: {
     },
     "pressed": {
       "root": {
-        "color": "var(--seed-color-bg-neutral-weak-pressed)"
+        "color": "var(--seed-color-bg-neutral-weak-pressed)",
+        "strokeWidth": "1px",
+        "strokeColor": "var(--seed-color-stroke-neutral-muted)"
       }
     },
     "selected": {

--- a/packages/css/vars/component/segmented-control-item.mjs
+++ b/packages/css/vars/component/segmented-control-item.mjs
@@ -22,7 +22,9 @@ export const vars = {
     },
     "pressed": {
       "root": {
-        "color": "var(--seed-color-bg-neutral-weak-pressed)"
+        "color": "var(--seed-color-bg-neutral-weak-pressed)",
+        "strokeWidth": "1px",
+        "strokeColor": "var(--seed-color-stroke-neutral-muted)"
       }
     },
     "selected": {

--- a/packages/qvism-preset/src/recipes/segmented-control.ts
+++ b/packages/qvism-preset/src/recipes/segmented-control.ts
@@ -95,12 +95,12 @@ const segmentedControl = defineSlotRecipe({
 
       [pseudo(not(disabled), checked, active)]: {
         backgroundColor: itemVars.base.selectedPressed.root.color,
-        boxShadow: `inset 0 0 0 ${vars.base.enabled.indicator.strokeWidth} ${vars.base.enabled.indicator.strokeColor}`,
+        boxShadow: `inset 0 0 0 ${itemVars.base.pressed.root.strokeWidth} ${itemVars.base.pressed.root.strokeColor}`,
       },
 
       [pseudo(not(disabled), not(checked), active)]: {
         backgroundColor: itemVars.base.pressed.root.color,
-        boxShadow: `inset 0 0 0 ${vars.base.enabled.indicator.strokeWidth} ${vars.base.enabled.indicator.strokeColor}`,
+        boxShadow: `inset 0 0 0 ${itemVars.base.pressed.root.strokeWidth} ${itemVars.base.pressed.root.strokeColor}`,
       },
     },
   },

--- a/packages/qvism-preset/src/vars/component/segmented-control-item.d.ts
+++ b/packages/qvism-preset/src/vars/component/segmented-control-item.d.ts
@@ -22,7 +22,9 @@ export declare const vars: {
     },
     "pressed": {
       "root": {
-        "color": "var(--seed-color-bg-neutral-weak-pressed)"
+        "color": "var(--seed-color-bg-neutral-weak-pressed)",
+        "strokeWidth": "1px",
+        "strokeColor": "var(--seed-color-stroke-neutral-muted)"
       }
     },
     "selected": {

--- a/packages/qvism-preset/src/vars/component/segmented-control-item.mjs
+++ b/packages/qvism-preset/src/vars/component/segmented-control-item.mjs
@@ -22,7 +22,9 @@ export const vars = {
     },
     "pressed": {
       "root": {
-        "color": "var(--seed-color-bg-neutral-weak-pressed)"
+        "color": "var(--seed-color-bg-neutral-weak-pressed)",
+        "strokeWidth": "1px",
+        "strokeColor": "var(--seed-color-stroke-neutral-muted)"
       }
     },
     "selected": {

--- a/packages/rootage/components/segmented-control-item.yaml
+++ b/packages/rootage/components/segmented-control-item.yaml
@@ -26,6 +26,10 @@ data:
             type: duration
           colorTimingFunction:
             type: cubicBezier
+          strokeWidth:
+            type: dimension
+          strokeColor:
+            type: color
       label:
         properties:
           fontSize:
@@ -62,6 +66,8 @@ data:
       pressed:
         root:
           color: $color.bg.neutral-weak-pressed
+          strokeWidth: 1px
+          strokeColor: $color.stroke.neutral-muted
       selected:
         label:
           color: $color.fg.neutral


### PR DESCRIPTION
…o enhance visual styling

- Introduced strokeWidth and strokeColor properties for pressed and selected states in segmented control components.
- Updated related JSON, TypeScript, and YAML files to reflect these new properties for consistent styling across implementations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Segmented Control Item 컴포넌트에 stroke width와 color 속성이 추가되었습니다.
  * 눌린 상태에서 새로운 스타일 옵션이 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->