### PR TITLE
feat(docs): add color copy functionality to docs token pages

### DIFF
--- a/docs/components/color-grid.tsx
+++ b/docs/components/color-grid.tsx
@@ -1,5 +1,6 @@
+import { resolveToken } from "@seed-design/rootage-core";
 import { getRootage } from "./rootage";
-import { AST } from "@seed-design/rootage-core";
+import { ColorSwatch } from "./color-swatch";
 
 export interface ColorGridProps {
   scales: {
@@ -14,15 +15,25 @@ export async function ColorGrid(props: ColorGridProps) {
   const rows = scales.map((scale) => {
     const tokens = rootage.tokenIds
       .filter((id) => id.startsWith(`$color.palette.${scale.prefix}`))
-      .map((id) => rootage.tokenEntities[id]);
+      .map((id) => {
+        const { value: lightValue } = resolveToken(rootage, id, {
+          global: "default",
+          color: "theme-light",
+        });
+        const { value: darkValue } = resolveToken(rootage, id, {
+          global: "default",
+          color: "theme-dark",
+        });
+        return {
+          identifier: id,
+          lightHex: (lightValue as { kind: "ColorHexLit"; value: string }).value,
+          darkHex: (darkValue as { kind: "ColorHexLit"; value: string }).value,
+        };
+      });
 
-    return {
-      name: scale.name,
-      tokens,
-    };
+    return { name: scale.name, tokens };
   });
 
-  // TODO: implement selectable theme instead of hard-coded values[0]
   return (
     <div className="flex flex-col gap-1 w-full">
       <div className="flex gap-1 justify-center">
@@ -36,27 +47,16 @@ export async function ColorGrid(props: ColorGridProps) {
       {rows.map(({ name, tokens }) => (
         <div key={name} className="flex gap-1 items-center">
           <div className="flex-1 text-sm text-fd-muted-foreground">{name}</div>
-          {tokens.map((color) => (
+          {tokens.map((token) => (
             <ColorSwatch
-              key={color.token.identifier}
-              value={(color.values[0].value as AST.ColorHexLit).value}
+              key={token.identifier}
+              identifier={token.identifier}
+              lightValue={token.lightHex}
+              darkValue={token.darkHex}
             />
           ))}
         </div>
       ))}
     </div>
-  );
-}
-
-interface ColorSwatchProps {
-  value: string;
-}
-
-function ColorSwatch(props: ColorSwatchProps) {
-  return (
-    <div
-      className="flex-1 h-12 border border-fd-border/20"
-      style={{ backgroundColor: props.value }}
-    />
   );
 }

--- a/docs/components/color-swatch.tsx
+++ b/docs/components/color-swatch.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { IconCheckmarkClipboardLine, IconCheckmarkFill } from "@karrotmarket/react-monochrome-icon";
-import { useEffect, useRef, useState } from "react";
+import { useCopyButton } from "fumadocs-ui/utils/use-copy-button";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 interface ColorSwatchProps {
@@ -14,6 +15,7 @@ export function ColorSwatch({ identifier, lightValue, darkValue }: ColorSwatchPr
   const [isOpen, setIsOpen] = useState(false);
   const [rect, setRect] = useState<DOMRect | null>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const popupRef = useRef<HTMLDivElement>(null);
 
   function handleClick() {
     if (buttonRef.current) {
@@ -21,6 +23,16 @@ export function ColorSwatch({ identifier, lightValue, darkValue }: ColorSwatchPr
     }
     setIsOpen(true);
   }
+
+  useLayoutEffect(() => {
+    if (!isOpen || !popupRef.current || !rect) return;
+    const el = popupRef.current;
+    const popupRect = el.getBoundingClientRect();
+    if (popupRect.right > window.innerWidth) {
+      el.style.left = "";
+      el.style.right = `${window.innerWidth - rect.right}px`;
+    }
+  }, [isOpen, rect]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -54,6 +66,7 @@ export function ColorSwatch({ identifier, lightValue, darkValue }: ColorSwatchPr
               onClick={() => setIsOpen(false)}
             />
             <div
+              ref={popupRef}
               className="fixed z-50 bg-fd-background border border-fd-border rounded-xl shadow-xl p-4 min-w-52"
               style={{
                 top: (rect?.bottom ?? 0) + 8,
@@ -72,19 +85,14 @@ export function ColorSwatch({ identifier, lightValue, darkValue }: ColorSwatchPr
 }
 
 function CopyRow({ label, value }: { label: string; value: string }) {
-  const [copied, setCopied] = useState(false);
-
-  function handleCopy() {
-    navigator.clipboard.writeText(value).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    });
-  }
+  const [copied, onClick] = useCopyButton(() => {
+    navigator.clipboard.writeText(value);
+  });
 
   return (
     <button
       type="button"
-      onClick={handleCopy}
+      onClick={onClick}
       className="flex items-center gap-2 w-full py-1.5 text-left hover:bg-fd-muted rounded-md px-1 transition-colors group"
     >
       <div

--- a/docs/components/color-swatch.tsx
+++ b/docs/components/color-swatch.tsx
@@ -2,7 +2,15 @@
 
 import { IconCheckmarkClipboardLine, IconCheckmarkFill } from "@karrotmarket/react-monochrome-icon";
 import { useCopyButton } from "fumadocs-ui/utils/use-copy-button";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  forwardRef,
+  RefObject,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 
 interface ColorSwatchProps {
@@ -11,86 +19,104 @@ interface ColorSwatchProps {
   darkValue: string;
 }
 
-export function ColorSwatch({ identifier, lightValue, darkValue }: ColorSwatchProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [rect, setRect] = useState<DOMRect | null>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const popupRef = useRef<HTMLDivElement>(null);
+export const ColorSwatch = forwardRef<HTMLButtonElement, ColorSwatchProps>(
+  ({ identifier, lightValue, darkValue }, forwardedRef) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [rect, setRect] = useState<DOMRect | null>(null);
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const popupRef = useRef<HTMLDivElement>(null);
 
-  function handleClick() {
-    if (buttonRef.current) {
-      setRect(buttonRef.current.getBoundingClientRect());
+    const composedRef = useCallback(
+      (node: HTMLButtonElement | null) => {
+        (buttonRef as RefObject<HTMLButtonElement | null>).current = node;
+        if (typeof forwardedRef === "function") forwardedRef(node);
+        else if (forwardedRef) (forwardedRef as RefObject<HTMLButtonElement | null>).current = node;
+      },
+      [forwardedRef],
+    );
+
+    function handleClick() {
+      if (buttonRef.current) {
+        setRect(buttonRef.current.getBoundingClientRect());
+      }
+      setIsOpen(true);
     }
-    setIsOpen(true);
-  }
 
-  useLayoutEffect(() => {
-    if (!isOpen || !popupRef.current || !rect) return;
-    const el = popupRef.current;
-    const popupRect = el.getBoundingClientRect();
-    if (popupRect.right > window.innerWidth) {
-      el.style.left = "";
-      el.style.right = `${window.innerWidth - rect.right}px`;
-    }
-  }, [isOpen, rect]);
+    useLayoutEffect(() => {
+      if (!isOpen || !popupRef.current || !rect) return;
+      const el = popupRef.current;
+      const popupRect = el.getBoundingClientRect();
+      if (popupRect.right > window.innerWidth) {
+        el.style.left = "";
+        el.style.right = `${window.innerWidth - rect.right}px`;
+      }
+    }, [isOpen, rect]);
 
-  useEffect(() => {
-    if (!isOpen) return;
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") setIsOpen(false);
-    }
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen]);
+    useEffect(() => {
+      if (!isOpen) return;
+      function handleKeyDown(e: KeyboardEvent) {
+        if (e.key === "Escape") setIsOpen(false);
+      }
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    }, [isOpen]);
 
-  const label = identifier.replace("$color.palette.", "");
+    const label = identifier.replace("$color.palette.", "");
 
-  return (
-    <>
-      <button
-        ref={buttonRef}
-        type="button"
-        className={`flex-1 h-12 border cursor-pointer hover:opacity-90 transition-opacity ${isOpen ? "border-fd-primary" : "border-fd-border/20"}`}
-        style={{ backgroundColor: lightValue }}
-        onClick={handleClick}
-        title={label}
-        aria-label={`${label} 색상 복사`}
-      />
-      {isOpen &&
-        createPortal(
-          <>
-            <button
-              type="button"
-              className="fixed inset-0 z-40 cursor-default"
-              aria-label="닫기"
-              onClick={() => setIsOpen(false)}
-            />
-            <div
-              ref={popupRef}
-              className="fixed z-50 bg-fd-background border border-fd-border rounded-xl shadow-xl p-4 min-w-52"
-              style={{
-                top: (rect?.bottom ?? 0) + 8,
-                left: rect?.left ?? 0,
-              }}
-            >
-              <p className="text-sm font-semibold mb-3">{label}</p>
-              <CopyRow label="Light" value={lightValue} />
-              <CopyRow label="Dark" value={darkValue} />
-            </div>
-          </>,
-          document.body,
-        )}
-    </>
-  );
+    return (
+      <>
+        <button
+          ref={composedRef}
+          type="button"
+          className={`flex-1 h-12 border cursor-pointer hover:opacity-90 transition-opacity ${isOpen ? "border-fd-primary" : "border-fd-border/20"}`}
+          style={{ backgroundColor: lightValue }}
+          onClick={handleClick}
+          title={label}
+          aria-label={`${label} 색상 정보 열기`}
+        />
+        {isOpen &&
+          createPortal(
+            <>
+              <button
+                type="button"
+                className="fixed inset-0 z-40 cursor-default"
+                aria-label="닫기"
+                onClick={() => setIsOpen(false)}
+              />
+              <div
+                ref={popupRef}
+                className="fixed z-50 bg-fd-background border border-fd-border rounded-xl shadow-xl p-4 min-w-52"
+                style={{
+                  top: (rect?.bottom ?? 0) + 8,
+                  left: rect?.left ?? 0,
+                }}
+              >
+                <p className="text-sm font-semibold mb-3">{label}</p>
+                <CopyRow label="Light" value={lightValue} />
+                <CopyRow label="Dark" value={darkValue} />
+              </div>
+            </>,
+            document.body,
+          )}
+      </>
+    );
+  },
+);
+ColorSwatch.displayName = "ColorSwatch";
+
+interface CopyRowProps {
+  label: string;
+  value: string;
 }
 
-function CopyRow({ label, value }: { label: string; value: string }) {
+const CopyRow = forwardRef<HTMLButtonElement, CopyRowProps>(({ label, value }, ref) => {
   const [copied, onClick] = useCopyButton(() => {
     navigator.clipboard.writeText(value);
   });
 
   return (
     <button
+      ref={ref}
       type="button"
       onClick={onClick}
       className="flex items-center gap-2 w-full py-1.5 text-left hover:bg-fd-muted rounded-md px-1 transition-colors group"
@@ -111,4 +137,5 @@ function CopyRow({ label, value }: { label: string; value: string }) {
       )}
     </button>
   );
-}
+});
+CopyRow.displayName = "CopyRow";

--- a/docs/components/color-swatch.tsx
+++ b/docs/components/color-swatch.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { IconCheckmarkClipboardLine, IconCheckmarkFill } from "@karrotmarket/react-monochrome-icon";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+interface ColorSwatchProps {
+  identifier: string;
+  lightValue: string;
+  darkValue: string;
+}
+
+export function ColorSwatch({ identifier, lightValue, darkValue }: ColorSwatchProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  function handleClick() {
+    if (buttonRef.current) {
+      setRect(buttonRef.current.getBoundingClientRect());
+    }
+    setIsOpen(true);
+  }
+
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setIsOpen(false);
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen]);
+
+  const label = identifier.replace("$color.palette.", "");
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        className={`flex-1 h-12 border cursor-pointer hover:opacity-90 transition-opacity ${isOpen ? "border-fd-primary" : "border-fd-border/20"}`}
+        style={{ backgroundColor: lightValue }}
+        onClick={handleClick}
+        title={label}
+        aria-label={`${label} 색상 복사`}
+      />
+      {isOpen &&
+        createPortal(
+          <>
+            <button
+              type="button"
+              className="fixed inset-0 z-40 cursor-default"
+              aria-label="닫기"
+              onClick={() => setIsOpen(false)}
+            />
+            <div
+              className="fixed z-50 bg-fd-background border border-fd-border rounded-xl shadow-xl p-4 min-w-52"
+              style={{
+                top: (rect?.bottom ?? 0) + 8,
+                left: rect?.left ?? 0,
+              }}
+            >
+              <p className="text-sm font-semibold mb-3">{label}</p>
+              <CopyRow label="Light" value={lightValue} />
+              <CopyRow label="Dark" value={darkValue} />
+            </div>
+          </>,
+          document.body,
+        )}
+    </>
+  );
+}
+
+function CopyRow({ label, value }: { label: string; value: string }) {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(value).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="flex items-center gap-2 w-full py-1.5 text-left hover:bg-fd-muted rounded-md px-1 transition-colors group"
+    >
+      <div
+        className="w-5 h-5 rounded-md border border-fd-border/50 flex-none"
+        style={{ backgroundColor: value }}
+      />
+      <span className="text-xs text-fd-muted-foreground flex-none w-8">{label}</span>
+      <code className="text-xs flex-1 font-mono">{value}</code>
+      {copied ? (
+        <IconCheckmarkFill size={14} className="flex-none" />
+      ) : (
+        <IconCheckmarkClipboardLine
+          size={14}
+          className="flex-none opacity-0 group-hover:opacity-100 transition-opacity text-fd-muted-foreground"
+        />
+      )}
+    </button>
+  );
+}

--- a/docs/components/copy-value.tsx
+++ b/docs/components/copy-value.tsx
@@ -9,7 +9,14 @@ export function CopyValue({ value }: { value: string }) {
   });
 
   return (
-    <button type="button" onClick={onClick} className="flex items-center gap-1 group/copy">
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick(e);
+      }}
+      className="flex items-center gap-1 group/copy"
+    >
       <span>{value}</span>
       {copied ? (
         <IconCheckmarkFill size={12} className="flex-none" />

--- a/docs/components/copy-value.tsx
+++ b/docs/components/copy-value.tsx
@@ -1,20 +1,15 @@
 "use client";
 
 import { IconCheckmarkFill, IconCheckmarkClipboardLine } from "@karrotmarket/react-monochrome-icon";
-import { useState } from "react";
+import { useCopyButton } from "fumadocs-ui/utils/use-copy-button";
 
 export function CopyValue({ value }: { value: string }) {
-  const [copied, setCopied] = useState(false);
-
-  function handleCopy() {
-    navigator.clipboard.writeText(value).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    });
-  }
+  const [copied, onClick] = useCopyButton(() => {
+    navigator.clipboard.writeText(value);
+  });
 
   return (
-    <button type="button" onClick={handleCopy} className="flex items-center gap-1 group/copy">
+    <button type="button" onClick={onClick} className="flex items-center gap-1 group/copy">
       <span>{value}</span>
       {copied ? (
         <IconCheckmarkFill size={12} className="flex-none" />

--- a/docs/components/copy-value.tsx
+++ b/docs/components/copy-value.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { IconCheckmarkFill, IconCheckmarkClipboardLine } from "@karrotmarket/react-monochrome-icon";
+import { useState } from "react";
+
+export function CopyValue({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(value).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
+
+  return (
+    <button type="button" onClick={handleCopy} className="flex items-center gap-1 group/copy">
+      <span>{value}</span>
+      {copied ? (
+        <IconCheckmarkFill size={12} className="flex-none" />
+      ) : (
+        <IconCheckmarkClipboardLine
+          size={12}
+          className="flex-none opacity-0 group-hover/copy:opacity-100 transition-opacity text-fd-muted-foreground"
+        />
+      )}
+    </button>
+  );
+}

--- a/docs/components/token-cell.tsx
+++ b/docs/components/token-cell.tsx
@@ -5,6 +5,7 @@ import {
 } from "@karrotmarket/react-monochrome-icon";
 import type { AST } from "@seed-design/rootage-core";
 import { Fragment } from "react";
+import { CopyValue } from "./copy-value";
 import { TokenLink } from "./token-link";
 import { TypeIndicator } from "./type-indicator";
 
@@ -84,7 +85,7 @@ export function TokenCell(props: TokenCellProps) {
                 ) : item.ref.startsWith("$") ? (
                   <TokenLink id={item.ref} description={item.description} />
                 ) : (
-                  item.ref
+                  <CopyValue value={item.ref} />
                 )}
               </div>
               {index < values.length - 1 ? (
@@ -104,7 +105,7 @@ export function TokenCell(props: TokenCellProps) {
             ) : values[0].ref.startsWith("$") ? (
               <TokenLink id={values[0].ref} description={values[0].description} />
             ) : (
-              values[0].ref
+              <CopyValue value={values[0].ref} />
             )}
           </div>
         )}

--- a/docs/components/token-table.tsx
+++ b/docs/components/token-table.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import { IconCheckmarkClipboardLine, IconCheckmarkFill } from "@karrotmarket/react-monochrome-icon";
 import { AST } from "@seed-design/rootage-core";
 import { useState } from "react";
 import { TokenCell, TokenValue } from "./token-cell";
 import { TokenLink } from "./token-link";
+
+function toCssVar(tokenId: string): string {
+  return `--seed-${tokenId.replace(/^\$/, "").replace(/\./g, "-")}`;
+}
 
 export interface TokenTableItem {
   id: string;
@@ -41,17 +46,41 @@ function TokenRow(props: { item: TokenTableItem }) {
   const { id, description, values, resolvedValue } = item;
 
   const [isExpanded, setIsExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
   const canExpand = values.length > 1;
+
+  function handleCopy(e: React.MouseEvent) {
+    e.stopPropagation();
+    navigator.clipboard.writeText(toCssVar(id)).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
 
   return (
     <tr
       key={id}
-      className={`hover:bg-fd-muted ${canExpand ? (isExpanded ? "cursor-zoom-out" : "cursor-zoom-in") : ""}`}
+      className={`group hover:bg-fd-muted ${canExpand ? (isExpanded ? "cursor-zoom-out" : "cursor-zoom-in") : ""}`}
       onClick={canExpand ? () => setIsExpanded((prev) => !prev) : undefined}
     >
       <td>
-        <div className="flex flex-col gap-1">
-          <TokenLink id={id} description={description} />
+        <div className="flex items-start gap-2 content-center">
+          <div className="flex flex-col gap-1 min-w-0">
+            <TokenLink id={id} description={description} />
+          </div>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="mt-0.5 flex-none opacity-0 group-hover:opacity-100 transition-opacity text-fd-muted-foreground hover:text-fd-foreground"
+            title={`CSS 변수 복사: ${toCssVar(id)}`}
+            aria-label={`${toCssVar(id)} 복사`}
+          >
+            {copied ? (
+              <IconCheckmarkFill size={14} className="flex-none" />
+            ) : (
+              <IconCheckmarkClipboardLine size={14} />
+            )}
+          </button>
         </div>
       </td>
       <td className="align-middle">

--- a/docs/components/token-table.tsx
+++ b/docs/components/token-table.tsx
@@ -2,6 +2,7 @@
 
 import { IconCheckmarkClipboardLine, IconCheckmarkFill } from "@karrotmarket/react-monochrome-icon";
 import { AST } from "@seed-design/rootage-core";
+import { useCopyButton } from "fumadocs-ui/utils/use-copy-button";
 import { useState } from "react";
 import { TokenCell, TokenValue } from "./token-cell";
 import { TokenLink } from "./token-link";
@@ -46,15 +47,15 @@ function TokenRow(props: { item: TokenTableItem }) {
   const { id, description, values, resolvedValue } = item;
 
   const [isExpanded, setIsExpanded] = useState(false);
-  const [copied, setCopied] = useState(false);
   const canExpand = values.length > 1;
+
+  const [copied, onCopyClick] = useCopyButton(() => {
+    navigator.clipboard.writeText(toCssVar(id));
+  });
 
   function handleCopy(e: React.MouseEvent) {
     e.stopPropagation();
-    navigator.clipboard.writeText(toCssVar(id)).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    });
+    onCopyClick(e);
   }
 
   return (


### PR DESCRIPTION

<img width="2072" height="996" alt="image" src="https://github.com/user-attachments/assets/72f4b7f6-e907-425c-b427-f4e520d16c67" />

- ColorSwatch: click opens popup with light/dark hex values, each copyable
- ColorGrid: resolve both light/dark theme values per token
- TokenTable: add CSS variable copy button with icon feedback
- TokenCell: wrap resolved plain values with CopyValue for inline copy
- CopyValue: new client component for hover-to-copy plain text values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 색상 스와치(라이트/다크) 팝업 추가로 색상 이름과 라이트/다크 값 확인 가능
  * 팝업 및 토큰용 복사 버튼 추가 — 클릭 시 값이 클립보드로 복사되고 체크마크로 피드백 제공
  * 토큰 표 및 셀에 복사 버튼 통합으로 CSS 변수명·토큰 값 손쉬운 복사
  * 팝업 오버플로우 자동 조정 및 ESC/오버레이 클릭으로 닫기 지원
* **접근성/UX**
  * 버튼 툴팁·aria 속성 추가 및 복사 클릭 시 행 이벤트 전파 방지
<!-- end of auto-generated comment: release notes by coderabbit.ai -->