### PR TITLE
feat(rootage): add kind: Breakpoints support

### DIFF
--- a/ecosystem/rootage/cli/src/index.ts
+++ b/ecosystem/rootage/cli/src/index.ts
@@ -6,6 +6,7 @@ import {
   css,
   runGenerator,
   exchange,
+  getBreakpointEntries,
   getComponentSpecDeclarations,
   getSourceFiles,
   getTokenCollectionDeclarations,
@@ -257,6 +258,22 @@ async function writeFile(filePath: string, content: string) {
   }
 }
 
+async function writeBreakpointsTs() {
+  const { ctx } = await prepare();
+  const tsStringifier = typescript.createStringifier();
+  const entries = getBreakpointEntries(ctx);
+
+  if (entries.length === 0) return;
+
+  const mjsCode = tsStringifier.getBreakpointsMjs(entries);
+  const mjsWritePath = path.join(process.cwd(), dir, "breakpoint.mjs");
+  writeFileSync({ filename: "breakpoint.mjs", code: mjsCode, writePath: mjsWritePath });
+
+  const dtsCode = tsStringifier.getBreakpointsDts(entries);
+  const dtsWritePath = path.join(process.cwd(), dir, "breakpoint.d.ts");
+  writeFileSync({ filename: "breakpoint.d.ts", code: dtsCode, writePath: dtsWritePath });
+}
+
 async function writeTailwind3Plugin(prefix?: string): Promise<string> {
   const { ctx } = await prepare();
   const tokens = getTokenDeclarations(ctx);
@@ -399,6 +416,22 @@ yargs(process.argv.slice(2))
     async () => {
       console.log("Start");
       await writeJson();
+      console.log("Done");
+    },
+  )
+  .command(
+    "breakpoints-ts <dir>",
+    "Generate TypeScript breakpoints",
+    (yargs) => {
+      return yargs.positional("dir", {
+        describe: "Output directory",
+        type: "string",
+        default: "./",
+      });
+    },
+    async () => {
+      console.log("Start");
+      await writeBreakpointsTs();
       console.log("Done");
     },
   )

