### PR TITLE
test: add visual snapshot stories for layout components

### DIFF
--- a/docs/stories/Box.stories.tsx
+++ b/docs/stories/Box.stories.tsx
@@ -44,32 +44,32 @@ const conditionMap = {
   condition: {
     bare: {},
     // not tested here: inset(t/r/b/l), position, display, zIndex
-    "padding": { padding: "x4" },
+    padding: { padding: "x4" },
     "px/py": { px: "x6", py: "x2" },
     "width/height": { width: "200px", height: "80px" },
     "width full": { width: "full", borderWidth: 1, borderColor: "palette.gray900" },
-    "minHeight": { minHeight: "300px", borderWidth: 1, borderColor: "palette.gray900" },
-    "minWidth": { minWidth: "100px", borderWidth: 1, borderColor: "palette.gray900" },
-    "maxHeight": { maxHeight: "x5", borderWidth: 1, borderColor: "palette.gray900" },
-    "maxWidth": { maxWidth: "x5", borderWidth: 1, borderColor: "palette.gray900" },
-    "bg": { bg: "palette.gray600" },
-    "bgGradient": { bgGradient: "highlightMagic", bgGradientDirection: "to right" },
-    "border": {
+    minHeight: { minHeight: "300px", borderWidth: 1, borderColor: "palette.gray900" },
+    minWidth: { minWidth: "100px", borderWidth: 1, borderColor: "palette.gray900" },
+    maxHeight: { maxHeight: "x5", borderWidth: 1, borderColor: "palette.gray900" },
+    maxWidth: { maxWidth: "x5", borderWidth: 1, borderColor: "palette.gray900" },
+    bg: { bg: "palette.gray600" },
+    bgGradient: { bgGradient: "highlightMagic", bgGradientDirection: "to right" },
+    border: {
       borderWidth: 4,
       borderColor: "palette.red600",
       borderRadius: "r4",
       borderRightWidth: 16,
       borderBottomRightRadius: "r2",
     },
-    "shadow": { boxShadow: "s3" },
+    shadow: { boxShadow: "s3" },
     "overflow hidden": {
       width: "x5",
       height: "x5",
       overflowX: "hidden",
       overflowY: "hidden",
     },
-    "bleedX": { bleedX: "x4" },
-    "color": { color: "fg.brand" },
+    bleedX: { bleedX: "x4" },
+    color: { color: "fg.brand" },
   },
 };
 
@@ -80,6 +80,74 @@ export const LightTheme: Story = {
       Component={meta.component}
       variantMap={{}}
       conditionMap={conditionMap}
+      {...args}
+    />
+  ),
+};
+
+const Placeholder = ({ label }: { label: string }) => (
+  <Box
+    bg="bg.informativeWeak"
+    color="fg.informativeContrast"
+    display="flex"
+    alignItems="center"
+    justifyContent="center"
+    borderRadius="r2"
+    width="full"
+    minWidth="x8"
+    height="full"
+    minHeight="x8"
+  >
+    {label}
+  </Box>
+);
+
+const nestedConditionMap = {
+  condition: {
+    layout: {
+      display: "flex",
+      flexDirection: "row",
+      gap: "x6",
+      width: "full",
+      height: "200px",
+      children: (
+        <>
+          <Box width="200px" height="full">
+            <Placeholder label="200px" />
+          </Box>
+          <Box flexGrow>
+            <Placeholder label="grow" />
+          </Box>
+        </>
+      ),
+    },
+    "nested stacks": {
+      display: "flex",
+      flexDirection: "column",
+      gap: "x8",
+      children: (
+        <>
+          <Box display="flex" flexDirection="row" gap="x4">
+            <Placeholder label="A1" />
+            <Placeholder label="A2" />
+            <Placeholder label="A3" />
+          </Box>
+          <Box display="flex" flexDirection="row" gap="x4">
+            <Placeholder label="B1" />
+            <Placeholder label="B2" />
+          </Box>
+        </>
+      ),
+    },
+  },
+};
+
+export const Nested: Story = {
+  render: (args) => (
+    <VariantTable
+      Component={meta.component}
+      variantMap={{}}
+      conditionMap={nestedConditionMap}
       {...args}
     />
   ),

--- a/docs/stories/Box.stories.tsx
+++ b/docs/stories/Box.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+
+import { Box } from "@seed-design/react";
+import { VariantTable } from "./components/variant-table";
+import { SeedThemeDecorator } from "./components/decorator";
+
+const meta = {
+  component: Box,
+  decorators: [SeedThemeDecorator],
+} satisfies Meta<typeof Box>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const Swatch = ({ label }: { label?: string }) => (
+  <div
+    style={{
+      width: 48,
+      height: 48,
+      background: "skyblue",
+      borderRadius: 9999,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      color: "blue",
+      fontSize: 12,
+    }}
+  >
+    {label}
+  </div>
+);
+
+const children = (
+  <>
+    <Swatch label="A" />
+    <Swatch label="B" />
+    <Swatch label="C" />
+    <span>test</span>
+  </>
+);
+
+const conditionMap = {
+  condition: {
+    bare: {},
+    // not tested here: inset(t/r/b/l), position, display, zIndex
+    "padding": { padding: "x4" },
+    "px/py": { px: "x6", py: "x2" },
+    "width/height": { width: "200px", height: "80px" },
+    "width full": { width: "full", borderWidth: 1, borderColor: "palette.gray900" },
+    "minHeight": { minHeight: "300px", borderWidth: 1, borderColor: "palette.gray900" },
+    "minWidth": { minWidth: "100px", borderWidth: 1, borderColor: "palette.gray900" },
+    "maxHeight": { maxHeight: "x5", borderWidth: 1, borderColor: "palette.gray900" },
+    "maxWidth": { maxWidth: "x5", borderWidth: 1, borderColor: "palette.gray900" },
+    "bg": { bg: "palette.gray600" },
+    "bgGradient": { bgGradient: "highlightMagic", bgGradientDirection: "to right" },
+    "border": {
+      borderWidth: 4,
+      borderColor: "palette.red600",
+      borderRadius: "r4",
+      borderRightWidth: 16,
+      borderBottomRightRadius: "r2",
+    },
+    "shadow": { boxShadow: "s3" },
+    "overflow hidden": {
+      width: "x5",
+      height: "x5",
+      overflowX: "hidden",
+      overflowY: "hidden",
+    },
+    "bleedX": { bleedX: "x4" },
+    "color": { color: "fg.brand" },
+  },
+};
+
+export const LightTheme: Story = {
+  args: { children },
+  render: (args) => (
+    <VariantTable
+      Component={meta.component}
+      variantMap={{}}
+      conditionMap={conditionMap}
+      {...args}
+    />
+  ),
+};

--- a/docs/stories/Flex.stories.tsx
+++ b/docs/stories/Flex.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+
+import { Flex } from "@seed-design/react";
+import { VariantTable } from "./components/variant-table";
+import { SeedThemeDecorator } from "./components/decorator";
+
+const meta = {
+  component: Flex,
+  decorators: [SeedThemeDecorator],
+} satisfies Meta<typeof Flex>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const Swatch = ({ label }: { label?: string }) => (
+  <div
+    style={{
+      width: 48,
+      height: 48,
+      background: "skyblue",
+      borderRadius: 9999,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      color: "blue",
+      fontSize: 12,
+    }}
+  >
+    {label}
+  </div>
+);
+
+const children = (
+  <>
+    <Swatch label="A" />
+    <Swatch label="B" />
+    <Swatch label="C" />
+    <span>test</span>
+  </>
+);
+
+const manyChildren = (
+  <>
+    {Array.from({ length: 8 }, (_, i) => (
+      <Swatch key={i} label={`${i + 1}`} />
+    ))}
+  </>
+);
+
+const conditionMap = {
+  condition: {
+    bare: {},
+    // not tested here: alignSelf, justifySelf, flexGrow, flexShrink
+    "direction row": { direction: "row" },
+    "direction column": { direction: "column" },
+    "gap": { gap: "x4" },
+    "align center": { align: "center" },
+    "align stretch": { align: "stretch" },
+    "justify center": { justify: "center" },
+    "justify space-between": { justify: "space-between", width: "500px" },
+    wrap: { wrap: "wrap" , children: manyChildren, width: "200px" },
+    "display none": { display: "none" },
+  },
+};
+
+export const LightTheme: Story = {
+  args: { children },
+  render: (args) => (
+    <VariantTable
+      Component={meta.component}
+      variantMap={{}}
+      conditionMap={conditionMap}
+      {...args}
+    />
+  ),
+};

--- a/docs/stories/Flex.stories.tsx
+++ b/docs/stories/Flex.stories.tsx
@@ -54,12 +54,12 @@ const conditionMap = {
     // not tested here: alignSelf, justifySelf, flexGrow, flexShrink
     "direction row": { direction: "row" },
     "direction column": { direction: "column" },
-    "gap": { gap: "x4" },
-    "align center": { align: "center" },
-    "align stretch": { align: "stretch" },
-    "justify center": { justify: "center" },
+    gap: { gap: "x4" },
+    "align center": { align: "center", height: "200px" },
+    "align flex-end": { align: "flex-end", height: "200px" },
+    "justify center": { justify: "center", width: "500px" },
     "justify space-between": { justify: "space-between", width: "500px" },
-    wrap: { wrap: "wrap" , children: manyChildren, width: "200px" },
+    wrap: { wrap: "wrap", children: manyChildren, width: "200px" },
     "display none": { display: "none" },
   },
 };

