### PR TITLE
feat(release-noti): release trigger slack message

### DIFF
--- a/.github/scripts/notify-release.js
+++ b/.github/scripts/notify-release.js
@@ -11,7 +11,6 @@ const IGNORED_LINE_PREFIXES = ["- Updated dependencies"];
 /** 순서 번호 이모지 */
 const NUMBER_EMOJIS = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣", "🔟"];
 const REPO = "daangn/seed-design";
-const INCLUDED_PACKAGES = new Set(["@seed-design/css", "@seed-design/react"]);
 
 /**
  * CHANGELOG 항목의 커밋 표기를 Slack 링크 표기로 변환
@@ -94,9 +93,7 @@ function main() {
     if (!latest) continue;
 
     const packageName = getPackageName(file);
-    if (INCLUDED_PACKAGES.has(packageName)) {
-      releases.push({ packageName, ...latest });
-    }
+    releases.push({ packageName, ...latest });
   }
 
   if (releases.length === 0) {
@@ -117,7 +114,7 @@ function main() {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "안녕하세요 프론트엔드 챕터 여러분~ 2주간 SEED 릴리즈 요약 전달드려요 :알잘딱:",
+        text: "안녕하세요 프론트엔드 챕터 여러분~ SEED 새로운 버전이 릴리즈되었어요 :알잘딱:",
       },
     },
     { type: "divider" },
@@ -155,7 +152,7 @@ function main() {
     type: "section",
     text: {
       type: "mrkdwn",
-      text: "질문이 있으시다면 #_design-system 에서 @design-system-fe-engineers 멘션 주세요 :wave:",
+      text: "질문이 있으시다면 #_design-system 채널에 남겨주세요 :wave: (테스트 중이라 멘션은 잠시 제외했어요.)",
     },
   });
 

--- a/.github/scripts/notify-release.js
+++ b/.github/scripts/notify-release.js
@@ -103,11 +103,14 @@ function main() {
   ];
 
   for (const release of releases) {
-    let text = `*${release.packageName}* v${release.version}\n`;
+    let text = `*${release.packageName}* \`v${release.version}\`\n`;
 
     for (const [sectionName, items] of Object.entries(release.sections)) {
       text += `${formatSectionName(sectionName)}\n`;
-      text += `${items.slice(0, 5).join("\n")}\n`;
+      text += `${items
+        .slice(0, 5)
+        .map((item) => item.replace(/^- /, "• "))
+        .join("\n")}\n`;
     }
 
     blocks.push({

--- a/.github/scripts/notify-release.js
+++ b/.github/scripts/notify-release.js
@@ -8,6 +8,9 @@ const prUrl = process.env.PR_URL;
 /** changeset이 자동 생성하는 노이즈 라인 접두사 목록 */
 const IGNORED_LINE_PREFIXES = ["- Updated dependencies"];
 
