### PR TITLE
fix(figma): ensure trailing newline in generated files

### DIFF
--- a/packages/figma/figma-extractor.config.ts
+++ b/packages/figma/figma-extractor.config.ts
@@ -5,6 +5,10 @@ import { camelCase, pascalCase } from "change-case";
 import type { ComponentNode, ComponentSetNode } from "@figma/rest-api-spec";
 import type { IconData, Style } from "./src/entities";
 
+function ensureTrailingNewline(content: string): string {
+  return content.endsWith("\n") ? content : `${content}\n`;
+}
+
 function getSafeIdentifierName(name: string) {
   const reservedWords = ["switch"];
 
@@ -151,8 +155,8 @@ const config = createConfig({
         const dts = items.map((item) => utils.toDts(getIdentifier(item), item).trim()).join("\n\n");
 
         await Promise.all([
-          write(`${pipelineName}/index.mjs`, mjs),
-          write(`${pipelineName}/index.d.ts`, dts),
+          write(`${pipelineName}/index.mjs`, ensureTrailingNewline(mjs)),
+          write(`${pipelineName}/index.d.ts`, ensureTrailingNewline(dts)),
         ]);
       }),
 
@@ -256,8 +260,8 @@ const config = createConfig({
         const dts = items.map((item) => utils.toDts(getIdentifier(item), item).trim()).join("\n\n");
 
         await Promise.all([
-          write(`${pipelineName}/index.mjs`, mjs),
-          write(`${pipelineName}/index.d.ts`, dts),
+          write(`${pipelineName}/index.mjs`, ensureTrailingNewline(mjs)),
+          write(`${pipelineName}/index.d.ts`, ensureTrailingNewline(dts)),
         ]);
       }),
 
@@ -279,8 +283,8 @@ export declare const FIGMA_VARIABLES: Record<string, Variable>;
 `;
 
         await Promise.all([
-          write(`${pipelineName}/index.mjs`, mjs),
-          write(`${pipelineName}/index.d.ts`, dts),
+          write(`${pipelineName}/index.mjs`, ensureTrailingNewline(mjs)),
+          write(`${pipelineName}/index.d.ts`, ensureTrailingNewline(dts)),
         ]);
       }),
 
@@ -310,8 +314,8 @@ export declare const FIGMA_VARIABLE_COLLECTIONS: Record<string, VariableCollecti
 `;
 
         await Promise.all([
-          write(`${pipelineName}/index.mjs`, mjs),
-          write(`${pipelineName}/index.d.ts`, dts),
+          write(`${pipelineName}/index.mjs`, ensureTrailingNewline(mjs)),
+          write(`${pipelineName}/index.d.ts`, ensureTrailingNewline(dts)),
         ]);
       }),
 
@@ -337,8 +341,8 @@ export declare const FIGMA_STYLES: Style[];
 `;
 
         await Promise.all([
-          write(`${pipelineName}/index.mjs`, mjs),
-          write(`${pipelineName}/index.d.ts`, dts),
+          write(`${pipelineName}/index.mjs`, ensureTrailingNewline(mjs)),
+          write(`${pipelineName}/index.d.ts`, ensureTrailingNewline(dts)),
         ]);
       }),
 
@@ -378,8 +382,8 @@ export declare const FIGMA_ICONS: Record<string, IconData>;
 `;
 
         await Promise.all([
-          write(`${pipelineName}/index.mjs`, mjs),
-          write(`${pipelineName}/index.d.ts`, dts),
+          write(`${pipelineName}/index.mjs`, ensureTrailingNewline(mjs)),
+          write(`${pipelineName}/index.d.ts`, ensureTrailingNewline(dts)),
         ]);
       }),
   },


### PR DESCRIPTION
## Summary
Figma extractor가 생성하는 파일들에 trailing newline이 없어서 매번 불필요한 diff가 발생하는 문제를 수정합니다.

## Changes
- `ensureTrailingNewline` 헬퍼 함수를 추가하여 모든 파이프라인의 `write()` 호출에서 생성되는 `.mjs` 및 `.d.ts` 파일에 trailing newline을 보장합니다.
- 6개 파이프라인(component-sets, components, variables, variable-collections, styles, icons)의 모든 write 호출에 적용
- 이미 trailing newline이 있는 경우 중복 추가하지 않도록 안전하게 처리

## Test plan
- [ ] Figma extractor 실행 후 생성된 파일들이 trailing newline으로 끝나는지 확인
- [ ] 반복 실행 시 불필요한 diff가 발생하지 않는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **수정 사항**
  * 생성되는 파일들의 후행 줄바꿈을 표준화하여 일관된 파일 형식 유지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->