### PR TITLE
feat(segmented-control): extract indicator into separate component spec

### DIFF
--- a/docs/public/rootage/components/segmented-control-indicator.json
+++ b/docs/public/rootage/components/segmented-control-indicator.json
@@ -1,0 +1,107 @@
+{
+  "kind": "ComponentSpec",
+  "metadata": {
+    "id": "segmented-control-indicator",
+    "name": "Segmented Control Indicator"
+  },
+  "data": {
+    "id": "segmented-control-indicator",
+    "name": "Segmented Control Indicator",
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color"
+            },
+            "cornerRadius": {
+              "type": "dimension"
+            },
+            "strokeWidth": {
+              "type": "dimension"
+            },
+            "strokeColor": {
+              "type": "color"
+            },
+            "transformDuration": {
+              "type": "duration"
+            },
+            "transformTimingFunction": {
+              "type": "cubicBezier"
+            }
+          }
+        }
+      },
+      "variants": {}
+    },
+    "definitions": [
+      {
+        "variants": {},
+        "definitions": [
+          {
+            "states": [
+              "enabled"
+            ],
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color",
+                  "value": "$color.palette.gray-00"
+                },
+                "strokeColor": {
+                  "type": "color",
+                  "value": "$color.stroke.neutral-muted"
+                },
+                "strokeWidth": {
+                  "type": "dimension",
+                  "value": {
+                    "value": 1,
+                    "unit": "px"
+                  }
+                },
+                "cornerRadius": {
+                  "type": "dimension",
+                  "value": "$radius.full"
+                },
+                "transformDuration": {
+                  "type": "duration",
+                  "value": "$duration.d4"
+                },
+                "transformTimingFunction": {
+                  "type": "cubicBezier",
+                  "value": "$timing-function.easing"
+                }
+              }
+            }
+          },
+          {
+            "states": [
+              "pressed"
+            ],
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color",
+                  "value": "$color.palette.gray-100"
+                }
+              }
+            }
+          },
+          {
+            "states": [
+              "disabled"
+            ],
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color",
+                  "value": "$color.bg.disabled"
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/public/rootage/components/segmented-control-item.json
+++ b/docs/public/rootage/components/segmented-control-item.json
@@ -37,6 +37,12 @@
             },
             "colorTimingFunction": {
               "type": "cubicBezier"
+            },
+            "strokeWidth": {
+              "type": "dimension"
+            },
+            "strokeColor": {
+              "type": "color"
             }
           }
         },
@@ -151,6 +157,17 @@
                 "color": {
                   "type": "color",
                   "value": "$color.bg.neutral-weak-pressed"
+                },
+                "strokeWidth": {
+                  "type": "dimension",
+                  "value": {
+                    "value": 1,
+                    "unit": "px"
+                  }
+                },
+                "strokeColor": {
+                  "type": "color",
+                  "value": "$color.stroke.neutral-muted"
                 }
               }
             }
@@ -170,20 +187,6 @@
           },
           {
             "states": [
-              "selected",
-              "pressed"
-            ],
-            "slots": {
-              "root": {
-                "color": {
-                  "type": "color",
-                  "value": "$color.palette.gray-100"
-                }
-              }
-            }
-          },
-          {
-            "states": [
               "disabled"
             ],
             "slots": {
@@ -191,20 +194,6 @@
                 "color": {
                   "type": "color",
                   "value": "$color.fg.disabled"
-                }
-              }
-            }
-          },
-          {
-            "states": [
-              "disabled",
-              "selected"
-            ],
-            "slots": {
-              "root": {
-                "color": {
-                  "type": "color",
-                  "value": "$color.bg.disabled"
                 }
               }
             }

--- a/docs/public/rootage/components/segmented-control.json
+++ b/docs/public/rootage/components/segmented-control.json
@@ -21,28 +21,6 @@
               "type": "color"
             }
           }
-        },
-        "indicator": {
-          "properties": {
-            "color": {
-              "type": "color"
-            },
-            "cornerRadius": {
-              "type": "dimension"
-            },
-            "strokeWidth": {
-              "type": "dimension"
-            },
-            "strokeColor": {
-              "type": "color"
-            },
-            "transformDuration": {
-              "type": "duration"
-            },
-            "transformTimingFunction": {
-              "type": "cubicBezier"
-            }
-          }
         }
       },
       "variants": {}
