### PR TITLE
perf(stackflow): add rAF debouncing and fix event stabilization in swipe-back

### DIFF
--- a/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.ts
@@ -58,6 +58,8 @@ export function useGlobalInteraction() {
   });
   const stackRef = useRef<HTMLDivElement>(null);
   const swipeBackTargetsRef = useRef<HTMLElement[]>([]);
+  const rafIdRef = useRef<number | null>(null);
+  const pendingMoveRef = useRef<MoveSwipeBackProps | null>(null);
 
   const resetSwipeBackVars = useCallback((element: HTMLElement) => {
     element.style.removeProperty("--swipe-back-displacement");
@@ -161,20 +163,51 @@ export function useGlobalInteraction() {
       };
 
       const moveSwipeBack = ({ x, t }: MoveSwipeBackProps) => {
-        const displacement = x - swipeBackContextRef.current.x0;
-        const displacementRatio = displacement / window.innerWidth;
-        const velocity = displacement / (t - swipeBackContextRef.current.t0);
-        setSwipeBackContext({
-          ...swipeBackContextRef.current,
-          displacement,
-          displacementRatio,
-          velocity,
-        });
+        // Store latest touch position; only apply CSS vars once per animation frame
+        pendingMoveRef.current = { x, t };
+
+        if (rafIdRef.current === null) {
+          rafIdRef.current = requestAnimationFrame(() => {
+            const pending = pendingMoveRef.current;
+            if (pending) {
+              const displacement = pending.x - swipeBackContextRef.current.x0;
+              const displacementRatio = displacement / window.innerWidth;
+              const velocity = displacement / (pending.t - swipeBackContextRef.current.t0);
+              setSwipeBackContext({
+                ...swipeBackContextRef.current,
+                displacement,
+                displacementRatio,
+                velocity,
+              });
+              onSwipeBackMove?.({ displacement, displacementRatio });
+            }
+            rafIdRef.current = null;
+          });
+        }
+
         setSwipeBackState((prev) => (prev === "swiping" ? prev : "swiping"));
-        onSwipeBackMove?.({ displacement, displacementRatio });
       };
 
       const endSwipeBack = (_: EndSwipeBackProps) => {
+        // Cancel any pending rAF and flush the latest position immediately
+        if (rafIdRef.current !== null) {
+          cancelAnimationFrame(rafIdRef.current);
+          rafIdRef.current = null;
+        }
+        const pending = pendingMoveRef.current;
+        if (pending) {
+          const displacement = pending.x - swipeBackContextRef.current.x0;
+          const displacementRatio = displacement / window.innerWidth;
+          const velocity = displacement / (pending.t - swipeBackContextRef.current.t0);
+          setSwipeBackContext({
+            ...swipeBackContextRef.current,
+            displacement,
+            displacementRatio,
+            velocity,
+          });
+          pendingMoveRef.current = null;
+        }
+
         const swiped =
           swipeBackContextRef.current.displacementRatio > displacementRatioThreshold ||
           swipeBackContextRef.current.velocity > velocityThreshold;
@@ -191,6 +224,11 @@ export function useGlobalInteraction() {
       };
 
       const reset = () => {
+        if (rafIdRef.current !== null) {
+          cancelAnimationFrame(rafIdRef.current);
+          rafIdRef.current = null;
+        }
+        pendingMoveRef.current = null;
         setSwipeBackContext({
           x0: 0,
           t0: 0,

--- a/packages/stackflow/src/primitive/GlobalInteraction/useSwipeBack.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/useSwipeBack.ts
@@ -13,9 +13,10 @@ export function useSwipeBack(props: UseSwipeBackProps) {
     onSwipeBackMove,
     onSwipeBackEnd,
   } = props;
+  const { getSwipeBackEvents } = globalInteraction;
   const events = useMemo(
     () =>
-      globalInteraction.getSwipeBackEvents({
+      getSwipeBackEvents({
         swipeBackDisplacementRatioThreshold,
         swipeBackVelocityThreshold,
         onSwipeBackStart,
@@ -23,7 +24,7 @@ export function useSwipeBack(props: UseSwipeBackProps) {
         onSwipeBackEnd,
       }),
     [
-      globalInteraction,
+      getSwipeBackEvents,
       swipeBackDisplacementRatioThreshold,
       swipeBackVelocityThreshold,
       onSwipeBackStart,


### PR DESCRIPTION
  기존 브랜치(fix/scope-swipe-back-vars)를 로컬에서 테스트하는 과정에서 개선안이 있을까 해서 찾아왔어요!                                                           
                                                                                          
  ## 변경 사항                                                                            
                                                                                          
  ### 1. 스와이프 중 진동(oscillation) 현상 수정                                          
  `useSwipeBack`의 `useMemo` deps에 `globalInteraction` 전체 객체가 포함되어 있어,
  `swipeBackState`가 변경될 때마다 `events`가 재생성되고 `useEffect` cleanup이 `reset()`을
   호출하는 문제가 있었어요

  touchStart → state: "swiping" → globalInteraction 객체 변경
  → events 재생성 → cleanup reset() 호출 → state: "idle"
  → touchmove에서 다시 "swiping" → 반복...

  deps를 `globalInteraction` → `getSwipeBackEvents` (stable ref)로 교체하여 수정했어요.

  ### 2. rAF 디바운싱으로 CSS 변수 갱신 빈도 제한
  `touchmove`는 최대 120Hz로 발생합니다. `requestAnimationFrame`으로 CSS 변수 갱신을
  프레임당 1회(~60fps)로 제한하여 불필요한 스타일 재계산 횟수를 줄였습니다.

  `endSwipeBack` 시에는 pending rAF를 취소하고 최신 위치를 즉시 반영하여 정확성을
  보장하도록 클린업했어요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 스와이프백 제스처 처리 최적화 - 애니메이션 프레임 기반 배치 업데이트로 계산 효율성 개선
  * 향상된 애니메이션 프레임 핸들링 및 리소스 정리

* **기타 개선**
  * 내부 의존성 추적 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->