### PR TITLE
feat: figma codegen changeset 추가

### DIFF
--- a/.changeset/all-parents-repair.md
+++ b/.changeset/all-parents-repair.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/figma": patch
+---
+
+TabsTrigger, ChipTabsTrigger Codegen 시 label 값이 누락되던 문제를 수정합니다. [`637f41d`](https://github.com/daangn/seed-design/commit/637f41d7dd8a0b9d1e580532289ea8ab4c08b491)

--- a/.changeset/shy-chairs-remain.md
+++ b/.changeset/shy-chairs-remain.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/figma": patch
+---
+
+MenuSheet Codegen 시 컴포넌트 이름이 `MenuSheet`로 잘못 생성되던 문제를 `MenuSheetRoot`로 수정합니다. [`0eab075`](https://github.com/daangn/seed-design/commit/0eab075680a2e77154d0ff8e4b3b8dc1b7a85ebf)

--- a/.changeset/wise-doors-shine.md
+++ b/.changeset/wise-doors-shine.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/figma": patch
+---
+
+BottomSheet Codegen 시 정적 컴포넌트 키 대신 props에서 동적으로 키를 참조하도록 수정하여 인스턴스 매칭 오류를 해결합니다. [`e2fb929`](https://github.com/daangn/seed-design/commit/e2fb929b49632193a4d0cec4fdd789e554ae4507)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* TabsTrigger 및 ChipTabsTrigger 코드 생성에서 누락되던 label 값이 이제 올바르게 포함됩니다.
* MenuSheet 코드 생성 시 생성되던 잘못된 컴포넌트 이름이 정확하게 수정되었습니다.
* BottomSheet 코드 생성에서 정적 키 대신 props에서 동적으로 키를 참조하도록 개선되어 인스턴스 매칭 오류가 해결됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->