### PR TITLE
fix(react-headless): fix focused trigger not being updated when navigating different tabs

### DIFF
--- a/.changeset/lazy-birds-rush.md
+++ b/.changeset/lazy-birds-rush.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react-tabs": patch
+---
+
+Tabs trigger에 포커스 후 키보드 조작으로 탭 변경 시 탭은 변경되지만 포커스가 이동하지 않는 문제를 수정합니다.

--- a/docs/stories/Tabs.stories.tsx
+++ b/docs/stories/Tabs.stories.tsx
@@ -9,13 +9,15 @@ import { createStoryWithParameters } from "@/stories/utils/parameters";
 
 const Component = (props: TabsRootProps) => {
   return (
-    <TabsRoot {...props}>
-      <TabsList>
-        <TabsTrigger value="1">Tab 1</TabsTrigger>
-        <TabsTrigger value="2">Tab 2</TabsTrigger>
-        <TabsTrigger value="3">Tab 3</TabsTrigger>
-      </TabsList>
-    </TabsRoot>
+    <div style={{ width: "100%" }}>
+      <TabsRoot {...props}>
+        <TabsList>
+          <TabsTrigger value="1">Tab 1</TabsTrigger>
+          <TabsTrigger value="2">Tab 2</TabsTrigger>
+          <TabsTrigger value="3">Tab 3</TabsTrigger>
+        </TabsList>
+      </TabsRoot>
+    </div>
   );
 };
 

--- a/docs/stories/Tabs.stories.tsx
+++ b/docs/stories/Tabs.stories.tsx
@@ -1,33 +1,28 @@
 import type { Meta, StoryObj } from "@storybook/nextjs";
 
-import {
-  ChipTabsRoot,
-  ChipTabsRootProps,
-  ChipTabsTrigger,
-  ChipTabsList,
-} from "seed-design/ui/chip-tabs";
+import { TabsRoot, TabsRootProps, TabsTrigger, TabsList } from "seed-design/ui/tabs";
 
-import { chipTabsVariantMap } from "@seed-design/css/recipes/chip-tabs";
+import { tabsVariantMap } from "@seed-design/css/recipes/tabs";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
 import { createStoryWithParameters } from "@/stories/utils/parameters";
 
-const Component = (props: ChipTabsRootProps) => {
+const Component = (props: TabsRootProps) => {
   return (
-    <ChipTabsRoot {...props}>
-      <ChipTabsList>
-        <ChipTabsTrigger value="1">Tab 1</ChipTabsTrigger>
-        <ChipTabsTrigger value="2">Tab 2</ChipTabsTrigger>
-        <ChipTabsTrigger value="3">Tab 3</ChipTabsTrigger>
-      </ChipTabsList>
-    </ChipTabsRoot>
+    <TabsRoot {...props}>
+      <TabsList>
+        <TabsTrigger value="1">Tab 1</TabsTrigger>
+        <TabsTrigger value="2">Tab 2</TabsTrigger>
+        <TabsTrigger value="3">Tab 3</TabsTrigger>
+      </TabsList>
+    </TabsRoot>
   );
 };
 
 const meta = {
-  component: ChipTabsRoot,
+  component: TabsRoot,
   decorators: [SeedThemeDecorator],
-} satisfies Meta<typeof ChipTabsRoot>;
+} satisfies Meta<typeof TabsRoot>;
 
 export default meta;
 
@@ -38,7 +33,7 @@ const CommonStoryTemplate: Story = {
     defaultValue: "1",
   },
   render: function Render(args) {
-    return <VariantTable Component={Component} variantMap={chipTabsVariantMap} {...args} />;
+    return <VariantTable Component={Component} variantMap={tabsVariantMap} {...args} />;
   },
 };
 