+/** 순서 번호 이모지 */
+const NUMBER_EMOJIS = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣", "🔟"];
+
 /**
  * CHANGELOG.md에서 가장 최신 버전 섹션을 추출
  * @param {string} content
@@ -34,8 +37,8 @@ function extractLatestVersion(content) {
           line.startsWith("- ") &&
           IGNORED_LINE_PREFIXES.every((prefix) => !line.startsWith(prefix)),
       )
-      // changeset 해시 제거: `- \`a1b2c3\`: 메시지` → `- 메시지`
-      .map((line) => line.replace(/^- [`']?[a-f0-9]{7,}[`']?:\s*/, "- "));
+      // changeset 해시를 `hash: 메시지` 형태로 변환
+      .map((line) => line.replace(/^- [`']?([a-f0-9]{7})[a-f0-9]*[`']?:\s*/, "- `$1`: "));
 
     if (items.length > 0) sections[sectionName] = items;
   }
@@ -54,16 +57,6 @@ function getPackageName(changelogPath) {
   } catch {
     return dir;
   }
-}
-
-/**
- * @param {string} name
- */
-function formatSectionName(name) {
-  if (name.includes("Major")) return "💥 Major Changes";
-  if (name.includes("Minor")) return "✨ Minor Changes";
-  if (name.includes("Patch")) return "🐛 Patch Changes";
-  return name;
 }
 
 function main() {
@@ -102,16 +95,15 @@ function main() {
     { type: "divider" },
   ];
 
-  for (const release of releases) {
-    let text = `*${release.packageName}* \`v${release.version}\`\n`;
+  for (const [i, release] of releases.entries()) {
+    const emoji = NUMBER_EMOJIS[i] ?? `${i + 1}.`;
+    const allItems = Object.values(release.sections).flat();
 
-    for (const [sectionName, items] of Object.entries(release.sections)) {
-      text += `${formatSectionName(sectionName)}\n`;
-      text += `${items
-        .slice(0, 5)
-        .map((item) => item.replace(/^- /, "• "))
-        .join("\n")}\n`;
-    }
+    const text = [
+      `${emoji} *${release.packageName}@${release.version}*`,
+      "",
+      ...allItems.slice(0, 10).map((item) => item.replace(/^- /, "")),
+    ].join("\n");
 
     blocks.push({
       type: "section",

--- a/.github/scripts/notify-release.js
+++ b/.github/scripts/notify-release.js
@@ -10,6 +10,26 @@ const IGNORED_LINE_PREFIXES = ["- Updated dependencies"];
 
 /** 순서 번호 이모지 */
 const NUMBER_EMOJIS = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣", "🔟"];
+const REPO = "daangn/seed-design";
+const INCLUDED_PACKAGES = new Set(["@seed-design/css", "@seed-design/react"]);
+
+/**
+ * CHANGELOG 항목의 커밋 표기를 Slack 링크 표기로 변환
+ * - [`abcdef1`](https://github.com/.../commit/abcdef1) -> <https://...|`abcdef1`>
+ * - `abcdef1`: ... -> <https://github.com/daangn/seed-design/commit/abcdef1|`abcdef1`>: ...
+ * @param {string} item
+ */
+function toSlackCommitLink(item) {
+  const withMarkdownLink = item.replace(
+    /\[`?([a-f0-9]{7,40})`?\]\((https:\/\/github\.com\/[^)]+\/commit\/[a-f0-9]{7,40})\)/gi,
+    (_, shortHash, url) => `<${url}|\`${shortHash}\`>`,
+  );
+
+  return withMarkdownLink.replace(
+    /^- [`']?([a-f0-9]{7,40})[`']?:\s*/i,
+    (_, hash) => `- <https://github.com/${REPO}/commit/${hash}|\`${hash.slice(0, 7)}\`>: `,
+  );
+}
 
 /**
  * CHANGELOG.md에서 가장 최신 버전 섹션을 추출
@@ -37,8 +57,7 @@ function extractLatestVersion(content) {
           line.startsWith("- ") &&
           IGNORED_LINE_PREFIXES.every((prefix) => !line.startsWith(prefix)),
       )
-      // changeset 해시를 `hash: 메시지` 형태로 변환
-      .map((line) => line.replace(/^- [`']?([a-f0-9]{7})[a-f0-9]*[`']?:\s*/, "- `$1`: "));
+      .map(toSlackCommitLink);
 
     if (items.length > 0) sections[sectionName] = items;
   }
@@ -75,7 +94,9 @@ function main() {
     if (!latest) continue;
 
     const packageName = getPackageName(file);
-    releases.push({ packageName, ...latest });
+    if (INCLUDED_PACKAGES.has(packageName)) {
+      releases.push({ packageName, ...latest });
+    }
   }
 
   if (releases.length === 0) {
@@ -92,6 +113,13 @@ function main() {
         text: "🌱 SEED Design 새 버전이 릴리즈됐어요!",
       },
     },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "안녕하세요 프론트엔드 챕터 여러분~ 2주간 SEED 릴리즈 요약 전달드려요 :알잘딱:",
+      },
+    },
     { type: "divider" },
   ];
 