--- a/docs/stories/Grid.stories.tsx
+++ b/docs/stories/Grid.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+
+import { Grid, GridItem } from "@seed-design/react";
+import { VariantTable } from "./components/variant-table";
+import { SeedThemeDecorator } from "./components/decorator";
+
+const meta = {
+  component: Grid,
+  decorators: [SeedThemeDecorator],
+} satisfies Meta<typeof Grid>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const Swatch = ({ label }: { label?: string }) => (
+  <div
+    style={{
+      minWidth: 48,
+      minHeight: 48,
+      background: "skyblue",
+      borderRadius: 9999,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      color: "blue",
+      fontSize: 12,
+    }}
+  >
+    {label}
+  </div>
+);
+
+const children = (
+  <>
+    <Swatch label="1" />
+    <Swatch label="2" />
+    <Swatch label="3" />
+    <Swatch label="4" />
+    <Swatch label="5" />
+    <Swatch label="6" />
+  </>
+);
+
+const conditionMap = {
+  condition: {
+    bare: {},
+    // not tested here: alignItems, justifyItems, autoFlow
+    "columns number": { columns: 3 },
+    "columns string": { columns: "1fr 2fr" },
+    "rows number": { rows: 2 },
+    "rows string": { rows: "100px auto" },
+    gap: { columns: 3, gap: "x4" },
+    autoRows: { columns: 3, autoRows: "80px" },
+    autoColumns: { autoFlow: "column", autoColumns: "120px" },
+    "display none": { display: "none" },
+  },
+};
+
+export const LightTheme: Story = {
+  args: { children },
+  render: (args) => (
+    <VariantTable
+      Component={meta.component}
+      variantMap={{}}
+      conditionMap={conditionMap}
+      {...args}
+    />
+  ),
+};
+
+/** GridItem: colSpan, rowSpan, colStart/colEnd */
+export const GridItemSpan: Story = {
+  render: () => (
+    <Grid columns={3} gap="8px" width="400px">
+      <GridItem colSpan={2}>
+        <Swatch label="col×2" />
+      </GridItem>
+      <Swatch label="1" />
+      <GridItem colSpan="full">
+        <Swatch label="full" />
+      </GridItem>
+      <GridItem colStart={2} colEnd={4}>
+        <Swatch label="2→4" />
+      </GridItem>
+      <GridItem rowSpan={2}>
+        <Swatch label="row×2" />
+      </GridItem>
+      <Swatch label="1" />
+      <Swatch label="1" />
+      <Swatch label="1" />
+    </Grid>
+  ),
+};