--- a/packages/react-headless/tabs/src/dom.ts
+++ b/packages/react-headless/tabs/src/dom.ts
@@ -8,6 +8,10 @@ export const getContentId = (value: string, id: string) => `tabs:${value}:${id}:
 /* Query -----------------------------------------------------------------------
 -------------------------------------------------------------------------------- */
 
+export const getTriggerByValue = (listEl: HTMLElement, value: string): HTMLElement | null => {
+  return listEl.querySelector(`[data-value="${value}"]`);
+};
+
 export const getEnabledValues = (el: HTMLElement) => {
   if (!el) return [];
   return Array.from(el.children)

--- a/packages/react-headless/tabs/src/useTabs.test.tsx
+++ b/packages/react-headless/tabs/src/useTabs.test.tsx
@@ -52,15 +52,23 @@ function Tabs(props: React.PropsWithChildren<UseTabsProps>) {
 function TabsList(props: React.PropsWithChildren) {
   const { api } = useTabsContext();
   const { listProps: tabTriggerListProps } = api;
-  return <div {...tabTriggerListProps}>{props.children}</div>;
+  return (
+    <div ref={api.refs.list} {...tabTriggerListProps}>
+      {props.children}
+    </div>
+  );
 }
 
 function TabsTrigger(props: React.PropsWithChildren<TriggerProps>) {
   const { api } = useTabsContext();
   const { getTriggerProps: getTabsTriggerProps } = api;
-  const { rootProps } = getTabsTriggerProps(props);
+  const triggerProps = getTabsTriggerProps(props);
 
-  return <button {...rootProps}>{props.children}</button>;
+  return (
+    <button ref={triggerProps.refs.root} {...triggerProps.rootProps}>
+      {props.children}
+    </button>
+  );
 }
 
 function TabsContent(props: React.PropsWithChildren<ContentProps>) {
@@ -146,6 +154,98 @@ describe("useTabs", () => {
     expect(queryByText(tabItems.tab2.label)).toBeInTheDocument();
     expect(queryByText(tabItems.tab1.content)).toBeInTheDocument();
     expect(queryByText(tabItems.tab2.content)).toBeInTheDocument();
+  });
+
+  describe("keyboard navigation", () => {
+    it("should move focus and selection with ArrowRight", async () => {
+      const { queryByText, user } = setUp(
+        <UncontrolledTabs items={tabItems} tabsProps={{ defaultValue: tabItems.tab1.value }} />,
+      );
+
+      const tab1 = queryByText(tabItems.tab1.label)!;
+      const tab2 = queryByText(tabItems.tab2.label)!;
+
+      await user.click(tab1);
+      await user.keyboard("{ArrowRight}");
+
+      expect(tab2).toHaveAttribute("data-selected");
+      expect(tab2).toHaveFocus();
+    });
+
+    it("should move focus and selection with ArrowLeft", async () => {
+      const { queryByText, user } = setUp(
+        <UncontrolledTabs items={tabItems} tabsProps={{ defaultValue: tabItems.tab2.value }} />,
+      );
+
+      const tab1 = queryByText(tabItems.tab1.label)!;
+      const tab2 = queryByText(tabItems.tab2.label)!;
+
+      await user.click(tab2);
+      await user.keyboard("{ArrowLeft}");
+
+      expect(tab1).toHaveAttribute("data-selected");
+      expect(tab1).toHaveFocus();
+    });
+
+    it("should cycle from last to first with ArrowRight", async () => {
+      const { queryByText, user } = setUp(
+        <UncontrolledTabs items={tabItems} tabsProps={{ defaultValue: tabItems.tab3.value }} />,
+      );
+
+      const tab1 = queryByText(tabItems.tab1.label)!;
+      const tab3 = queryByText(tabItems.tab3.label)!;
+
+      await user.click(tab3);
+      await user.keyboard("{ArrowRight}");
+
+      expect(tab1).toHaveAttribute("data-selected");
+      expect(tab1).toHaveFocus();
+    });
+
+    it("should move focus with Home and End", async () => {
+      const { queryByText, user } = setUp(
+        <UncontrolledTabs items={tabItems} tabsProps={{ defaultValue: tabItems.tab2.value }} />,
+      );
+
+      const tab1 = queryByText(tabItems.tab1.label)!;
+      const tab2 = queryByText(tabItems.tab2.label)!;
+      const tab3 = queryByText(tabItems.tab3.label)!;
+
+      await user.click(tab2);
+      await user.keyboard("{End}");
+
+      expect(tab3).toHaveAttribute("data-selected");
+      expect(tab3).toHaveFocus();
+
+      await user.keyboard("{Home}");
+
+      expect(tab1).toHaveAttribute("data-selected");
+      expect(tab1).toHaveFocus();
+    });
+
+    it("should skip disabled tabs when navigating", async () => {
+      const itemsWithDisabled = {
+        tab1: { value: "Tab 1", label: "Label 1", content: "Content 1" },
+        tab2: { value: "Tab 2", label: "Label 2", content: "Content 2", disabled: true },
+        tab3: { value: "Tab 3", label: "Label 3", content: "Content 3" },
+      } as const satisfies Record<string, TabItem>;
+
+      const { queryByText, user } = setUp(
+        <UncontrolledTabs
+          items={itemsWithDisabled}
+          tabsProps={{ defaultValue: itemsWithDisabled.tab1.value }}
+        />,
+      );
+
+      const tab1 = queryByText(itemsWithDisabled.tab1.label)!;
+      const tab3 = queryByText(itemsWithDisabled.tab3.label)!;
+
+      await user.click(tab1);
+      await user.keyboard("{ArrowRight}");
+
+      expect(tab3).toHaveAttribute("data-selected");
+      expect(tab3).toHaveFocus();
+    });
   });
 
   describe("disabled tab test", () => {

--- a/packages/react-headless/tabs/src/useTabs.ts
+++ b/packages/react-headless/tabs/src/useTabs.ts
@@ -48,6 +48,15 @@ function useTabsState(props: UseTabsStateProps) {
     }
   }, [selectedTriggerEl, listEl]);
 
+  const focusTriggerByValue = useCallback(
+    (value: string) => {
+      if (listEl) {
+        dom.getTriggerByValue(listEl, value)?.focus();
+      }
+    },
+    [listEl],
+  );
+
   const selectPrevAction = useCallback(() => {
     const prevValue = enabledValues[prevIndex];
     if (!prevValue) return;
@@ -100,56 +109,102 @@ function useTabsState(props: UseTabsStateProps) {
   const arrowPrevEvent = useCallback(() => {
     if (interactionState === "focused") {
       actions.selectPrev();
+      focusTriggerByValue(enabledValues[prevIndex] ?? "");
       if (isFocusVisibleSupported) {
         setIsFocusVisible(true);
       }
     }
-  }, [interactionState, actions.selectPrev, isFocusVisibleSupported]);
+  }, [
+    interactionState,
+    actions.selectPrev,
+    focusTriggerByValue,
+    enabledValues,
+    prevIndex,
+    isFocusVisibleSupported,
+  ]);
 
   const arrowNextEvent = useCallback(() => {
     if (interactionState === "focused") {
       actions.selectNext();
+      focusTriggerByValue(enabledValues[nextIndex] ?? "");
       if (isFocusVisibleSupported) {
         setIsFocusVisible(true);
       }
     }
-  }, [interactionState, actions.selectNext, isFocusVisibleSupported]);
+  }, [
+    interactionState,
+    actions.selectNext,
+    focusTriggerByValue,
+    enabledValues,
+    nextIndex,
+    isFocusVisibleSupported,
+  ]);
 
   const arrowUpEvent = useCallback(() => {
     if (interactionState === "focused") {
       actions.selectPrev();
+      focusTriggerByValue(enabledValues[prevIndex] ?? "");
       if (isFocusVisibleSupported) {
         setIsFocusVisible(true);
       }
     }
-  }, [interactionState, actions.selectPrev, isFocusVisibleSupported]);
+  }, [
+    interactionState,
+    actions.selectPrev,
+    focusTriggerByValue,
+    enabledValues,
+    prevIndex,
+    isFocusVisibleSupported,
+  ]);
 
   const arrowDownEvent = useCallback(() => {
     if (interactionState === "focused") {
       actions.selectNext();
+      focusTriggerByValue(enabledValues[nextIndex] ?? "");
       if (isFocusVisibleSupported) {
         setIsFocusVisible(true);
       }
     }
-  }, [interactionState, actions.selectNext, isFocusVisibleSupported]);
+  }, [
+    interactionState,
+    actions.selectNext,
+    focusTriggerByValue,
+    enabledValues,
+    nextIndex,
+    isFocusVisibleSupported,
+  ]);
 
   const homeEvent = useCallback(() => {
     if (interactionState === "focused") {
       actions.selectFirst();
+      focusTriggerByValue(enabledValues[0] ?? "");
       if (isFocusVisibleSupported) {
         setIsFocusVisible(true);
       }
     }
-  }, [interactionState, actions.selectFirst, isFocusVisibleSupported]);
+  }, [
+    interactionState,
+    actions.selectFirst,
+    focusTriggerByValue,
+    enabledValues,
+    isFocusVisibleSupported,
+  ]);
 
   const endEvent = useCallback(() => {
     if (interactionState === "focused") {
       actions.selectLast();
+      focusTriggerByValue(enabledValues[enabledValues.length - 1] ?? "");
       if (isFocusVisibleSupported) {
         setIsFocusVisible(true);
       }
     }
-  }, [interactionState, actions.selectLast, isFocusVisibleSupported]);
+  }, [
+    interactionState,
+    actions.selectLast,
+    focusTriggerByValue,
+    enabledValues,
+    isFocusVisibleSupported,
+  ]);
 
   const tabFocusEvent = useCallback(
     (value: string) => {


### PR DESCRIPTION
## Summary
- Tabs 컴포넌트에서 ←/→/Home/End 키로 탭 전환 시 포커스가 함께 이동하지 않던 버그 수정
- 키보드 핸들러에서 DOM 쿼리를 통해 다음 트리거 엘리먼트를 찾아 직접 `.focus()` 호출
- 테스트 픽스처의 ref 연결 누락 수정 및 키보드 네비게이션 테스트 케이스 5개 추가
- Tabs variant stories 추가, ChipTabs stories의 `value` → `defaultValue` 수정

## Test plan
- [x] `bun headless:test` 통과 (331 tests, 0 fail)
- [x] `bun react:test` 통과
- [ ] Storybook에서 Tabs 키보드 네비게이션 수동 확인

Closes DES-1299

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 탭 키보드 네비게이션 시 새로 선택된 탭으로 포커스가 이동하지 않던 문제 해결

* **문서**
  * Tabs 컴포넌트에 대한 Storybook 문서 추가 (라이트/다크 테마, 폰트 스케일링 변형 포함)

* **테스트**
  * 키보드 네비게이션 포커스 관리 포괄 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->