@@ -102,7 +130,7 @@ function main() {
     const text = [
       `${emoji} *${release.packageName}@${release.version}*`,
       "",
-      ...allItems.slice(0, 10).map((item) => item.replace(/^- /, "")),
+      ...allItems.slice(0, 10).map((item) => `• ${item.replace(/^- /, "")}`),
     ].join("\n");
 
     blocks.push({
@@ -121,6 +149,14 @@ function main() {
         url: prUrl ?? "",
       },
     ],
+  });
+
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: "질문이 있으시다면 #_design-system 에서 @design-system-fe-engineers 멘션 주세요 :wave:",
+    },
   });
 
   // GITHUB_OUTPUT에 blocks 출력

--- a/.github/scripts/notify-release.js
+++ b/.github/scripts/notify-release.js
@@ -11,6 +11,8 @@ const IGNORED_LINE_PREFIXES = ["- Updated dependencies"];
 /** 순서 번호 이모지 */
 const NUMBER_EMOJIS = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣", "🔟"];
 const REPO = "daangn/seed-design";
+const VERSION_PATTERN =
+  String.raw`\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?`;
 
 /**
  * CHANGELOG 항목의 커밋 표기를 Slack 링크 표기로 변환
@@ -36,7 +38,9 @@ function toSlackCommitLink(item) {
  * @returns {{ version: string, sections: Record<string, string[]> } | null}
  */
 function extractLatestVersion(content) {
-  const versionMatch = content.match(/## (\d+\.\d+\.\d+)([\s\S]*?)(?=\n## \d|\n# |$)/);
+  const versionMatch = content.match(
+    new RegExp(`## (${VERSION_PATTERN})([\\s\\S]*?)(?=\\n## ${VERSION_PATTERN}|\\n# |$)`),
+  );
   if (!versionMatch) return null;
 
   const version = versionMatch[1];

--- a/.github/scripts/notify-release.js
+++ b/.github/scripts/notify-release.js
@@ -1,0 +1,133 @@
+// @ts-check
+const fs = require("node:fs");
+const path = require("node:path");
+
+const changelogFiles = process.env.CHANGELOG_FILES?.split("\n").filter(Boolean) ?? [];
+const prUrl = process.env.PR_URL;
+
+/**
+ * CHANGELOG.md에서 가장 최신 버전 섹션을 추출
+ * @param {string} content
+ * @returns {{ version: string, sections: Record<string, string[]> } | null}
+ */
+function extractLatestVersion(content) {
+  const versionMatch = content.match(/## (\d+\.\d+\.\d+)([\s\S]*?)(?=\n## \d|\n# |$)/);
+  if (!versionMatch) return null;
+
+  const version = versionMatch[1];
+  const body = versionMatch[2].trim();
+
+  /** @type {Record<string, string[]>} */
+  const sections = {};
+  const sectionRegex = /### (.+?)\n([\s\S]*?)(?=\n### |\n## |$)/g;
+  let match;
+
+  for (match = sectionRegex.exec(body); match !== null; match = sectionRegex.exec(body)) {
+    const sectionName = match[1].trim();
+    const items = match[2]
+      .split("\n")
+      .filter((line) => line.startsWith("- "))
+      // changeset 해시 제거: `- \`a1b2c3\`: 메시지` → `- 메시지`
+      .map((line) => line.replace(/^- [`']?[a-f0-9]{7,}[`']?:\s*/, "- "));
+
+    if (items.length > 0) sections[sectionName] = items;
+  }
+
+  return { version, sections };
+}
+
+/**
+ * @param {string} changelogPath
+ */
+function getPackageName(changelogPath) {
+  const dir = path.dirname(changelogPath);
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf8"));
+    return pkg.name;
+  } catch {
+    return dir;
+  }
+}
+
+/**
+ * @param {string} name
+ */
+function formatSectionName(name) {
+  if (name.includes("Major")) return "💥 Major Changes";
+  if (name.includes("Minor")) return "✨ Minor Changes";
+  if (name.includes("Patch")) return "🐛 Patch Changes";
+  return name;
+}
+
+function main() {
+  if (changelogFiles.length === 0) {
+    console.log("변경된 CHANGELOG.md 파일이 없어요.");
+    process.exit(0);
+  }
+
+  const releases = [];
+
+  for (const file of changelogFiles) {
+    if (!fs.existsSync(file)) continue;
+
+    const content = fs.readFileSync(file, "utf8");
+    const latest = extractLatestVersion(content);
+    if (!latest) continue;
+
+    const packageName = getPackageName(file);
+    releases.push({ packageName, ...latest });
+  }
+
+  if (releases.length === 0) {
+    console.log("파싱할 릴리즈가 없어요.");
+    process.exit(0);
+  }
+
+  // Block Kit 구성
+  const blocks = [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: "🌱 SEED Design 새 버전이 릴리즈됐어요!",
+      },
+    },
+    { type: "divider" },
+  ];
+
+  for (const release of releases) {
+    let text = `*${release.packageName}* v${release.version}\n`;
+
+    for (const [sectionName, items] of Object.entries(release.sections)) {
+      text += `${formatSectionName(sectionName)}\n`;
+      text += `${items.slice(0, 5).join("\n")}\n`;
+    }
+
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: text.trim() },
+    });
+  }
+
+  blocks.push({
+    type: "actions",
+    elements: [
+      {
+        type: "button",
+        style: "primary",
+        text: { type: "plain_text", text: "PR 보기" },
+        url: prUrl ?? "",
+      },
+    ],
+  });
+
+  // GITHUB_OUTPUT에 blocks 출력
+  const output = JSON.stringify(blocks);
+  const githubOutput = process.env.GITHUB_OUTPUT;
+  if (!githubOutput) throw new Error("GITHUB_OUTPUT 환경변수가 설정되지 않았어요.");
+  fs.appendFileSync(githubOutput, `blocks<<EOF\n${output}\nEOF\n`);
+
+  console.log("Slack payload 생성 완료!");
+}
+
+main();

