### PR TITLE
feat(react-headless): add aria-disabled to useToggle

### DIFF
--- a/.changeset/upset-rockets-bet.md
+++ b/.changeset/upset-rockets-bet.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react-toggle": patch
+---
+
+ToggleButton이 비활성화 상태에서 `aria-disabled="true"`를 갖도록 수정합니다.

--- a/packages/react-headless/toggle/src/useToggle.test.tsx
+++ b/packages/react-headless/toggle/src/useToggle.test.tsx
@@ -18,17 +18,19 @@ function Toggle(props: ToggleRootProps) {
 }
 
 describe("useToggle", () => {
-  it("should render the toggle correctly", () => {
+  it("should render with aria-pressed even without defaultPressed", () => {
     const { getByRole } = setUp(<Toggle />);
     const button = getByRole("button", { name: "Toggle" });
 
     expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute("aria-pressed", "false");
   });
 
   it("should toggle pressed state on click", async () => {
-    const { getByRole, user } = setUp(<Toggle defaultPressed={false} />);
+    const { getByRole, user } = setUp(<Toggle />);
     const button = getByRole("button", { name: "Toggle" });
 
+    expect(button).toHaveAttribute("aria-pressed", "false");
     expect(button).not.toHaveAttribute("data-pressed");
 
     await user.click(button);
@@ -36,6 +38,7 @@ describe("useToggle", () => {
     expect(button).toHaveAttribute("data-pressed");
 
     await user.click(button);
+    expect(button).toHaveAttribute("aria-pressed", "false");
     expect(button).not.toHaveAttribute("data-pressed");
   });
 
@@ -58,13 +61,11 @@ describe("useToggle", () => {
 
   it("should not toggle when disabled", async () => {
     const onPressedChange = mock();
-    const { getByRole, user } = setUp(
-      <Toggle disabled defaultPressed={false} onPressedChange={onPressedChange} />,
-    );
+    const { getByRole, user } = setUp(<Toggle disabled onPressedChange={onPressedChange} />);
     const button = getByRole("button", { name: "Toggle" });
 
     await user.click(button);
-    expect(button).not.toHaveAttribute("data-pressed");
+    expect(button).toHaveAttribute("aria-pressed", "false");
     expect(onPressedChange).not.toHaveBeenCalled();
   });
 

--- a/packages/react-headless/toggle/src/useToggle.test.tsx
+++ b/packages/react-headless/toggle/src/useToggle.test.tsx
@@ -1,0 +1,94 @@
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, mock } from "bun:test";
+
+import type { ReactElement } from "react";
+
+import { ToggleRoot, type ToggleRootProps } from "./Toggle";
+
+function setUp(jsx: ReactElement) {
+  return {
+    user: userEvent.setup(),
+    ...render(jsx),
+  };
+}
+
+function Toggle(props: ToggleRootProps) {
+  return <ToggleRoot {...props}>Toggle</ToggleRoot>;
+}
+
+describe("useToggle", () => {
+  it("should render the toggle correctly", () => {
+    const { getByRole } = setUp(<Toggle />);
+    const button = getByRole("button", { name: "Toggle" });
+
+    expect(button).toBeInTheDocument();
+  });
+
+  it("should toggle pressed state on click", async () => {
+    const { getByRole, user } = setUp(<Toggle defaultPressed={false} />);
+    const button = getByRole("button", { name: "Toggle" });
+
+    expect(button).not.toHaveAttribute("data-pressed");
+
+    await user.click(button);
+    expect(button).toHaveAttribute("aria-pressed", "true");
+    expect(button).toHaveAttribute("data-pressed");
+
+    await user.click(button);
+    expect(button).not.toHaveAttribute("data-pressed");
+  });
+
+  it("should call onPressedChange when toggled", async () => {
+    const onPressedChange = mock();
+    const { getByRole, user } = setUp(<Toggle onPressedChange={onPressedChange} />);
+    const button = getByRole("button", { name: "Toggle" });
+
+    await user.click(button);
+    expect(onPressedChange).toHaveBeenCalledWith(true);
+  });
+
+  it("should have aria-disabled when disabled prop is true", () => {
+    const { getByRole } = setUp(<Toggle disabled />);
+    const button = getByRole("button", { name: "Toggle" });
+
+    expect(button).toHaveAttribute("aria-disabled", "true");
+    expect(button).toHaveAttribute("data-disabled");
+  });
+
+  it("should not toggle when disabled", async () => {
+    const onPressedChange = mock();
+    const { getByRole, user } = setUp(
+      <Toggle disabled defaultPressed={false} onPressedChange={onPressedChange} />,
+    );
+    const button = getByRole("button", { name: "Toggle" });
+
+    await user.click(button);
+    expect(button).not.toHaveAttribute("data-pressed");
+    expect(onPressedChange).not.toHaveBeenCalled();
+  });
+
+  it("should remain focusable when disabled", async () => {
+    const { getByRole, user } = setUp(<Toggle disabled />);
+    const button = getByRole("button", { name: "Toggle" });
+
+    await user.tab();
+    expect(button).toHaveFocus();
+  });
+
+  it("should support controlled pressed state", () => {
+    const { getByRole } = setUp(<Toggle pressed />);
+    const button = getByRole("button", { name: "Toggle" });
+
+    expect(button).toHaveAttribute("aria-pressed", "true");
+    expect(button).toHaveAttribute("data-pressed");
+  });
+
+  it("should support defaultPressed", () => {
+    const { getByRole } = setUp(<Toggle defaultPressed />);
+    const button = getByRole("button", { name: "Toggle" });
+
+    expect(button).toHaveAttribute("aria-pressed", "true");
+    expect(button).toHaveAttribute("data-pressed");
+  });
+});

--- a/packages/react-headless/toggle/src/useToggle.ts
+++ b/packages/react-headless/toggle/src/useToggle.ts
@@ -1,7 +1,7 @@
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import { useCallback, useMemo } from "react";
 
-import { buttonProps, dataAttr, elementProps } from "@seed-design/dom-utils";
+import { ariaAttr, buttonProps, dataAttr, elementProps } from "@seed-design/dom-utils";
 
 export interface UseToggleStateProps {
   pressed?: boolean;
@@ -53,6 +53,7 @@ export function useToggle(props: UseToggleProps) {
     rootProps: buttonProps({
       ...stateProps,
       "aria-pressed": isPressed,
+      "aria-disabled": ariaAttr(props.disabled),
       onClick() {
         if (props.disabled) return;
         toggle();

--- a/packages/react-headless/toggle/src/useToggle.ts
+++ b/packages/react-headless/toggle/src/useToggle.ts
@@ -52,7 +52,7 @@ export function useToggle(props: UseToggleProps) {
     stateProps,
     rootProps: buttonProps({
       ...stateProps,
-      "aria-pressed": isPressed,
+      "aria-pressed": isPressed ?? false,
       "aria-disabled": ariaAttr(props.disabled),
       onClick() {
         if (props.disabled) return;


### PR DESCRIPTION
## Summary
- `useToggle` 훅의 `rootProps`에 `aria-disabled` 속성을 추가합니다
- native `disabled` 대신 `aria-disabled="true"`를 사용하여 비활성 상태에서도 키보드 포커스를 유지합니다
- `useToggle` 테스트를 새로 작성합니다

## Test plan
- [x] `bun headless:build` 성공
- [x] `bun headless:test` 전체 통과 (289 tests, 0 fail)
- [x] `bun react:test` 전체 통과
- [x] disabled 상태에서 `aria-disabled="true"` 렌더링 확인
- [x] disabled 상태에서 클릭 시 toggle 동작하지 않는 것 확인
- [x] disabled 상태에서 Tab 포커스 가능한 것 확인

Resolves DES-1265

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Toggle 컴포넌트의 접근성 속성 개선: aria-pressed 및 aria-disabled가 비활성화 상태와 버튼 상태를 정확히 반영하도록 수정되었습니다.

* **Tests**
  * Toggle 컴포넌트의 렌더링, 토글 동작, onPressedChange 호출, 비활성화 동작, 포커스 유지, 제어/비제어 상태 및 접근성 속성을 검증하는 포괄적인 테스트 스위트가 추가되었습니다.

* **Chores**
  * 패치 릴리스용 변경 로그가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->