### PR TITLE
fix(figma): update bottom sheet handler to use dynamic component key

### DIFF
--- a/packages/figma/src/codegen/targets/react/component/handlers/bottom-sheet.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/bottom-sheet.ts
@@ -1,7 +1,6 @@
 import type { BottomSheetProperties } from "@/codegen/component-properties";
 import { createElement, defineComponentHandler } from "@/codegen/core";
 import * as metadata from "@/entities/data/__generated__/component-sets";
-import * as components from "@/entities/data/__generated__/components";
 import { match } from "ts-pattern";
 import { createLocalSnippetHelper } from "../../element-factories";
 import type { ComponentHandlerDeps } from "../deps.interface";
@@ -33,7 +32,7 @@ export const createBottomSheetHandler = (_ctx: ComponentHandlerDeps) =>
 
       const bodyNodes = findAllInstances({
         node,
-        key: components.privateComponentBottomSheetContentsPlaceholder.key,
+        key: props["Contents#25320:0"].componentKey,
       });
 
       const bottomSheetBody =


### PR DESCRIPTION
- bottomsheet 코드젠 에서 body 에 연결된 인스턴스랑 key 매칭되도록 수정

## as-is
- 인스턴스로 연결된 컴포넌트 코드젠이 No content available 이라고 나옴
<img width="792" height="1142" alt="image" src="https://github.com/user-attachments/assets/1861aed4-975d-4134-89b9-3bfb8ad6cedf" />

## to-be
<img width="1090" height="1688" alt="image" src="https://github.com/user-attachments/assets/c26caf46-e182-4178-920c-75db717d1e49" />