--- a/.github/scripts/notify-release.js
+++ b/.github/scripts/notify-release.js
@@ -5,6 +5,9 @@ const path = require("node:path");
 const changelogFiles = process.env.CHANGELOG_FILES?.split("\n").filter(Boolean) ?? [];
 const prUrl = process.env.PR_URL;
 
+/** changeset이 자동 생성하는 노이즈 라인 접두사 목록 */
+const IGNORED_LINE_PREFIXES = ["- Updated dependencies"];
+
 /**
  * CHANGELOG.md에서 가장 최신 버전 섹션을 추출
  * @param {string} content
@@ -26,7 +29,11 @@ function extractLatestVersion(content) {
     const sectionName = match[1].trim();
     const items = match[2]
       .split("\n")
-      .filter((line) => line.startsWith("- "))
+      .filter(
+        (line) =>
+          line.startsWith("- ") &&
+          IGNORED_LINE_PREFIXES.every((prefix) => !line.startsWith(prefix)),
+      )
       // changeset 해시 제거: `- \`a1b2c3\`: 메시지` → `- 메시지`
       .map((line) => line.replace(/^- [`']?[a-f0-9]{7,}[`']?:\s*/, "- "));
 

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -1,9 +1,6 @@
 name: Release Notification
 
 on:
-  push:
-    branches:
-      - feat/release-noti
   pull_request:
     types: [closed]
     branches: [dev]
@@ -11,10 +8,9 @@ on:
 jobs:
   notify:
     name: Send Release Notification
-    # TODO: 테스트 후 아래 if 조건 복구
-    # if: |
-    #   github.event.pull_request.merged == true &&
-    #   github.event.pull_request.title == 'release: version packages'
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.title == 'release: version packages'
     runs-on: ubuntu-latest
 
     permissions:
@@ -24,24 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # TODO: 테스트 후 제거 — 현재 브랜치엔 CHANGELOG 변경이 없으므로 4b9b789 시점 파일을 덮어씀
-      - name: "[TEST] Restore CHANGELOG files from test commit"
-        if: github.event_name == 'push'
-        run: |
-          git fetch origin 4b9b78912e6b244df689d40f3a4a4caaa8c01a09
-          git checkout 4b9b78912e6b244df689d40f3a4a4caaa8c01a09 -- \
-            packages/css/CHANGELOG.md \
-            packages/figma/CHANGELOG.md \
-            packages/react/CHANGELOG.md \
-            packages/react-headless/field-button/CHANGELOG.md \
-            packages/react-headless/slider/CHANGELOG.md \
-            packages/react-headless/toggle/CHANGELOG.md \
-            packages/tailwind3-plugin/CHANGELOG.md \
-            packages/tailwind4-theme/CHANGELOG.md
-
       - name: Get changed CHANGELOG files
         id: changelogs
