### PR TITLE
feat(lynx-spa): add foundation catalog pages for color and typography

### DIFF
--- a/examples/lynx-spa/src/App.tsx
+++ b/examples/lynx-spa/src/App.tsx
@@ -34,14 +34,15 @@ export function App(props: { onRender?: () => void }) {
   props.onRender?.();
 
   return (
-    <view
+    <scroll-view
+      scroll-y
       style={{
         padding: "16px",
         paddingTop: "calc(16px + env(safe-area-inset-top))",
         paddingBottom: "calc(16px + env(safe-area-inset-bottom))",
         display: "flex",
         flexDirection: "column",
-        minHeight: "100vh",
+        height: "100vh",
       }}
     >
       {currentPage !== "home" && <BackButton onBack={() => setCurrentPage("home")} />}
@@ -51,6 +52,6 @@ export function App(props: { onRender?: () => void }) {
       {currentPage === "nested-vars-test" && <NestedVarsTestPage />}
       {currentPage === "foundation-color" && <FoundationColorPage />}
       {currentPage === "foundation-typography" && <FoundationTypographyPage />}
-    </view>
+    </scroll-view>
   );
 }

--- a/examples/lynx-spa/src/App.tsx
+++ b/examples/lynx-spa/src/App.tsx
@@ -1,11 +1,19 @@
 import { useState } from "@lynx-js/react";
 
 import { ActionButtonPage } from "./pages/ActionButtonPage.jsx";
+import { FoundationColorPage } from "./pages/FoundationColorPage.jsx";
+import { FoundationTypographyPage } from "./pages/FoundationTypographyPage.jsx";
 import { HomePage } from "./pages/HomePage.jsx";
 import { NestedVarsTestPage } from "./pages/NestedVarsTestPage.jsx";
 import { ThemingPage } from "./pages/ThemingPage.jsx";
 
-export type Page = "home" | "theming" | "action-button" | "nested-vars-test";
+export type Page =
+  | "home"
+  | "theming"
+  | "action-button"
+  | "nested-vars-test"
+  | "foundation-color"
+  | "foundation-typography";
 
 function BackButton({ onBack }: { onBack: () => void }) {
   return (
@@ -41,6 +49,8 @@ export function App(props: { onRender?: () => void }) {
       {currentPage === "theming" && <ThemingPage />}
       {currentPage === "action-button" && <ActionButtonPage />}
       {currentPage === "nested-vars-test" && <NestedVarsTestPage />}
+      {currentPage === "foundation-color" && <FoundationColorPage />}
+      {currentPage === "foundation-typography" && <FoundationTypographyPage />}
     </view>
   );
 }

--- a/examples/lynx-spa/src/pages/ActionButtonPage.tsx
+++ b/examples/lynx-spa/src/pages/ActionButtonPage.tsx
@@ -2,7 +2,7 @@ import { ActionButton } from '@seed-design/lynx-react';
 
 export function ActionButtonPage() {
   return (
-    <view style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+    <scroll-view scroll-y style={{ display: 'flex', flexDirection: 'column', gap: '12px', flex: 1 }}>
       <text style={{ fontSize: '20px', fontWeight: 'bold' }}>ActionButton</text>
 
       <text style={{ fontSize: '16px', fontWeight: 'bold' }}>Variants</text>
@@ -59,6 +59,6 @@ export function ActionButtonPage() {
           Disabled Outline
         </ActionButton>
       </view>
-    </view>
+    </scroll-view>
   );
 }

--- a/examples/lynx-spa/src/pages/FoundationColorPage.tsx
+++ b/examples/lynx-spa/src/pages/FoundationColorPage.tsx
@@ -107,7 +107,7 @@ function renderEntries(
 
 export function FoundationColorPage() {
   return (
-    <view style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+    <scroll-view scroll-y style={{ display: "flex", flexDirection: "column", gap: "4px", flex: 1 }}>
       <text style={{ fontSize: "20px", fontWeight: "bold" }}>Color</text>
       <text style={{ fontSize: "13px", color: "#999", marginBottom: "8px" }}>
         @seed-design/css/vars — $color tokens
@@ -148,6 +148,6 @@ export function FoundationColorPage() {
       >
         {renderEntries($color.stroke, "stroke")}
       </view>
-    </view>
+    </scroll-view>
   );
 }

--- a/examples/lynx-spa/src/pages/FoundationColorPage.tsx
+++ b/examples/lynx-spa/src/pages/FoundationColorPage.tsx
@@ -1,0 +1,153 @@
+import { vars } from "@seed-design/css/vars";
+
+const { $color } = vars;
+
+function SectionTitle({ children }: { children: string }) {
+  return (
+    <text
+      style={{
+        fontSize: "18px",
+        fontWeight: "bold",
+        marginTop: "20px",
+        marginBottom: "8px",
+      }}
+    >
+      {children}
+    </text>
+  );
+}
+
+function ColorSwatch({
+  name,
+  varRef,
+  mode,
+}: {
+  name: string;
+  varRef: string;
+  mode: "fg" | "bg" | "stroke";
+}) {
+  if (mode === "fg") {
+    return (
+      <view
+        style={{
+          padding: "6px 8px",
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "center",
+          gap: "8px",
+        }}
+      >
+        <text style={{ color: varRef, fontSize: "14px", fontWeight: "bold" }}>
+          Aa
+        </text>
+        <text style={{ fontSize: "12px", color: "#666" }}>{name}</text>
+      </view>
+    );
+  }
+
+  if (mode === "bg") {
+    return (
+      <view
+        style={{
+          padding: "6px 8px",
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "center",
+          gap: "8px",
+        }}
+      >
+        <view
+          style={{
+            width: "32px",
+            height: "32px",
+            backgroundColor: varRef,
+            borderRadius: "4px",
+            borderWidth: "1px",
+            borderColor: "rgba(0,0,0,0.1)",
+          }}
+        />
+        <text style={{ fontSize: "12px", color: "#666" }}>{name}</text>
+      </view>
+    );
+  }
+
+  // stroke
+  return (
+    <view
+      style={{
+        padding: "6px 8px",
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        gap: "8px",
+      }}
+    >
+      <view
+        style={{
+          width: "32px",
+          height: "32px",
+          borderWidth: "2px",
+          borderColor: varRef,
+          borderRadius: "4px",
+        }}
+      />
+      <text style={{ fontSize: "12px", color: "#666" }}>{name}</text>
+    </view>
+  );
+}
+
+function renderEntries(
+  obj: Record<string, string>,
+  mode: "fg" | "bg" | "stroke",
+) {
+  return Object.entries(obj).map(([name, varRef]) => (
+    <ColorSwatch key={name} name={name} varRef={varRef} mode={mode} />
+  ));
+}
+
+export function FoundationColorPage() {
+  return (
+    <view style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+      <text style={{ fontSize: "20px", fontWeight: "bold" }}>Color</text>
+      <text style={{ fontSize: "13px", color: "#999", marginBottom: "8px" }}>
+        @seed-design/css/vars — $color tokens
+      </text>
+
+      <SectionTitle>Foreground (fg)</SectionTitle>
+      <view
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          flexWrap: "wrap",
+          gap: "4px",
+        }}
+      >
+        {renderEntries($color.fg, "fg")}
+      </view>
+
+      <SectionTitle>Background (bg)</SectionTitle>
+      <view
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          flexWrap: "wrap",
+          gap: "4px",
+        }}
+      >
+        {renderEntries($color.bg, "bg")}
+      </view>
+
+      <SectionTitle>Stroke</SectionTitle>
+      <view
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          flexWrap: "wrap",
+          gap: "4px",
+        }}
+      >
+        {renderEntries($color.stroke, "stroke")}
+      </view>
+    </view>
+  );
+}

