### PR TITLE
fix: fix `layerOffset*` in AppScreen bleeding into AppBar DOM

### DIFF
--- a/.changeset/curly-clowns-throw.md
+++ b/.changeset/curly-clowns-throw.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/stackflow": patch
+---
+
+AppScreen에 `layerOffsetTop` 또는 `layerOffsetBottom` 사용 시 해당 속성에 AppBar DOM에 attribute로 설정되는 문제를 수정합니다.

--- a/.changeset/curly-clowns-throw.md
+++ b/.changeset/curly-clowns-throw.md
@@ -2,4 +2,4 @@
 "@seed-design/stackflow": patch
 ---
 
-AppScreen에 `layerOffsetTop` 또는 `layerOffsetBottom` 사용 시 해당 속성에 AppBar DOM에 attribute로 설정되는 문제를 수정합니다.
+AppScreen에 `layerOffsetTop` 또는 `layerOffsetBottom` 사용 시 해당 속성이 AppBar DOM에 attribute로 설정되는 문제를 수정합니다.

--- a/packages/stackflow/src/components/AppScreen/AppScreen.tsx
+++ b/packages/stackflow/src/components/AppScreen/AppScreen.tsx
@@ -6,6 +6,7 @@ import { createStyleContext } from "../../utils/createStyleContext";
 import { AppBarPropsProvider } from "../AppBar/AppBar";
 import { useTopActivity } from "../../primitive/private/useTopActivity";
 import { useActivity } from "@stackflow/react";
+import { appBar } from "@seed-design/css/recipes/app-bar";
 
 const { ClassNamesProvider, PropsProvider, withContext, useProps } = createStyleContext(appScreen);
 
@@ -36,12 +37,17 @@ export const AppScreenRoot = forwardRef<HTMLDivElement, AppScreenRootProps>((pro
       : (topActivityTransitionStyle as NonNullable<AppScreenVariantProps["transitionStyle"]>),
   });
 
+  const [appBarVariantProps] = useMemo(
+    () => appBar.splitVariantProps(variantProps),
+    [variantProps],
+  );
+
   return (
     <ClassNamesProvider value={classNames}>
       <AppBarPropsProvider
         value={useMemo(
-          () => ({ ...variantProps, transitionStyle }),
-          [variantProps, transitionStyle],
+          () => ({ ...appBarVariantProps, transitionStyle }),
+          [appBarVariantProps, transitionStyle],
         )}
       >
         <AppScreenPrimitive.Root


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * AppScreen에서 layerOffsetTop 또는 layerOffsetBottom 속성 사용 시 이들이 AppBar DOM에 불필요한 속성으로 추가되는 문제를 해결했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->