### PR TITLE
fix(lynx-spa): replace hardcoded colors with seed design vars for dark mode

### DIFF
--- a/examples/lynx-spa/src/App.tsx
+++ b/examples/lynx-spa/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState } from "@lynx-js/react";
+import { vars } from "@seed-design/css/vars";
 
 import { ActionButtonPage } from "./pages/ActionButtonPage.jsx";
 import { FoundationColorPage } from "./pages/FoundationColorPage.jsx";
@@ -24,7 +25,7 @@ function BackButton({ onBack }: { onBack: () => void }) {
         marginBottom: "8px",
       }}
     >
-      <text style={{ fontSize: "16px", color: "#3498db" }}>{"← Back"}</text>
+      <text style={{ fontSize: "16px", color: vars.$color.fg.brand }}>{"← Back"}</text>
     </view>
   );
 }

--- a/examples/lynx-spa/src/pages/FoundationColorPage.tsx
+++ b/examples/lynx-spa/src/pages/FoundationColorPage.tsx
@@ -40,7 +40,7 @@ function ColorSwatch({
         <text style={{ color: varRef, fontSize: "14px", fontWeight: "bold" }}>
           Aa
         </text>
-        <text style={{ fontSize: "12px", color: "#666" }}>{name}</text>
+        <text style={{ fontSize: "12px", color: $color.fg.neutralMuted }}>{name}</text>
       </view>
     );
   }
@@ -63,10 +63,10 @@ function ColorSwatch({
             backgroundColor: varRef,
             borderRadius: "4px",
             borderWidth: "1px",
-            borderColor: "rgba(0,0,0,0.1)",
+            borderColor: $color.stroke.neutralMuted,
           }}
         />
-        <text style={{ fontSize: "12px", color: "#666" }}>{name}</text>
+        <text style={{ fontSize: "12px", color: $color.fg.neutralMuted }}>{name}</text>
       </view>
     );
   }
@@ -91,7 +91,7 @@ function ColorSwatch({
           borderRadius: "4px",
         }}
       />
-      <text style={{ fontSize: "12px", color: "#666" }}>{name}</text>
+      <text style={{ fontSize: "12px", color: $color.fg.neutralMuted }}>{name}</text>
     </view>
   );
 }