--- a/examples/lynx-spa/src/pages/FoundationTypographyPage.tsx
+++ b/examples/lynx-spa/src/pages/FoundationTypographyPage.tsx
@@ -1,5 +1,18 @@
 import { vars } from "@seed-design/css/vars";
 
+type CSSFontWeight =
+  | "bold"
+  | "normal"
+  | "100"
+  | "200"
+  | "300"
+  | "400"
+  | "500"
+  | "600"
+  | "700"
+  | "800"
+  | "900";
+
 const { $fontSize, $lineHeight, $fontWeight } = vars;
 
 function SectionTitle({ children }: { children: string }) {
@@ -74,7 +87,7 @@ function FontWeightRow({
       <text style={{ fontSize: "11px", color: "#999" }}>
         {name} → {weightVar}
       </text>
-      <text style={{ fontSize: "16px", fontWeight: weightVar }}>
+      <text style={{ fontSize: "16px", fontWeight: weightVar as CSSFontWeight }}>
         다람쥐 헌 쳇바퀴에 타고파 The quick brown fox
       </text>
     </view>

--- a/examples/lynx-spa/src/pages/FoundationTypographyPage.tsx
+++ b/examples/lynx-spa/src/pages/FoundationTypographyPage.tsx
@@ -113,7 +113,7 @@ const staticSizes = [
 
 export function FoundationTypographyPage() {
   return (
-    <view style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+    <scroll-view scroll-y style={{ display: "flex", flexDirection: "column", gap: "4px", flex: 1 }}>
       <text style={{ fontSize: "20px", fontWeight: "bold" }}>Typography</text>
       <text style={{ fontSize: "13px", color: "#999", marginBottom: "8px" }}>
         @seed-design/css/vars — $fontSize, $lineHeight, $fontWeight tokens
@@ -149,6 +149,6 @@ export function FoundationTypographyPage() {
           lineHeightVar={item.lh}
         />
       ))}
-    </view>
+    </scroll-view>
   );
 }

--- a/examples/lynx-spa/src/pages/FoundationTypographyPage.tsx
+++ b/examples/lynx-spa/src/pages/FoundationTypographyPage.tsx
@@ -1,0 +1,154 @@
+import { vars } from "@seed-design/css/vars";
+
+const { $fontSize, $lineHeight, $fontWeight } = vars;
+
+function SectionTitle({ children }: { children: string }) {
+  return (
+    <text
+      style={{
+        fontSize: "18px",
+        fontWeight: "bold",
+        marginTop: "20px",
+        marginBottom: "8px",
+      }}
+    >
+      {children}
+    </text>
+  );
+}
+
+function FontSizeRow({
+  name,
+  sizeVar,
+  lineHeightVar,
+}: {
+  name: string;
+  sizeVar: string;
+  lineHeightVar?: string;
+}) {
+  return (
+    <view
+      style={{
+        padding: "8px",
+        borderBottomWidth: "1px",
+        borderBottomColor: "#eee",
+        display: "flex",
+        flexDirection: "column",
+        gap: "4px",
+      }}
+    >
+      <text style={{ fontSize: "11px", color: "#999" }}>
+        {name} → {sizeVar}
+        {lineHeightVar ? ` / ${lineHeightVar}` : ""}
+      </text>
+      <text
+        style={{
+          fontSize: sizeVar,
+          lineHeight: lineHeightVar ?? "normal",
+        }}
+      >
+        다람쥐 헌 쳇바퀴에 타고파 The quick brown fox
+      </text>
+    </view>
+  );
+}
+
+function FontWeightRow({
+  name,
+  weightVar,
+}: {
+  name: string;
+  weightVar: string;
+}) {
+  return (
+    <view
+      style={{
+        padding: "8px",
+        borderBottomWidth: "1px",
+        borderBottomColor: "#eee",
+        display: "flex",
+        flexDirection: "column",
+        gap: "4px",
+      }}
+    >
+      <text style={{ fontSize: "11px", color: "#999" }}>
+        {name} → {weightVar}
+      </text>
+      <text style={{ fontSize: "16px", fontWeight: weightVar }}>
+        다람쥐 헌 쳇바퀴에 타고파 The quick brown fox
+      </text>
+    </view>
+  );
+}
+
+const dynamicSizes = [
+  { name: "t1", size: $fontSize.t1, lh: $lineHeight.t1 },
+  { name: "t2", size: $fontSize.t2, lh: $lineHeight.t2 },
+  { name: "t3", size: $fontSize.t3, lh: $lineHeight.t3 },
+  { name: "t4", size: $fontSize.t4, lh: $lineHeight.t4 },
+  { name: "t5", size: $fontSize.t5, lh: $lineHeight.t5 },
+  { name: "t6", size: $fontSize.t6, lh: $lineHeight.t6 },
+  { name: "t7", size: $fontSize.t7, lh: $lineHeight.t7 },
+  { name: "t8", size: $fontSize.t8, lh: $lineHeight.t8 },
+  { name: "t9", size: $fontSize.t9, lh: $lineHeight.t9 },
+  { name: "t10", size: $fontSize.t10, lh: $lineHeight.t10 },
+];
+
+const staticSizes = [
+  { name: "t1Static", size: $fontSize.t1Static, lh: $lineHeight.t1Static },
+  { name: "t2Static", size: $fontSize.t2Static, lh: $lineHeight.t2Static },
+  { name: "t3Static", size: $fontSize.t3Static, lh: $lineHeight.t3Static },
+  { name: "t4Static", size: $fontSize.t4Static, lh: $lineHeight.t4Static },
+  { name: "t5Static", size: $fontSize.t5Static, lh: $lineHeight.t5Static },
+  { name: "t6Static", size: $fontSize.t6Static, lh: $lineHeight.t6Static },
+  { name: "t7Static", size: $fontSize.t7Static, lh: $lineHeight.t7Static },
+  { name: "t8Static", size: $fontSize.t8Static, lh: $lineHeight.t8Static },
+  { name: "t9Static", size: $fontSize.t9Static, lh: $lineHeight.t9Static },
+  {
+    name: "t10Static",
+    size: $fontSize.t10Static,
+    lh: $lineHeight.t10Static,
+  },
+];
+
+export function FoundationTypographyPage() {
+  return (
+    <view style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+      <text style={{ fontSize: "20px", fontWeight: "bold" }}>Typography</text>
+      <text style={{ fontSize: "13px", color: "#999", marginBottom: "8px" }}>
+        @seed-design/css/vars — $fontSize, $lineHeight, $fontWeight tokens
+      </text>
+
+      <SectionTitle>Font Weight</SectionTitle>
+      <FontWeightRow name="regular" weightVar={$fontWeight.regular} />
+      <FontWeightRow name="medium" weightVar={$fontWeight.medium} />
+      <FontWeightRow name="bold" weightVar={$fontWeight.bold} />
+
+      <SectionTitle>Font Size (Dynamic)</SectionTitle>
+      <text style={{ fontSize: "12px", color: "#999", marginBottom: "4px" }}>
+        사용자 설정에 따라 크기가 변하는 동적 사이즈
+      </text>
+      {dynamicSizes.map((item) => (
+        <FontSizeRow
+          key={item.name}
+          name={item.name}
+          sizeVar={item.size}
+          lineHeightVar={item.lh}
+        />
+      ))}
+
+      <SectionTitle>Font Size (Static)</SectionTitle>
+      <text style={{ fontSize: "12px", color: "#999", marginBottom: "4px" }}>
+        고정 크기 사이즈
+      </text>
+      {staticSizes.map((item) => (
+        <FontSizeRow
+          key={item.name}
+          name={item.name}
+          sizeVar={item.size}
+          lineHeightVar={item.lh}
+        />
+      ))}
+    </view>
+  );
+}

--- a/examples/lynx-spa/src/pages/HomePage.tsx
+++ b/examples/lynx-spa/src/pages/HomePage.tsx
@@ -20,6 +20,25 @@ function ListItem({ title, onTap }: { title: string; onTap: () => void }) {
   );
 }
 
+function SectionHeader({ children }: { children: string }) {
+  return (
+    <text
+      style={{
+        fontSize: '13px',
+        fontWeight: 'bold',
+        color: '#999',
+        marginTop: '16px',
+        marginBottom: '4px',
+        paddingLeft: '12px',
+        textTransform: 'uppercase',
+        letterSpacing: '0.5px',
+      }}
+    >
+      {children}
+    </text>
+  );
+}
+
 export function HomePage({ navigate }: { navigate: (page: Page) => void }) {
   return (
     <view style={{ display: 'flex', flexDirection: 'column' }}>
@@ -33,8 +52,16 @@ export function HomePage({ navigate }: { navigate: (page: Page) => void }) {
       >
         SEED Design Lynx Catalog
       </text>
-      <ListItem title="Theming" onTap={() => navigate('theming')} />
+
+      <SectionHeader>Foundation</SectionHeader>
+      <ListItem title="Color" onTap={() => navigate('foundation-color')} />
+      <ListItem title="Typography" onTap={() => navigate('foundation-typography')} />
+
+      <SectionHeader>Components</SectionHeader>
       <ListItem title="ActionButton" onTap={() => navigate('action-button')} />
+
+      <SectionHeader>Test</SectionHeader>
+      <ListItem title="Theming" onTap={() => navigate('theming')} />
       <ListItem title="Nested Vars Test (Lynx 3.6+)" onTap={() => navigate('nested-vars-test')} />
     </view>
   );

--- a/examples/lynx-spa/src/pages/HomePage.tsx
+++ b/examples/lynx-spa/src/pages/HomePage.tsx
@@ -41,7 +41,7 @@ function SectionHeader({ children }: { children: string }) {
 
 export function HomePage({ navigate }: { navigate: (page: Page) => void }) {
   return (
-    <view style={{ display: 'flex', flexDirection: 'column' }}>
+    <scroll-view scroll-y style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
       <text
         style={{
           fontSize: '22px',
@@ -63,6 +63,6 @@ export function HomePage({ navigate }: { navigate: (page: Page) => void }) {
       <SectionHeader>Test</SectionHeader>
       <ListItem title="Theming" onTap={() => navigate('theming')} />
       <ListItem title="Nested Vars Test (Lynx 3.6+)" onTap={() => navigate('nested-vars-test')} />
-    </view>
+    </scroll-view>
   );
 }

--- a/examples/lynx-spa/src/pages/NestedVarsTestPage.tsx
+++ b/examples/lynx-spa/src/pages/NestedVarsTestPage.tsx
@@ -52,7 +52,7 @@ function TestResult({
 
 export function NestedVarsTestPage() {
   return (
-    <view style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+    <scroll-view scroll-y style={{ display: 'flex', flexDirection: 'column', gap: '8px', flex: 1 }}>
       <text style={{ fontSize: '20px', fontWeight: 'bold' }}>
         Nested CSS Variables Test
       </text>
@@ -163,6 +163,6 @@ export function NestedVarsTestPage() {
       <TestResult label="fontSize: 20px 직접 지정" expected="20px 폰트">
         <text style={{ fontSize: '20px' }}>20px 텍스트 (테스트 B와 비교)</text>
       </TestResult>
-    </view>
+    </scroll-view>
   );
 }

--- a/examples/lynx-spa/src/pages/ThemingPage.tsx
+++ b/examples/lynx-spa/src/pages/ThemingPage.tsx
@@ -17,7 +17,7 @@ export function ThemingPage() {
   );
 
   return (
-    <view style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+    <scroll-view scroll-y style={{ display: 'flex', flexDirection: 'column', gap: '12px', flex: 1 }}>
       <text style={{ fontSize: '20px', fontWeight: 'bold' }}>Theming</text>
 
       <view
@@ -75,6 +75,6 @@ export function ThemingPage() {
         <ActionButton variant="neutralOutline">Neutral Outline</ActionButton>
         <ActionButton variant="ghost">Ghost</ActionButton>
       </view>
-    </view>
+    </scroll-view>
   );
 }


### PR DESCRIPTION
## Summary
- Add **Foundation** section to the Lynx SPA catalog home page with Color and Typography sub-pages
- `FoundationColorPage` renders all `$color.fg`, `$color.bg`, `$color.stroke` tokens from `@seed-design/css/vars` as visual swatches
- `FoundationTypographyPage` renders `$fontSize` (dynamic/static t1–t10), `$lineHeight`, and `$fontWeight` tokens with sample text
- Reorganize HomePage into Foundation / Components / Test sections

## Test plan
- [ ] `bun --filter @seed-design/lynx-spa dev` 로 개발 서버 실행
- [ ] 홈페이지에서 Foundation > Color 진입 → fg/bg/stroke 토큰 색상 렌더링 확인
- [ ] 홈페이지에서 Foundation > Typography 진입 → fontSize/lineHeight/fontWeight 토큰 적용 확인
- [ ] 라이트/다크 테마 전환 시 컬러 토큰이 올바르게 변경되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)