--- a/docs/stories/Stack.stories.tsx
+++ b/docs/stories/Stack.stories.tsx
@@ -44,10 +44,10 @@ const vstackConditionMap = {
   condition: {
     bare: {},
     gap: { gap: "x4" },
-    "align center": { align: "center" },
-    "align stretch": { align: "stretch" },
-    "justify center": { justify: "center", height: "300px" },
-    "justify space-between": { justify: "space-between", height: "300px" },
+    "align center": { align: "center", height: "200px" },
+    "align flex-end": { align: "flex-end", height: "200px" },
+    "justify center": { justify: "center", width: "500px" },
+    "justify space-between": { justify: "space-between", width: "500px" },
     wrap: { wrap: "wrap", height: "120px" },
   },
 };
@@ -63,9 +63,9 @@ const hstackConditionMap = {
   condition: {
     bare: {},
     gap: { gap: "x4" },
-    "align center": { align: "center" },
-    "align stretch": { align: "stretch" },
-    "justify center": { justify: "center" },
+    "align center": { align: "center", height: "120px" },
+    "align stretch": { align: "stretch", height: "120px" },
+    "justify center": { justify: "center", width: "500px" },
     "justify space-between": { justify: "space-between", width: "500px" },
     wrap: { wrap: "wrap", width: "120px" },
   },

--- a/docs/stories/Stack.stories.tsx
+++ b/docs/stories/Stack.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+
+import { VStack, HStack } from "@seed-design/react";
+import { VariantTable } from "./components/variant-table";
+import { SeedThemeDecorator } from "./components/decorator";
+
+const meta = {
+  component: VStack,
+  decorators: [SeedThemeDecorator],
+} satisfies Meta<typeof VStack>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const Swatch = ({ label }: { label?: string }) => (
+  <div
+    style={{
+      width: 48,
+      height: 48,
+      background: "skyblue",
+      borderRadius: 9999,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      color: "blue",
+      fontSize: 12,
+    }}
+  >
+    {label}
+  </div>
+);
+
+const children = (
+  <>
+    <Swatch label="A" />
+    <Swatch label="B" />
+    <Swatch label="C" />
+    <span>test</span>
+  </>
+);
+
+const vstackConditionMap = {
+  condition: {
+    bare: {},
+    gap: { gap: "x4" },
+    "align center": { align: "center" },
+    "align stretch": { align: "stretch" },
+    "justify center": { justify: "center", height: "300px" },
+    "justify space-between": { justify: "space-between", height: "300px" },
+    wrap: { wrap: "wrap", height: "120px" },
+  },
+};
+
+export const VStackLightTheme: Story = {
+  args: { children },
+  render: (args) => (
+    <VariantTable Component={VStack} variantMap={{}} conditionMap={vstackConditionMap} {...args} />
+  ),
+};
+
+const hstackConditionMap = {
+  condition: {
+    bare: {},
+    gap: { gap: "x4" },
+    "align center": { align: "center" },
+    "align stretch": { align: "stretch" },
+    "justify center": { justify: "center" },
+    "justify space-between": { justify: "space-between", width: "500px" },
+    wrap: { wrap: "wrap", width: "120px" },
+  },
+};
+
+export const HStackLightTheme: Story = {
+  args: { children },
+  render: (args) => (
+    <VariantTable Component={HStack} variantMap={{}} conditionMap={hstackConditionMap} {...args} />
+  ),
+};


### PR DESCRIPTION
## Summary

- Box/Flex/Grid/VStack/HStack 레이아웃 컴포넌트에 Storybook story 추가
- responsive-styling PR 머지 전 visual baseline 확보 목적
- 각 컴포넌트의 고유 props가 CSS variable로 정상 반영되는지 시나리오별 검증

## Test plan

- [ ] Storybook에서 Box/Flex/Grid/Stack stories 렌더링 확인
- [ ] Chromatic snapshot baseline 생성 확인

Resolves DES-1355

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * Box, Flex, Grid, VStack(HStack) 컴포넌트용 Storybook 스토리가 추가되었습니다.
  * 각 컴포넌트에 대해 Light 테마용 대화형 VariantTable이 제공되어 레이아웃/배치/간격/정렬/랩 등 다양한 옵션을 시각적으로 확인할 수 있습니다.
  * Grid의 colspan/rowspan 예시(GridItemSpan)와 Box의 중첩 레이아웃 데모(Nested)가 포함되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->