@@ -68,35 +46,6 @@
                 "color": {
                   "type": "color",
                   "value": "$color.bg.neutral-weak-alpha"
-                }
-              },
-              "indicator": {
-                "color": {
-                  "type": "color",
-                  "value": "$color.palette.gray-00"
-                },
-                "cornerRadius": {
-                  "type": "dimension",
-                  "value": "$radius.full"
-                },
-                "strokeWidth": {
-                  "type": "dimension",
-                  "value": {
-                    "value": 1,
-                    "unit": "px"
-                  }
-                },
-                "strokeColor": {
-                  "type": "color",
-                  "value": "$color.stroke.neutral-muted"
-                },
-                "transformDuration": {
-                  "type": "duration",
-                  "value": "$duration.d4"
-                },
-                "transformTimingFunction": {
-                  "type": "cubicBezier",
-                  "value": "$timing-function.easing"
                 }
               }
             }

--- a/docs/public/rootage/index.json
+++ b/docs/public/rootage/index.json
@@ -171,6 +171,9 @@
       "path": "/components/scroll-fog.json"
     },
     {
+      "path": "/components/segmented-control-indicator.json"
+    },
+    {
       "path": "/components/segmented-control-item.json"
     },
     {

--- a/packages/css/vars/component/index.d.ts
+++ b/packages/css/vars/component/index.d.ts
@@ -52,6 +52,7 @@ export { vars as radio } from "./radio";
 export { vars as radiomark } from "./radiomark";
 export { vars as reactionButton } from "./reaction-button";
 export { vars as scrollFog } from "./scroll-fog";
+export { vars as segmentedControlIndicator } from "./segmented-control-indicator";
 export { vars as segmentedControlItem } from "./segmented-control-item";
 export { vars as segmentedControl } from "./segmented-control";
 export { vars as selectBoxCheckmark } from "./select-box-checkmark";

--- a/packages/css/vars/component/index.mjs
+++ b/packages/css/vars/component/index.mjs
@@ -52,6 +52,7 @@ export { vars as radio } from "./radio.mjs";
 export { vars as radiomark } from "./radiomark.mjs";
 export { vars as reactionButton } from "./reaction-button.mjs";
 export { vars as scrollFog } from "./scroll-fog.mjs";
+export { vars as segmentedControlIndicator } from "./segmented-control-indicator.mjs";
 export { vars as segmentedControlItem } from "./segmented-control-item.mjs";
 export { vars as segmentedControl } from "./segmented-control.mjs";
 export { vars as selectBoxCheckmark } from "./select-box-checkmark.mjs";

--- a/packages/css/vars/component/segmented-control-indicator.d.ts
+++ b/packages/css/vars/component/segmented-control-indicator.d.ts
@@ -1,0 +1,24 @@
+export declare const vars: {
+  "base": {
+    "enabled": {
+      "root": {
+        "color": "var(--seed-color-palette-gray-00)",
+        "strokeColor": "var(--seed-color-stroke-neutral-muted)",
+        "strokeWidth": "1px",
+        "cornerRadius": "var(--seed-radius-full)",
+        "transformDuration": "var(--seed-duration-d4)",
+        "transformTimingFunction": "var(--seed-timing-function-easing)"
+      }
+    },
+    "pressed": {
+      "root": {
+        "color": "var(--seed-color-palette-gray-100)"
+      }
+    },
+    "disabled": {
+      "root": {
+        "color": "var(--seed-color-bg-disabled)"
+      }
+    }
+  }
+}

--- a/packages/css/vars/component/segmented-control-indicator.mjs
+++ b/packages/css/vars/component/segmented-control-indicator.mjs
@@ -1,0 +1,24 @@
+export const vars = {
+  "base": {
+    "enabled": {
+      "root": {
+        "color": "var(--seed-color-palette-gray-00)",
+        "strokeColor": "var(--seed-color-stroke-neutral-muted)",
+        "strokeWidth": "1px",
+        "cornerRadius": "var(--seed-radius-full)",
+        "transformDuration": "var(--seed-duration-d4)",
+        "transformTimingFunction": "var(--seed-timing-function-easing)"
+      }
+    },
+    "pressed": {
+      "root": {
+        "color": "var(--seed-color-palette-gray-100)"
+      }
+    },
+    "disabled": {
+      "root": {
+        "color": "var(--seed-color-bg-disabled)"
+      }
+    }
+  }
+}

--- a/packages/css/vars/component/segmented-control-item.d.ts
+++ b/packages/css/vars/component/segmented-control-item.d.ts
@@ -22,7 +22,9 @@ export declare const vars: {
     },
     "pressed": {
       "root": {
-        "color": "var(--seed-color-bg-neutral-weak-pressed)"
+        "color": "var(--seed-color-bg-neutral-weak-pressed)",
+        "strokeWidth": "1px",
+        "strokeColor": "var(--seed-color-stroke-neutral-muted)"
       }
     },
     "selected": {
@@ -30,19 +32,9 @@ export declare const vars: {
         "color": "var(--seed-color-fg-neutral)"
       }
     },
-    "selectedPressed": {
-      "root": {
-        "color": "var(--seed-color-palette-gray-100)"
-      }
-    },
     "disabled": {
       "label": {
         "color": "var(--seed-color-fg-disabled)"
-      }
-    },
-    "disabledSelected": {
-      "root": {
-        "color": "var(--seed-color-bg-disabled)"
       }
     }
   }

