### PR TITLE
fix(color-grid): update token display to use identifier instead of index

### DIFF
--- a/docs/components/color-grid.tsx
+++ b/docs/components/color-grid.tsx
@@ -38,9 +38,9 @@ export async function ColorGrid(props: ColorGridProps) {
     <div className="flex flex-col gap-1 w-full">
       <div className="flex gap-1 justify-center">
         <div className="flex-1" />
-        {rows[0].tokens.map((_, i) => (
+        {rows[0].tokens.map((token, i) => (
           <div key={i} className="flex-1 text-xs text-center text-fd-muted-foreground">
-            {i * 100}
+            {token.identifier.split("-").at(-1)}
           </div>
         ))}
       </div>


### PR DESCRIPTION
## 변경 내용

컬러 그리드에서 헤더 레이블이 잘못 표시되는 버그를 수정했어요.

### 문제
헤더 레이블이 배열 인덱스 기반(`i * 100`)으로 계산되어 실제 토큰 스케일과 불일치했어요.
- Chromatic(carrot, blue 등) 토큰은 100부터 시작하지만 그리드는 0, 100, 200으로 표시

### 수정
https://feat-docs-color-grid.seed-design.pages.dev/docs/foundation/color/palette

토큰 identifier에서 직접 스케일 번호를 추출하도록 변경했어요.
- `$color.palette.carrot-100` → `"100"` 표시
- `$color.palette.gray-00` → `"00"` 표시


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 컬러 그리드 표시 방식이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->