@@ -109,7 +109,7 @@ export function FoundationColorPage() {
   return (
     <scroll-view scroll-y style={{ display: "flex", flexDirection: "column", gap: "4px", flex: 1 }}>
       <text style={{ fontSize: "20px", fontWeight: "bold" }}>Color</text>
-      <text style={{ fontSize: "13px", color: "#999", marginBottom: "8px" }}>
+      <text style={{ fontSize: "13px", color: $color.fg.neutralSubtle, marginBottom: "8px" }}>
         @seed-design/css/vars — $color tokens
       </text>
 

--- a/examples/lynx-spa/src/pages/FoundationTypographyPage.tsx
+++ b/examples/lynx-spa/src/pages/FoundationTypographyPage.tsx
@@ -13,7 +13,7 @@ type CSSFontWeight =
   | "800"
   | "900";
 
-const { $fontSize, $lineHeight, $fontWeight } = vars;
+const { $color, $fontSize, $lineHeight, $fontWeight } = vars;
 
 function SectionTitle({ children }: { children: string }) {
   return (
@@ -44,13 +44,13 @@ function FontSizeRow({
       style={{
         padding: "8px",
         borderBottomWidth: "1px",
-        borderBottomColor: "#eee",
+        borderBottomColor: $color.stroke.neutralMuted,
         display: "flex",
         flexDirection: "column",
         gap: "4px",
       }}
     >
-      <text style={{ fontSize: "11px", color: "#999" }}>
+      <text style={{ fontSize: "11px", color: $color.fg.neutralSubtle }}>
         {name} → {sizeVar}
         {lineHeightVar ? ` / ${lineHeightVar}` : ""}
       </text>
@@ -78,13 +78,13 @@ function FontWeightRow({
       style={{
         padding: "8px",
         borderBottomWidth: "1px",
-        borderBottomColor: "#eee",
+        borderBottomColor: $color.stroke.neutralMuted,
         display: "flex",
         flexDirection: "column",
         gap: "4px",
       }}
     >
-      <text style={{ fontSize: "11px", color: "#999" }}>
+      <text style={{ fontSize: "11px", color: $color.fg.neutralSubtle }}>
         {name} → {weightVar}
       </text>
       <text style={{ fontSize: "16px", fontWeight: weightVar as CSSFontWeight }}>
@@ -128,7 +128,7 @@ export function FoundationTypographyPage() {
   return (
     <scroll-view scroll-y style={{ display: "flex", flexDirection: "column", gap: "4px", flex: 1 }}>
       <text style={{ fontSize: "20px", fontWeight: "bold" }}>Typography</text>
-      <text style={{ fontSize: "13px", color: "#999", marginBottom: "8px" }}>
+      <text style={{ fontSize: "13px", color: $color.fg.neutralSubtle, marginBottom: "8px" }}>
         @seed-design/css/vars — $fontSize, $lineHeight, $fontWeight tokens
       </text>
 
@@ -138,7 +138,7 @@ export function FoundationTypographyPage() {
       <FontWeightRow name="bold" weightVar={$fontWeight.bold} />
 
       <SectionTitle>Font Size (Dynamic)</SectionTitle>
-      <text style={{ fontSize: "12px", color: "#999", marginBottom: "4px" }}>
+      <text style={{ fontSize: "12px", color: $color.fg.neutralSubtle, marginBottom: "4px" }}>
         사용자 설정에 따라 크기가 변하는 동적 사이즈
       </text>
       {dynamicSizes.map((item) => (
@@ -151,7 +151,7 @@ export function FoundationTypographyPage() {
       ))}
 
       <SectionTitle>Font Size (Static)</SectionTitle>
-      <text style={{ fontSize: "12px", color: "#999", marginBottom: "4px" }}>
+      <text style={{ fontSize: "12px", color: $color.fg.neutralSubtle, marginBottom: "4px" }}>
         고정 크기 사이즈
       </text>
       {staticSizes.map((item) => (

--- a/examples/lynx-spa/src/pages/HomePage.tsx
+++ b/examples/lynx-spa/src/pages/HomePage.tsx
@@ -1,4 +1,8 @@
+import { vars } from "@seed-design/css/vars";
+
 import type { Page } from '../App.jsx';
+
+const { $color } = vars;
 
 function ListItem({ title, onTap }: { title: string; onTap: () => void }) {
   return (
@@ -7,15 +11,15 @@ function ListItem({ title, onTap }: { title: string; onTap: () => void }) {
       style={{
         padding: '14px 12px',
         borderBottomWidth: '1px',
-        borderBottomColor: '#eee',
+        borderBottomColor: $color.stroke.neutralMuted,
         display: 'flex',
         flexDirection: 'row',
         justifyContent: 'space-between',
         alignItems: 'center',
       }}
     >
-      <text style={{ fontSize: '16px', color: '#333' }}>{title}</text>
-      <text style={{ fontSize: '16px', color: '#999' }}>{'→'}</text>
+      <text style={{ fontSize: '16px', color: $color.fg.neutral }}>{title}</text>
+      <text style={{ fontSize: '16px', color: $color.fg.neutralSubtle }}>{'→'}</text>
     </view>
   );
 }
@@ -26,7 +30,7 @@ function SectionHeader({ children }: { children: string }) {
       style={{
         fontSize: '13px',
         fontWeight: 'bold',
-        color: '#999',
+        color: $color.fg.neutralSubtle,
         marginTop: '16px',
         marginBottom: '4px',
         paddingLeft: '12px',
@@ -47,7 +51,7 @@ export function HomePage({ navigate }: { navigate: (page: Page) => void }) {
           fontSize: '22px',
           fontWeight: 'bold',
           marginBottom: '16px',
-          color: '#3498db',
+          color: $color.fg.brand,
         }}
       >
         SEED Design Lynx Catalog

--- a/examples/lynx-spa/src/pages/NestedVarsTestPage.tsx
+++ b/examples/lynx-spa/src/pages/NestedVarsTestPage.tsx
@@ -1,4 +1,8 @@
+import { vars } from "@seed-design/css/vars";
+
 import '../styles/nested-vars-test.css';
+
+const { $color } = vars;
 
 /**
  * Lynx 3.6+ Nested CSS Variables 테스트 페이지
@@ -39,10 +43,10 @@ function TestResult({
         padding: '8px',
         marginBottom: '6px',
         borderBottomWidth: '1px',
-        borderBottomColor: '#eee',
+        borderBottomColor: $color.stroke.neutralMuted,
       }}
     >
-      <text style={{ fontSize: '13px', color: '#999', marginBottom: '4px' }}>
+      <text style={{ fontSize: '13px', color: $color.fg.neutralSubtle, marginBottom: '4px' }}>
         {label} (기대: {expected})
       </text>
       {children}
@@ -56,7 +60,7 @@ export function NestedVarsTestPage() {
       <text style={{ fontSize: '20px', fontWeight: 'bold' }}>
         Nested CSS Variables Test
       </text>
-      <text style={{ fontSize: '13px', color: '#999' }}>
+      <text style={{ fontSize: '13px', color: $color.fg.neutralSubtle }}>
         Lynx 3.6+ nested var() 지원 검증
       </text>
 
@@ -94,7 +98,7 @@ export function NestedVarsTestPage() {
         label="calc() 내 var(): --test-spacing-lg = calc(var(--test-spacing-base) * 2)"
         expected="16px padding"
       >
-        <view style={{ backgroundColor: '#f0f0f0', borderRadius: '4px' }}>
+        <view style={{ backgroundColor: $color.bg.neutralWeak, borderRadius: '4px' }}>
           <text className="nested-test-brand">
             이 텍스트 주변에 16px padding이 있으면 calc(var()) 동작
           </text>

--- a/examples/lynx-spa/src/pages/ThemingPage.tsx
+++ b/examples/lynx-spa/src/pages/ThemingPage.tsx
@@ -1,5 +1,8 @@
 import { ActionButton } from '@seed-design/lynx-react';
+import { vars } from '@seed-design/css/vars';
 import { getThemeClassName } from '@seed-design/rsbuild-plugin/lynx';
+
+const { $color } = vars;
 
 declare const __SEED_COLOR_MODE__: string;
 
@@ -23,26 +26,26 @@ export function ThemingPage() {
       <view
         style={{
           padding: '12px',
-          backgroundColor: '#f0f0f0',
+          backgroundColor: $color.bg.neutralWeak,
           borderRadius: '8px',
           display: 'flex',
           flexDirection: 'column',
           gap: '6px',
         }}
       >
-        <text style={{ fontSize: '14px', fontWeight: 'bold', color: '#333' }}>
+        <text style={{ fontSize: '14px', fontWeight: 'bold', color: $color.fg.neutral }}>
           Environment
         </text>
-        <text style={{ fontSize: '13px', color: '#555' }}>
+        <text style={{ fontSize: '13px', color: $color.fg.neutralMuted }}>
           colorMode (plugin): "{colorMode}"
         </text>
-        <text style={{ fontSize: '13px', color: '#555' }}>
+        <text style={{ fontSize: '13px', color: $color.fg.neutralMuted }}>
           systemTheme (device): "{systemTheme}"
         </text>
-        <text style={{ fontSize: '13px', color: '#555' }}>
+        <text style={{ fontSize: '13px', color: $color.fg.neutralMuted }}>
           frontendTheme (app): "{frontendTheme}"
         </text>
-        <text style={{ fontSize: '13px', color: '#555' }}>
+        <text style={{ fontSize: '13px', color: $color.fg.neutralMuted }}>
           Applied class: "{themeClass}"
         </text>
       </view>


### PR DESCRIPTION
## Summary
- lynx-spa 예제 앱의 모든 하드코딩된 색상값을 `@seed-design/css/vars`의 `vars` 객체로 교체
- `$color.fg.neutral`, `$color.fg.neutralSubtle`, `$color.bg.neutralWeak`, `$color.stroke.neutralMuted` 등 시맨틱 토큰 사용
- 다크모드에서 텍스트와 배경이 정상적으로 렌더링되도록 수정

## Changed files (6)
- `App.tsx` — Back 버튼 색상
- `HomePage.tsx` — 리스트 아이템, 섹션 헤더, 제목 색상
- `ThemingPage.tsx` — Environment 카드 배경/텍스트 색상
- `FoundationColorPage.tsx` — swatch 라벨, 서브타이틀, border 색상
- `FoundationTypographyPage.tsx` — 라벨 텍스트, 구분선 색상
- `NestedVarsTestPage.tsx` — 테스트 결과 라벨, 구분선, 배경 색상

## Test plan
- [x] `bun --filter lynx-spa build` 빌드 성공 확인
- [x] 기존 테스트 실패는 변경 전에도 동일 (본 변경과 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)