--- a/packages/css/vars/component/segmented-control-item.mjs
+++ b/packages/css/vars/component/segmented-control-item.mjs
@@ -22,7 +22,9 @@ export const vars = {
     },
     "pressed": {
       "root": {
-        "color": "var(--seed-color-bg-neutral-weak-pressed)"
+        "color": "var(--seed-color-bg-neutral-weak-pressed)",
+        "strokeWidth": "1px",
+        "strokeColor": "var(--seed-color-stroke-neutral-muted)"
       }
     },
     "selected": {
@@ -30,19 +32,9 @@ export const vars = {
         "color": "var(--seed-color-fg-neutral)"
       }
     },
-    "selectedPressed": {
-      "root": {
-        "color": "var(--seed-color-palette-gray-100)"
-      }
-    },
     "disabled": {
       "label": {
         "color": "var(--seed-color-fg-disabled)"
-      }
-    },
-    "disabledSelected": {
-      "root": {
-        "color": "var(--seed-color-bg-disabled)"
       }
     }
   }

--- a/packages/css/vars/component/segmented-control.d.ts
+++ b/packages/css/vars/component/segmented-control.d.ts
@@ -5,14 +5,6 @@ export declare const vars: {
         "padding": "var(--seed-dimension-x1)",
         "cornerRadius": "var(--seed-radius-full)",
         "color": "var(--seed-color-bg-neutral-weak-alpha)"
-      },
-      "indicator": {
-        "color": "var(--seed-color-palette-gray-00)",
-        "cornerRadius": "var(--seed-radius-full)",
-        "strokeWidth": "1px",
-        "strokeColor": "var(--seed-color-stroke-neutral-muted)",
-        "transformDuration": "var(--seed-duration-d4)",
-        "transformTimingFunction": "var(--seed-timing-function-easing)"
       }
     }
   }

--- a/packages/css/vars/component/segmented-control.mjs
+++ b/packages/css/vars/component/segmented-control.mjs
@@ -5,14 +5,6 @@ export const vars = {
         "padding": "var(--seed-dimension-x1)",
         "cornerRadius": "var(--seed-radius-full)",
         "color": "var(--seed-color-bg-neutral-weak-alpha)"
-      },
-      "indicator": {
-        "color": "var(--seed-color-palette-gray-00)",
-        "cornerRadius": "var(--seed-radius-full)",
-        "strokeWidth": "1px",
-        "strokeColor": "var(--seed-color-stroke-neutral-muted)",
-        "transformDuration": "var(--seed-duration-d4)",
-        "transformTimingFunction": "var(--seed-timing-function-easing)"
       }
     }
   }

--- a/packages/qvism-preset/src/recipes/segmented-control.ts
+++ b/packages/qvism-preset/src/recipes/segmented-control.ts
@@ -1,4 +1,8 @@
-import { segmentedControlItem as itemVars, segmentedControl as vars } from "../vars/component";
+import {
+  segmentedControlItem as itemVars,
+  segmentedControl as vars,
+  segmentedControlIndicator as indicatorVars,
+} from "../vars/component";
 import { defineSlotRecipe } from "../utils/define";
 import { active, checked, disabled, not, pseudo } from "../utils/pseudo";
 
