### PR TITLE
feat(figma): specify the type of the unhandled node

### DIFF
--- a/.changeset/flat-clubs-talk.md
+++ b/.changeset/flat-clubs-talk.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/figma": patch
+---
+
+Figma Codegen 과정에서 지원되지 않는 종류의 레이어를 발견하는 경우 어떤 종류인지 결과에 명시합니다.

--- a/packages/figma/src/codegen/core/codegen.ts
+++ b/packages/figma/src/codegen/core/codegen.ts
@@ -12,6 +12,7 @@ import { match } from "ts-pattern";
 import { appendSource, createElement, stringifyElement, type ElementNode } from "../core/jsx";
 import type { ElementTransformer } from "./element-transformer";
 import { applyInferredLayout, inferLayout } from "./infer-layout";
+import { pascalCase } from "change-case";
 
 export interface CodeGeneratorDeps {
   frameTransformer: ElementTransformer<
@@ -77,7 +78,9 @@ export function createCodeGenerator({
       .with({ type: "INSTANCE" }, (node) => instanceTransformer(node, traverse))
       .with({ type: "VECTOR" }, (node) => vectorTransformer(node, traverse))
       .with({ type: "BOOLEAN_OPERATION" }, (node) => booleanOperationTransformer(node, traverse))
-      .with({ type: "UNHANDLED" }, () => createElement("UnhandledFigmaNode"))
+      .with({ type: "UNHANDLED" }, (node) =>
+        createElement(`Unhandled${pascalCase(node.original.type)}Node`),
+      )
       .exhaustive();
 
     if (result) {
@@ -94,7 +97,7 @@ export function createCodeGenerator({
   function generateCode(node: NormalizedSceneNode, options: { shouldPrintSource: boolean }) {
     if (isSkippedInstance(node)) {
       return { imports: "", jsx: "// This component is intentionally excluded from codegen" };
-     }
+    }
 
     const jsxTree = generateJsxTree(node);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선사항**
  * Figma 코드 생성 시 지원되지 않는 노드 타입을 더 정확하게 식별하고 각 타입별로 구분하여 결과에 반영합니다.
* **문서**
  * 패치 릴리스용 변경 내역이 추가되어, 지원되지 않는 레이어 타입이 처리 결과에 표시된다는 점이 명시되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->