### PR TITLE
fix(stackflow): prevent reverse swipe-back by clamping displacement

### DIFF
--- a/.changeset/fix-swipe-back-reverse.md
+++ b/.changeset/fix-swipe-back-reverse.md
@@ -1,0 +1,8 @@
+---
+"@seed-design/stackflow": patch
+---
+
+AppScreen 스와이프 백 제스처가 좌→우 단방향으로만 동작하도록 수정합니다.
+
+- 스와이프 백 중 초기 위치보다 왼쪽(역방향)으로 드래그할 수 없도록 수정합니다.
+- `onSwipeBackMove` 콜백의 `displacement` 및 `displacementRatio` 값이 항상 0 이상으로 전달되도록 수정합니다.

--- a/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.ts
@@ -96,7 +96,7 @@ export function useGlobalInteraction() {
 
       const moveSwipeBack = useCallback(
         ({ x, t }: MoveSwipeBackProps) => {
-          const displacement = x - swipeBackContextRef.current.x0;
+          const displacement = Math.max(0, x - swipeBackContextRef.current.x0);
           const displacementRatio = displacement / window.innerWidth;
           const velocity = displacement / (t - swipeBackContextRef.current.t0);
           setSwipeBackContext({


### PR DESCRIPTION
## Summary
- Clamp swipe-back displacement to `Math.max(0, ...)` so the screen cannot be dragged leftward (reverse direction) during swipe-back, matching iOS native behavior

## Test plan
- [ ] Trigger swipe-back gesture and attempt to drag leftward past the initial touch point
- [ ] Verify the screen stays at the origin position (no reverse movement)
- [ ] Verify normal rightward swipe-back still works correctly (complete and cancel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 뒤로 가기 스와이프를 왼→오 방향으로만 허용하도록 개선하여 의도치 않은 반대 방향 드래그를 방지
  * 초기 위치보다 왼쪽으로 드래그되지 않도록 제약 추가
  * 스와이프 이동 이벤트에 음수가 아닌 보정된 이동값과 비율만 전달되도록 수정하여 상호작용 안정성 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->