### PR TITLE
fix(react-headless): prevent default scroll on tabs keyboard navigation

### DIFF
--- a/.changeset/thirty-guests-rescue.md
+++ b/.changeset/thirty-guests-rescue.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react-tabs": patch
+---
+
+Tabs trigger에 포커스된 상태에서 키보드 조작 시 스크롤 등 브라우저 기본 동작이 발생하지 않도록 수정합니다.

--- a/packages/react-headless/tabs/src/useTabs.ts
+++ b/packages/react-headless/tabs/src/useTabs.ts
@@ -407,25 +407,31 @@ export function useTabs(props: UseTabsProps) {
         switch (event.key) {
           case "ArrowLeft":
             if (orientation !== "horizontal") return;
+            event.preventDefault();
             events.arrowPrev();
             break;
           case "ArrowRight":
             if (orientation !== "horizontal") return;
+            event.preventDefault();
             events.arrowNext();
             break;
           case "ArrowUp":
             if (orientation !== "vertical") return;
+            event.preventDefault();
             events.arrowPrev();
             break;
           case "ArrowDown":
             if (orientation !== "vertical") return;
+            event.preventDefault();
             events.arrowNext();
             break;
           case "Home": {
+            event.preventDefault();
             events.home();
             break;
           }
           case "End": {
+            event.preventDefault();
             events.end();
             break;
           }


### PR DESCRIPTION
## Summary
- Call `event.preventDefault()` on Arrow, Home, and End key events within the tab list to prevent browser default scroll behavior

## Test plan
- [x] `bun headless:test` passing
- [x] `bun react:test` passing
- [ ] Verify Home/End keys don't scroll the page in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* Tabs 컴포넌트에서 화살표 키, Home, End 키를 사용한 키보드 네비게이션 시 브라우저의 기본 동작(스크롤, 선택 등)이 더 이상 발생하지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->