@@ -38,12 +42,12 @@ const segmentedControl = defineSlotRecipe({
       left: vars.base.enabled.root.padding,
       width: `calc((100% - ${vars.base.enabled.root.padding} * 2) / var(--segment-count))`,
 
-      borderRadius: vars.base.enabled.indicator.cornerRadius,
-      backgroundColor: vars.base.enabled.indicator.color,
+      borderRadius: indicatorVars.base.enabled.root.cornerRadius,
+      backgroundColor: indicatorVars.base.enabled.root.color,
 
-      boxShadow: `inset 0 0 0 ${vars.base.enabled.indicator.strokeWidth} ${vars.base.enabled.indicator.strokeColor}`,
+      boxShadow: `inset 0 0 0 ${indicatorVars.base.enabled.root.strokeWidth} ${indicatorVars.base.enabled.root.strokeColor}`,
 
-      transition: `transform ${vars.base.enabled.indicator.transformDuration} ${vars.base.enabled.indicator.transformTimingFunction}`,
+      transition: `transform ${indicatorVars.base.enabled.root.transformDuration} ${indicatorVars.base.enabled.root.transformTimingFunction}`,
     },
     item: {
       display: "flex",
@@ -87,20 +91,20 @@ const segmentedControl = defineSlotRecipe({
 
       [pseudo(disabled, checked)]: {
         // this covers the indicator
-        backgroundColor: itemVars.base.disabledSelected.root.color,
+        backgroundColor: indicatorVars.base.disabled.root.color,
 
         // this is the same as the indicator stroke
-        boxShadow: `inset 0 0 0 ${vars.base.enabled.indicator.strokeWidth} ${vars.base.enabled.indicator.strokeColor}`,
+        boxShadow: `inset 0 0 0 ${indicatorVars.base.enabled.root.strokeWidth} ${indicatorVars.base.enabled.root.strokeColor}`,
       },
 
       [pseudo(not(disabled), checked, active)]: {
-        backgroundColor: itemVars.base.selectedPressed.root.color,
-        boxShadow: `inset 0 0 0 ${vars.base.enabled.indicator.strokeWidth} ${vars.base.enabled.indicator.strokeColor}`,
+        backgroundColor: indicatorVars.base.pressed.root.color,
+        boxShadow: `inset 0 0 0 ${indicatorVars.base.enabled.root.strokeWidth} ${indicatorVars.base.enabled.root.strokeColor}`,
       },
 
       [pseudo(not(disabled), not(checked), active)]: {
         backgroundColor: itemVars.base.pressed.root.color,
-        boxShadow: `inset 0 0 0 ${vars.base.enabled.indicator.strokeWidth} ${vars.base.enabled.indicator.strokeColor}`,
+        boxShadow: `inset 0 0 0 ${itemVars.base.pressed.root.strokeWidth} ${itemVars.base.pressed.root.strokeColor}`,
       },
     },
   },

--- a/packages/qvism-preset/src/vars/component/index.d.ts
+++ b/packages/qvism-preset/src/vars/component/index.d.ts
@@ -52,6 +52,7 @@ export { vars as radio } from "./radio";
 export { vars as radiomark } from "./radiomark";
 export { vars as reactionButton } from "./reaction-button";
 export { vars as scrollFog } from "./scroll-fog";
+export { vars as segmentedControlIndicator } from "./segmented-control-indicator";
 export { vars as segmentedControlItem } from "./segmented-control-item";
 export { vars as segmentedControl } from "./segmented-control";
 export { vars as selectBoxCheckmark } from "./select-box-checkmark";

--- a/packages/qvism-preset/src/vars/component/index.mjs
+++ b/packages/qvism-preset/src/vars/component/index.mjs
@@ -52,6 +52,7 @@ export { vars as radio } from "./radio.mjs";
 export { vars as radiomark } from "./radiomark.mjs";
 export { vars as reactionButton } from "./reaction-button.mjs";
 export { vars as scrollFog } from "./scroll-fog.mjs";
+export { vars as segmentedControlIndicator } from "./segmented-control-indicator.mjs";
 export { vars as segmentedControlItem } from "./segmented-control-item.mjs";
 export { vars as segmentedControl } from "./segmented-control.mjs";
 export { vars as selectBoxCheckmark } from "./select-box-checkmark.mjs";

--- a/packages/qvism-preset/src/vars/component/segmented-control-indicator.d.ts
+++ b/packages/qvism-preset/src/vars/component/segmented-control-indicator.d.ts
@@ -1,0 +1,24 @@
+export declare const vars: {
+  "base": {
+    "enabled": {
+      "root": {
+        "color": "var(--seed-color-palette-gray-00)",
+        "strokeColor": "var(--seed-color-stroke-neutral-muted)",
+        "strokeWidth": "1px",
+        "cornerRadius": "var(--seed-radius-full)",
+        "transformDuration": "var(--seed-duration-d4)",
+        "transformTimingFunction": "var(--seed-timing-function-easing)"
+      }
+    },
+    "pressed": {
+      "root": {
+        "color": "var(--seed-color-palette-gray-100)"
+      }
+    },
+    "disabled": {
+      "root": {
+        "color": "var(--seed-color-bg-disabled)"
+      }
+    }
+  }
+}

--- a/packages/qvism-preset/src/vars/component/segmented-control-indicator.mjs
+++ b/packages/qvism-preset/src/vars/component/segmented-control-indicator.mjs
@@ -1,0 +1,24 @@
+export const vars = {
+  "base": {
+    "enabled": {
+      "root": {
+        "color": "var(--seed-color-palette-gray-00)",
+        "strokeColor": "var(--seed-color-stroke-neutral-muted)",
+        "strokeWidth": "1px",
+        "cornerRadius": "var(--seed-radius-full)",
+        "transformDuration": "var(--seed-duration-d4)",
+        "transformTimingFunction": "var(--seed-timing-function-easing)"
+      }
+    },
+    "pressed": {
+      "root": {
+        "color": "var(--seed-color-palette-gray-100)"
+      }
+    },
+    "disabled": {
+      "root": {
+        "color": "var(--seed-color-bg-disabled)"
+      }
+    }
+  }
+}

--- a/packages/qvism-preset/src/vars/component/segmented-control-item.d.ts
+++ b/packages/qvism-preset/src/vars/component/segmented-control-item.d.ts
@@ -22,7 +22,9 @@ export declare const vars: {
     },
     "pressed": {
       "root": {
-        "color": "var(--seed-color-bg-neutral-weak-pressed)"
+        "color": "var(--seed-color-bg-neutral-weak-pressed)",
+        "strokeWidth": "1px",
+        "strokeColor": "var(--seed-color-stroke-neutral-muted)"
       }
     },
     "selected": {
@@ -30,19 +32,9 @@ export declare const vars: {
         "color": "var(--seed-color-fg-neutral)"
       }
     },
-    "selectedPressed": {
-      "root": {
-        "color": "var(--seed-color-palette-gray-100)"
-      }
-    },
     "disabled": {
       "label": {
         "color": "var(--seed-color-fg-disabled)"
-      }
-    },
-    "disabledSelected": {
-      "root": {
-        "color": "var(--seed-color-bg-disabled)"
       }
     }
   }

--- a/packages/qvism-preset/src/vars/component/segmented-control-item.mjs
+++ b/packages/qvism-preset/src/vars/component/segmented-control-item.mjs
@@ -22,7 +22,9 @@ export const vars = {
     },
     "pressed": {
       "root": {
-        "color": "var(--seed-color-bg-neutral-weak-pressed)"
+        "color": "var(--seed-color-bg-neutral-weak-pressed)",
+        "strokeWidth": "1px",
+        "strokeColor": "var(--seed-color-stroke-neutral-muted)"
       }
     },
     "selected": {
@@ -30,19 +32,9 @@ export const vars = {
         "color": "var(--seed-color-fg-neutral)"
       }
     },
-    "selectedPressed": {
-      "root": {
-        "color": "var(--seed-color-palette-gray-100)"
-      }
-    },
     "disabled": {
       "label": {
         "color": "var(--seed-color-fg-disabled)"
-      }
-    },
-    "disabledSelected": {
-      "root": {
-        "color": "var(--seed-color-bg-disabled)"
       }
     }
   }