-        if: github.event_name == 'pull_request'
         run: |
           FILES=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
             --jq '[.[] | select(.filename | endswith("CHANGELOG.md")) | .filename] | join("\n")')
@@ -51,28 +31,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      # TODO: 테스트 후 제거 — PR #1273 (4b9b789) 기준 파일 목록 하드코딩
-      - name: "[TEST] Set test CHANGELOG files for push trigger"
-        id: test_changelogs
-        if: github.event_name == 'push'
-        run: |
-          echo "files<<EOF" >> $GITHUB_OUTPUT
-          echo "packages/css/CHANGELOG.md" >> $GITHUB_OUTPUT
-          echo "packages/figma/CHANGELOG.md" >> $GITHUB_OUTPUT
-          echo "packages/react/CHANGELOG.md" >> $GITHUB_OUTPUT
-          echo "packages/react-headless/field-button/CHANGELOG.md" >> $GITHUB_OUTPUT
-          echo "packages/react-headless/slider/CHANGELOG.md" >> $GITHUB_OUTPUT
-          echo "packages/react-headless/toggle/CHANGELOG.md" >> $GITHUB_OUTPUT
-          echo "packages/tailwind3-plugin/CHANGELOG.md" >> $GITHUB_OUTPUT
-          echo "packages/tailwind4-theme/CHANGELOG.md" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
       - name: Build Slack payload
         id: payload
         run: node .github/scripts/notify-release.js
         env:
-          CHANGELOG_FILES: ${{ steps.changelogs.outputs.files || steps.test_changelogs.outputs.files }}
-          PR_URL: ${{ github.event_name == 'push' && 'https://github.com/daangn/seed-design/pull/1273' || github.event.pull_request.html_url }}
+          CHANGELOG_FILES: ${{ steps.changelogs.outputs.files }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
 
       - name: Send Slack notification
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
@@ -80,6 +44,6 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            channel: ${{ secrets.SLACK_NOTI_CHANNEL_ID }}
+            channel: ${{ secrets.SLACK_FRONTEND_CHANNEL_ID }}
             text: "🌱 SEED Design 새 버전이 릴리즈됐어요!"
             blocks: ${{ steps.payload.outputs.blocks }}

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -1,6 +1,9 @@
 name: Release Notification
 
 on:
+  push:
+    branches:
+      - feat/release-noti
   pull_request:
     types: [closed]
     branches: [dev]
@@ -8,9 +11,10 @@ on:
 jobs:
   notify:
     name: Send Release Notification
-    if: |
-      github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'changeset-release/dev')
+    # TODO: 테스트 후 아래 if 조건 복구
+    # if: |
+    #   github.event.pull_request.merged == true &&
+    #   github.event.pull_request.title == 'release: version packages'
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -22,10 +22,22 @@ jobs:
       pull-requests: read
 
     steps:
-      # TODO: 테스트 후 ref 제거
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event_name == 'push' && '4b9b78912e6b244df689d40f3a4a4caaa8c01a09' || github.sha }}
+
+      # TODO: 테스트 후 제거 — 현재 브랜치엔 CHANGELOG 변경이 없으므로 4b9b789 시점 파일을 덮어씀
+      - name: "[TEST] Restore CHANGELOG files from test commit"
+        if: github.event_name == 'push'
+        run: |
+          git fetch origin 4b9b78912e6b244df689d40f3a4a4caaa8c01a09
+          git checkout 4b9b78912e6b244df689d40f3a4a4caaa8c01a09 -- \
+            packages/css/CHANGELOG.md \
+            packages/figma/CHANGELOG.md \
+            packages/react/CHANGELOG.md \
+            packages/react-headless/field-button/CHANGELOG.md \
+            packages/react-headless/slider/CHANGELOG.md \
+            packages/react-headless/toggle/CHANGELOG.md \
+            packages/tailwind3-plugin/CHANGELOG.md \
+            packages/tailwind4-theme/CHANGELOG.md
 
       - name: Get changed CHANGELOG files
         id: changelogs

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -22,10 +22,14 @@ jobs:
       pull-requests: read
 
     steps:
