### PR TITLE
fix(figma): rename MenuSheet to MenuSheetRoot in menu-sheet handler

### DIFF
--- a/packages/figma/src/codegen/targets/react/component/handlers/menu-sheet.ts
+++ b/packages/figma/src/codegen/targets/react/component/handlers/menu-sheet.ts
@@ -105,7 +105,7 @@ export const createMenuSheetHandler = (ctx: ComponentHandlerDeps) => {
         createLocalSnippetElementTrigger("ActionButton", {}, "MenuSheet 열기"),
       );
 
-      return createLocalSnippetElement("MenuSheet", undefined, [trigger, content]);
+      return createLocalSnippetElement("MenuSheetRoot", undefined, [trigger, content]);
     },
   );
 };


### PR DESCRIPTION
- figma codegen 에 대해서 MenuSheetRott 의 컴포넌트 포맷으로 제공하기

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경사항**
  * 생성된 React 컴포넌트의 루트 요소 이름이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->