--- a/packages/qvism-preset/src/vars/component/segmented-control.d.ts
+++ b/packages/qvism-preset/src/vars/component/segmented-control.d.ts
@@ -5,14 +5,6 @@ export declare const vars: {
         "padding": "var(--seed-dimension-x1)",
         "cornerRadius": "var(--seed-radius-full)",
         "color": "var(--seed-color-bg-neutral-weak-alpha)"
-      },
-      "indicator": {
-        "color": "var(--seed-color-palette-gray-00)",
-        "cornerRadius": "var(--seed-radius-full)",
-        "strokeWidth": "1px",
-        "strokeColor": "var(--seed-color-stroke-neutral-muted)",
-        "transformDuration": "var(--seed-duration-d4)",
-        "transformTimingFunction": "var(--seed-timing-function-easing)"
       }
     }
   }

--- a/packages/qvism-preset/src/vars/component/segmented-control.mjs
+++ b/packages/qvism-preset/src/vars/component/segmented-control.mjs
@@ -5,14 +5,6 @@ export const vars = {
         "padding": "var(--seed-dimension-x1)",
         "cornerRadius": "var(--seed-radius-full)",
         "color": "var(--seed-color-bg-neutral-weak-alpha)"
-      },
-      "indicator": {
-        "color": "var(--seed-color-palette-gray-00)",
-        "cornerRadius": "var(--seed-radius-full)",
-        "strokeWidth": "1px",
-        "strokeColor": "var(--seed-color-stroke-neutral-muted)",
-        "transformDuration": "var(--seed-duration-d4)",
-        "transformTimingFunction": "var(--seed-timing-function-easing)"
       }
     }
   }