+      # TODO: 테스트 후 ref 제거
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'push' && '4b9b78912e6b244df689d40f3a4a4caaa8c01a09' || github.sha }}
 
       - name: Get changed CHANGELOG files
         id: changelogs
+        if: github.event_name == 'pull_request'
         run: |
           FILES=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
             --jq '[.[] | select(.filename | endswith("CHANGELOG.md")) | .filename] | join("\n")')
@@ -35,12 +39,28 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      # TODO: 테스트 후 제거 — PR #1273 (4b9b789) 기준 파일 목록 하드코딩
+      - name: "[TEST] Set test CHANGELOG files for push trigger"
+        id: test_changelogs
+        if: github.event_name == 'push'
+        run: |
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "packages/css/CHANGELOG.md" >> $GITHUB_OUTPUT
+          echo "packages/figma/CHANGELOG.md" >> $GITHUB_OUTPUT
+          echo "packages/react/CHANGELOG.md" >> $GITHUB_OUTPUT
+          echo "packages/react-headless/field-button/CHANGELOG.md" >> $GITHUB_OUTPUT
+          echo "packages/react-headless/slider/CHANGELOG.md" >> $GITHUB_OUTPUT
+          echo "packages/react-headless/toggle/CHANGELOG.md" >> $GITHUB_OUTPUT
+          echo "packages/tailwind3-plugin/CHANGELOG.md" >> $GITHUB_OUTPUT
+          echo "packages/tailwind4-theme/CHANGELOG.md" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Build Slack payload
         id: payload
         run: node .github/scripts/notify-release.js
         env:
-          CHANGELOG_FILES: ${{ steps.changelogs.outputs.files }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          CHANGELOG_FILES: ${{ steps.changelogs.outputs.files || steps.test_changelogs.outputs.files }}
+          PR_URL: ${{ github.event_name == 'push' && 'https://github.com/daangn/seed-design/pull/1273' || github.event.pull_request.html_url }}
 
       - name: Send Slack notification
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
@@ -48,6 +68,6 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            channel: ${{ secrets.SLACK_NOTI_CHANNEL_ID }}
             text: "🌱 SEED Design 새 버전이 릴리즈됐어요!"
             blocks: ${{ steps.payload.outputs.blocks }}

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -1,0 +1,49 @@
+name: Release Notification
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [dev]
+
+jobs:
+  notify:
+    name: Send Release Notification
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'changeset-release/dev')
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Get changed CHANGELOG files
+        id: changelogs
+        run: |
+          FILES=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
+            --jq '[.[] | select(.filename | endswith("CHANGELOG.md")) | .filename] | join("\n")')
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "$FILES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Build Slack payload
+        id: payload
+        run: node .github/scripts/notify-release.js
+        env:
+          CHANGELOG_FILES: ${{ steps.changelogs.outputs.files }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "🌱 SEED Design 새 버전이 릴리즈됐어요!"
+            blocks: ${{ steps.payload.outputs.blocks }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit
- 우선 noti-seed-test 채널 로 알림이 가도록 세팅 (release pr 머지될 때 잘 동작하는 거 확인 후 프론트엔드 챕터로 보내볼 예정)

## 릴리스 노트

* **Chores**
  * 릴리스 병합 시 CHANGELOG 내용을 취합해 Slack에 포맷된 블록 메시지로 자동 발송되도록 GitHub Actions 워크플로와 스크립트를 추가했습니다.
  * PR의 변경된 패키지별 최신 버전 항목을 최대 항목 수로 제한하여 요약하고, PR 링크를 포함한 액션 버튼을 포함합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->