--- a/ecosystem/rootage/core/src/analyzer/context.ts
+++ b/ecosystem/rootage/core/src/analyzer/context.ts
@@ -1,4 +1,5 @@
 import type {
+  BreakpointEntry,
   ComponentSpecDeclaration,
   TokenCollectionDeclaration,
   TokenDeclaration,
@@ -98,6 +99,10 @@ export function buildContext(files: SourceFile[]): RootageCtx {
     .map((x) => x.ast)
     .filter((x) => x.kind === "ComponentSpecDocument")
     .map((x) => x.data);
+  const breakpointEntries = files
+    .map((x) => x.ast)
+    .filter((x) => x.kind === "BreakpointsDocument")
+    .flatMap((x) => x.data);
 
   const tokenIds = tokens.map((x) => x.token.identifier);
   const tokenEntities = Object.fromEntries(tokens.map((x) => [x.token.identifier, x]));
@@ -118,7 +123,12 @@ export function buildContext(files: SourceFile[]): RootageCtx {
     componentSpecEntities,
     dependencyGraph,
     referenceGraph,
+    breakpointEntries,
   };
+}
+
+export function getBreakpointEntries(ctx: RootageCtx): BreakpointEntry[] {
+  return ctx.breakpointEntries;
 }
 
 export function getSourceFiles(ctx: RootageCtx): SourceFile[] {

--- a/ecosystem/rootage/core/src/analyzer/index.ts
+++ b/ecosystem/rootage/core/src/analyzer/index.ts
@@ -1,5 +1,6 @@
 export {
   buildContext,
+  getBreakpointEntries,
   getComponentSpecDeclarations,
   getTokenCollectionDeclarations,
   getTokenDeclarations,

--- a/ecosystem/rootage/core/src/analyzer/types.ts
+++ b/ecosystem/rootage/core/src/analyzer/types.ts
@@ -35,7 +35,11 @@ export interface ReferenceGraph {
 
 export interface SourceFile {
   fileName: string;
-  ast: AST.TokensDocument | AST.TokenCollectionsDocument | AST.ComponentSpecDocument;
+  ast:
+    | AST.TokensDocument
+    | AST.TokenCollectionsDocument
+    | AST.ComponentSpecDocument
+    | AST.BreakpointsDocument;
 }
 
 export interface RootageCtx {
@@ -48,4 +52,5 @@ export interface RootageCtx {
   componentSpecEntities: Record<string, AST.ComponentSpecDeclaration>;
   dependencyGraph: DependencyGraph;
   referenceGraph: ReferenceGraph;
+  breakpointEntries: AST.BreakpointEntry[];
 }

--- a/ecosystem/rootage/core/src/languages/exchange/index.ts
+++ b/ecosystem/rootage/core/src/languages/exchange/index.ts
@@ -2,7 +2,11 @@ import type { AST, Authoring, Exchange } from "../../parser";
 import { compactObject } from "../../utils/compact";
 
 export function getModel(
-  ast: AST.TokensDocument | AST.TokenCollectionsDocument | AST.ComponentSpecDocument,
+  ast:
+    | AST.TokensDocument
+    | AST.TokenCollectionsDocument
+    | AST.ComponentSpecDocument
+    | AST.BreakpointsDocument,
 ): Exchange.Model {
   switch (ast.kind) {
     case "TokenCollectionsDocument":
@@ -11,7 +15,20 @@ export function getModel(
       return getTokensModel(ast);
     case "ComponentSpecDocument":
       return getComponentSpecModel(ast);
+    case "BreakpointsDocument":
+      return getBreakpointsModel(ast);
   }
+}
+
+export function getBreakpointsModel(ast: AST.BreakpointsDocument): Exchange.BreakpointsModel {
+  const metadata = getMetadata(ast.metadata);
+  return {
+    kind: "Breakpoints",
+    metadata,
+    data: {
+      breakpoints: Object.fromEntries(ast.data.map((e) => [e.name, e.minWidth])),
+    },
+  };
 }
 
 export function getTokenCollectionsModel(

--- a/ecosystem/rootage/core/src/languages/typescript.test.ts
+++ b/ecosystem/rootage/core/src/languages/typescript.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it, test } from "bun:test";
 import YAML from "yaml";
 import { Authoring } from "../parser";
+import * as factory from "../parser/factory";
 import { createStringifier } from "./typescript";
 
-const { getComponentSpecDts, getComponentSpecMjs, getTokenDts, getTokenMjs } = createStringifier({
+const {
+  getComponentSpecDts,
+  getComponentSpecMjs,
+  getTokenDts,
+  getTokenMjs,
+  getBreakpointsMjs,
+  getBreakpointsDts,
+} = createStringifier({
   prefix: "test",
 });
 
@@ -528,4 +536,68 @@ test("getTokenDts should generate JSDoc for token descriptions", () => {
       },
     ]
   `);
+});
+
+describe("getBreakpointsMjs", () => {
+  it("should generate raw numbers and up queries", () => {
+    const entries = [
+      factory.createBreakpointEntry("base", 0),
+      factory.createBreakpointEntry("sm", 480),
+      factory.createBreakpointEntry("md", 768),
+      factory.createBreakpointEntry("lg", 1280),
+      factory.createBreakpointEntry("xl", 1440),
+    ];
+
+    const result = getBreakpointsMjs(entries);
+
+    expect(result).toMatchInlineSnapshot(`
+      "export const base = 0;
+      export const sm = 480;
+      export const md = 768;
+      export const lg = 1280;
+      export const xl = 1440;
+      export const smUp = "(min-width: 480px)";
+      export const mdUp = "(min-width: 768px)";
+      export const lgUp = "(min-width: 1280px)";
+      export const xlUp = "(min-width: 1440px)";"
+    `);
+  });
+
+  it("should sort entries by minWidth", () => {
+    const entries = [
+      factory.createBreakpointEntry("lg", 1280),
+      factory.createBreakpointEntry("base", 0),
+      factory.createBreakpointEntry("sm", 480),
+    ];
+
+    const result = getBreakpointsMjs(entries);
+
+    expect(result).toMatchInlineSnapshot(`
+      "export const base = 0;
+      export const sm = 480;
+      export const lg = 1280;
+      export const smUp = "(min-width: 480px)";
+      export const lgUp = "(min-width: 1280px)";"
+    `);
+  });
+});
+
+describe("getBreakpointsDts", () => {
+  it("should generate literal types", () => {
+    const entries = [
+      factory.createBreakpointEntry("base", 0),
+      factory.createBreakpointEntry("sm", 480),
+      factory.createBreakpointEntry("md", 768),
+    ];
+
+    const result = getBreakpointsDts(entries);
+
+    expect(result).toMatchInlineSnapshot(`
+      "export declare const base: 0;
+      export declare const sm: 480;
+      export declare const md: 768;
+      export declare const smUp: "(min-width: 480px)";
+      export declare const mdUp: "(min-width: 768px)";"
+    `);
+  });
 });

--- a/ecosystem/rootage/core/src/languages/typescript.ts
+++ b/ecosystem/rootage/core/src/languages/typescript.ts
@@ -1,5 +1,6 @@
 import { camelCase } from "change-case";
 import type {
+  BreakpointEntry,
   ComponentSpecDeclaration,
   StateExpression,
   TokenDeclaration,
@@ -281,6 +282,38 @@ export function createStringifier(options: { prefix?: string } = {}) {
     return generateTokenCode(groups, true);
   }
 
+  function getBreakpointsMjs(entries: BreakpointEntry[]): string {
+    const sorted = [...entries].sort((a, b) => a.minWidth - b.minWidth);
+    const lines: string[] = [];
+
+    for (const entry of sorted) {
+      lines.push(`export const ${entry.name} = ${entry.minWidth};`);
+    }
+
+    for (const entry of sorted) {
+      if (entry.minWidth === 0) continue;
+      lines.push(`export const ${entry.name}Up = "(min-width: ${entry.minWidth}px)";`);
+    }
+
+    return lines.join("\n");
+  }
+
+  function getBreakpointsDts(entries: BreakpointEntry[]): string {
+    const sorted = [...entries].sort((a, b) => a.minWidth - b.minWidth);
+    const lines: string[] = [];
+
+    for (const entry of sorted) {
+      lines.push(`export declare const ${entry.name}: ${entry.minWidth};`);
+    }
+
+    for (const entry of sorted) {
+      if (entry.minWidth === 0) continue;
+      lines.push(`export declare const ${entry.name}Up: "(min-width: ${entry.minWidth}px)";`);
+    }
+
+    return lines.join("\n");
+  }
+
   return {
     getComponentSpecMjs,
     getComponentSpecDts,
@@ -288,5 +321,7 @@ export function createStringifier(options: { prefix?: string } = {}) {
     getComponentSpecIndexDts,
     getTokenMjs,
     getTokenDts,
+    getBreakpointsMjs,
+    getBreakpointsDts,
   };
 }

--- a/ecosystem/rootage/core/src/parser/ast.ts
+++ b/ecosystem/rootage/core/src/parser/ast.ts
@@ -361,6 +361,19 @@ export interface ComponentSpecDocument {
   data: ComponentSpecDeclaration;
 }
 
+// Breakpoints
+export interface BreakpointEntry {
+  kind: "BreakpointEntry";
+  name: string;
+  minWidth: number;
+}
+
+export interface BreakpointsDocument {
+  kind: "BreakpointsDocument";
+  metadata: MetadataDeclaration;
+  data: BreakpointEntry[];
+}
+
 export type Node =
   | ColorHexLit
   | DimensionLit
@@ -407,4 +420,6 @@ export type Node =
   | VariantExpression
   | VariantDeclaration
   | ComponentSpecDeclaration
-  | ComponentSpecDocument;
+  | ComponentSpecDocument
+  | BreakpointEntry
+  | BreakpointsDocument;

--- a/ecosystem/rootage/core/src/parser/authoring/breakpoints.test.ts
+++ b/ecosystem/rootage/core/src/parser/authoring/breakpoints.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import * as factory from "../factory";
+import { fromString } from "./parse";
+
+describe("parseBreakpointsDocument", () => {
+  it("should parse breakpoints YAML to AST", () => {
+    const yaml = `
+kind: Breakpoints
+metadata:
+  id: breakpoint
+  name: Breakpoint
+data:
+  breakpoints:
+    base: 0
+    sm: 480
+    md: 768
+    lg: 1280
+    xl: 1440
+`;
+
+    const result = fromString(yaml);
+
+    expect(result).toEqual(
+      factory.createBreakpointsDocument(
+        factory.createMetadataDeclaration([
+          factory.createMetadataFieldDeclaration("id", "breakpoint"),
+          factory.createMetadataFieldDeclaration("name", "Breakpoint"),
+        ]),
+        [
+          factory.createBreakpointEntry("base", 0),
+          factory.createBreakpointEntry("sm", 480),
+          factory.createBreakpointEntry("md", 768),
+          factory.createBreakpointEntry("lg", 1280),
+          factory.createBreakpointEntry("xl", 1440),
+        ],
+      ),
+    );
+  });
+
+  it("should sort entries by minWidth regardless of YAML order", () => {
+    const yaml = `
+kind: Breakpoints
+metadata:
+  id: breakpoint
+  name: Breakpoint
+data:
+  breakpoints:
+    xl: 1440
+    base: 0
+    sm: 480
+`;
+
+    const result = fromString(yaml);
+
+    expect(result.kind).toBe("BreakpointsDocument");
+    if (result.kind === "BreakpointsDocument") {
+      expect(result.data.map((e) => e.name)).toEqual(["base", "sm", "xl"]);
+    }
+  });
+});

--- a/ecosystem/rootage/core/src/parser/authoring/parse.ts
+++ b/ecosystem/rootage/core/src/parser/authoring/parse.ts
@@ -1,13 +1,20 @@
 import * as YAML from "yaml";
-import type { ComponentSpecDocument, TokenCollectionsDocument, TokensDocument } from "../ast";
+import type {
+  BreakpointsDocument,
+  ComponentSpecDocument,
+  TokenCollectionsDocument,
+  TokensDocument,
+} from "../ast";
+import * as factory from "../factory";
 import { parseComponentSpecDocument } from "./component-spec";
+import { parseMetadataDeclaration } from "./metadata";
 import type * as Document from "./types";
 import { parseTokenCollectionsDocument } from "./token-collections";
 import { parseTokensDocument } from "./tokens";
 
 export function fromString(
   text: string,
-): TokenCollectionsDocument | TokensDocument | ComponentSpecDocument {
+): TokenCollectionsDocument | TokensDocument | ComponentSpecDocument | BreakpointsDocument {
   const model = YAML.parse(text) as Document.Model;
 
   return fromObject(model);
@@ -15,7 +22,7 @@ export function fromString(
 
 export function fromObject(
   model: Document.Model,
-): TokenCollectionsDocument | TokensDocument | ComponentSpecDocument {
+): TokenCollectionsDocument | TokensDocument | ComponentSpecDocument | BreakpointsDocument {
   switch (model.kind) {
     case "TokenCollections":
       return parseTokenCollectionsDocument(model);
@@ -23,8 +30,18 @@ export function fromObject(
       return parseTokensDocument(model);
     case "ComponentSpec":
       return parseComponentSpecDocument(model);
+    case "Breakpoints":
+      return parseBreakpointsDocument(model);
     default:
       // @ts-expect-error
       throw new Error(`Unknown document kind: ${model.kind}`);
   }
+}
+
+function parseBreakpointsDocument(model: Document.BreakpointsModel): BreakpointsDocument {
+  const metadata = parseMetadataDeclaration(model.metadata);
+  const entries = Object.entries(model.data.breakpoints)
+    .map(([name, minWidth]) => factory.createBreakpointEntry(name, minWidth))
+    .sort((a, b) => a.minWidth - b.minWidth);
+  return factory.createBreakpointsDocument(metadata, entries);
 }

--- a/ecosystem/rootage/core/src/parser/authoring/types.ts
+++ b/ecosystem/rootage/core/src/parser/authoring/types.ts
@@ -133,4 +133,16 @@ export interface ComponentSpecSchema {
   variants: ComponentSpecVariantSchema;
 }
 
-export type Model = TokenCollectionsModel | TokensModel | ComponentSpecModel;
+export interface BreakpointsModel {
+  kind: "Breakpoints";
+  metadata: {
+    id: string;
+    name: string;
+    [key: string]: string | number | boolean;
+  };
+  data: {
+    breakpoints: Record<string, number>;
+  };
+}
+
+export type Model = TokenCollectionsModel | TokensModel | ComponentSpecModel | BreakpointsModel;

--- a/ecosystem/rootage/core/src/parser/exchange/parse.ts
+++ b/ecosystem/rootage/core/src/parser/exchange/parse.ts
@@ -1,4 +1,10 @@
-import type { ComponentSpecDocument, TokenCollectionsDocument, TokensDocument } from "../ast";
+import type {
+  BreakpointsDocument,
+  ComponentSpecDocument,
+  TokenCollectionsDocument,
+  TokensDocument,
+} from "../ast";
+import * as factory from "../factory";
 import { parseComponentSpecDocument } from "./component-spec";
 import type * as Document from "./types";
 import { parseTokenCollectionsDocument } from "./token-collections";
@@ -6,7 +12,7 @@ import { parseTokensDocument } from "./tokens";
 
 export function fromString(
   text: string,
-): TokenCollectionsDocument | TokensDocument | ComponentSpecDocument {
+): TokenCollectionsDocument | TokensDocument | ComponentSpecDocument | BreakpointsDocument {
   const model = JSON.parse(text) as Document.Model;
 
   return fromObject(model);
@@ -14,7 +20,7 @@ export function fromString(
 
 export function fromObject(
   model: Document.Model,
-): TokenCollectionsDocument | TokensDocument | ComponentSpecDocument {
+): TokenCollectionsDocument | TokensDocument | ComponentSpecDocument | BreakpointsDocument {
   switch (model.kind) {
     case "TokenCollections":
       return parseTokenCollectionsDocument(model);
@@ -22,8 +28,22 @@ export function fromObject(
       return parseTokensDocument(model);
     case "ComponentSpec":
       return parseComponentSpecDocument(model);
+    case "Breakpoints":
+      return parseBreakpointsDocument(model);
     default:
       // @ts-expect-error
       throw new Error(`Unknown document kind: ${model.kind}`);
   }
+}
+
+function parseBreakpointsDocument(model: Document.BreakpointsModel): BreakpointsDocument {
+  const metadata = factory.createMetadataDeclaration(
+    Object.entries(model.metadata).map(([key, value]) =>
+      factory.createMetadataFieldDeclaration(key, value),
+    ),
+  );
+  const entries = Object.entries(model.data.breakpoints)
+    .map(([name, minWidth]) => factory.createBreakpointEntry(name, minWidth))
+    .sort((a, b) => a.minWidth - b.minWidth);
+  return factory.createBreakpointsDocument(metadata, entries);
 }

--- a/ecosystem/rootage/core/src/parser/exchange/types.ts
+++ b/ecosystem/rootage/core/src/parser/exchange/types.ts
@@ -149,4 +149,16 @@ export interface TokenCollectionsModel {
   }>;
 }
 
-export type Model = ComponentSpecModel | TokensModel | TokenCollectionsModel;
+export interface BreakpointsModel {
+  kind: "Breakpoints";
+  metadata: {
+    id: string;
+    name: string;
+    [key: string]: string | number | boolean;
+  };
+  data: {
+    breakpoints: Record<string, number>;
+  };
+}
+
+export type Model = ComponentSpecModel | TokensModel | TokenCollectionsModel | BreakpointsModel;

--- a/ecosystem/rootage/core/src/parser/factory.ts
+++ b/ecosystem/rootage/core/src/parser/factory.ts
@@ -52,6 +52,8 @@ import type {
   SlotSchemaDeclaration,
   VariantSchemaDeclaration,
   VariantValueSchemaDeclaration,
+  BreakpointEntry,
+  BreakpointsDocument,
 } from "./ast";
 
 /**
@@ -913,4 +915,15 @@ export function createComponentSpecDocument(
     metadata,
     data,
   };
+}
+
+export function createBreakpointEntry(name: string, minWidth: number): BreakpointEntry {
+  return { kind: "BreakpointEntry", name, minWidth };
+}
+
+export function createBreakpointsDocument(
+  metadata: MetadataDeclaration,
+  data: BreakpointEntry[],
+): BreakpointsDocument {
+  return { kind: "BreakpointsDocument", metadata, data };
 }

--- a/ecosystem/rootage/core/src/parser/visit.ts
+++ b/ecosystem/rootage/core/src/parser/visit.ts
@@ -121,5 +121,15 @@ export function visitEachChild<T extends Node>(node: T, fn: (node: Node) => Node
         ...node,
         value: fn(node.value),
       };
+
+    // Breakpoints
+    case "BreakpointsDocument":
+      return {
+        ...node,
+        metadata: fn(node.metadata),
+        data: node.data.map((entry) => fn(entry)),
+      };
+    case "BreakpointEntry":
+      return node;
   }
 }

--- a/packages/qvism-preset/package.json
+++ b/packages/qvism-preset/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "clean": "rm -rf lib",
     "build:generator": "bun build ./src/seed-css.ts --outfile=./lib/seed-css.js --target=node",
-    "rootage:generate": "bun run build:generator && bun rootage token-css ./src --generator ./lib/seed-css.js --prefix seed && bun run ./write-tokens.mjs --prefix seed && bun rootage token-ts ./src/vars --prefix seed && rootage component-spec ./src/vars/component --prefix seed",
+    "rootage:generate": "bun run build:generator && bun rootage token-css ./src --generator ./lib/seed-css.js --prefix seed && bun run ./write-tokens.mjs --prefix seed && bun rootage token-ts ./src/vars --prefix seed && rootage component-spec ./src/vars/component --prefix seed && rootage breakpoints-ts ./src/vars",
     "build": "bunchee",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/qvism-preset/src/vars/breakpoint.d.ts
+++ b/packages/qvism-preset/src/vars/breakpoint.d.ts
@@ -1,0 +1,9 @@
+export declare const base: 0;
+export declare const sm: 480;
+export declare const md: 768;
+export declare const lg: 1280;
+export declare const xl: 1440;
+export declare const smUp: "(min-width: 480px)";
+export declare const mdUp: "(min-width: 768px)";
+export declare const lgUp: "(min-width: 1280px)";
+export declare const xlUp: "(min-width: 1440px)";

--- a/packages/qvism-preset/src/vars/breakpoint.mjs
+++ b/packages/qvism-preset/src/vars/breakpoint.mjs
@@ -1,0 +1,9 @@
+export const base = 0;
+export const sm = 480;
+export const md = 768;
+export const lg = 1280;
+export const xl = 1440;
+export const smUp = "(min-width: 480px)";
+export const mdUp = "(min-width: 768px)";
+export const lgUp = "(min-width: 1280px)";
+export const xlUp = "(min-width: 1440px)";

--- a/packages/rootage/breakpoint.yaml
+++ b/packages/rootage/breakpoint.yaml
@@ -1,0 +1,11 @@
+kind: Breakpoints
+metadata:
+  id: breakpoint
+  name: Breakpoint
+data:
+  breakpoints:
+    base: 0
+    sm: 480
+    md: 768
+    lg: 1280
+    xl: 1440


### PR DESCRIPTION
## Summary

- rootage에 새 document kind `Breakpoints` 추가 (YAML → AST → TypeScript 생성)
- `@media` 쿼리에서 CSS custom property를 사용할 수 없으므로, CSS 변수 대신 **raw number + min-width 쿼리 문자열**을 TypeScript 상수로 생성
- CLI에 `breakpoints-ts <dir>` 커맨드 추가, `packages/rootage/breakpoint.yaml` SSOT 정의 포함

## 논의가 필요한 부분: Breakpoints의 위계

현재 Breakpoints를 Tokens / TokenCollections / ComponentSpec과 **같은 레벨의 document kind**로 추가했습니다. 이 설계가 적절한지 논의가 필요합니다.

### 기존 document kind와의 비교

| | 컬렉션/모드 | CSS 변수 생성 | 토큰 참조 | 중첩 구조 |
|---|---|---|---|---|
| Tokens | ✅ | ✅ | ✅ | ✅ |
| TokenCollections | ✅ | – | – | – |
| ComponentSpec | – | ✅ | ✅ | ✅ |
| **Breakpoints** | ❌ | ❌ | ❌ | ❌ |

Breakpoints는 사실상 **flat key-value config**입니다. 같은 Document kind로 올리면 AST 노드, factory, visitor, authoring/exchange parser, analyzer context를 모두 확장해야 하는데, 이 인프라를 거쳐도 결국 TS 상수만 나옵니다.

### 고려할 수 있는 대안

1. **`kind: Config` 범용 타입** — breakpoints를 특수 인스턴스로 처리하여, 향후 z-index layers 등 유사한 static config도 같은 메커니즘으로 수용
2. **rootage 외부 별도 config** — 단, single source of truth 원칙이 깨짐
3. **현재 접근 유지** — 일관성 우선. 추후 비슷한 static config 추가 시 패턴 재사용 가능

### 추상화 비용 vs 가치

- **비용**: 새 document kind 하나에 AST 2타입, factory 2함수, visitor 2case, parser 2개(authoring/exchange), analyzer context 확장 필요
- **가치**: YAML single source of truth, 기존 CLI/생성 파이프라인 재사용, 타입 안전성

이 트레이드오프에 대한 의견을 남겨주세요.

## Test plan

- [x] `bun rootage:test` — 87 pass (breakpoints parser + TS generator 테스트 포함)
- [x] `bun rootage:generate` — breakpoint.mjs + .d.ts 생성 확인
- [ ] 소비처(qvism-preset, css/breakpoints) 연결은 별도 PR(DES-1313)에서 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)