--- a/packages/rootage/components/segmented-control-indicator.yaml
+++ b/packages/rootage/components/segmented-control-indicator.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=./schema.json
+kind: ComponentSpec
+metadata:
+  id: segmented-control-indicator
+  name: Segmented Control Indicator
+data:
+  schema:
+    slots:
+      root:
+        properties:
+          color:
+            type: color
+          cornerRadius:
+            type: dimension
+          strokeWidth:
+            type: dimension
+          strokeColor:
+            type: color
+          transformDuration:
+            type: duration
+          transformTimingFunction:
+            type: cubicBezier
+  definitions:
+    base:
+      enabled:
+        root:
+          color: $color.palette.gray-00
+          strokeColor: $color.stroke.neutral-muted
+          strokeWidth: 1px
+          cornerRadius: $radius.full
+          transformDuration: $duration.d4
+          transformTimingFunction: $timing-function.easing
+      pressed:
+        root:
+          color: $color.palette.gray-100
+      disabled:
+        root:
+          color: $color.bg.disabled

--- a/packages/rootage/components/segmented-control-item.yaml
+++ b/packages/rootage/components/segmented-control-item.yaml
@@ -26,6 +26,10 @@ data:
             type: duration
           colorTimingFunction:
             type: cubicBezier
+          strokeWidth:
+            type: dimension
+          strokeColor:
+            type: color
       label:
         properties:
           fontSize:
@@ -62,15 +66,11 @@ data:
       pressed:
         root:
           color: $color.bg.neutral-weak-pressed
+          strokeWidth: 1px
+          strokeColor: $color.stroke.neutral-muted
       selected:
         label:
           color: $color.fg.neutral
-      selected,pressed:
-        root:
-          color: $color.palette.gray-100
       disabled:
         label:
           color: $color.fg.disabled
-      disabled,selected:
-        root:
-          color: $color.bg.disabled

--- a/packages/rootage/components/segmented-control.yaml
+++ b/packages/rootage/components/segmented-control.yaml
@@ -14,20 +14,6 @@ data:
             type: dimension
           color:
             type: color
-      indicator:
-        properties:
-          color:
-            type: color
-          cornerRadius:
-            type: dimension
-          strokeWidth:
-            type: dimension
-          strokeColor:
-            type: color
-          transformDuration:
-            type: duration
-          transformTimingFunction:
-            type: cubicBezier
   definitions:
     base:
       enabled:
@@ -35,10 +21,3 @@ data:
           padding: $dimension.x1
           cornerRadius: $radius.full
           color: $color.bg.neutral-weak-alpha
-        indicator:
-          color: $color.palette.gray-00
-          cornerRadius: $radius.full
-          strokeWidth: 1px
-          strokeColor: $color.stroke.neutral-muted
-          transformDuration: $duration.d4
-          transformTimingFunction: $timing-function.easing


### PR DESCRIPTION
## Summary
- `segmented-control.yaml`에서 `indicator` 슬롯을 별도의 `segmented-control-indicator.yaml` 컴포넌트 스펙으로 분리
- `segmented-control-item`의 pressed 상태에 `strokeWidth`/`strokeColor` 추가하고 불필요한 복합 상태(`selected,pressed`, `disabled,selected`) 제거
- Recipe에서 indicator 변수 참조를 새로운 `segmentedControlIndicator` vars로 변경

## Test plan
- [ ] `bun generate:all` 실행하여 생성물이 일치하는지 확인
- [ ] `bun test:all` 실행하여 기존 테스트 통과 확인
- [ ] Storybook에서 segmented-control 컴포넌트 시각적 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 세그먼트 제어 표시기 스타일링 구조를 재정렬하여 유지보수성을 개선했습니다.
  * 표시기 관련 스타일 지정을 전용 구성으로 통합하여 코드 조직을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->