### PR TITLE
fix: fix TagGroupRoot showing unnecessary separators when conditionally rendering TagGroupItem

### DIFF
--- a/.changeset/goofy-planets-shout.md
+++ b/.changeset/goofy-planets-shout.md
@@ -1,0 +1,12 @@
+---
+"@seed-design/react": patch
+---
+
+TagGroupRoot 내부에서 `""`, 0 등 falsy한 값으로 조건부 렌더링 시 불필요한 separator가 표시될 수 있는 문제를 수정합니다.
+
+```tsx
+<TagGroupRoot>
+  {distance && <TagGroupItem label=`${distance}m` />} // distance === 0인 경우 separator 표시되는 문제 수정
+  {label && <TagGroupItem label={label} />} // label === ""인 경우 separator 표시되는 문제 수정
+</TagGroupRoot>
+```

--- a/.changeset/goofy-planets-shout.md
+++ b/.changeset/goofy-planets-shout.md
@@ -6,7 +6,9 @@ TagGroupRoot 내부에서 `""`, 0 등 falsy한 값으로 조건부 렌더링 시
 
 ```tsx
 <TagGroupRoot>
-  {distance && <TagGroupItem label=`${distance}m` />} // distance === 0인 경우 separator 표시되는 문제 수정
-  {label && <TagGroupItem label={label} />} // label === ""인 경우 separator 표시되는 문제 수정
+  {distance && <TagGroupItem label={`${distance}m`} />} // distance === 0인 경우
+  separator 표시되는 문제 수정
+  {label && <TagGroupItem label={label} />} // label === ""인 경우 separator
+  표시되는 문제 수정
 </TagGroupRoot>
 ```

--- a/packages/react/src/components/TagGroup/TagGroup.tsx
+++ b/packages/react/src/components/TagGroup/TagGroup.tsx
@@ -31,7 +31,10 @@ export const TagGroupRoot = forwardRef<HTMLSpanElement, TagGroupRootProps>(
       <PropsProvider value={tagGroupItemVariantProps}>
         <Primitive.span ref={ref} className={clsx(classNames.root, className)} {...otherProps}>
           {Children.toArray(children)
-            .filter((child) => child !== null && child !== undefined)
+            // putting something other than TagGroupItem in TagGroupRoot is not a good idea,
+            // but we shouldn't throw an error for it either
+            // thus .filter(React.isValidElement) is too strict here
+            .filter(Boolean)
             .map((child, index) => (
               // biome-ignore lint/suspicious/noArrayIndexKey: those fragments won't change order
               <Fragment key={index}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * TagGroup 컴포넌트에서 조건부 렌더링 시 빈 문자열("")이나 0 같은 거짓값으로 인해 불필요한 구분자가 표시되던 문제를 수정했습니다.
* **잡무(Chore)**
  * 해당 수정 사항을 반영한 패치 릴리스 문서를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->