### PR TITLE
fix(tabs-codegen): Tab Trigger codegen

### DIFF
--- a/packages/figma/src/codegen/targets/react/component/handlers/tabs.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/tabs.ts
@@ -156,7 +156,7 @@ const createLineTriggerHugHandler = (_ctx: ComponentHandlerDeps) =>
         }),
       };
 
-      return createTabsLocalSnippetElement("TabsTrigger", commonProps);
+      return createTabsLocalSnippetElement("TabsTrigger", commonProps, props["Label#4478:2"].value);
     },
   );
 
@@ -174,7 +174,7 @@ const createLineTriggerFillHandler = (_ctx: ComponentHandlerDeps) =>
         }),
       };
 
-      return createTabsLocalSnippetElement("TabsTrigger", commonProps);
+      return createTabsLocalSnippetElement("TabsTrigger", commonProps, props["Label#4478:2"].value);
     },
   );
 
@@ -289,6 +289,10 @@ const createChipTabsTriggerHandler = (_ctx: ComponentHandlerDeps) =>
         }),
       };
 
-      return createChipTabsLocalSnippetElement("ChipTabsTrigger", commonProps);
+      return createChipTabsLocalSnippetElement(
+        "ChipTabsTrigger",
+        commonProps,
+        chipProps["Label#7185:0"].value,
+      );
     },
   );


### PR DESCRIPTION
### as-is
<img width="796" height="700" alt="image" src="https://github.com/user-attachments/assets/055ccaaa-b9e3-4574-8dda-bff19c382155" />

### to-be
<img width="2618" height="1280" alt="image" src="https://github.com/user-attachments/assets/6c019a4a-abd9-4ba0-a225-35fead0d5f16" />

## 버그 수정
* Figma 디자인에서 React로 변환될 때 탭 컴포넌트에 라벨 정보가 올바르게 포함되도록 개선했습니다.

## 리팩토링
* 탭 및 칩 탭 컴포넌트 생성 로직을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->