### PR TITLE
feat(lynx-spa): add monochrome and multicolor icon pages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -247,6 +247,8 @@
       "name": "lynx-spa",
       "version": "1.0.0",
       "dependencies": {
+        "@karrotmarket/lynx-monochrome-icon": "^1.4.0",
+        "@karrotmarket/lynx-multicolor-icon": "^1.6.0",
         "@lynx-js/react": "^0.116.3",
         "@seed-design/css": "^1.2.4",
         "@seed-design/lynx-react": "workspace:*",
@@ -267,6 +269,7 @@
         "@types/react": "^18.3.28",
         "jsdom": "^27.4.0",
         "postcss": "^8.5.8",
+        "sharp": "^0.34.5",
         "typescript": "~5.9.3",
         "vitest": "^3.2.4",
       },
@@ -1805,49 +1808,53 @@
 
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.4", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.3" }, "os": "darwin", "cpu": "arm64" }, "sha512-sitdlPzDVyvmINUdJle3TNHl+AG9QcwiAMsXmccqsCOMZNIdW2/7S26w0LyU8euiLVzFBL3dXPwVCq/ODnf2vA=="],
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
 
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.4", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.3" }, "os": "darwin", "cpu": "x64" }, "sha512-rZheupWIoa3+SOdF/IcUe1ah4ZDpKBGWcsPX6MT0lYniH9micvIU7HQkYTfrx5Xi8u+YqwLtxC/3vl8TQN6rMg=="],
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
 
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QzWAKo7kpHxbuHqUC28DZ9pIKpSi2ts2OJnoIGI26+HMgq92ZZ4vk8iJd4XsxN+tYfNJxzH6W62X5eTcsBymHw=="],
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
 
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-Ju+g2xn1E2AKO6YBhxjj+ACcsPQRHT0bhpglxcEf+3uyPY+/gL8veniKoo96335ZaPo03bdDXMv0t+BBFAbmRA=="],
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
 
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.3", "", { "os": "linux", "cpu": "arm" }, "sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA=="],
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
 
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ=="],
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
 
-    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg=="],
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
 
-    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w=="],
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
 
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg=="],
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
 
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw=="],
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
 
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g=="],
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
 
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.4", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.3" }, "os": "linux", "cpu": "arm" }, "sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA=="],
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
 
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.4", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.3" }, "os": "linux", "cpu": "arm64" }, "sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ=="],
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
 
-    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.4", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.3" }, "os": "linux", "cpu": "ppc64" }, "sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ=="],
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
 
-    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.4", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.3" }, "os": "linux", "cpu": "s390x" }, "sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw=="],
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
 
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.4", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.3" }, "os": "linux", "cpu": "x64" }, "sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A=="],
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
 
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.4", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.3" }, "os": "linux", "cpu": "arm64" }, "sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA=="],
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
 
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.4", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.3" }, "os": "linux", "cpu": "x64" }, "sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg=="],
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
 
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.4", "", { "dependencies": { "@emnapi/runtime": "^1.5.0" }, "cpu": "none" }, "sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA=="],
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
 
-    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-2Q250do/5WXTwxW3zjsEuMSv5sUU4Tq9VThWKlU2EYLm4MB7ZeMwF+SFJutldYODXF6jzc6YEOC+VfX0SZQPqA=="],
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
 
-    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-3ZeLue5V82dT92CNL6rsal6I2weKw1cYu+rGKm8fOCCtJTR2gYeUfY3FqUnIJsMUPIH68oS5jmZ0NiJ508YpEw=="],
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
 
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.4", "", { "os": "win32", "cpu": "x64" }, "sha512-xIyj4wpYs8J18sVN3mSQjwrw7fKUqRw+Z5rnHNCy5fYTxigBz81u5mOMPmFumwjcn8+ld1ppptMBCLic1nz6ig=="],
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 
@@ -1935,7 +1942,15 @@
 
     "@juggle/resize-observer": ["@juggle/resize-observer@3.4.0", "", {}, "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="],
 
+    "@karrotmarket/assets-monochrome": ["@karrotmarket/assets-monochrome@1.11.0", "", {}, "sha512-/R6bS8Cc6UI0sPC/tITR67j+3J4nJ76vKFl176WItHC792aaeV+B+NIfu/s2uEZhyGAbJhuCUQQmXEXepmbmEg=="],
+
+    "@karrotmarket/assets-multicolor": ["@karrotmarket/assets-multicolor@1.10.0", "", {}, "sha512-JlFedwrkmLDq5j4doQoexspE3MKMziv7LGg4r6hKLjOkhjBOIPdjbM1pFbyTvMdsLTHGzq4acerAmhqTsTPO+Q=="],
+
     "@karrotmarket/icon-data": ["@karrotmarket/icon-data@1.17.0", "", {}, "sha512-7XLtuqSX6uKR0IyAGyH7VEES1haH7QfxMfgAKn3ClJb7cwvrxT+8iLv8toZteXIbuogbSV9vtLHE4lyj+XItfg=="],
+
+    "@karrotmarket/lynx-monochrome-icon": ["@karrotmarket/lynx-monochrome-icon@1.4.0", "", { "peerDependencies": { "@karrotmarket/assets-monochrome": "^1.11.0" } }, "sha512-bgBr72hQJ5msvSOKclqi4g33VG5ERvqTMDIarOSsOXSI2XnlylFfEt+eAL+LHq2wX153RcMGIaymiZhq5NrOiA=="],
+
+    "@karrotmarket/lynx-multicolor-icon": ["@karrotmarket/lynx-multicolor-icon@1.6.0", "", { "dependencies": { "@karrotmarket/assets-multicolor": "^1.10.0" } }, "sha512-ZRzdRHHfq3CoiB40Txme5p0q5t2BNHyZ2+IoN0np+cef+wZPBbYvekn+5FnvOr6GjRIO7wlZkJCh2JFiNkmfjA=="],
 
     "@karrotmarket/react-monochrome-icon": ["@karrotmarket/react-monochrome-icon@1.10.0", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-qtmjAbMFh/Xq2XDKrA5BP8RR0kbZ5x9zloBIbcLcB/G/vczCoDJc1rOTlJuTAq0Erbwgtc3Y/03oKyDxxZYRjA=="],
 
@@ -5249,7 +5264,7 @@
 
     "shallowequal": ["shallowequal@1.1.0", "", {}, "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="],
 
-    "sharp": ["sharp@0.34.4", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.0", "semver": "^7.7.2" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.4", "@img/sharp-darwin-x64": "0.34.4", "@img/sharp-libvips-darwin-arm64": "1.2.3", "@img/sharp-libvips-darwin-x64": "1.2.3", "@img/sharp-libvips-linux-arm": "1.2.3", "@img/sharp-libvips-linux-arm64": "1.2.3", "@img/sharp-libvips-linux-ppc64": "1.2.3", "@img/sharp-libvips-linux-s390x": "1.2.3", "@img/sharp-libvips-linux-x64": "1.2.3", "@img/sharp-libvips-linuxmusl-arm64": "1.2.3", "@img/sharp-libvips-linuxmusl-x64": "1.2.3", "@img/sharp-linux-arm": "0.34.4", "@img/sharp-linux-arm64": "0.34.4", "@img/sharp-linux-ppc64": "0.34.4", "@img/sharp-linux-s390x": "0.34.4", "@img/sharp-linux-x64": "0.34.4", "@img/sharp-linuxmusl-arm64": "0.34.4", "@img/sharp-linuxmusl-x64": "0.34.4", "@img/sharp-wasm32": "0.34.4", "@img/sharp-win32-arm64": "0.34.4", "@img/sharp-win32-ia32": "0.34.4", "@img/sharp-win32-x64": "0.34.4" } }, "sha512-FUH39xp3SBPnxWvd5iib1X8XY7J0K0X7d93sie9CJg2PO8/7gmg89Nve6OjItK53/MlAushNNxteBYfM6DEuoA=="],
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -6563,6 +6578,8 @@
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
+    "next/sharp": ["sharp@0.34.4", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.0", "semver": "^7.7.2" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.4", "@img/sharp-darwin-x64": "0.34.4", "@img/sharp-libvips-darwin-arm64": "1.2.3", "@img/sharp-libvips-darwin-x64": "1.2.3", "@img/sharp-libvips-linux-arm": "1.2.3", "@img/sharp-libvips-linux-arm64": "1.2.3", "@img/sharp-libvips-linux-ppc64": "1.2.3", "@img/sharp-libvips-linux-s390x": "1.2.3", "@img/sharp-libvips-linux-x64": "1.2.3", "@img/sharp-libvips-linuxmusl-arm64": "1.2.3", "@img/sharp-libvips-linuxmusl-x64": "1.2.3", "@img/sharp-linux-arm": "0.34.4", "@img/sharp-linux-arm64": "0.34.4", "@img/sharp-linux-ppc64": "0.34.4", "@img/sharp-linux-s390x": "0.34.4", "@img/sharp-linux-x64": "0.34.4", "@img/sharp-linuxmusl-arm64": "0.34.4", "@img/sharp-linuxmusl-x64": "0.34.4", "@img/sharp-wasm32": "0.34.4", "@img/sharp-win32-arm64": "0.34.4", "@img/sharp-win32-ia32": "0.34.4", "@img/sharp-win32-x64": "0.34.4" } }, "sha512-FUH39xp3SBPnxWvd5iib1X8XY7J0K0X7d93sie9CJg2PO8/7gmg89Nve6OjItK53/MlAushNNxteBYfM6DEuoA=="],
+
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "node-polyfill-webpack-plugin/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
@@ -7740,6 +7757,50 @@
     "miniflare/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
 
     "mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
+
+    "next/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.4", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.3" }, "os": "darwin", "cpu": "arm64" }, "sha512-sitdlPzDVyvmINUdJle3TNHl+AG9QcwiAMsXmccqsCOMZNIdW2/7S26w0LyU8euiLVzFBL3dXPwVCq/ODnf2vA=="],
+
+    "next/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.4", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.3" }, "os": "darwin", "cpu": "x64" }, "sha512-rZheupWIoa3+SOdF/IcUe1ah4ZDpKBGWcsPX6MT0lYniH9micvIU7HQkYTfrx5Xi8u+YqwLtxC/3vl8TQN6rMg=="],
+
+    "next/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QzWAKo7kpHxbuHqUC28DZ9pIKpSi2ts2OJnoIGI26+HMgq92ZZ4vk8iJd4XsxN+tYfNJxzH6W62X5eTcsBymHw=="],
+
+    "next/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-Ju+g2xn1E2AKO6YBhxjj+ACcsPQRHT0bhpglxcEf+3uyPY+/gL8veniKoo96335ZaPo03bdDXMv0t+BBFAbmRA=="],
+
+    "next/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.3", "", { "os": "linux", "cpu": "arm" }, "sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA=="],
+
+    "next/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ=="],
+
+    "next/sharp/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg=="],
+
+    "next/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w=="],
+
+    "next/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg=="],
+
+    "next/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw=="],
+
+    "next/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g=="],
+
+    "next/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.4", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.3" }, "os": "linux", "cpu": "arm" }, "sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA=="],
+
+    "next/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.4", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.3" }, "os": "linux", "cpu": "arm64" }, "sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ=="],
+
+    "next/sharp/@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.4", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.3" }, "os": "linux", "cpu": "ppc64" }, "sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ=="],
+
+    "next/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.4", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.3" }, "os": "linux", "cpu": "s390x" }, "sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw=="],
+
+    "next/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.4", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.3" }, "os": "linux", "cpu": "x64" }, "sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A=="],
+
+    "next/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.4", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.3" }, "os": "linux", "cpu": "arm64" }, "sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA=="],
+
+    "next/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.4", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.3" }, "os": "linux", "cpu": "x64" }, "sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg=="],
+
+    "next/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.4", "", { "dependencies": { "@emnapi/runtime": "^1.5.0" }, "cpu": "none" }, "sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA=="],
+
+    "next/sharp/@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-2Q250do/5WXTwxW3zjsEuMSv5sUU4Tq9VThWKlU2EYLm4MB7ZeMwF+SFJutldYODXF6jzc6YEOC+VfX0SZQPqA=="],
+
+    "next/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-3ZeLue5V82dT92CNL6rsal6I2weKw1cYu+rGKm8fOCCtJTR2gYeUfY3FqUnIJsMUPIH68oS5jmZ0NiJ508YpEw=="],
+
+    "next/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.4", "", { "os": "win32", "cpu": "x64" }, "sha512-xIyj4wpYs8J18sVN3mSQjwrw7fKUqRw+Z5rnHNCy5fYTxigBz81u5mOMPmFumwjcn8+ld1ppptMBCLic1nz6ig=="],
 
     "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 

--- a/docs/content/lynx/foundation/iconography.mdx
+++ b/docs/content/lynx/foundation/iconography.mdx
@@ -1,5 +1,5 @@
 ---
-title: Icon
+title: Iconography
 description: Lynx 아이콘 패키지를 사용하는 방법을 설명합니다.
 ---
 

--- a/docs/content/lynx/foundation/meta.json
+++ b/docs/content/lynx/foundation/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Foundation",
+  "pages": ["iconography"]
+}

--- a/examples/lynx-spa/icon-loader.js
+++ b/examples/lynx-spa/icon-loader.js
@@ -1,0 +1,43 @@
+import sharp from 'sharp';
+
+const MONOCHROME_ICON_MAX_SIZE = 24 * 3;
+const MONOCHROME_ICON_QUALITY = 90;
+const ICON_MONOCHROME_PATH = '@karrotmarket/assets-monochrome/svg/';
+const ICON_MULTICOLOR_PATH = '@karrotmarket/assets-multicolor/svg/';
+
+async function iconLoader(source) {
+  const callback = this.async();
+  const resourcePath = this.resourcePath;
+
+  if (
+    !resourcePath.includes(ICON_MONOCHROME_PATH) &&
+    !resourcePath.includes(ICON_MULTICOLOR_PATH)
+  ) {
+    return callback(null, source);
+  }
+
+  const size = MONOCHROME_ICON_MAX_SIZE;
+  const quality = MONOCHROME_ICON_QUALITY;
+
+  try {
+    const buffer = await sharp(Buffer.from(source))
+      .resize({
+        width: size,
+        fit: 'contain',
+        background: { r: 0, g: 0, b: 0, alpha: 0 },
+      })
+      .webp({ quality })
+      .toBuffer();
+
+    const base64String = buffer.toString('base64');
+    const dataUrl = `data:image/webp;base64,${base64String}`;
+
+    callback(null, `export default "${dataUrl}"`);
+  } catch (err) {
+    callback(err);
+  }
+}
+
+iconLoader.raw = true;
+
+export default iconLoader;

--- a/examples/lynx-spa/lynx.config.ts
+++ b/examples/lynx-spa/lynx.config.ts
@@ -1,10 +1,10 @@
-import { defineConfig } from "@lynx-js/rspeedy";
+import { defineConfig } from '@lynx-js/rspeedy';
 
-import { pluginQRCode } from "@lynx-js/qrcode-rsbuild-plugin";
-import { pluginReactLynx } from "@lynx-js/react-rsbuild-plugin";
-import { pluginTypeCheck } from "@rsbuild/plugin-type-check";
-import { pluginLynxConfig } from "@lynx-js/config-rsbuild-plugin";
-import { seedDesign } from "@seed-design/rsbuild-plugin/lynx";
+import { pluginQRCode } from '@lynx-js/qrcode-rsbuild-plugin';
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
+import { pluginLynxConfig } from '@lynx-js/config-rsbuild-plugin';
+import { seedDesign } from '@seed-design/rsbuild-plugin/lynx';
 
 export default defineConfig({
   plugins: [
@@ -19,10 +19,41 @@ export default defineConfig({
     pluginLynxConfig({
       enableCSSInlineVariables: true,
     }),
-    seedDesign({ colorMode: "system" }),
+    seedDesign({ colorMode: 'system' }),
   ],
   output: {
-    filename: "[name].[platform].bundle",
+    filename: '[name].[platform].bundle',
+  },
+  tools: {
+    rspack(config) {
+      if (config.module?.rules) {
+        config.module.rules = config.module.rules.map((rule) => {
+          if (
+            !rule ||
+            typeof rule !== 'object' ||
+            !(rule.test instanceof RegExp)
+          ) {
+            return rule;
+          }
+
+          return {
+            ...rule,
+            exclude: [
+              ...(Array.isArray(rule.exclude) ? rule.exclude : []),
+              /\.svg$/,
+            ],
+          };
+        });
+        config.module.rules.unshift({
+          test: /\.svg$/,
+          use: {
+            loader: './icon-loader.js',
+          },
+        });
+      }
+
+      return config;
+    },
   },
   environments: {
     web: {},

--- a/examples/lynx-spa/package.json
+++ b/examples/lynx-spa/package.json
@@ -11,6 +11,8 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@karrotmarket/lynx-monochrome-icon": "^1.4.0",
+    "@karrotmarket/lynx-multicolor-icon": "^1.6.0",
     "@lynx-js/react": "^0.116.3",
     "@seed-design/css": "^1.2.4",
     "@seed-design/lynx-react": "workspace:*",
@@ -20,10 +22,10 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.14",
+    "@lynx-js/config-rsbuild-plugin": "^0.0.1",
     "@lynx-js/preact-devtools": "^5.0.1",
     "@lynx-js/qrcode-rsbuild-plugin": "^0.4.5",
     "@lynx-js/react-rsbuild-plugin": "^0.12.8",
-    "@lynx-js/config-rsbuild-plugin": "^0.0.1",
     "@lynx-js/rspeedy": "^0.13.4",
     "@lynx-js/types": "3.7.0",
     "@rsbuild/plugin-type-check": "1.3.3",
@@ -31,6 +33,7 @@
     "@types/react": "^18.3.28",
     "jsdom": "^27.4.0",
     "postcss": "^8.5.8",
+    "sharp": "^0.34.5",
     "typescript": "~5.9.3",
     "vitest": "^3.2.4"
   },

--- a/examples/lynx-spa/package.json
+++ b/examples/lynx-spa/package.json
@@ -6,6 +6,7 @@
     "build": "rspeedy build",
     "check": "biome check --write",
     "dev": "rspeedy dev",
+    "generate:icons": "node scripts/generate-icon-pages.js",
     "format": "biome format --write",
     "preview": "rspeedy preview",
     "test": "vitest run"

--- a/examples/lynx-spa/scripts/generate-icon-pages.js
+++ b/examples/lynx-spa/scripts/generate-icon-pages.js
@@ -76,14 +76,13 @@ export function FoundationMonochromeIconPage() {
           display: "flex",
           flexDirection: "row",
           flexWrap: "wrap",
-          gap: "4px",
         }}
       >
         {icons.map(({ component: IconComp, name }) => (
           <view
             key={name}
             style={{
-              width: "80px",
+              width: "25%",
               padding: "8px 4px",
               display: "flex",
               flexDirection: "column",
@@ -160,14 +159,13 @@ export function FoundationMulticolorIconPage() {
           display: "flex",
           flexDirection: "row",
           flexWrap: "wrap",
-          gap: "4px",
         }}
       >
         {icons.map(({ component: IconComp, name }) => (
           <view
             key={name}
             style={{
-              width: "80px",
+              width: "25%",
               padding: "8px 4px",
               display: "flex",
               flexDirection: "column",

--- a/examples/lynx-spa/scripts/generate-icon-pages.js
+++ b/examples/lynx-spa/scripts/generate-icon-pages.js
@@ -1,0 +1,217 @@
+/**
+ * Generates icon page components from installed icon packages.
+ *
+ * Reads the lib/ directory of @karrotmarket/lynx-monochrome-icon and
+ * @karrotmarket/lynx-multicolor-icon to discover available icons,
+ * then generates corresponding page components.
+ *
+ * Usage: node scripts/generate-icon-pages.js
+ */
+
+import { readdirSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+function getIconNames(packageName) {
+  const entryPath = require.resolve(packageName);
+  const libDir = dirname(entryPath);
+  return readdirSync(libDir)
+    .filter(
+      (f) => f.endsWith('.js') && !f.endsWith('.cjs') && f.startsWith('Icon'),
+    )
+    .map((f) => f.replace('.js', ''))
+    .sort();
+}
+
+function generateMonochromePage(iconNames) {
+  const imports = iconNames
+    .map(
+      (name) =>
+        `import ${name} from "@karrotmarket/lynx-monochrome-icon/${name}";`,
+    )
+    .join('\n');
+
+  const entries = iconNames
+    .map((name) => {
+      const label = name.replace(/^Icon/, '');
+      return `  { component: ${name}, name: "${label}" },`;
+    })
+    .join('\n');
+
+  return `import { vars } from "@seed-design/css/vars";
+
+${imports}
+
+const { $color } = vars;
+
+interface IconEntry {
+  component: (props: { size?: number; color: string }) => JSX.Element;
+  name: string;
+}
+
+const icons: IconEntry[] = [
+${entries}
+];
+
+export function FoundationMonochromeIconPage() {
+  return (
+    <scroll-view scroll-y style={{ display: "flex", flexDirection: "column", flex: 1 }}>
+      <text style={{ fontSize: "20px", fontWeight: "bold" }}>Monochrome Icon</text>
+      <text
+        style={{
+          fontSize: "13px",
+          color: $color.fg.neutralSubtle,
+          marginBottom: "8px",
+        }}
+      >
+        @karrotmarket/lynx-monochrome-icon — {icons.length} icons
+      </text>
+
+      <view
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          flexWrap: "wrap",
+          gap: "4px",
+        }}
+      >
+        {icons.map(({ component: IconComp, name }) => (
+          <view
+            key={name}
+            style={{
+              width: "80px",
+              padding: "8px 4px",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "4px",
+            }}
+          >
+            <IconComp size={24} color={$color.fg.neutral} />
+            <text
+              style={{
+                fontSize: "9px",
+                color: $color.fg.neutralMuted,
+                textAlign: "center",
+                wordBreak: "break-all",
+              }}
+            >
+              {name}
+            </text>
+          </view>
+        ))}
+      </view>
+    </scroll-view>
+  );
+}
+`;
+}
+
+function generateMulticolorPage(iconNames) {
+  const imports = iconNames
+    .map(
+      (name) =>
+        `import ${name} from "@karrotmarket/lynx-multicolor-icon/${name}";`,
+    )
+    .join('\n');
+
+  const entries = iconNames
+    .map((name) => {
+      const label = name.replace(/^Icon/, '');
+      return `  { component: ${name}, name: "${label}" },`;
+    })
+    .join('\n');
+
+  return `import { vars } from "@seed-design/css/vars";
+
+${imports}
+
+const { $color } = vars;
+
+interface IconEntry {
+  component: (props: { size?: number }) => JSX.Element;
+  name: string;
+}
+
+const icons: IconEntry[] = [
+${entries}
+];
+
+export function FoundationMulticolorIconPage() {
+  return (
+    <scroll-view scroll-y style={{ display: "flex", flexDirection: "column", flex: 1 }}>
+      <text style={{ fontSize: "20px", fontWeight: "bold" }}>Multicolor Icon</text>
+      <text
+        style={{
+          fontSize: "13px",
+          color: $color.fg.neutralSubtle,
+          marginBottom: "8px",
+        }}
+      >
+        @karrotmarket/lynx-multicolor-icon — {icons.length} icons
+      </text>
+
+      <view
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          flexWrap: "wrap",
+          gap: "4px",
+        }}
+      >
+        {icons.map(({ component: IconComp, name }) => (
+          <view
+            key={name}
+            style={{
+              width: "80px",
+              padding: "8px 4px",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "4px",
+            }}
+          >
+            <IconComp size={24} />
+            <text
+              style={{
+                fontSize: "9px",
+                color: $color.fg.neutralMuted,
+                textAlign: "center",
+                wordBreak: "break-all",
+              }}
+            >
+              {name}
+            </text>
+          </view>
+        ))}
+      </view>
+    </scroll-view>
+  );
+}
+`;
+}
+
+const monoIcons = getIconNames('@karrotmarket/lynx-monochrome-icon');
+const multiIcons = getIconNames('@karrotmarket/lynx-multicolor-icon');
+
+const outDir = resolve(__dirname, '../src/pages');
+
+writeFileSync(
+  resolve(outDir, 'FoundationMonochromeIconPage.tsx'),
+  generateMonochromePage(monoIcons),
+);
+console.log(
+  `Generated FoundationMonochromeIconPage.tsx (${monoIcons.length} icons)`,
+);
+
+writeFileSync(
+  resolve(outDir, 'FoundationMulticolorIconPage.tsx'),
+  generateMulticolorPage(multiIcons),
+);
+console.log(
+  `Generated FoundationMulticolorIconPage.tsx (${multiIcons.length} icons)`,
+);

--- a/examples/lynx-spa/src/App.tsx
+++ b/examples/lynx-spa/src/App.tsx
@@ -3,6 +3,8 @@ import { vars } from "@seed-design/css/vars";
 
 import { ActionButtonPage } from "./pages/ActionButtonPage.jsx";
 import { FoundationColorPage } from "./pages/FoundationColorPage.jsx";
+import { FoundationMonochromeIconPage } from "./pages/FoundationMonochromeIconPage.jsx";
+import { FoundationMulticolorIconPage } from "./pages/FoundationMulticolorIconPage.jsx";
 import { FoundationTypographyPage } from "./pages/FoundationTypographyPage.jsx";
 import { HomePage } from "./pages/HomePage.jsx";
 import { NestedVarsTestPage } from "./pages/NestedVarsTestPage.jsx";
@@ -16,6 +18,8 @@ export type Page =
   | "action-button"
   | "nested-vars-test"
   | "foundation-color"
+  | "foundation-monochrome-icon"
+  | "foundation-multicolor-icon"
   | "foundation-typography";
 
 function BackButton({ onBack }: { onBack: () => void }) {
@@ -54,6 +58,8 @@ export function App(props: { onRender?: () => void }) {
       {currentPage === "action-button" && <ActionButtonPage />}
       {currentPage === "nested-vars-test" && <NestedVarsTestPage />}
       {currentPage === "foundation-color" && <FoundationColorPage />}
+      {currentPage === "foundation-monochrome-icon" && <FoundationMonochromeIconPage />}
+      {currentPage === "foundation-multicolor-icon" && <FoundationMulticolorIconPage />}
       {currentPage === "foundation-typography" && <FoundationTypographyPage />}
       <Suspense>
         <LynxConsole theme="light" />

--- a/examples/lynx-spa/src/pages/FoundationMonochromeIconPage.tsx
+++ b/examples/lynx-spa/src/pages/FoundationMonochromeIconPage.tsx
@@ -1,0 +1,1618 @@
+// Total: 636 icons
+import { vars } from '@seed-design/css/vars';
+
+import IconAUppercaseALowercaseFill from '@karrotmarket/lynx-monochrome-icon/IconAUppercaseALowercaseFill';
+import IconAUppercaseALowercaseLine from '@karrotmarket/lynx-monochrome-icon/IconAUppercaseALowercaseLine';
+import IconAUppercaseOutlineFill from '@karrotmarket/lynx-monochrome-icon/IconAUppercaseOutlineFill';
+import IconAUppercaseOutlineLine from '@karrotmarket/lynx-monochrome-icon/IconAUppercaseOutlineLine';
+import IconAUppercaseSquareFill from '@karrotmarket/lynx-monochrome-icon/IconAUppercaseSquareFill';
+import IconAUppercaseSquareLine from '@karrotmarket/lynx-monochrome-icon/IconAUppercaseSquareLine';
+import IconAndroidshareFill from '@karrotmarket/lynx-monochrome-icon/IconAndroidshareFill';
+import IconAndroidshareLine from '@karrotmarket/lynx-monochrome-icon/IconAndroidshareLine';
+import IconAppleFill from '@karrotmarket/lynx-monochrome-icon/IconAppleFill';
+import IconAppleLine from '@karrotmarket/lynx-monochrome-icon/IconAppleLine';
+import IconArrow2ClockwiseCircularFill from '@karrotmarket/lynx-monochrome-icon/IconArrow2ClockwiseCircularFill';
+import IconArrow2ClockwiseCircularLine from '@karrotmarket/lynx-monochrome-icon/IconArrow2ClockwiseCircularLine';
+import IconArrowClockwiseCircularFill from '@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseCircularFill';
+import IconArrowClockwiseCircularLine from '@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseCircularLine';
+import IconArrowClockwiseOvalFill from '@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseOvalFill';
+import IconArrowClockwiseOvalLine from '@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseOvalLine';
+import IconArrowCounterclockwiseCircularFill from '@karrotmarket/lynx-monochrome-icon/IconArrowCounterclockwiseCircularFill';
+import IconArrowCounterclockwiseCircularLine from '@karrotmarket/lynx-monochrome-icon/IconArrowCounterclockwiseCircularLine';
+import IconArrowDownFill from '@karrotmarket/lynx-monochrome-icon/IconArrowDownFill';
+import IconArrowDownHorizlineFill from '@karrotmarket/lynx-monochrome-icon/IconArrowDownHorizlineFill';
+import IconArrowDownHorizlineLine from '@karrotmarket/lynx-monochrome-icon/IconArrowDownHorizlineLine';
+import IconArrowDownLine from '@karrotmarket/lynx-monochrome-icon/IconArrowDownLine';
+import IconArrowDownLineVerticalArrowUpSquareFill from '@karrotmarket/lynx-monochrome-icon/IconArrowDownLineVerticalArrowUpSquareFill';
+import IconArrowDownLineVerticalArrowUpSquareLine from '@karrotmarket/lynx-monochrome-icon/IconArrowDownLineVerticalArrowUpSquareLine';
+import IconArrowDownRightArrowUpLeftFill from '@karrotmarket/lynx-monochrome-icon/IconArrowDownRightArrowUpLeftFill';
+import IconArrowDownRightArrowUpLeftLine from '@karrotmarket/lynx-monochrome-icon/IconArrowDownRightArrowUpLeftLine';
+import IconArrowLeftBracketRightFill from '@karrotmarket/lynx-monochrome-icon/IconArrowLeftBracketRightFill';
+import IconArrowLeftBracketRightLine from '@karrotmarket/lynx-monochrome-icon/IconArrowLeftBracketRightLine';
+import IconArrowLeftFill from '@karrotmarket/lynx-monochrome-icon/IconArrowLeftFill';
+import IconArrowLeftLine from '@karrotmarket/lynx-monochrome-icon/IconArrowLeftLine';
+import IconArrowRightAngledFill from '@karrotmarket/lynx-monochrome-icon/IconArrowRightAngledFill';
+import IconArrowRightAngledLine from '@karrotmarket/lynx-monochrome-icon/IconArrowRightAngledLine';
+import IconArrowRightArrowLeftFill from '@karrotmarket/lynx-monochrome-icon/IconArrowRightArrowLeftFill';
+import IconArrowRightArrowLeftLine from '@karrotmarket/lynx-monochrome-icon/IconArrowRightArrowLeftLine';
+import IconArrowRightFill from '@karrotmarket/lynx-monochrome-icon/IconArrowRightFill';
+import IconArrowRightLine from '@karrotmarket/lynx-monochrome-icon/IconArrowRightLine';
+import IconArrowUpArrowDownFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpArrowDownFill';
+import IconArrowUpArrowDownLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpArrowDownLine';
+import IconArrowUpBracketDownFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpBracketDownFill';
+import IconArrowUpBracketDownLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpBracketDownLine';
+import IconArrowUpFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpFill';
+import IconArrowUpLeftFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpLeftFill';
+import IconArrowUpLeftLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpLeftLine';
+import IconArrowUpLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpLine';
+import IconArrowUpRightArrowDownLeftFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftFill';
+import IconArrowUpRightArrowDownLeftLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftLine';
+import IconArrowUpRightArrowDownLeftSquareFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftSquareFill';
+import IconArrowUpRightArrowDownLeftSquareLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftSquareLine';
+import IconArrowUpRightFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightFill';
+import IconArrowUpRightLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightLine';
+import IconArrowUpRightShoppingbagTiltedFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightShoppingbagTiltedFill';
+import IconArrowUpRightShoppingbagTiltedLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightShoppingbagTiltedLine';
+import IconArrowUturnLeftFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUturnLeftFill';
+import IconArrowUturnLeftLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUturnLeftLine';
+import IconArrowUturnRightFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUturnRightFill';
+import IconArrowUturnRightLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUturnRightLine';
+import IconArticleFill from '@karrotmarket/lynx-monochrome-icon/IconArticleFill';
+import IconArticleLine from '@karrotmarket/lynx-monochrome-icon/IconArticleLine';
+import IconAsteriskHorizrectangleCoolwave3Fill from '@karrotmarket/lynx-monochrome-icon/IconAsteriskHorizrectangleCoolwave3Fill';
+import IconAsteriskHorizrectangleCoolwave3Line from '@karrotmarket/lynx-monochrome-icon/IconAsteriskHorizrectangleCoolwave3Line';
+import IconAtFill from '@karrotmarket/lynx-monochrome-icon/IconAtFill';
+import IconAtLine from '@karrotmarket/lynx-monochrome-icon/IconAtLine';
+import IconBUppercaseFill from '@karrotmarket/lynx-monochrome-icon/IconBUppercaseFill';
+import IconBUppercaseLine from '@karrotmarket/lynx-monochrome-icon/IconBUppercaseLine';
+import IconBackspacekeyFill from '@karrotmarket/lynx-monochrome-icon/IconBackspacekeyFill';
+import IconBackspacekeyLine from '@karrotmarket/lynx-monochrome-icon/IconBackspacekeyLine';
+import IconBarchartBoardFill from '@karrotmarket/lynx-monochrome-icon/IconBarchartBoardFill';
+import IconBarchartBoardLine from '@karrotmarket/lynx-monochrome-icon/IconBarchartBoardLine';
+import IconBarchartSquareFill from '@karrotmarket/lynx-monochrome-icon/IconBarchartSquareFill';
+import IconBarchartSquareLine from '@karrotmarket/lynx-monochrome-icon/IconBarchartSquareLine';
+import IconBedFrontsideFill from '@karrotmarket/lynx-monochrome-icon/IconBedFrontsideFill';
+import IconBedFrontsideLine from '@karrotmarket/lynx-monochrome-icon/IconBedFrontsideLine';
+import IconBellFill from '@karrotmarket/lynx-monochrome-icon/IconBellFill';
+import IconBellLine from '@karrotmarket/lynx-monochrome-icon/IconBellLine';
+import IconBellSlashFill from '@karrotmarket/lynx-monochrome-icon/IconBellSlashFill';
+import IconBellSlashLine from '@karrotmarket/lynx-monochrome-icon/IconBellSlashLine';
+import IconBookFill from '@karrotmarket/lynx-monochrome-icon/IconBookFill';
+import IconBookLine from '@karrotmarket/lynx-monochrome-icon/IconBookLine';
+import IconBookOpenFill from '@karrotmarket/lynx-monochrome-icon/IconBookOpenFill';
+import IconBookOpenLine from '@karrotmarket/lynx-monochrome-icon/IconBookOpenLine';
+import IconBookmarkFill from '@karrotmarket/lynx-monochrome-icon/IconBookmarkFill';
+import IconBookmarkLine from '@karrotmarket/lynx-monochrome-icon/IconBookmarkLine';
+import IconBoxFlapFill from '@karrotmarket/lynx-monochrome-icon/IconBoxFlapFill';
+import IconBoxFlapLine from '@karrotmarket/lynx-monochrome-icon/IconBoxFlapLine';
+import IconBracketLeftArrowRightFill from '@karrotmarket/lynx-monochrome-icon/IconBracketLeftArrowRightFill';
+import IconBracketLeftArrowRightLine from '@karrotmarket/lynx-monochrome-icon/IconBracketLeftArrowRightLine';
+import IconBuilding2Fill from '@karrotmarket/lynx-monochrome-icon/IconBuilding2Fill';
+import IconBuilding2Line from '@karrotmarket/lynx-monochrome-icon/IconBuilding2Line';
+import IconCalendarFill from '@karrotmarket/lynx-monochrome-icon/IconCalendarFill';
+import IconCalendarLine from '@karrotmarket/lynx-monochrome-icon/IconCalendarLine';
+import IconCamcorderFill from '@karrotmarket/lynx-monochrome-icon/IconCamcorderFill';
+import IconCamcorderLine from '@karrotmarket/lynx-monochrome-icon/IconCamcorderLine';
+import IconCameraFill from '@karrotmarket/lynx-monochrome-icon/IconCameraFill';
+import IconCameraLine from '@karrotmarket/lynx-monochrome-icon/IconCameraLine';
+import IconCarFill from '@karrotmarket/lynx-monochrome-icon/IconCarFill';
+import IconCarFrontUpsideWave2ReversedUpFill from '@karrotmarket/lynx-monochrome-icon/IconCarFrontUpsideWave2ReversedUpFill';
+import IconCarFrontUpsideWave2ReversedUpLine from '@karrotmarket/lynx-monochrome-icon/IconCarFrontUpsideWave2ReversedUpLine';
+import IconCarFrontsideFill from '@karrotmarket/lynx-monochrome-icon/IconCarFrontsideFill';
+import IconCarFrontsideLine from '@karrotmarket/lynx-monochrome-icon/IconCarFrontsideLine';
+import IconCarLine from '@karrotmarket/lynx-monochrome-icon/IconCarLine';
+import IconCarRearTrunkOpenLeftsideFill from '@karrotmarket/lynx-monochrome-icon/IconCarRearTrunkOpenLeftsideFill';
+import IconCarRearTrunkOpenLeftsideLine from '@karrotmarket/lynx-monochrome-icon/IconCarRearTrunkOpenLeftsideLine';
+import IconCarRearUpsideSectorDownFill from '@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideSectorDownFill';
+import IconCarRearUpsideSectorDownLine from '@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideSectorDownLine';
+import IconCarRearUpsideWave2ReversedDownFill from '@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownFill';
+import IconCarRearUpsideWave2ReversedDownLeftFill from '@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownLeftFill';
+import IconCarRearUpsideWave2ReversedDownLeftLine from '@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownLeftLine';
+import IconCarRearUpsideWave2ReversedDownLine from '@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownLine';
+import IconCardFill from '@karrotmarket/lynx-monochrome-icon/IconCardFill';
+import IconCardLine from '@karrotmarket/lynx-monochrome-icon/IconCardLine';
+import IconCarrotFill from '@karrotmarket/lynx-monochrome-icon/IconCarrotFill';
+import IconCarrotLine from '@karrotmarket/lynx-monochrome-icon/IconCarrotLine';
+import IconCartFill from '@karrotmarket/lynx-monochrome-icon/IconCartFill';
+import IconCartItemsFill from '@karrotmarket/lynx-monochrome-icon/IconCartItemsFill';
+import IconCartItemsLine from '@karrotmarket/lynx-monochrome-icon/IconCartItemsLine';
+import IconCartLine from '@karrotmarket/lynx-monochrome-icon/IconCartLine';
+import IconCartLoadFill from '@karrotmarket/lynx-monochrome-icon/IconCartLoadFill';
+import IconCartLoadLine from '@karrotmarket/lynx-monochrome-icon/IconCartLoadLine';
+import IconCheckmarkBadgeFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkBadgeFill';
+import IconCheckmarkBadgeLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkBadgeLine';
+import IconCheckmarkBallotboxFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkBallotboxFill';
+import IconCheckmarkBallotboxLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkBallotboxLine';
+import IconCheckmarkCalendarFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkCalendarFill';
+import IconCheckmarkCalendarLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkCalendarLine';
+import IconCheckmarkChatbubbleLeftFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkChatbubbleLeftFill';
+import IconCheckmarkChatbubbleLeftLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkChatbubbleLeftLine';
+import IconCheckmarkCircleFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkCircleFill';
+import IconCheckmarkCircleLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkCircleLine';
+import IconCheckmarkClipboardFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkClipboardFill';
+import IconCheckmarkClipboardLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkClipboardLine';
+import IconCheckmarkCouponFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkCouponFill';
+import IconCheckmarkCouponLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkCouponLine';
+import IconCheckmarkFatFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkFatFill';
+import IconCheckmarkFatLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkFatLine';
+import IconCheckmarkFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkFill';
+import IconCheckmarkFlowerFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkFlowerFill';
+import IconCheckmarkFlowerLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkFlowerLine';
+import IconCheckmarkHorizlineFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkHorizlineFill';
+import IconCheckmarkHorizlineLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkHorizlineLine';
+import IconCheckmarkLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkLine';
+import IconCheckmarkScaleFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkScaleFill';
+import IconCheckmarkScaleLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkScaleLine';
+import IconCheckmarkShieldFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkShieldFill';
+import IconCheckmarkShieldLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkShieldLine';
+import IconCheckmarkhorizline2VerticalFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkhorizline2VerticalFill';
+import IconCheckmarkhorizline2VerticalLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkhorizline2VerticalLine';
+import IconChevronDownFill from '@karrotmarket/lynx-monochrome-icon/IconChevronDownFill';
+import IconChevronDownLine from '@karrotmarket/lynx-monochrome-icon/IconChevronDownLine';
+import IconChevronDownSmallFill from '@karrotmarket/lynx-monochrome-icon/IconChevronDownSmallFill';
+import IconChevronDownSmallLine from '@karrotmarket/lynx-monochrome-icon/IconChevronDownSmallLine';
+import IconChevronLeftFill from '@karrotmarket/lynx-monochrome-icon/IconChevronLeftFill';
+import IconChevronLeftLine from '@karrotmarket/lynx-monochrome-icon/IconChevronLeftLine';
+import IconChevronLeftSmallFill from '@karrotmarket/lynx-monochrome-icon/IconChevronLeftSmallFill';
+import IconChevronLeftSmallLine from '@karrotmarket/lynx-monochrome-icon/IconChevronLeftSmallLine';
+import IconChevronRightFill from '@karrotmarket/lynx-monochrome-icon/IconChevronRightFill';
+import IconChevronRightLine from '@karrotmarket/lynx-monochrome-icon/IconChevronRightLine';
+import IconChevronRightSmallFill from '@karrotmarket/lynx-monochrome-icon/IconChevronRightSmallFill';
+import IconChevronRightSmallLine from '@karrotmarket/lynx-monochrome-icon/IconChevronRightSmallLine';
+import IconChevronUpFill from '@karrotmarket/lynx-monochrome-icon/IconChevronUpFill';
+import IconChevronUpLine from '@karrotmarket/lynx-monochrome-icon/IconChevronUpLine';
+import IconChevronUpSmallFill from '@karrotmarket/lynx-monochrome-icon/IconChevronUpSmallFill';
+import IconChevronUpSmallLine from '@karrotmarket/lynx-monochrome-icon/IconChevronUpSmallLine';
+import IconCircle4SquareFill from '@karrotmarket/lynx-monochrome-icon/IconCircle4SquareFill';
+import IconCircle4SquareLine from '@karrotmarket/lynx-monochrome-icon/IconCircle4SquareLine';
+import IconClockFill from '@karrotmarket/lynx-monochrome-icon/IconClockFill';
+import IconClockLine from '@karrotmarket/lynx-monochrome-icon/IconClockLine';
+import IconCompassFill from '@karrotmarket/lynx-monochrome-icon/IconCompassFill';
+import IconCompassLine from '@karrotmarket/lynx-monochrome-icon/IconCompassLine';
+import IconCorner4InwardFill from '@karrotmarket/lynx-monochrome-icon/IconCorner4InwardFill';
+import IconCorner4InwardLine from '@karrotmarket/lynx-monochrome-icon/IconCorner4InwardLine';
+import IconCorner4OutwardFill from '@karrotmarket/lynx-monochrome-icon/IconCorner4OutwardFill';
+import IconCorner4OutwardLine from '@karrotmarket/lynx-monochrome-icon/IconCorner4OutwardLine';
+import IconCornerDownLeftFill from '@karrotmarket/lynx-monochrome-icon/IconCornerDownLeftFill';
+import IconCornerDownLeftLine from '@karrotmarket/lynx-monochrome-icon/IconCornerDownLeftLine';
+import IconCouponFill from '@karrotmarket/lynx-monochrome-icon/IconCouponFill';
+import IconCouponLine from '@karrotmarket/lynx-monochrome-icon/IconCouponLine';
+import IconCropmarkFill from '@karrotmarket/lynx-monochrome-icon/IconCropmarkFill';
+import IconCropmarkLine from '@karrotmarket/lynx-monochrome-icon/IconCropmarkLine';
+import IconCrosshairFill from '@karrotmarket/lynx-monochrome-icon/IconCrosshairFill';
+import IconCrosshairLine from '@karrotmarket/lynx-monochrome-icon/IconCrosshairLine';
+import IconCrosshairQuestionmarkFill from '@karrotmarket/lynx-monochrome-icon/IconCrosshairQuestionmarkFill';
+import IconCrosshairQuestionmarkLine from '@karrotmarket/lynx-monochrome-icon/IconCrosshairQuestionmarkLine';
+import IconCrownFill from '@karrotmarket/lynx-monochrome-icon/IconCrownFill';
+import IconCrownLine from '@karrotmarket/lynx-monochrome-icon/IconCrownLine';
+import IconCupHeatwaveFill from '@karrotmarket/lynx-monochrome-icon/IconCupHeatwaveFill';
+import IconCupHeatwaveLine from '@karrotmarket/lynx-monochrome-icon/IconCupHeatwaveLine';
+import IconDiamondFill from '@karrotmarket/lynx-monochrome-icon/IconDiamondFill';
+import IconDiamondLine from '@karrotmarket/lynx-monochrome-icon/IconDiamondLine';
+import IconDocumentArrowLeftFill from '@karrotmarket/lynx-monochrome-icon/IconDocumentArrowLeftFill';
+import IconDocumentArrowLeftLine from '@karrotmarket/lynx-monochrome-icon/IconDocumentArrowLeftLine';
+import IconDocumentCheckmarkFill from '@karrotmarket/lynx-monochrome-icon/IconDocumentCheckmarkFill';
+import IconDocumentCheckmarkLine from '@karrotmarket/lynx-monochrome-icon/IconDocumentCheckmarkLine';
+import IconDocumentFill from '@karrotmarket/lynx-monochrome-icon/IconDocumentFill';
+import IconDocumentLine from '@karrotmarket/lynx-monochrome-icon/IconDocumentLine';
+import IconDocumentMagnifyingglassFill from '@karrotmarket/lynx-monochrome-icon/IconDocumentMagnifyingglassFill';
+import IconDocumentMagnifyingglassLine from '@karrotmarket/lynx-monochrome-icon/IconDocumentMagnifyingglassLine';
+import IconDocumentPenFill from '@karrotmarket/lynx-monochrome-icon/IconDocumentPenFill';
+import IconDocumentPenLine from '@karrotmarket/lynx-monochrome-icon/IconDocumentPenLine';
+import IconDocumentPlusFill from '@karrotmarket/lynx-monochrome-icon/IconDocumentPlusFill';
+import IconDocumentPlusLine from '@karrotmarket/lynx-monochrome-icon/IconDocumentPlusLine';
+import IconDollarCircleArrowRightFill from '@karrotmarket/lynx-monochrome-icon/IconDollarCircleArrowRightFill';
+import IconDollarCircleArrowRightLine from '@karrotmarket/lynx-monochrome-icon/IconDollarCircleArrowRightLine';
+import IconDollarCircleFill from '@karrotmarket/lynx-monochrome-icon/IconDollarCircleFill';
+import IconDollarCircleLine from '@karrotmarket/lynx-monochrome-icon/IconDollarCircleLine';
+import IconDollarFill from '@karrotmarket/lynx-monochrome-icon/IconDollarFill';
+import IconDollarLine from '@karrotmarket/lynx-monochrome-icon/IconDollarLine';
+import IconDot3CircleFill from '@karrotmarket/lynx-monochrome-icon/IconDot3CircleFill';
+import IconDot3CircleLine from '@karrotmarket/lynx-monochrome-icon/IconDot3CircleLine';
+import IconDot3HorizontalChatbubbleLeftFill from '@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftFill';
+import IconDot3HorizontalChatbubbleLeftLine from '@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftLine';
+import IconDot3HorizontalChatbubbleLeftSlashFill from '@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftSlashFill';
+import IconDot3HorizontalChatbubbleLeftSlashLine from '@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftSlashLine';
+import IconDot3HorizontalFill from '@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalFill';
+import IconDot3HorizontalLine from '@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalLine';
+import IconDot3VerticalFill from '@karrotmarket/lynx-monochrome-icon/IconDot3VerticalFill';
+import IconDot3VerticalLine from '@karrotmarket/lynx-monochrome-icon/IconDot3VerticalLine';
+import IconDothorizline3VerticalFill from '@karrotmarket/lynx-monochrome-icon/IconDothorizline3VerticalFill';
+import IconDothorizline3VerticalLine from '@karrotmarket/lynx-monochrome-icon/IconDothorizline3VerticalLine';
+import IconDumbbellFill from '@karrotmarket/lynx-monochrome-icon/IconDumbbellFill';
+import IconDumbbellLine from '@karrotmarket/lynx-monochrome-icon/IconDumbbellLine';
+import IconEarthFill from '@karrotmarket/lynx-monochrome-icon/IconEarthFill';
+import IconEarthLine from '@karrotmarket/lynx-monochrome-icon/IconEarthLine';
+import IconEnvelopeFill from '@karrotmarket/lynx-monochrome-icon/IconEnvelopeFill';
+import IconEnvelopeLine from '@karrotmarket/lynx-monochrome-icon/IconEnvelopeLine';
+import IconEpbFill from '@karrotmarket/lynx-monochrome-icon/IconEpbFill';
+import IconEpbLine from '@karrotmarket/lynx-monochrome-icon/IconEpbLine';
+import IconEraserHorizlineFill from '@karrotmarket/lynx-monochrome-icon/IconEraserHorizlineFill';
+import IconEraserHorizlineLine from '@karrotmarket/lynx-monochrome-icon/IconEraserHorizlineLine';
+import IconExclamationmarkChatbubbleRectangularCenterFill from '@karrotmarket/lynx-monochrome-icon/IconExclamationmarkChatbubbleRectangularCenterFill';
+import IconExclamationmarkChatbubbleRectangularCenterLine from '@karrotmarket/lynx-monochrome-icon/IconExclamationmarkChatbubbleRectangularCenterLine';
+import IconExclamationmarkCircleFill from '@karrotmarket/lynx-monochrome-icon/IconExclamationmarkCircleFill';
+import IconExclamationmarkCircleLine from '@karrotmarket/lynx-monochrome-icon/IconExclamationmarkCircleLine';
+import IconEyeFill from '@karrotmarket/lynx-monochrome-icon/IconEyeFill';
+import IconEyeLine from '@karrotmarket/lynx-monochrome-icon/IconEyeLine';
+import IconEyeSlashFill from '@karrotmarket/lynx-monochrome-icon/IconEyeSlashFill';
+import IconEyeSlashLine from '@karrotmarket/lynx-monochrome-icon/IconEyeSlashLine';
+import IconFaceFrustratedCircleFill from '@karrotmarket/lynx-monochrome-icon/IconFaceFrustratedCircleFill';
+import IconFaceFrustratedCircleLine from '@karrotmarket/lynx-monochrome-icon/IconFaceFrustratedCircleLine';
+import IconFaceSadCircleFill from '@karrotmarket/lynx-monochrome-icon/IconFaceSadCircleFill';
+import IconFaceSadCircleLine from '@karrotmarket/lynx-monochrome-icon/IconFaceSadCircleLine';
+import IconFaceSmileCircleFill from '@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleFill';
+import IconFaceSmileCircleFoldedFill from '@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleFoldedFill';
+import IconFaceSmileCircleFoldedLine from '@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleFoldedLine';
+import IconFaceSmileCircleLine from '@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleLine';
+import IconFaceSurprisedCircleFill from '@karrotmarket/lynx-monochrome-icon/IconFaceSurprisedCircleFill';
+import IconFaceSurprisedCircleLine from '@karrotmarket/lynx-monochrome-icon/IconFaceSurprisedCircleLine';
+import IconFaceViewfinderFill from '@karrotmarket/lynx-monochrome-icon/IconFaceViewfinderFill';
+import IconFaceViewfinderLine from '@karrotmarket/lynx-monochrome-icon/IconFaceViewfinderLine';
+import IconFigureBikeFill from '@karrotmarket/lynx-monochrome-icon/IconFigureBikeFill';
+import IconFigureBikeLine from '@karrotmarket/lynx-monochrome-icon/IconFigureBikeLine';
+import IconFigureOvalFill from '@karrotmarket/lynx-monochrome-icon/IconFigureOvalFill';
+import IconFigureOvalLine from '@karrotmarket/lynx-monochrome-icon/IconFigureOvalLine';
+import IconFigureRunFill from '@karrotmarket/lynx-monochrome-icon/IconFigureRunFill';
+import IconFigureRunLine from '@karrotmarket/lynx-monochrome-icon/IconFigureRunLine';
+import IconFigureWalkFill from '@karrotmarket/lynx-monochrome-icon/IconFigureWalkFill';
+import IconFigureWalkLine from '@karrotmarket/lynx-monochrome-icon/IconFigureWalkLine';
+import IconFigureWheelchairFill from '@karrotmarket/lynx-monochrome-icon/IconFigureWheelchairFill';
+import IconFigureWheelchairLine from '@karrotmarket/lynx-monochrome-icon/IconFigureWheelchairLine';
+import IconFingerprintFill from '@karrotmarket/lynx-monochrome-icon/IconFingerprintFill';
+import IconFingerprintLine from '@karrotmarket/lynx-monochrome-icon/IconFingerprintLine';
+import IconFireworkFill from '@karrotmarket/lynx-monochrome-icon/IconFireworkFill';
+import IconFireworkLine from '@karrotmarket/lynx-monochrome-icon/IconFireworkLine';
+import IconFishWave2Fill from '@karrotmarket/lynx-monochrome-icon/IconFishWave2Fill';
+import IconFishWave2Line from '@karrotmarket/lynx-monochrome-icon/IconFishWave2Line';
+import IconFlagFill from '@karrotmarket/lynx-monochrome-icon/IconFlagFill';
+import IconFlagHillFill from '@karrotmarket/lynx-monochrome-icon/IconFlagHillFill';
+import IconFlagHillLine from '@karrotmarket/lynx-monochrome-icon/IconFlagHillLine';
+import IconFlagLine from '@karrotmarket/lynx-monochrome-icon/IconFlagLine';
+import IconFlameFill from '@karrotmarket/lynx-monochrome-icon/IconFlameFill';
+import IconFlameLine from '@karrotmarket/lynx-monochrome-icon/IconFlameLine';
+import IconFlaskFill from '@karrotmarket/lynx-monochrome-icon/IconFlaskFill';
+import IconFlaskLine from '@karrotmarket/lynx-monochrome-icon/IconFlaskLine';
+import IconForkSpoonBagFill from '@karrotmarket/lynx-monochrome-icon/IconForkSpoonBagFill';
+import IconForkSpoonBagLine from '@karrotmarket/lynx-monochrome-icon/IconForkSpoonBagLine';
+import IconForkSpoonFill from '@karrotmarket/lynx-monochrome-icon/IconForkSpoonFill';
+import IconForkSpoonLine from '@karrotmarket/lynx-monochrome-icon/IconForkSpoonLine';
+import IconFridgeFill from '@karrotmarket/lynx-monochrome-icon/IconFridgeFill';
+import IconFridgeLine from '@karrotmarket/lynx-monochrome-icon/IconFridgeLine';
+import IconGearFill from '@karrotmarket/lynx-monochrome-icon/IconGearFill';
+import IconGearLine from '@karrotmarket/lynx-monochrome-icon/IconGearLine';
+import IconGiftFill from '@karrotmarket/lynx-monochrome-icon/IconGiftFill';
+import IconGiftLine from '@karrotmarket/lynx-monochrome-icon/IconGiftLine';
+import IconGlobeFill from '@karrotmarket/lynx-monochrome-icon/IconGlobeFill';
+import IconGlobeLine from '@karrotmarket/lynx-monochrome-icon/IconGlobeLine';
+import IconGraduationcapFill from '@karrotmarket/lynx-monochrome-icon/IconGraduationcapFill';
+import IconGraduationcapLine from '@karrotmarket/lynx-monochrome-icon/IconGraduationcapLine';
+import IconGridDot5Fill from '@karrotmarket/lynx-monochrome-icon/IconGridDot5Fill';
+import IconGridDot5Line from '@karrotmarket/lynx-monochrome-icon/IconGridDot5Line';
+import IconGridFill from '@karrotmarket/lynx-monochrome-icon/IconGridFill';
+import IconGridHeartFill from '@karrotmarket/lynx-monochrome-icon/IconGridHeartFill';
+import IconGridHeartLine from '@karrotmarket/lynx-monochrome-icon/IconGridHeartLine';
+import IconGridLine from '@karrotmarket/lynx-monochrome-icon/IconGridLine';
+import IconHandPointUpFill from '@karrotmarket/lynx-monochrome-icon/IconHandPointUpFill';
+import IconHandPointUpLine from '@karrotmarket/lynx-monochrome-icon/IconHandPointUpLine';
+import IconHandWaveFill from '@karrotmarket/lynx-monochrome-icon/IconHandWaveFill';
+import IconHandWaveLine from '@karrotmarket/lynx-monochrome-icon/IconHandWaveLine';
+import IconHashFill from '@karrotmarket/lynx-monochrome-icon/IconHashFill';
+import IconHashLine from '@karrotmarket/lynx-monochrome-icon/IconHashLine';
+import IconHeadsetFill from '@karrotmarket/lynx-monochrome-icon/IconHeadsetFill';
+import IconHeadsetLine from '@karrotmarket/lynx-monochrome-icon/IconHeadsetLine';
+import IconHeartFill from '@karrotmarket/lynx-monochrome-icon/IconHeartFill';
+import IconHeartLine from '@karrotmarket/lynx-monochrome-icon/IconHeartLine';
+import IconHorizline2VerticalChatbubbleRectangularRightFill from '@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightFill';
+import IconHorizline2VerticalChatbubbleRectangularRightLine from '@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightLine';
+import IconHorizline2VerticalChatbubbleRectangularRightSlashFill from '@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightSlashFill';
+import IconHorizline2VerticalChatbubbleRectangularRightSlashLine from '@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightSlashLine';
+import IconHorizline3VerticalCheckmarkFill from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalCheckmarkFill';
+import IconHorizline3VerticalCheckmarkLine from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalCheckmarkLine';
+import IconHorizline3VerticalFill from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalFill';
+import IconHorizline3VerticalLine from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalLine';
+import IconHorizline3VerticalStarFill from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalStarFill';
+import IconHorizline3VerticalStarLine from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalStarLine';
+import IconHorizline3VerticalTightFill from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalTightFill';
+import IconHorizline3VerticalTightLine from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalTightLine';
+import IconHorizlineViewfinderFill from '@karrotmarket/lynx-monochrome-icon/IconHorizlineViewfinderFill';
+import IconHorizlineViewfinderLine from '@karrotmarket/lynx-monochrome-icon/IconHorizlineViewfinderLine';
+import IconHorizrectangleHorizline2VerticalFill from '@karrotmarket/lynx-monochrome-icon/IconHorizrectangleHorizline2VerticalFill';
+import IconHorizrectangleHorizline2VerticalLine from '@karrotmarket/lynx-monochrome-icon/IconHorizrectangleHorizline2VerticalLine';
+import IconHospitalcrossBuildingFill from '@karrotmarket/lynx-monochrome-icon/IconHospitalcrossBuildingFill';
+import IconHospitalcrossBuildingLine from '@karrotmarket/lynx-monochrome-icon/IconHospitalcrossBuildingLine';
+import IconHospitalcrossSquareFill from '@karrotmarket/lynx-monochrome-icon/IconHospitalcrossSquareFill';
+import IconHospitalcrossSquareLine from '@karrotmarket/lynx-monochrome-icon/IconHospitalcrossSquareLine';
+import IconHouseFill from '@karrotmarket/lynx-monochrome-icon/IconHouseFill';
+import IconHouseLine from '@karrotmarket/lynx-monochrome-icon/IconHouseLine';
+import IconHousePlusFill from '@karrotmarket/lynx-monochrome-icon/IconHousePlusFill';
+import IconHousePlusLine from '@karrotmarket/lynx-monochrome-icon/IconHousePlusLine';
+import IconHouseSquareFill from '@karrotmarket/lynx-monochrome-icon/IconHouseSquareFill';
+import IconHouseSquareLine from '@karrotmarket/lynx-monochrome-icon/IconHouseSquareLine';
+import IconILowercaseSerifCircleFill from '@karrotmarket/lynx-monochrome-icon/IconILowercaseSerifCircleFill';
+import IconILowercaseSerifCircleLine from '@karrotmarket/lynx-monochrome-icon/IconILowercaseSerifCircleLine';
+import IconKeyboardChevronDownFill from '@karrotmarket/lynx-monochrome-icon/IconKeyboardChevronDownFill';
+import IconKeyboardChevronDownLine from '@karrotmarket/lynx-monochrome-icon/IconKeyboardChevronDownLine';
+import IconKeyholeShieldFill from '@karrotmarket/lynx-monochrome-icon/IconKeyholeShieldFill';
+import IconKeyholeShieldLine from '@karrotmarket/lynx-monochrome-icon/IconKeyholeShieldLine';
+import IconLaptopFill from '@karrotmarket/lynx-monochrome-icon/IconLaptopFill';
+import IconLaptopLine from '@karrotmarket/lynx-monochrome-icon/IconLaptopLine';
+import IconLeafFill from '@karrotmarket/lynx-monochrome-icon/IconLeafFill';
+import IconLeafLine from '@karrotmarket/lynx-monochrome-icon/IconLeafLine';
+import IconLightbulbDot5Fill from '@karrotmarket/lynx-monochrome-icon/IconLightbulbDot5Fill';
+import IconLightbulbDot5Line from '@karrotmarket/lynx-monochrome-icon/IconLightbulbDot5Line';
+import IconLightningFill from '@karrotmarket/lynx-monochrome-icon/IconLightningFill';
+import IconLightningLine from '@karrotmarket/lynx-monochrome-icon/IconLightningLine';
+import IconLightningSlashFill from '@karrotmarket/lynx-monochrome-icon/IconLightningSlashFill';
+import IconLightningSlashLine from '@karrotmarket/lynx-monochrome-icon/IconLightningSlashLine';
+import IconLinechartUpXaxisFill from '@karrotmarket/lynx-monochrome-icon/IconLinechartUpXaxisFill';
+import IconLinechartUpXaxisLine from '@karrotmarket/lynx-monochrome-icon/IconLinechartUpXaxisLine';
+import IconLocationpinFill from '@karrotmarket/lynx-monochrome-icon/IconLocationpinFill';
+import IconLocationpinLine from '@karrotmarket/lynx-monochrome-icon/IconLocationpinLine';
+import IconLockFill from '@karrotmarket/lynx-monochrome-icon/IconLockFill';
+import IconLockLine from '@karrotmarket/lynx-monochrome-icon/IconLockLine';
+import IconLockOpenedFill from '@karrotmarket/lynx-monochrome-icon/IconLockOpenedFill';
+import IconLockOpenedLine from '@karrotmarket/lynx-monochrome-icon/IconLockOpenedLine';
+import IconMagnifyingglassFill from '@karrotmarket/lynx-monochrome-icon/IconMagnifyingglassFill';
+import IconMagnifyingglassLine from '@karrotmarket/lynx-monochrome-icon/IconMagnifyingglassLine';
+import IconMalesymbolFemalesymbolFill from '@karrotmarket/lynx-monochrome-icon/IconMalesymbolFemalesymbolFill';
+import IconMalesymbolFemalesymbolLine from '@karrotmarket/lynx-monochrome-icon/IconMalesymbolFemalesymbolLine';
+import IconMapFill from '@karrotmarket/lynx-monochrome-icon/IconMapFill';
+import IconMapLine from '@karrotmarket/lynx-monochrome-icon/IconMapLine';
+import IconMapLocationpinFill from '@karrotmarket/lynx-monochrome-icon/IconMapLocationpinFill';
+import IconMapLocationpinLine from '@karrotmarket/lynx-monochrome-icon/IconMapLocationpinLine';
+import IconMegaphoneFill from '@karrotmarket/lynx-monochrome-icon/IconMegaphoneFill';
+import IconMegaphoneLine from '@karrotmarket/lynx-monochrome-icon/IconMegaphoneLine';
+import IconMegaphoneTiltedFill from '@karrotmarket/lynx-monochrome-icon/IconMegaphoneTiltedFill';
+import IconMegaphoneTiltedLine from '@karrotmarket/lynx-monochrome-icon/IconMegaphoneTiltedLine';
+import IconMetroFrontsideFill from '@karrotmarket/lynx-monochrome-icon/IconMetroFrontsideFill';
+import IconMetroFrontsideLine from '@karrotmarket/lynx-monochrome-icon/IconMetroFrontsideLine';
+import IconMicrophoneFill from '@karrotmarket/lynx-monochrome-icon/IconMicrophoneFill';
+import IconMicrophoneLine from '@karrotmarket/lynx-monochrome-icon/IconMicrophoneLine';
+import IconMicrophoneSlashFill from '@karrotmarket/lynx-monochrome-icon/IconMicrophoneSlashFill';
+import IconMicrophoneSlashLine from '@karrotmarket/lynx-monochrome-icon/IconMicrophoneSlashLine';
+import IconMicrowaveFill from '@karrotmarket/lynx-monochrome-icon/IconMicrowaveFill';
+import IconMicrowaveLine from '@karrotmarket/lynx-monochrome-icon/IconMicrowaveLine';
+import IconMidcutSquareFill from '@karrotmarket/lynx-monochrome-icon/IconMidcutSquareFill';
+import IconMidcutSquareLine from '@karrotmarket/lynx-monochrome-icon/IconMidcutSquareLine';
+import IconMinusCircleFill from '@karrotmarket/lynx-monochrome-icon/IconMinusCircleFill';
+import IconMinusCircleLine from '@karrotmarket/lynx-monochrome-icon/IconMinusCircleLine';
+import IconMinusFatFill from '@karrotmarket/lynx-monochrome-icon/IconMinusFatFill';
+import IconMinusFatLine from '@karrotmarket/lynx-monochrome-icon/IconMinusFatLine';
+import IconMinusFill from '@karrotmarket/lynx-monochrome-icon/IconMinusFill';
+import IconMinusLine from '@karrotmarket/lynx-monochrome-icon/IconMinusLine';
+import IconMobileFill from '@karrotmarket/lynx-monochrome-icon/IconMobileFill';
+import IconMobileLine from '@karrotmarket/lynx-monochrome-icon/IconMobileLine';
+import IconMoonFill from '@karrotmarket/lynx-monochrome-icon/IconMoonFill';
+import IconMoonLine from '@karrotmarket/lynx-monochrome-icon/IconMoonLine';
+import IconMusicalnoteDoubleFill from '@karrotmarket/lynx-monochrome-icon/IconMusicalnoteDoubleFill';
+import IconMusicalnoteDoubleLine from '@karrotmarket/lynx-monochrome-icon/IconMusicalnoteDoubleLine';
+import IconNUppercaseCircleFill from '@karrotmarket/lynx-monochrome-icon/IconNUppercaseCircleFill';
+import IconNUppercaseCircleLine from '@karrotmarket/lynx-monochrome-icon/IconNUppercaseCircleLine';
+import IconNailpolishFill from '@karrotmarket/lynx-monochrome-icon/IconNailpolishFill';
+import IconNailpolishLine from '@karrotmarket/lynx-monochrome-icon/IconNailpolishLine';
+import IconNeedleScaleFill from '@karrotmarket/lynx-monochrome-icon/IconNeedleScaleFill';
+import IconNeedleScaleLine from '@karrotmarket/lynx-monochrome-icon/IconNeedleScaleLine';
+import IconPUppercaseCircleFill from '@karrotmarket/lynx-monochrome-icon/IconPUppercaseCircleFill';
+import IconPUppercaseCircleLine from '@karrotmarket/lynx-monochrome-icon/IconPUppercaseCircleLine';
+import IconPaintrollerFill from '@karrotmarket/lynx-monochrome-icon/IconPaintrollerFill';
+import IconPaintrollerLine from '@karrotmarket/lynx-monochrome-icon/IconPaintrollerLine';
+import IconPaletteFill from '@karrotmarket/lynx-monochrome-icon/IconPaletteFill';
+import IconPaletteLine from '@karrotmarket/lynx-monochrome-icon/IconPaletteLine';
+import IconPaperclipFill from '@karrotmarket/lynx-monochrome-icon/IconPaperclipFill';
+import IconPaperclipLine from '@karrotmarket/lynx-monochrome-icon/IconPaperclipLine';
+import IconPaperplaneFill from '@karrotmarket/lynx-monochrome-icon/IconPaperplaneFill';
+import IconPaperplaneLine from '@karrotmarket/lynx-monochrome-icon/IconPaperplaneLine';
+import IconPaperplaneTiltedFill from '@karrotmarket/lynx-monochrome-icon/IconPaperplaneTiltedFill';
+import IconPaperplaneTiltedLine from '@karrotmarket/lynx-monochrome-icon/IconPaperplaneTiltedLine';
+import IconPawprintFill from '@karrotmarket/lynx-monochrome-icon/IconPawprintFill';
+import IconPawprintLine from '@karrotmarket/lynx-monochrome-icon/IconPawprintLine';
+import IconPenHorizlineFill from '@karrotmarket/lynx-monochrome-icon/IconPenHorizlineFill';
+import IconPenHorizlineLine from '@karrotmarket/lynx-monochrome-icon/IconPenHorizlineLine';
+import IconPencilFill from '@karrotmarket/lynx-monochrome-icon/IconPencilFill';
+import IconPencilLine from '@karrotmarket/lynx-monochrome-icon/IconPencilLine';
+import IconPeople3Fill from '@karrotmarket/lynx-monochrome-icon/IconPeople3Fill';
+import IconPeople3Line from '@karrotmarket/lynx-monochrome-icon/IconPeople3Line';
+import IconPercentFill from '@karrotmarket/lynx-monochrome-icon/IconPercentFill';
+import IconPercentFlowerFill from '@karrotmarket/lynx-monochrome-icon/IconPercentFlowerFill';
+import IconPercentFlowerLine from '@karrotmarket/lynx-monochrome-icon/IconPercentFlowerLine';
+import IconPercentLine from '@karrotmarket/lynx-monochrome-icon/IconPercentLine';
+import IconPerson2Fill from '@karrotmarket/lynx-monochrome-icon/IconPerson2Fill';
+import IconPerson2Line from '@karrotmarket/lynx-monochrome-icon/IconPerson2Line';
+import IconPerson2OpenarmsFill from '@karrotmarket/lynx-monochrome-icon/IconPerson2OpenarmsFill';
+import IconPerson2OpenarmsLine from '@karrotmarket/lynx-monochrome-icon/IconPerson2OpenarmsLine';
+import IconPersonCircleFill from '@karrotmarket/lynx-monochrome-icon/IconPersonCircleFill';
+import IconPersonCircleLine from '@karrotmarket/lynx-monochrome-icon/IconPersonCircleLine';
+import IconPersonFill from '@karrotmarket/lynx-monochrome-icon/IconPersonFill';
+import IconPersonFlowerFill from '@karrotmarket/lynx-monochrome-icon/IconPersonFlowerFill';
+import IconPersonFlowerLine from '@karrotmarket/lynx-monochrome-icon/IconPersonFlowerLine';
+import IconPersonLine from '@karrotmarket/lynx-monochrome-icon/IconPersonLine';
+import IconPersonMagnifyingglassFill from '@karrotmarket/lynx-monochrome-icon/IconPersonMagnifyingglassFill';
+import IconPersonMagnifyingglassLine from '@karrotmarket/lynx-monochrome-icon/IconPersonMagnifyingglassLine';
+import IconPersonPlusFill from '@karrotmarket/lynx-monochrome-icon/IconPersonPlusFill';
+import IconPersonPlusLine from '@karrotmarket/lynx-monochrome-icon/IconPersonPlusLine';
+import IconPersonShieldFill from '@karrotmarket/lynx-monochrome-icon/IconPersonShieldFill';
+import IconPersonShieldLine from '@karrotmarket/lynx-monochrome-icon/IconPersonShieldLine';
+import IconPhoneFill from '@karrotmarket/lynx-monochrome-icon/IconPhoneFill';
+import IconPhoneLine from '@karrotmarket/lynx-monochrome-icon/IconPhoneLine';
+import IconPhoneXmarkFill from '@karrotmarket/lynx-monochrome-icon/IconPhoneXmarkFill';
+import IconPhoneXmarkLine from '@karrotmarket/lynx-monochrome-icon/IconPhoneXmarkLine';
+import IconPicture2StackedFill from '@karrotmarket/lynx-monochrome-icon/IconPicture2StackedFill';
+import IconPicture2StackedLine from '@karrotmarket/lynx-monochrome-icon/IconPicture2StackedLine';
+import IconPictureFill from '@karrotmarket/lynx-monochrome-icon/IconPictureFill';
+import IconPictureLine from '@karrotmarket/lynx-monochrome-icon/IconPictureLine';
+import IconPlusCircleFill from '@karrotmarket/lynx-monochrome-icon/IconPlusCircleFill';
+import IconPlusCircleLine from '@karrotmarket/lynx-monochrome-icon/IconPlusCircleLine';
+import IconPlusFill from '@karrotmarket/lynx-monochrome-icon/IconPlusFill';
+import IconPlusLine from '@karrotmarket/lynx-monochrome-icon/IconPlusLine';
+import IconPlusSmallFill from '@karrotmarket/lynx-monochrome-icon/IconPlusSmallFill';
+import IconPlusSmallLine from '@karrotmarket/lynx-monochrome-icon/IconPlusSmallLine';
+import IconPlusSquareFill from '@karrotmarket/lynx-monochrome-icon/IconPlusSquareFill';
+import IconPlusSquareLine from '@karrotmarket/lynx-monochrome-icon/IconPlusSquareLine';
+import IconPostFill from '@karrotmarket/lynx-monochrome-icon/IconPostFill';
+import IconPostLine from '@karrotmarket/lynx-monochrome-icon/IconPostLine';
+import IconPushpinFill from '@karrotmarket/lynx-monochrome-icon/IconPushpinFill';
+import IconPushpinLine from '@karrotmarket/lynx-monochrome-icon/IconPushpinLine';
+import IconQUppercaseChatbubbleRightFill from '@karrotmarket/lynx-monochrome-icon/IconQUppercaseChatbubbleRightFill';
+import IconQUppercaseChatbubbleRightLine from '@karrotmarket/lynx-monochrome-icon/IconQUppercaseChatbubbleRightLine';
+import IconQuestionmarkCircleFill from '@karrotmarket/lynx-monochrome-icon/IconQuestionmarkCircleFill';
+import IconQuestionmarkCircleLine from '@karrotmarket/lynx-monochrome-icon/IconQuestionmarkCircleLine';
+import IconQuestionmarkSquareFill from '@karrotmarket/lynx-monochrome-icon/IconQuestionmarkSquareFill';
+import IconQuestionmarkSquareLine from '@karrotmarket/lynx-monochrome-icon/IconQuestionmarkSquareLine';
+import IconQuotationmark2LeftFill from '@karrotmarket/lynx-monochrome-icon/IconQuotationmark2LeftFill';
+import IconQuotationmark2LeftLine from '@karrotmarket/lynx-monochrome-icon/IconQuotationmark2LeftLine';
+import IconQuotationmark2RightFill from '@karrotmarket/lynx-monochrome-icon/IconQuotationmark2RightFill';
+import IconQuotationmark2RightLine from '@karrotmarket/lynx-monochrome-icon/IconQuotationmark2RightLine';
+import IconReceiptFill from '@karrotmarket/lynx-monochrome-icon/IconReceiptFill';
+import IconReceiptLine from '@karrotmarket/lynx-monochrome-icon/IconReceiptLine';
+import IconRectangleSplitedLineVerticalFill from '@karrotmarket/lynx-monochrome-icon/IconRectangleSplitedLineVerticalFill';
+import IconRectangleSplitedLineVerticalLine from '@karrotmarket/lynx-monochrome-icon/IconRectangleSplitedLineVerticalLine';
+import IconRoadlaneFill from '@karrotmarket/lynx-monochrome-icon/IconRoadlaneFill';
+import IconRoadlaneLine from '@karrotmarket/lynx-monochrome-icon/IconRoadlaneLine';
+import IconRocketFill from '@karrotmarket/lynx-monochrome-icon/IconRocketFill';
+import IconRocketLine from '@karrotmarket/lynx-monochrome-icon/IconRocketLine';
+import IconRooftoproomFill from '@karrotmarket/lynx-monochrome-icon/IconRooftoproomFill';
+import IconRooftoproomLine from '@karrotmarket/lynx-monochrome-icon/IconRooftoproomLine';
+import IconSUppercaseHorizlineCenterFill from '@karrotmarket/lynx-monochrome-icon/IconSUppercaseHorizlineCenterFill';
+import IconSUppercaseHorizlineCenterLine from '@karrotmarket/lynx-monochrome-icon/IconSUppercaseHorizlineCenterLine';
+import IconScissorsFill from '@karrotmarket/lynx-monochrome-icon/IconScissorsFill';
+import IconScissorsLine from '@karrotmarket/lynx-monochrome-icon/IconScissorsLine';
+import IconScribbleFill from '@karrotmarket/lynx-monochrome-icon/IconScribbleFill';
+import IconScribbleLine from '@karrotmarket/lynx-monochrome-icon/IconScribbleLine';
+import IconSeatLeftFanFill from '@karrotmarket/lynx-monochrome-icon/IconSeatLeftFanFill';
+import IconSeatLeftFanLine from '@karrotmarket/lynx-monochrome-icon/IconSeatLeftFanLine';
+import IconSeatLeftFill from '@karrotmarket/lynx-monochrome-icon/IconSeatLeftFill';
+import IconSeatLeftHeatwave2Fill from '@karrotmarket/lynx-monochrome-icon/IconSeatLeftHeatwave2Fill';
+import IconSeatLeftHeatwave2Line from '@karrotmarket/lynx-monochrome-icon/IconSeatLeftHeatwave2Line';
+import IconSeatLeftLine from '@karrotmarket/lynx-monochrome-icon/IconSeatLeftLine';
+import IconShoppingbag2StackedFill from '@karrotmarket/lynx-monochrome-icon/IconShoppingbag2StackedFill';
+import IconShoppingbag2StackedLine from '@karrotmarket/lynx-monochrome-icon/IconShoppingbag2StackedLine';
+import IconShoppingbagFill from '@karrotmarket/lynx-monochrome-icon/IconShoppingbagFill';
+import IconShoppingbagItemsFill from '@karrotmarket/lynx-monochrome-icon/IconShoppingbagItemsFill';
+import IconShoppingbagItemsLine from '@karrotmarket/lynx-monochrome-icon/IconShoppingbagItemsLine';
+import IconShoppingbagLine from '@karrotmarket/lynx-monochrome-icon/IconShoppingbagLine';
+import IconSidemirrorWaveFill from '@karrotmarket/lynx-monochrome-icon/IconSidemirrorWaveFill';
+import IconSidemirrorWaveLine from '@karrotmarket/lynx-monochrome-icon/IconSidemirrorWaveLine';
+import IconSignboardFill from '@karrotmarket/lynx-monochrome-icon/IconSignboardFill';
+import IconSignboardLine from '@karrotmarket/lynx-monochrome-icon/IconSignboardLine';
+import IconSlashCircleFill from '@karrotmarket/lynx-monochrome-icon/IconSlashCircleFill';
+import IconSlashCircleLine from '@karrotmarket/lynx-monochrome-icon/IconSlashCircleLine';
+import IconSlashSemicircle2Fill from '@karrotmarket/lynx-monochrome-icon/IconSlashSemicircle2Fill';
+import IconSlashSemicircle2Line from '@karrotmarket/lynx-monochrome-icon/IconSlashSemicircle2Line';
+import IconSlider2HorizontalFill from '@karrotmarket/lynx-monochrome-icon/IconSlider2HorizontalFill';
+import IconSlider2HorizontalLine from '@karrotmarket/lynx-monochrome-icon/IconSlider2HorizontalLine';
+import IconSmartkeyFill from '@karrotmarket/lynx-monochrome-icon/IconSmartkeyFill';
+import IconSmartkeyLine from '@karrotmarket/lynx-monochrome-icon/IconSmartkeyLine';
+import IconSneakerLiftedLeftsideFill from '@karrotmarket/lynx-monochrome-icon/IconSneakerLiftedLeftsideFill';
+import IconSneakerLiftedLeftsideLine from '@karrotmarket/lynx-monochrome-icon/IconSneakerLiftedLeftsideLine';
+import IconSofaFill from '@karrotmarket/lynx-monochrome-icon/IconSofaFill';
+import IconSofaLine from '@karrotmarket/lynx-monochrome-icon/IconSofaLine';
+import IconSparkle2Fill from '@karrotmarket/lynx-monochrome-icon/IconSparkle2Fill';
+import IconSparkle2Line from '@karrotmarket/lynx-monochrome-icon/IconSparkle2Line';
+import IconSparkleViewfinderFill from '@karrotmarket/lynx-monochrome-icon/IconSparkleViewfinderFill';
+import IconSparkleViewfinderLine from '@karrotmarket/lynx-monochrome-icon/IconSparkleViewfinderLine';
+import IconSpeakerWave2Fill from '@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2Fill';
+import IconSpeakerWave2Line from '@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2Line';
+import IconSpeakerWave2SlashFill from '@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2SlashFill';
+import IconSpeakerWave2SlashLine from '@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2SlashLine';
+import IconSpeedometerFill from '@karrotmarket/lynx-monochrome-icon/IconSpeedometerFill';
+import IconSpeedometerLine from '@karrotmarket/lynx-monochrome-icon/IconSpeedometerLine';
+import IconSpeedometer_1xFill from '@karrotmarket/lynx-monochrome-icon/IconSpeedometer_1xFill';
+import IconSpeedometer_1xLine from '@karrotmarket/lynx-monochrome-icon/IconSpeedometer_1xLine';
+import IconSpeedometer_2xFill from '@karrotmarket/lynx-monochrome-icon/IconSpeedometer_2xFill';
+import IconSpeedometer_2xLine from '@karrotmarket/lynx-monochrome-icon/IconSpeedometer_2xLine';
+import IconSpeedometer_3xFill from '@karrotmarket/lynx-monochrome-icon/IconSpeedometer_3xFill';
+import IconSpeedometer_3xLine from '@karrotmarket/lynx-monochrome-icon/IconSpeedometer_3xLine';
+import IconSplitedGridSquareFill from '@karrotmarket/lynx-monochrome-icon/IconSplitedGridSquareFill';
+import IconSplitedGridSquareLine from '@karrotmarket/lynx-monochrome-icon/IconSplitedGridSquareLine';
+import IconSpraybottleSpongeFill from '@karrotmarket/lynx-monochrome-icon/IconSpraybottleSpongeFill';
+import IconSpraybottleSpongeLine from '@karrotmarket/lynx-monochrome-icon/IconSpraybottleSpongeLine';
+import IconSquare2StackedFill from '@karrotmarket/lynx-monochrome-icon/IconSquare2StackedFill';
+import IconSquare2StackedLine from '@karrotmarket/lynx-monochrome-icon/IconSquare2StackedLine';
+import IconSquareline2VerticalFill from '@karrotmarket/lynx-monochrome-icon/IconSquareline2VerticalFill';
+import IconSquareline2VerticalLine from '@karrotmarket/lynx-monochrome-icon/IconSquareline2VerticalLine';
+import IconStarFill from '@karrotmarket/lynx-monochrome-icon/IconStarFill';
+import IconStarLine from '@karrotmarket/lynx-monochrome-icon/IconStarLine';
+import IconSteeringwheelHeatwave2Fill from '@karrotmarket/lynx-monochrome-icon/IconSteeringwheelHeatwave2Fill';
+import IconSteeringwheelHeatwave2Line from '@karrotmarket/lynx-monochrome-icon/IconSteeringwheelHeatwave2Line';
+import IconStepsFill from '@karrotmarket/lynx-monochrome-icon/IconStepsFill';
+import IconStepsLine from '@karrotmarket/lynx-monochrome-icon/IconStepsLine';
+import IconStoreCheckmarkFill from '@karrotmarket/lynx-monochrome-icon/IconStoreCheckmarkFill';
+import IconStoreCheckmarkLine from '@karrotmarket/lynx-monochrome-icon/IconStoreCheckmarkLine';
+import IconStoreFill from '@karrotmarket/lynx-monochrome-icon/IconStoreFill';
+import IconStoreLine from '@karrotmarket/lynx-monochrome-icon/IconStoreLine';
+import IconStorePenFill from '@karrotmarket/lynx-monochrome-icon/IconStorePenFill';
+import IconStorePenLine from '@karrotmarket/lynx-monochrome-icon/IconStorePenLine';
+import IconSunFill from '@karrotmarket/lynx-monochrome-icon/IconSunFill';
+import IconSunLine from '@karrotmarket/lynx-monochrome-icon/IconSunLine';
+import IconTUppercaseSerifFill from '@karrotmarket/lynx-monochrome-icon/IconTUppercaseSerifFill';
+import IconTUppercaseSerifLine from '@karrotmarket/lynx-monochrome-icon/IconTUppercaseSerifLine';
+import IconTUppercaseTLowercaseFill from '@karrotmarket/lynx-monochrome-icon/IconTUppercaseTLowercaseFill';
+import IconTUppercaseTLowercaseLine from '@karrotmarket/lynx-monochrome-icon/IconTUppercaseTLowercaseLine';
+import IconTagFill from '@karrotmarket/lynx-monochrome-icon/IconTagFill';
+import IconTagLine from '@karrotmarket/lynx-monochrome-icon/IconTagLine';
+import IconTextAligncenterFill from '@karrotmarket/lynx-monochrome-icon/IconTextAligncenterFill';
+import IconTextAligncenterLine from '@karrotmarket/lynx-monochrome-icon/IconTextAligncenterLine';
+import IconTextAlignleftFill from '@karrotmarket/lynx-monochrome-icon/IconTextAlignleftFill';
+import IconTextAlignleftLine from '@karrotmarket/lynx-monochrome-icon/IconTextAlignleftLine';
+import IconTextAlignrightFill from '@karrotmarket/lynx-monochrome-icon/IconTextAlignrightFill';
+import IconTextAlignrightLine from '@karrotmarket/lynx-monochrome-icon/IconTextAlignrightLine';
+import IconThumbDownFill from '@karrotmarket/lynx-monochrome-icon/IconThumbDownFill';
+import IconThumbDownLine from '@karrotmarket/lynx-monochrome-icon/IconThumbDownLine';
+import IconThumbUpFill from '@karrotmarket/lynx-monochrome-icon/IconThumbUpFill';
+import IconThumbUpLine from '@karrotmarket/lynx-monochrome-icon/IconThumbUpLine';
+import IconTimerFill from '@karrotmarket/lynx-monochrome-icon/IconTimerFill';
+import IconTimerLine from '@karrotmarket/lynx-monochrome-icon/IconTimerLine';
+import IconTimer_10Fill from '@karrotmarket/lynx-monochrome-icon/IconTimer_10Fill';
+import IconTimer_10Line from '@karrotmarket/lynx-monochrome-icon/IconTimer_10Line';
+import IconTimer_3Fill from '@karrotmarket/lynx-monochrome-icon/IconTimer_3Fill';
+import IconTimer_3Line from '@karrotmarket/lynx-monochrome-icon/IconTimer_3Line';
+import IconToolboxFill from '@karrotmarket/lynx-monochrome-icon/IconToolboxFill';
+import IconToolboxLine from '@karrotmarket/lynx-monochrome-icon/IconToolboxLine';
+import IconTranslationFill from '@karrotmarket/lynx-monochrome-icon/IconTranslationFill';
+import IconTranslationLine from '@karrotmarket/lynx-monochrome-icon/IconTranslationLine';
+import IconTrashcanFill from '@karrotmarket/lynx-monochrome-icon/IconTrashcanFill';
+import IconTrashcanLine from '@karrotmarket/lynx-monochrome-icon/IconTrashcanLine';
+import IconTriangleDownSmallFill from '@karrotmarket/lynx-monochrome-icon/IconTriangleDownSmallFill';
+import IconTriangleDownSmallLine from '@karrotmarket/lynx-monochrome-icon/IconTriangleDownSmallLine';
+import IconTriangleRightChatbubbleLeftFill from '@karrotmarket/lynx-monochrome-icon/IconTriangleRightChatbubbleLeftFill';
+import IconTriangleRightChatbubbleLeftLine from '@karrotmarket/lynx-monochrome-icon/IconTriangleRightChatbubbleLeftLine';
+import IconTriangleRightFill from '@karrotmarket/lynx-monochrome-icon/IconTriangleRightFill';
+import IconTriangleRightLine from '@karrotmarket/lynx-monochrome-icon/IconTriangleRightLine';
+import IconTriangleRightRectangleSplitedLineVerticalFill from '@karrotmarket/lynx-monochrome-icon/IconTriangleRightRectangleSplitedLineVerticalFill';
+import IconTriangleRightRectangleSplitedLineVerticalLine from '@karrotmarket/lynx-monochrome-icon/IconTriangleRightRectangleSplitedLineVerticalLine';
+import IconTriangleUpSmallFill from '@karrotmarket/lynx-monochrome-icon/IconTriangleUpSmallFill';
+import IconTriangleUpSmallLine from '@karrotmarket/lynx-monochrome-icon/IconTriangleUpSmallLine';
+import IconTrophyFill from '@karrotmarket/lynx-monochrome-icon/IconTrophyFill';
+import IconTrophyLine from '@karrotmarket/lynx-monochrome-icon/IconTrophyLine';
+import IconTruckFill from '@karrotmarket/lynx-monochrome-icon/IconTruckFill';
+import IconTruckLine from '@karrotmarket/lynx-monochrome-icon/IconTruckLine';
+import IconTshirtBubble2Fill from '@karrotmarket/lynx-monochrome-icon/IconTshirtBubble2Fill';
+import IconTshirtBubble2Line from '@karrotmarket/lynx-monochrome-icon/IconTshirtBubble2Line';
+import IconUUppercaseHorizlineFill from '@karrotmarket/lynx-monochrome-icon/IconUUppercaseHorizlineFill';
+import IconUUppercaseHorizlineLine from '@karrotmarket/lynx-monochrome-icon/IconUUppercaseHorizlineLine';
+import IconVertline3ViewfinderFill from '@karrotmarket/lynx-monochrome-icon/IconVertline3ViewfinderFill';
+import IconVertline3ViewfinderLine from '@karrotmarket/lynx-monochrome-icon/IconVertline3ViewfinderLine';
+import IconVertline4SparkleFill from '@karrotmarket/lynx-monochrome-icon/IconVertline4SparkleFill';
+import IconVertline4SparkleLine from '@karrotmarket/lynx-monochrome-icon/IconVertline4SparkleLine';
+import IconVertlineCouponFill from '@karrotmarket/lynx-monochrome-icon/IconVertlineCouponFill';
+import IconVertlineCouponLine from '@karrotmarket/lynx-monochrome-icon/IconVertlineCouponLine';
+import IconVertrectangle2HorizontalFill from '@karrotmarket/lynx-monochrome-icon/IconVertrectangle2HorizontalFill';
+import IconVertrectangle2HorizontalLine from '@karrotmarket/lynx-monochrome-icon/IconVertrectangle2HorizontalLine';
+import IconVertrectangleFoldedFill from '@karrotmarket/lynx-monochrome-icon/IconVertrectangleFoldedFill';
+import IconVertrectangleFoldedLine from '@karrotmarket/lynx-monochrome-icon/IconVertrectangleFoldedLine';
+import IconVotingstampFill from '@karrotmarket/lynx-monochrome-icon/IconVotingstampFill';
+import IconVotingstampLine from '@karrotmarket/lynx-monochrome-icon/IconVotingstampLine';
+import IconWandFill from '@karrotmarket/lynx-monochrome-icon/IconWandFill';
+import IconWandLine from '@karrotmarket/lynx-monochrome-icon/IconWandLine';
+import IconWashingmachineFill from '@karrotmarket/lynx-monochrome-icon/IconWashingmachineFill';
+import IconWashingmachineLine from '@karrotmarket/lynx-monochrome-icon/IconWashingmachineLine';
+import IconWindow2StoreFill from '@karrotmarket/lynx-monochrome-icon/IconWindow2StoreFill';
+import IconWindow2StoreLine from '@karrotmarket/lynx-monochrome-icon/IconWindow2StoreLine';
+import IconWindow4HouseFill from '@karrotmarket/lynx-monochrome-icon/IconWindow4HouseFill';
+import IconWindow4HouseLine from '@karrotmarket/lynx-monochrome-icon/IconWindow4HouseLine';
+import IconWonArrowClockwiseCircularFill from '@karrotmarket/lynx-monochrome-icon/IconWonArrowClockwiseCircularFill';
+import IconWonArrowClockwiseCircularLine from '@karrotmarket/lynx-monochrome-icon/IconWonArrowClockwiseCircularLine';
+import IconWonCircleArrowLeftFill from '@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowLeftFill';
+import IconWonCircleArrowLeftLine from '@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowLeftLine';
+import IconWonCircleArrowRightFill from '@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowRightFill';
+import IconWonCircleArrowRightLine from '@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowRightLine';
+import IconWonCircleFill from '@karrotmarket/lynx-monochrome-icon/IconWonCircleFill';
+import IconWonCircleLine from '@karrotmarket/lynx-monochrome-icon/IconWonCircleLine';
+import IconWonFill from '@karrotmarket/lynx-monochrome-icon/IconWonFill';
+import IconWonLine from '@karrotmarket/lynx-monochrome-icon/IconWonLine';
+import IconWonShieldFill from '@karrotmarket/lynx-monochrome-icon/IconWonShieldFill';
+import IconWonShieldLine from '@karrotmarket/lynx-monochrome-icon/IconWonShieldLine';
+import IconWrenchFill from '@karrotmarket/lynx-monochrome-icon/IconWrenchFill';
+import IconWrenchLine from '@karrotmarket/lynx-monochrome-icon/IconWrenchLine';
+import IconXmarkCircleFill from '@karrotmarket/lynx-monochrome-icon/IconXmarkCircleFill';
+import IconXmarkCircleLine from '@karrotmarket/lynx-monochrome-icon/IconXmarkCircleLine';
+import IconXmarkFill from '@karrotmarket/lynx-monochrome-icon/IconXmarkFill';
+import IconXmarkLine from '@karrotmarket/lynx-monochrome-icon/IconXmarkLine';
+import IconXmarkScaleFill from '@karrotmarket/lynx-monochrome-icon/IconXmarkScaleFill';
+import IconXmarkScaleLine from '@karrotmarket/lynx-monochrome-icon/IconXmarkScaleLine';
+import IconYenCircleArrowRightFill from '@karrotmarket/lynx-monochrome-icon/IconYenCircleArrowRightFill';
+import IconYenCircleArrowRightLine from '@karrotmarket/lynx-monochrome-icon/IconYenCircleArrowRightLine';
+import IconYenCircleFill from '@karrotmarket/lynx-monochrome-icon/IconYenCircleFill';
+import IconYenCircleLine from '@karrotmarket/lynx-monochrome-icon/IconYenCircleLine';
+import IconYenFill from '@karrotmarket/lynx-monochrome-icon/IconYenFill';
+import IconYenLine from '@karrotmarket/lynx-monochrome-icon/IconYenLine';
+
+const { $color } = vars;
+
+interface IconEntry {
+  component: (props: { size?: number; color: string }) => JSX.Element;
+  name: string;
+}
+
+const icons: IconEntry[] = [
+  { component: IconAUppercaseALowercaseFill, name: 'AUppercaseALowercaseFill' },
+  { component: IconAUppercaseALowercaseLine, name: 'AUppercaseALowercaseLine' },
+  { component: IconAUppercaseOutlineFill, name: 'AUppercaseOutlineFill' },
+  { component: IconAUppercaseOutlineLine, name: 'AUppercaseOutlineLine' },
+  { component: IconAUppercaseSquareFill, name: 'AUppercaseSquareFill' },
+  { component: IconAUppercaseSquareLine, name: 'AUppercaseSquareLine' },
+  { component: IconAndroidshareFill, name: 'AndroidshareFill' },
+  { component: IconAndroidshareLine, name: 'AndroidshareLine' },
+  { component: IconAppleFill, name: 'AppleFill' },
+  { component: IconAppleLine, name: 'AppleLine' },
+  {
+    component: IconArrow2ClockwiseCircularFill,
+    name: 'Arrow2ClockwiseCircularFill',
+  },
+  {
+    component: IconArrow2ClockwiseCircularLine,
+    name: 'Arrow2ClockwiseCircularLine',
+  },
+  {
+    component: IconArrowClockwiseCircularFill,
+    name: 'ArrowClockwiseCircularFill',
+  },
+  {
+    component: IconArrowClockwiseCircularLine,
+    name: 'ArrowClockwiseCircularLine',
+  },
+  { component: IconArrowClockwiseOvalFill, name: 'ArrowClockwiseOvalFill' },
+  { component: IconArrowClockwiseOvalLine, name: 'ArrowClockwiseOvalLine' },
+  {
+    component: IconArrowCounterclockwiseCircularFill,
+    name: 'ArrowCounterclockwiseCircularFill',
+  },
+  {
+    component: IconArrowCounterclockwiseCircularLine,
+    name: 'ArrowCounterclockwiseCircularLine',
+  },
+  { component: IconArrowDownFill, name: 'ArrowDownFill' },
+  { component: IconArrowDownHorizlineFill, name: 'ArrowDownHorizlineFill' },
+  { component: IconArrowDownHorizlineLine, name: 'ArrowDownHorizlineLine' },
+  { component: IconArrowDownLine, name: 'ArrowDownLine' },
+  {
+    component: IconArrowDownLineVerticalArrowUpSquareFill,
+    name: 'ArrowDownLineVerticalArrowUpSquareFill',
+  },
+  {
+    component: IconArrowDownLineVerticalArrowUpSquareLine,
+    name: 'ArrowDownLineVerticalArrowUpSquareLine',
+  },
+  {
+    component: IconArrowDownRightArrowUpLeftFill,
+    name: 'ArrowDownRightArrowUpLeftFill',
+  },
+  {
+    component: IconArrowDownRightArrowUpLeftLine,
+    name: 'ArrowDownRightArrowUpLeftLine',
+  },
+  {
+    component: IconArrowLeftBracketRightFill,
+    name: 'ArrowLeftBracketRightFill',
+  },
+  {
+    component: IconArrowLeftBracketRightLine,
+    name: 'ArrowLeftBracketRightLine',
+  },
+  { component: IconArrowLeftFill, name: 'ArrowLeftFill' },
+  { component: IconArrowLeftLine, name: 'ArrowLeftLine' },
+  { component: IconArrowRightAngledFill, name: 'ArrowRightAngledFill' },
+  { component: IconArrowRightAngledLine, name: 'ArrowRightAngledLine' },
+  { component: IconArrowRightArrowLeftFill, name: 'ArrowRightArrowLeftFill' },
+  { component: IconArrowRightArrowLeftLine, name: 'ArrowRightArrowLeftLine' },
+  { component: IconArrowRightFill, name: 'ArrowRightFill' },
+  { component: IconArrowRightLine, name: 'ArrowRightLine' },
+  { component: IconArrowUpArrowDownFill, name: 'ArrowUpArrowDownFill' },
+  { component: IconArrowUpArrowDownLine, name: 'ArrowUpArrowDownLine' },
+  { component: IconArrowUpBracketDownFill, name: 'ArrowUpBracketDownFill' },
+  { component: IconArrowUpBracketDownLine, name: 'ArrowUpBracketDownLine' },
+  { component: IconArrowUpFill, name: 'ArrowUpFill' },
+  { component: IconArrowUpLeftFill, name: 'ArrowUpLeftFill' },
+  { component: IconArrowUpLeftLine, name: 'ArrowUpLeftLine' },
+  { component: IconArrowUpLine, name: 'ArrowUpLine' },
+  {
+    component: IconArrowUpRightArrowDownLeftFill,
+    name: 'ArrowUpRightArrowDownLeftFill',
+  },
+  {
+    component: IconArrowUpRightArrowDownLeftLine,
+    name: 'ArrowUpRightArrowDownLeftLine',
+  },
+  {
+    component: IconArrowUpRightArrowDownLeftSquareFill,
+    name: 'ArrowUpRightArrowDownLeftSquareFill',
+  },
+  {
+    component: IconArrowUpRightArrowDownLeftSquareLine,
+    name: 'ArrowUpRightArrowDownLeftSquareLine',
+  },
+  { component: IconArrowUpRightFill, name: 'ArrowUpRightFill' },
+  { component: IconArrowUpRightLine, name: 'ArrowUpRightLine' },
+  {
+    component: IconArrowUpRightShoppingbagTiltedFill,
+    name: 'ArrowUpRightShoppingbagTiltedFill',
+  },
+  {
+    component: IconArrowUpRightShoppingbagTiltedLine,
+    name: 'ArrowUpRightShoppingbagTiltedLine',
+  },
+  { component: IconArrowUturnLeftFill, name: 'ArrowUturnLeftFill' },
+  { component: IconArrowUturnLeftLine, name: 'ArrowUturnLeftLine' },
+  { component: IconArrowUturnRightFill, name: 'ArrowUturnRightFill' },
+  { component: IconArrowUturnRightLine, name: 'ArrowUturnRightLine' },
+  { component: IconArticleFill, name: 'ArticleFill' },
+  { component: IconArticleLine, name: 'ArticleLine' },
+  {
+    component: IconAsteriskHorizrectangleCoolwave3Fill,
+    name: 'AsteriskHorizrectangleCoolwave3Fill',
+  },
+  {
+    component: IconAsteriskHorizrectangleCoolwave3Line,
+    name: 'AsteriskHorizrectangleCoolwave3Line',
+  },
+  { component: IconAtFill, name: 'AtFill' },
+  { component: IconAtLine, name: 'AtLine' },
+  { component: IconBUppercaseFill, name: 'BUppercaseFill' },
+  { component: IconBUppercaseLine, name: 'BUppercaseLine' },
+  { component: IconBackspacekeyFill, name: 'BackspacekeyFill' },
+  { component: IconBackspacekeyLine, name: 'BackspacekeyLine' },
+  { component: IconBarchartBoardFill, name: 'BarchartBoardFill' },
+  { component: IconBarchartBoardLine, name: 'BarchartBoardLine' },
+  { component: IconBarchartSquareFill, name: 'BarchartSquareFill' },
+  { component: IconBarchartSquareLine, name: 'BarchartSquareLine' },
+  { component: IconBedFrontsideFill, name: 'BedFrontsideFill' },
+  { component: IconBedFrontsideLine, name: 'BedFrontsideLine' },
+  { component: IconBellFill, name: 'BellFill' },
+  { component: IconBellLine, name: 'BellLine' },
+  { component: IconBellSlashFill, name: 'BellSlashFill' },
+  { component: IconBellSlashLine, name: 'BellSlashLine' },
+  { component: IconBookFill, name: 'BookFill' },
+  { component: IconBookLine, name: 'BookLine' },
+  { component: IconBookOpenFill, name: 'BookOpenFill' },
+  { component: IconBookOpenLine, name: 'BookOpenLine' },
+  { component: IconBookmarkFill, name: 'BookmarkFill' },
+  { component: IconBookmarkLine, name: 'BookmarkLine' },
+  { component: IconBoxFlapFill, name: 'BoxFlapFill' },
+  { component: IconBoxFlapLine, name: 'BoxFlapLine' },
+  {
+    component: IconBracketLeftArrowRightFill,
+    name: 'BracketLeftArrowRightFill',
+  },
+  {
+    component: IconBracketLeftArrowRightLine,
+    name: 'BracketLeftArrowRightLine',
+  },
+  { component: IconBuilding2Fill, name: 'Building2Fill' },
+  { component: IconBuilding2Line, name: 'Building2Line' },
+  { component: IconCalendarFill, name: 'CalendarFill' },
+  { component: IconCalendarLine, name: 'CalendarLine' },
+  { component: IconCamcorderFill, name: 'CamcorderFill' },
+  { component: IconCamcorderLine, name: 'CamcorderLine' },
+  { component: IconCameraFill, name: 'CameraFill' },
+  { component: IconCameraLine, name: 'CameraLine' },
+  { component: IconCarFill, name: 'CarFill' },
+  {
+    component: IconCarFrontUpsideWave2ReversedUpFill,
+    name: 'CarFrontUpsideWave2ReversedUpFill',
+  },
+  {
+    component: IconCarFrontUpsideWave2ReversedUpLine,
+    name: 'CarFrontUpsideWave2ReversedUpLine',
+  },
+  { component: IconCarFrontsideFill, name: 'CarFrontsideFill' },
+  { component: IconCarFrontsideLine, name: 'CarFrontsideLine' },
+  { component: IconCarLine, name: 'CarLine' },
+  {
+    component: IconCarRearTrunkOpenLeftsideFill,
+    name: 'CarRearTrunkOpenLeftsideFill',
+  },
+  {
+    component: IconCarRearTrunkOpenLeftsideLine,
+    name: 'CarRearTrunkOpenLeftsideLine',
+  },
+  {
+    component: IconCarRearUpsideSectorDownFill,
+    name: 'CarRearUpsideSectorDownFill',
+  },
+  {
+    component: IconCarRearUpsideSectorDownLine,
+    name: 'CarRearUpsideSectorDownLine',
+  },
+  {
+    component: IconCarRearUpsideWave2ReversedDownFill,
+    name: 'CarRearUpsideWave2ReversedDownFill',
+  },
+  {
+    component: IconCarRearUpsideWave2ReversedDownLeftFill,
+    name: 'CarRearUpsideWave2ReversedDownLeftFill',
+  },
+  {
+    component: IconCarRearUpsideWave2ReversedDownLeftLine,
+    name: 'CarRearUpsideWave2ReversedDownLeftLine',
+  },
+  {
+    component: IconCarRearUpsideWave2ReversedDownLine,
+    name: 'CarRearUpsideWave2ReversedDownLine',
+  },
+  { component: IconCardFill, name: 'CardFill' },
+  { component: IconCardLine, name: 'CardLine' },
+  { component: IconCarrotFill, name: 'CarrotFill' },
+  { component: IconCarrotLine, name: 'CarrotLine' },
+  { component: IconCartFill, name: 'CartFill' },
+  { component: IconCartItemsFill, name: 'CartItemsFill' },
+  { component: IconCartItemsLine, name: 'CartItemsLine' },
+  { component: IconCartLine, name: 'CartLine' },
+  { component: IconCartLoadFill, name: 'CartLoadFill' },
+  { component: IconCartLoadLine, name: 'CartLoadLine' },
+  { component: IconCheckmarkBadgeFill, name: 'CheckmarkBadgeFill' },
+  { component: IconCheckmarkBadgeLine, name: 'CheckmarkBadgeLine' },
+  { component: IconCheckmarkBallotboxFill, name: 'CheckmarkBallotboxFill' },
+  { component: IconCheckmarkBallotboxLine, name: 'CheckmarkBallotboxLine' },
+  { component: IconCheckmarkCalendarFill, name: 'CheckmarkCalendarFill' },
+  { component: IconCheckmarkCalendarLine, name: 'CheckmarkCalendarLine' },
+  {
+    component: IconCheckmarkChatbubbleLeftFill,
+    name: 'CheckmarkChatbubbleLeftFill',
+  },
+  {
+    component: IconCheckmarkChatbubbleLeftLine,
+    name: 'CheckmarkChatbubbleLeftLine',
+  },
+  { component: IconCheckmarkCircleFill, name: 'CheckmarkCircleFill' },
+  { component: IconCheckmarkCircleLine, name: 'CheckmarkCircleLine' },
+  { component: IconCheckmarkClipboardFill, name: 'CheckmarkClipboardFill' },
+  { component: IconCheckmarkClipboardLine, name: 'CheckmarkClipboardLine' },
+  { component: IconCheckmarkCouponFill, name: 'CheckmarkCouponFill' },
+  { component: IconCheckmarkCouponLine, name: 'CheckmarkCouponLine' },
+  { component: IconCheckmarkFatFill, name: 'CheckmarkFatFill' },
+  { component: IconCheckmarkFatLine, name: 'CheckmarkFatLine' },
+  { component: IconCheckmarkFill, name: 'CheckmarkFill' },
+  { component: IconCheckmarkFlowerFill, name: 'CheckmarkFlowerFill' },
+  { component: IconCheckmarkFlowerLine, name: 'CheckmarkFlowerLine' },
+  { component: IconCheckmarkHorizlineFill, name: 'CheckmarkHorizlineFill' },
+  { component: IconCheckmarkHorizlineLine, name: 'CheckmarkHorizlineLine' },
+  { component: IconCheckmarkLine, name: 'CheckmarkLine' },
+  { component: IconCheckmarkScaleFill, name: 'CheckmarkScaleFill' },
+  { component: IconCheckmarkScaleLine, name: 'CheckmarkScaleLine' },
+  { component: IconCheckmarkShieldFill, name: 'CheckmarkShieldFill' },
+  { component: IconCheckmarkShieldLine, name: 'CheckmarkShieldLine' },
+  {
+    component: IconCheckmarkhorizline2VerticalFill,
+    name: 'Checkmarkhorizline2VerticalFill',
+  },
+  {
+    component: IconCheckmarkhorizline2VerticalLine,
+    name: 'Checkmarkhorizline2VerticalLine',
+  },
+  { component: IconChevronDownFill, name: 'ChevronDownFill' },
+  { component: IconChevronDownLine, name: 'ChevronDownLine' },
+  { component: IconChevronDownSmallFill, name: 'ChevronDownSmallFill' },
+  { component: IconChevronDownSmallLine, name: 'ChevronDownSmallLine' },
+  { component: IconChevronLeftFill, name: 'ChevronLeftFill' },
+  { component: IconChevronLeftLine, name: 'ChevronLeftLine' },
+  { component: IconChevronLeftSmallFill, name: 'ChevronLeftSmallFill' },
+  { component: IconChevronLeftSmallLine, name: 'ChevronLeftSmallLine' },
+  { component: IconChevronRightFill, name: 'ChevronRightFill' },
+  { component: IconChevronRightLine, name: 'ChevronRightLine' },
+  { component: IconChevronRightSmallFill, name: 'ChevronRightSmallFill' },
+  { component: IconChevronRightSmallLine, name: 'ChevronRightSmallLine' },
+  { component: IconChevronUpFill, name: 'ChevronUpFill' },
+  { component: IconChevronUpLine, name: 'ChevronUpLine' },
+  { component: IconChevronUpSmallFill, name: 'ChevronUpSmallFill' },
+  { component: IconChevronUpSmallLine, name: 'ChevronUpSmallLine' },
+  { component: IconCircle4SquareFill, name: 'Circle4SquareFill' },
+  { component: IconCircle4SquareLine, name: 'Circle4SquareLine' },
+  { component: IconClockFill, name: 'ClockFill' },
+  { component: IconClockLine, name: 'ClockLine' },
+  { component: IconCompassFill, name: 'CompassFill' },
+  { component: IconCompassLine, name: 'CompassLine' },
+  { component: IconCorner4InwardFill, name: 'Corner4InwardFill' },
+  { component: IconCorner4InwardLine, name: 'Corner4InwardLine' },
+  { component: IconCorner4OutwardFill, name: 'Corner4OutwardFill' },
+  { component: IconCorner4OutwardLine, name: 'Corner4OutwardLine' },
+  { component: IconCornerDownLeftFill, name: 'CornerDownLeftFill' },
+  { component: IconCornerDownLeftLine, name: 'CornerDownLeftLine' },
+  { component: IconCouponFill, name: 'CouponFill' },
+  { component: IconCouponLine, name: 'CouponLine' },
+  { component: IconCropmarkFill, name: 'CropmarkFill' },
+  { component: IconCropmarkLine, name: 'CropmarkLine' },
+  { component: IconCrosshairFill, name: 'CrosshairFill' },
+  { component: IconCrosshairLine, name: 'CrosshairLine' },
+  {
+    component: IconCrosshairQuestionmarkFill,
+    name: 'CrosshairQuestionmarkFill',
+  },
+  {
+    component: IconCrosshairQuestionmarkLine,
+    name: 'CrosshairQuestionmarkLine',
+  },
+  { component: IconCrownFill, name: 'CrownFill' },
+  { component: IconCrownLine, name: 'CrownLine' },
+  { component: IconCupHeatwaveFill, name: 'CupHeatwaveFill' },
+  { component: IconCupHeatwaveLine, name: 'CupHeatwaveLine' },
+  { component: IconDiamondFill, name: 'DiamondFill' },
+  { component: IconDiamondLine, name: 'DiamondLine' },
+  { component: IconDocumentArrowLeftFill, name: 'DocumentArrowLeftFill' },
+  { component: IconDocumentArrowLeftLine, name: 'DocumentArrowLeftLine' },
+  { component: IconDocumentCheckmarkFill, name: 'DocumentCheckmarkFill' },
+  { component: IconDocumentCheckmarkLine, name: 'DocumentCheckmarkLine' },
+  { component: IconDocumentFill, name: 'DocumentFill' },
+  { component: IconDocumentLine, name: 'DocumentLine' },
+  {
+    component: IconDocumentMagnifyingglassFill,
+    name: 'DocumentMagnifyingglassFill',
+  },
+  {
+    component: IconDocumentMagnifyingglassLine,
+    name: 'DocumentMagnifyingglassLine',
+  },
+  { component: IconDocumentPenFill, name: 'DocumentPenFill' },
+  { component: IconDocumentPenLine, name: 'DocumentPenLine' },
+  { component: IconDocumentPlusFill, name: 'DocumentPlusFill' },
+  { component: IconDocumentPlusLine, name: 'DocumentPlusLine' },
+  {
+    component: IconDollarCircleArrowRightFill,
+    name: 'DollarCircleArrowRightFill',
+  },
+  {
+    component: IconDollarCircleArrowRightLine,
+    name: 'DollarCircleArrowRightLine',
+  },
+  { component: IconDollarCircleFill, name: 'DollarCircleFill' },
+  { component: IconDollarCircleLine, name: 'DollarCircleLine' },
+  { component: IconDollarFill, name: 'DollarFill' },
+  { component: IconDollarLine, name: 'DollarLine' },
+  { component: IconDot3CircleFill, name: 'Dot3CircleFill' },
+  { component: IconDot3CircleLine, name: 'Dot3CircleLine' },
+  {
+    component: IconDot3HorizontalChatbubbleLeftFill,
+    name: 'Dot3HorizontalChatbubbleLeftFill',
+  },
+  {
+    component: IconDot3HorizontalChatbubbleLeftLine,
+    name: 'Dot3HorizontalChatbubbleLeftLine',
+  },
+  {
+    component: IconDot3HorizontalChatbubbleLeftSlashFill,
+    name: 'Dot3HorizontalChatbubbleLeftSlashFill',
+  },
+  {
+    component: IconDot3HorizontalChatbubbleLeftSlashLine,
+    name: 'Dot3HorizontalChatbubbleLeftSlashLine',
+  },
+  { component: IconDot3HorizontalFill, name: 'Dot3HorizontalFill' },
+  { component: IconDot3HorizontalLine, name: 'Dot3HorizontalLine' },
+  { component: IconDot3VerticalFill, name: 'Dot3VerticalFill' },
+  { component: IconDot3VerticalLine, name: 'Dot3VerticalLine' },
+  {
+    component: IconDothorizline3VerticalFill,
+    name: 'Dothorizline3VerticalFill',
+  },
+  {
+    component: IconDothorizline3VerticalLine,
+    name: 'Dothorizline3VerticalLine',
+  },
+  { component: IconDumbbellFill, name: 'DumbbellFill' },
+  { component: IconDumbbellLine, name: 'DumbbellLine' },
+  { component: IconEarthFill, name: 'EarthFill' },
+  { component: IconEarthLine, name: 'EarthLine' },
+  { component: IconEnvelopeFill, name: 'EnvelopeFill' },
+  { component: IconEnvelopeLine, name: 'EnvelopeLine' },
+  { component: IconEpbFill, name: 'EpbFill' },
+  { component: IconEpbLine, name: 'EpbLine' },
+  { component: IconEraserHorizlineFill, name: 'EraserHorizlineFill' },
+  { component: IconEraserHorizlineLine, name: 'EraserHorizlineLine' },
+  {
+    component: IconExclamationmarkChatbubbleRectangularCenterFill,
+    name: 'ExclamationmarkChatbubbleRectangularCenterFill',
+  },
+  {
+    component: IconExclamationmarkChatbubbleRectangularCenterLine,
+    name: 'ExclamationmarkChatbubbleRectangularCenterLine',
+  },
+  {
+    component: IconExclamationmarkCircleFill,
+    name: 'ExclamationmarkCircleFill',
+  },
+  {
+    component: IconExclamationmarkCircleLine,
+    name: 'ExclamationmarkCircleLine',
+  },
+  { component: IconEyeFill, name: 'EyeFill' },
+  { component: IconEyeLine, name: 'EyeLine' },
+  { component: IconEyeSlashFill, name: 'EyeSlashFill' },
+  { component: IconEyeSlashLine, name: 'EyeSlashLine' },
+  { component: IconFaceFrustratedCircleFill, name: 'FaceFrustratedCircleFill' },
+  { component: IconFaceFrustratedCircleLine, name: 'FaceFrustratedCircleLine' },
+  { component: IconFaceSadCircleFill, name: 'FaceSadCircleFill' },
+  { component: IconFaceSadCircleLine, name: 'FaceSadCircleLine' },
+  { component: IconFaceSmileCircleFill, name: 'FaceSmileCircleFill' },
+  {
+    component: IconFaceSmileCircleFoldedFill,
+    name: 'FaceSmileCircleFoldedFill',
+  },
+  {
+    component: IconFaceSmileCircleFoldedLine,
+    name: 'FaceSmileCircleFoldedLine',
+  },
+  { component: IconFaceSmileCircleLine, name: 'FaceSmileCircleLine' },
+  { component: IconFaceSurprisedCircleFill, name: 'FaceSurprisedCircleFill' },
+  { component: IconFaceSurprisedCircleLine, name: 'FaceSurprisedCircleLine' },
+  { component: IconFaceViewfinderFill, name: 'FaceViewfinderFill' },
+  { component: IconFaceViewfinderLine, name: 'FaceViewfinderLine' },
+  { component: IconFigureBikeFill, name: 'FigureBikeFill' },
+  { component: IconFigureBikeLine, name: 'FigureBikeLine' },
+  { component: IconFigureOvalFill, name: 'FigureOvalFill' },
+  { component: IconFigureOvalLine, name: 'FigureOvalLine' },
+  { component: IconFigureRunFill, name: 'FigureRunFill' },
+  { component: IconFigureRunLine, name: 'FigureRunLine' },
+  { component: IconFigureWalkFill, name: 'FigureWalkFill' },
+  { component: IconFigureWalkLine, name: 'FigureWalkLine' },
+  { component: IconFigureWheelchairFill, name: 'FigureWheelchairFill' },
+  { component: IconFigureWheelchairLine, name: 'FigureWheelchairLine' },
+  { component: IconFingerprintFill, name: 'FingerprintFill' },
+  { component: IconFingerprintLine, name: 'FingerprintLine' },
+  { component: IconFireworkFill, name: 'FireworkFill' },
+  { component: IconFireworkLine, name: 'FireworkLine' },
+  { component: IconFishWave2Fill, name: 'FishWave2Fill' },
+  { component: IconFishWave2Line, name: 'FishWave2Line' },
+  { component: IconFlagFill, name: 'FlagFill' },
+  { component: IconFlagHillFill, name: 'FlagHillFill' },
+  { component: IconFlagHillLine, name: 'FlagHillLine' },
+  { component: IconFlagLine, name: 'FlagLine' },
+  { component: IconFlameFill, name: 'FlameFill' },
+  { component: IconFlameLine, name: 'FlameLine' },
+  { component: IconFlaskFill, name: 'FlaskFill' },
+  { component: IconFlaskLine, name: 'FlaskLine' },
+  { component: IconForkSpoonBagFill, name: 'ForkSpoonBagFill' },
+  { component: IconForkSpoonBagLine, name: 'ForkSpoonBagLine' },
+  { component: IconForkSpoonFill, name: 'ForkSpoonFill' },
+  { component: IconForkSpoonLine, name: 'ForkSpoonLine' },
+  { component: IconFridgeFill, name: 'FridgeFill' },
+  { component: IconFridgeLine, name: 'FridgeLine' },
+  { component: IconGearFill, name: 'GearFill' },
+  { component: IconGearLine, name: 'GearLine' },
+  { component: IconGiftFill, name: 'GiftFill' },
+  { component: IconGiftLine, name: 'GiftLine' },
+  { component: IconGlobeFill, name: 'GlobeFill' },
+  { component: IconGlobeLine, name: 'GlobeLine' },
+  { component: IconGraduationcapFill, name: 'GraduationcapFill' },
+  { component: IconGraduationcapLine, name: 'GraduationcapLine' },
+  { component: IconGridDot5Fill, name: 'GridDot5Fill' },
+  { component: IconGridDot5Line, name: 'GridDot5Line' },
+  { component: IconGridFill, name: 'GridFill' },
+  { component: IconGridHeartFill, name: 'GridHeartFill' },
+  { component: IconGridHeartLine, name: 'GridHeartLine' },
+  { component: IconGridLine, name: 'GridLine' },
+  { component: IconHandPointUpFill, name: 'HandPointUpFill' },
+  { component: IconHandPointUpLine, name: 'HandPointUpLine' },
+  { component: IconHandWaveFill, name: 'HandWaveFill' },
+  { component: IconHandWaveLine, name: 'HandWaveLine' },
+  { component: IconHashFill, name: 'HashFill' },
+  { component: IconHashLine, name: 'HashLine' },
+  { component: IconHeadsetFill, name: 'HeadsetFill' },
+  { component: IconHeadsetLine, name: 'HeadsetLine' },
+  { component: IconHeartFill, name: 'HeartFill' },
+  { component: IconHeartLine, name: 'HeartLine' },
+  {
+    component: IconHorizline2VerticalChatbubbleRectangularRightFill,
+    name: 'Horizline2VerticalChatbubbleRectangularRightFill',
+  },
+  {
+    component: IconHorizline2VerticalChatbubbleRectangularRightLine,
+    name: 'Horizline2VerticalChatbubbleRectangularRightLine',
+  },
+  {
+    component: IconHorizline2VerticalChatbubbleRectangularRightSlashFill,
+    name: 'Horizline2VerticalChatbubbleRectangularRightSlashFill',
+  },
+  {
+    component: IconHorizline2VerticalChatbubbleRectangularRightSlashLine,
+    name: 'Horizline2VerticalChatbubbleRectangularRightSlashLine',
+  },
+  {
+    component: IconHorizline3VerticalCheckmarkFill,
+    name: 'Horizline3VerticalCheckmarkFill',
+  },
+  {
+    component: IconHorizline3VerticalCheckmarkLine,
+    name: 'Horizline3VerticalCheckmarkLine',
+  },
+  { component: IconHorizline3VerticalFill, name: 'Horizline3VerticalFill' },
+  { component: IconHorizline3VerticalLine, name: 'Horizline3VerticalLine' },
+  {
+    component: IconHorizline3VerticalStarFill,
+    name: 'Horizline3VerticalStarFill',
+  },
+  {
+    component: IconHorizline3VerticalStarLine,
+    name: 'Horizline3VerticalStarLine',
+  },
+  {
+    component: IconHorizline3VerticalTightFill,
+    name: 'Horizline3VerticalTightFill',
+  },
+  {
+    component: IconHorizline3VerticalTightLine,
+    name: 'Horizline3VerticalTightLine',
+  },
+  { component: IconHorizlineViewfinderFill, name: 'HorizlineViewfinderFill' },
+  { component: IconHorizlineViewfinderLine, name: 'HorizlineViewfinderLine' },
+  {
+    component: IconHorizrectangleHorizline2VerticalFill,
+    name: 'HorizrectangleHorizline2VerticalFill',
+  },
+  {
+    component: IconHorizrectangleHorizline2VerticalLine,
+    name: 'HorizrectangleHorizline2VerticalLine',
+  },
+  {
+    component: IconHospitalcrossBuildingFill,
+    name: 'HospitalcrossBuildingFill',
+  },
+  {
+    component: IconHospitalcrossBuildingLine,
+    name: 'HospitalcrossBuildingLine',
+  },
+  { component: IconHospitalcrossSquareFill, name: 'HospitalcrossSquareFill' },
+  { component: IconHospitalcrossSquareLine, name: 'HospitalcrossSquareLine' },
+  { component: IconHouseFill, name: 'HouseFill' },
+  { component: IconHouseLine, name: 'HouseLine' },
+  { component: IconHousePlusFill, name: 'HousePlusFill' },
+  { component: IconHousePlusLine, name: 'HousePlusLine' },
+  { component: IconHouseSquareFill, name: 'HouseSquareFill' },
+  { component: IconHouseSquareLine, name: 'HouseSquareLine' },
+  {
+    component: IconILowercaseSerifCircleFill,
+    name: 'ILowercaseSerifCircleFill',
+  },
+  {
+    component: IconILowercaseSerifCircleLine,
+    name: 'ILowercaseSerifCircleLine',
+  },
+  { component: IconKeyboardChevronDownFill, name: 'KeyboardChevronDownFill' },
+  { component: IconKeyboardChevronDownLine, name: 'KeyboardChevronDownLine' },
+  { component: IconKeyholeShieldFill, name: 'KeyholeShieldFill' },
+  { component: IconKeyholeShieldLine, name: 'KeyholeShieldLine' },
+  { component: IconLaptopFill, name: 'LaptopFill' },
+  { component: IconLaptopLine, name: 'LaptopLine' },
+  { component: IconLeafFill, name: 'LeafFill' },
+  { component: IconLeafLine, name: 'LeafLine' },
+  { component: IconLightbulbDot5Fill, name: 'LightbulbDot5Fill' },
+  { component: IconLightbulbDot5Line, name: 'LightbulbDot5Line' },
+  { component: IconLightningFill, name: 'LightningFill' },
+  { component: IconLightningLine, name: 'LightningLine' },
+  { component: IconLightningSlashFill, name: 'LightningSlashFill' },
+  { component: IconLightningSlashLine, name: 'LightningSlashLine' },
+  { component: IconLinechartUpXaxisFill, name: 'LinechartUpXaxisFill' },
+  { component: IconLinechartUpXaxisLine, name: 'LinechartUpXaxisLine' },
+  { component: IconLocationpinFill, name: 'LocationpinFill' },
+  { component: IconLocationpinLine, name: 'LocationpinLine' },
+  { component: IconLockFill, name: 'LockFill' },
+  { component: IconLockLine, name: 'LockLine' },
+  { component: IconLockOpenedFill, name: 'LockOpenedFill' },
+  { component: IconLockOpenedLine, name: 'LockOpenedLine' },
+  { component: IconMagnifyingglassFill, name: 'MagnifyingglassFill' },
+  { component: IconMagnifyingglassLine, name: 'MagnifyingglassLine' },
+  {
+    component: IconMalesymbolFemalesymbolFill,
+    name: 'MalesymbolFemalesymbolFill',
+  },
+  {
+    component: IconMalesymbolFemalesymbolLine,
+    name: 'MalesymbolFemalesymbolLine',
+  },
+  { component: IconMapFill, name: 'MapFill' },
+  { component: IconMapLine, name: 'MapLine' },
+  { component: IconMapLocationpinFill, name: 'MapLocationpinFill' },
+  { component: IconMapLocationpinLine, name: 'MapLocationpinLine' },
+  { component: IconMegaphoneFill, name: 'MegaphoneFill' },
+  { component: IconMegaphoneLine, name: 'MegaphoneLine' },
+  { component: IconMegaphoneTiltedFill, name: 'MegaphoneTiltedFill' },
+  { component: IconMegaphoneTiltedLine, name: 'MegaphoneTiltedLine' },
+  { component: IconMetroFrontsideFill, name: 'MetroFrontsideFill' },
+  { component: IconMetroFrontsideLine, name: 'MetroFrontsideLine' },
+  { component: IconMicrophoneFill, name: 'MicrophoneFill' },
+  { component: IconMicrophoneLine, name: 'MicrophoneLine' },
+  { component: IconMicrophoneSlashFill, name: 'MicrophoneSlashFill' },
+  { component: IconMicrophoneSlashLine, name: 'MicrophoneSlashLine' },
+  { component: IconMicrowaveFill, name: 'MicrowaveFill' },
+  { component: IconMicrowaveLine, name: 'MicrowaveLine' },
+  { component: IconMidcutSquareFill, name: 'MidcutSquareFill' },
+  { component: IconMidcutSquareLine, name: 'MidcutSquareLine' },
+  { component: IconMinusCircleFill, name: 'MinusCircleFill' },
+  { component: IconMinusCircleLine, name: 'MinusCircleLine' },
+  { component: IconMinusFatFill, name: 'MinusFatFill' },
+  { component: IconMinusFatLine, name: 'MinusFatLine' },
+  { component: IconMinusFill, name: 'MinusFill' },
+  { component: IconMinusLine, name: 'MinusLine' },
+  { component: IconMobileFill, name: 'MobileFill' },
+  { component: IconMobileLine, name: 'MobileLine' },
+  { component: IconMoonFill, name: 'MoonFill' },
+  { component: IconMoonLine, name: 'MoonLine' },
+  { component: IconMusicalnoteDoubleFill, name: 'MusicalnoteDoubleFill' },
+  { component: IconMusicalnoteDoubleLine, name: 'MusicalnoteDoubleLine' },
+  { component: IconNUppercaseCircleFill, name: 'NUppercaseCircleFill' },
+  { component: IconNUppercaseCircleLine, name: 'NUppercaseCircleLine' },
+  { component: IconNailpolishFill, name: 'NailpolishFill' },
+  { component: IconNailpolishLine, name: 'NailpolishLine' },
+  { component: IconNeedleScaleFill, name: 'NeedleScaleFill' },
+  { component: IconNeedleScaleLine, name: 'NeedleScaleLine' },
+  { component: IconPUppercaseCircleFill, name: 'PUppercaseCircleFill' },
+  { component: IconPUppercaseCircleLine, name: 'PUppercaseCircleLine' },
+  { component: IconPaintrollerFill, name: 'PaintrollerFill' },
+  { component: IconPaintrollerLine, name: 'PaintrollerLine' },
+  { component: IconPaletteFill, name: 'PaletteFill' },
+  { component: IconPaletteLine, name: 'PaletteLine' },
+  { component: IconPaperclipFill, name: 'PaperclipFill' },
+  { component: IconPaperclipLine, name: 'PaperclipLine' },
+  { component: IconPaperplaneFill, name: 'PaperplaneFill' },
+  { component: IconPaperplaneLine, name: 'PaperplaneLine' },
+  { component: IconPaperplaneTiltedFill, name: 'PaperplaneTiltedFill' },
+  { component: IconPaperplaneTiltedLine, name: 'PaperplaneTiltedLine' },
+  { component: IconPawprintFill, name: 'PawprintFill' },
+  { component: IconPawprintLine, name: 'PawprintLine' },
+  { component: IconPenHorizlineFill, name: 'PenHorizlineFill' },
+  { component: IconPenHorizlineLine, name: 'PenHorizlineLine' },
+  { component: IconPencilFill, name: 'PencilFill' },
+  { component: IconPencilLine, name: 'PencilLine' },
+  { component: IconPeople3Fill, name: 'People3Fill' },
+  { component: IconPeople3Line, name: 'People3Line' },
+  { component: IconPercentFill, name: 'PercentFill' },
+  { component: IconPercentFlowerFill, name: 'PercentFlowerFill' },
+  { component: IconPercentFlowerLine, name: 'PercentFlowerLine' },
+  { component: IconPercentLine, name: 'PercentLine' },
+  { component: IconPerson2Fill, name: 'Person2Fill' },
+  { component: IconPerson2Line, name: 'Person2Line' },
+  { component: IconPerson2OpenarmsFill, name: 'Person2OpenarmsFill' },
+  { component: IconPerson2OpenarmsLine, name: 'Person2OpenarmsLine' },
+  { component: IconPersonCircleFill, name: 'PersonCircleFill' },
+  { component: IconPersonCircleLine, name: 'PersonCircleLine' },
+  { component: IconPersonFill, name: 'PersonFill' },
+  { component: IconPersonFlowerFill, name: 'PersonFlowerFill' },
+  { component: IconPersonFlowerLine, name: 'PersonFlowerLine' },
+  { component: IconPersonLine, name: 'PersonLine' },
+  {
+    component: IconPersonMagnifyingglassFill,
+    name: 'PersonMagnifyingglassFill',
+  },
+  {
+    component: IconPersonMagnifyingglassLine,
+    name: 'PersonMagnifyingglassLine',
+  },
+  { component: IconPersonPlusFill, name: 'PersonPlusFill' },
+  { component: IconPersonPlusLine, name: 'PersonPlusLine' },
+  { component: IconPersonShieldFill, name: 'PersonShieldFill' },
+  { component: IconPersonShieldLine, name: 'PersonShieldLine' },
+  { component: IconPhoneFill, name: 'PhoneFill' },
+  { component: IconPhoneLine, name: 'PhoneLine' },
+  { component: IconPhoneXmarkFill, name: 'PhoneXmarkFill' },
+  { component: IconPhoneXmarkLine, name: 'PhoneXmarkLine' },
+  { component: IconPicture2StackedFill, name: 'Picture2StackedFill' },
+  { component: IconPicture2StackedLine, name: 'Picture2StackedLine' },
+  { component: IconPictureFill, name: 'PictureFill' },
+  { component: IconPictureLine, name: 'PictureLine' },
+  { component: IconPlusCircleFill, name: 'PlusCircleFill' },
+  { component: IconPlusCircleLine, name: 'PlusCircleLine' },
+  { component: IconPlusFill, name: 'PlusFill' },
+  { component: IconPlusLine, name: 'PlusLine' },
+  { component: IconPlusSmallFill, name: 'PlusSmallFill' },
+  { component: IconPlusSmallLine, name: 'PlusSmallLine' },
+  { component: IconPlusSquareFill, name: 'PlusSquareFill' },
+  { component: IconPlusSquareLine, name: 'PlusSquareLine' },
+  { component: IconPostFill, name: 'PostFill' },
+  { component: IconPostLine, name: 'PostLine' },
+  { component: IconPushpinFill, name: 'PushpinFill' },
+  { component: IconPushpinLine, name: 'PushpinLine' },
+  {
+    component: IconQUppercaseChatbubbleRightFill,
+    name: 'QUppercaseChatbubbleRightFill',
+  },
+  {
+    component: IconQUppercaseChatbubbleRightLine,
+    name: 'QUppercaseChatbubbleRightLine',
+  },
+  { component: IconQuestionmarkCircleFill, name: 'QuestionmarkCircleFill' },
+  { component: IconQuestionmarkCircleLine, name: 'QuestionmarkCircleLine' },
+  { component: IconQuestionmarkSquareFill, name: 'QuestionmarkSquareFill' },
+  { component: IconQuestionmarkSquareLine, name: 'QuestionmarkSquareLine' },
+  { component: IconQuotationmark2LeftFill, name: 'Quotationmark2LeftFill' },
+  { component: IconQuotationmark2LeftLine, name: 'Quotationmark2LeftLine' },
+  { component: IconQuotationmark2RightFill, name: 'Quotationmark2RightFill' },
+  { component: IconQuotationmark2RightLine, name: 'Quotationmark2RightLine' },
+  { component: IconReceiptFill, name: 'ReceiptFill' },
+  { component: IconReceiptLine, name: 'ReceiptLine' },
+  {
+    component: IconRectangleSplitedLineVerticalFill,
+    name: 'RectangleSplitedLineVerticalFill',
+  },
+  {
+    component: IconRectangleSplitedLineVerticalLine,
+    name: 'RectangleSplitedLineVerticalLine',
+  },
+  { component: IconRoadlaneFill, name: 'RoadlaneFill' },
+  { component: IconRoadlaneLine, name: 'RoadlaneLine' },
+  { component: IconRocketFill, name: 'RocketFill' },
+  { component: IconRocketLine, name: 'RocketLine' },
+  { component: IconRooftoproomFill, name: 'RooftoproomFill' },
+  { component: IconRooftoproomLine, name: 'RooftoproomLine' },
+  {
+    component: IconSUppercaseHorizlineCenterFill,
+    name: 'SUppercaseHorizlineCenterFill',
+  },
+  {
+    component: IconSUppercaseHorizlineCenterLine,
+    name: 'SUppercaseHorizlineCenterLine',
+  },
+  { component: IconScissorsFill, name: 'ScissorsFill' },
+  { component: IconScissorsLine, name: 'ScissorsLine' },
+  { component: IconScribbleFill, name: 'ScribbleFill' },
+  { component: IconScribbleLine, name: 'ScribbleLine' },
+  { component: IconSeatLeftFanFill, name: 'SeatLeftFanFill' },
+  { component: IconSeatLeftFanLine, name: 'SeatLeftFanLine' },
+  { component: IconSeatLeftFill, name: 'SeatLeftFill' },
+  { component: IconSeatLeftHeatwave2Fill, name: 'SeatLeftHeatwave2Fill' },
+  { component: IconSeatLeftHeatwave2Line, name: 'SeatLeftHeatwave2Line' },
+  { component: IconSeatLeftLine, name: 'SeatLeftLine' },
+  { component: IconShoppingbag2StackedFill, name: 'Shoppingbag2StackedFill' },
+  { component: IconShoppingbag2StackedLine, name: 'Shoppingbag2StackedLine' },
+  { component: IconShoppingbagFill, name: 'ShoppingbagFill' },
+  { component: IconShoppingbagItemsFill, name: 'ShoppingbagItemsFill' },
+  { component: IconShoppingbagItemsLine, name: 'ShoppingbagItemsLine' },
+  { component: IconShoppingbagLine, name: 'ShoppingbagLine' },
+  { component: IconSidemirrorWaveFill, name: 'SidemirrorWaveFill' },
+  { component: IconSidemirrorWaveLine, name: 'SidemirrorWaveLine' },
+  { component: IconSignboardFill, name: 'SignboardFill' },
+  { component: IconSignboardLine, name: 'SignboardLine' },
+  { component: IconSlashCircleFill, name: 'SlashCircleFill' },
+  { component: IconSlashCircleLine, name: 'SlashCircleLine' },
+  { component: IconSlashSemicircle2Fill, name: 'SlashSemicircle2Fill' },
+  { component: IconSlashSemicircle2Line, name: 'SlashSemicircle2Line' },
+  { component: IconSlider2HorizontalFill, name: 'Slider2HorizontalFill' },
+  { component: IconSlider2HorizontalLine, name: 'Slider2HorizontalLine' },
+  { component: IconSmartkeyFill, name: 'SmartkeyFill' },
+  { component: IconSmartkeyLine, name: 'SmartkeyLine' },
+  {
+    component: IconSneakerLiftedLeftsideFill,
+    name: 'SneakerLiftedLeftsideFill',
+  },
+  {
+    component: IconSneakerLiftedLeftsideLine,
+    name: 'SneakerLiftedLeftsideLine',
+  },
+  { component: IconSofaFill, name: 'SofaFill' },
+  { component: IconSofaLine, name: 'SofaLine' },
+  { component: IconSparkle2Fill, name: 'Sparkle2Fill' },
+  { component: IconSparkle2Line, name: 'Sparkle2Line' },
+  { component: IconSparkleViewfinderFill, name: 'SparkleViewfinderFill' },
+  { component: IconSparkleViewfinderLine, name: 'SparkleViewfinderLine' },
+  { component: IconSpeakerWave2Fill, name: 'SpeakerWave2Fill' },
+  { component: IconSpeakerWave2Line, name: 'SpeakerWave2Line' },
+  { component: IconSpeakerWave2SlashFill, name: 'SpeakerWave2SlashFill' },
+  { component: IconSpeakerWave2SlashLine, name: 'SpeakerWave2SlashLine' },
+  { component: IconSpeedometerFill, name: 'SpeedometerFill' },
+  { component: IconSpeedometerLine, name: 'SpeedometerLine' },
+  { component: IconSpeedometer_1xFill, name: 'Speedometer_1xFill' },
+  { component: IconSpeedometer_1xLine, name: 'Speedometer_1xLine' },
+  { component: IconSpeedometer_2xFill, name: 'Speedometer_2xFill' },
+  { component: IconSpeedometer_2xLine, name: 'Speedometer_2xLine' },
+  { component: IconSpeedometer_3xFill, name: 'Speedometer_3xFill' },
+  { component: IconSpeedometer_3xLine, name: 'Speedometer_3xLine' },
+  { component: IconSplitedGridSquareFill, name: 'SplitedGridSquareFill' },
+  { component: IconSplitedGridSquareLine, name: 'SplitedGridSquareLine' },
+  { component: IconSpraybottleSpongeFill, name: 'SpraybottleSpongeFill' },
+  { component: IconSpraybottleSpongeLine, name: 'SpraybottleSpongeLine' },
+  { component: IconSquare2StackedFill, name: 'Square2StackedFill' },
+  { component: IconSquare2StackedLine, name: 'Square2StackedLine' },
+  { component: IconSquareline2VerticalFill, name: 'Squareline2VerticalFill' },
+  { component: IconSquareline2VerticalLine, name: 'Squareline2VerticalLine' },
+  { component: IconStarFill, name: 'StarFill' },
+  { component: IconStarLine, name: 'StarLine' },
+  {
+    component: IconSteeringwheelHeatwave2Fill,
+    name: 'SteeringwheelHeatwave2Fill',
+  },
+  {
+    component: IconSteeringwheelHeatwave2Line,
+    name: 'SteeringwheelHeatwave2Line',
+  },
+  { component: IconStepsFill, name: 'StepsFill' },
+  { component: IconStepsLine, name: 'StepsLine' },
+  { component: IconStoreCheckmarkFill, name: 'StoreCheckmarkFill' },
+  { component: IconStoreCheckmarkLine, name: 'StoreCheckmarkLine' },
+  { component: IconStoreFill, name: 'StoreFill' },
+  { component: IconStoreLine, name: 'StoreLine' },
+  { component: IconStorePenFill, name: 'StorePenFill' },
+  { component: IconStorePenLine, name: 'StorePenLine' },
+  { component: IconSunFill, name: 'SunFill' },
+  { component: IconSunLine, name: 'SunLine' },
+  { component: IconTUppercaseSerifFill, name: 'TUppercaseSerifFill' },
+  { component: IconTUppercaseSerifLine, name: 'TUppercaseSerifLine' },
+  { component: IconTUppercaseTLowercaseFill, name: 'TUppercaseTLowercaseFill' },
+  { component: IconTUppercaseTLowercaseLine, name: 'TUppercaseTLowercaseLine' },
+  { component: IconTagFill, name: 'TagFill' },
+  { component: IconTagLine, name: 'TagLine' },
+  { component: IconTextAligncenterFill, name: 'TextAligncenterFill' },
+  { component: IconTextAligncenterLine, name: 'TextAligncenterLine' },
+  { component: IconTextAlignleftFill, name: 'TextAlignleftFill' },
+  { component: IconTextAlignleftLine, name: 'TextAlignleftLine' },
+  { component: IconTextAlignrightFill, name: 'TextAlignrightFill' },
+  { component: IconTextAlignrightLine, name: 'TextAlignrightLine' },
+  { component: IconThumbDownFill, name: 'ThumbDownFill' },
+  { component: IconThumbDownLine, name: 'ThumbDownLine' },
+  { component: IconThumbUpFill, name: 'ThumbUpFill' },
+  { component: IconThumbUpLine, name: 'ThumbUpLine' },
+  { component: IconTimerFill, name: 'TimerFill' },
+  { component: IconTimerLine, name: 'TimerLine' },
+  { component: IconTimer_10Fill, name: 'Timer_10Fill' },
+  { component: IconTimer_10Line, name: 'Timer_10Line' },
+  { component: IconTimer_3Fill, name: 'Timer_3Fill' },
+  { component: IconTimer_3Line, name: 'Timer_3Line' },
+  { component: IconToolboxFill, name: 'ToolboxFill' },
+  { component: IconToolboxLine, name: 'ToolboxLine' },
+  { component: IconTranslationFill, name: 'TranslationFill' },
+  { component: IconTranslationLine, name: 'TranslationLine' },
+  { component: IconTrashcanFill, name: 'TrashcanFill' },
+  { component: IconTrashcanLine, name: 'TrashcanLine' },
+  { component: IconTriangleDownSmallFill, name: 'TriangleDownSmallFill' },
+  { component: IconTriangleDownSmallLine, name: 'TriangleDownSmallLine' },
+  {
+    component: IconTriangleRightChatbubbleLeftFill,
+    name: 'TriangleRightChatbubbleLeftFill',
+  },
+  {
+    component: IconTriangleRightChatbubbleLeftLine,
+    name: 'TriangleRightChatbubbleLeftLine',
+  },
+  { component: IconTriangleRightFill, name: 'TriangleRightFill' },
+  { component: IconTriangleRightLine, name: 'TriangleRightLine' },
+  {
+    component: IconTriangleRightRectangleSplitedLineVerticalFill,
+    name: 'TriangleRightRectangleSplitedLineVerticalFill',
+  },
+  {
+    component: IconTriangleRightRectangleSplitedLineVerticalLine,
+    name: 'TriangleRightRectangleSplitedLineVerticalLine',
+  },
+  { component: IconTriangleUpSmallFill, name: 'TriangleUpSmallFill' },
+  { component: IconTriangleUpSmallLine, name: 'TriangleUpSmallLine' },
+  { component: IconTrophyFill, name: 'TrophyFill' },
+  { component: IconTrophyLine, name: 'TrophyLine' },
+  { component: IconTruckFill, name: 'TruckFill' },
+  { component: IconTruckLine, name: 'TruckLine' },
+  { component: IconTshirtBubble2Fill, name: 'TshirtBubble2Fill' },
+  { component: IconTshirtBubble2Line, name: 'TshirtBubble2Line' },
+  { component: IconUUppercaseHorizlineFill, name: 'UUppercaseHorizlineFill' },
+  { component: IconUUppercaseHorizlineLine, name: 'UUppercaseHorizlineLine' },
+  { component: IconVertline3ViewfinderFill, name: 'Vertline3ViewfinderFill' },
+  { component: IconVertline3ViewfinderLine, name: 'Vertline3ViewfinderLine' },
+  { component: IconVertline4SparkleFill, name: 'Vertline4SparkleFill' },
+  { component: IconVertline4SparkleLine, name: 'Vertline4SparkleLine' },
+  { component: IconVertlineCouponFill, name: 'VertlineCouponFill' },
+  { component: IconVertlineCouponLine, name: 'VertlineCouponLine' },
+  {
+    component: IconVertrectangle2HorizontalFill,
+    name: 'Vertrectangle2HorizontalFill',
+  },
+  {
+    component: IconVertrectangle2HorizontalLine,
+    name: 'Vertrectangle2HorizontalLine',
+  },
+  { component: IconVertrectangleFoldedFill, name: 'VertrectangleFoldedFill' },
+  { component: IconVertrectangleFoldedLine, name: 'VertrectangleFoldedLine' },
+  { component: IconVotingstampFill, name: 'VotingstampFill' },
+  { component: IconVotingstampLine, name: 'VotingstampLine' },
+  { component: IconWandFill, name: 'WandFill' },
+  { component: IconWandLine, name: 'WandLine' },
+  { component: IconWashingmachineFill, name: 'WashingmachineFill' },
+  { component: IconWashingmachineLine, name: 'WashingmachineLine' },
+  { component: IconWindow2StoreFill, name: 'Window2StoreFill' },
+  { component: IconWindow2StoreLine, name: 'Window2StoreLine' },
+  { component: IconWindow4HouseFill, name: 'Window4HouseFill' },
+  { component: IconWindow4HouseLine, name: 'Window4HouseLine' },
+  {
+    component: IconWonArrowClockwiseCircularFill,
+    name: 'WonArrowClockwiseCircularFill',
+  },
+  {
+    component: IconWonArrowClockwiseCircularLine,
+    name: 'WonArrowClockwiseCircularLine',
+  },
+  { component: IconWonCircleArrowLeftFill, name: 'WonCircleArrowLeftFill' },
+  { component: IconWonCircleArrowLeftLine, name: 'WonCircleArrowLeftLine' },
+  { component: IconWonCircleArrowRightFill, name: 'WonCircleArrowRightFill' },
+  { component: IconWonCircleArrowRightLine, name: 'WonCircleArrowRightLine' },
+  { component: IconWonCircleFill, name: 'WonCircleFill' },
+  { component: IconWonCircleLine, name: 'WonCircleLine' },
+  { component: IconWonFill, name: 'WonFill' },
+  { component: IconWonLine, name: 'WonLine' },
+  { component: IconWonShieldFill, name: 'WonShieldFill' },
+  { component: IconWonShieldLine, name: 'WonShieldLine' },
+  { component: IconWrenchFill, name: 'WrenchFill' },
+  { component: IconWrenchLine, name: 'WrenchLine' },
+  { component: IconXmarkCircleFill, name: 'XmarkCircleFill' },
+  { component: IconXmarkCircleLine, name: 'XmarkCircleLine' },
+  { component: IconXmarkFill, name: 'XmarkFill' },
+  { component: IconXmarkLine, name: 'XmarkLine' },
+  { component: IconXmarkScaleFill, name: 'XmarkScaleFill' },
+  { component: IconXmarkScaleLine, name: 'XmarkScaleLine' },
+  { component: IconYenCircleArrowRightFill, name: 'YenCircleArrowRightFill' },
+  { component: IconYenCircleArrowRightLine, name: 'YenCircleArrowRightLine' },
+  { component: IconYenCircleFill, name: 'YenCircleFill' },
+  { component: IconYenCircleLine, name: 'YenCircleLine' },
+  { component: IconYenFill, name: 'YenFill' },
+  { component: IconYenLine, name: 'YenLine' },
+];
+
+export function FoundationMonochromeIconPage() {
+  return (
+    <scroll-view
+      scroll-y
+      style={{ display: 'flex', flexDirection: 'column', flex: 1 }}
+    >
+      <text style={{ fontSize: '20px', fontWeight: 'bold' }}>
+        Monochrome Icon
+      </text>
+      <text
+        style={{
+          fontSize: '13px',
+          color: $color.fg.neutralSubtle,
+          marginBottom: '8px',
+        }}
+      >
+        @karrotmarket/lynx-monochrome-icon — {icons.length} icons
+      </text>
+
+      <view
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          flexWrap: 'wrap',
+          gap: '4px',
+        }}
+      >
+        {icons.map(({ component: IconComp, name }) => (
+          <view
+            key={name}
+            style={{
+              width: '80px',
+              padding: '8px 4px',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: '4px',
+            }}
+          >
+            <IconComp size={24} color={$color.fg.neutral} />
+            <text
+              style={{
+                fontSize: '9px',
+                color: $color.fg.neutralMuted,
+                textAlign: 'center',
+                wordBreak: 'break-all',
+              }}
+            >
+              {name}
+            </text>
+          </view>
+        ))}
+      </view>
+    </scroll-view>
+  );
+}

--- a/examples/lynx-spa/src/pages/FoundationMonochromeIconPage.tsx
+++ b/examples/lynx-spa/src/pages/FoundationMonochromeIconPage.tsx
@@ -1302,14 +1302,13 @@ export function FoundationMonochromeIconPage() {
           display: "flex",
           flexDirection: "row",
           flexWrap: "wrap",
-          gap: "4px",
         }}
       >
         {icons.map(({ component: IconComp, name }) => (
           <view
             key={name}
             style={{
-              width: "80px",
+              width: "25%",
               padding: "8px 4px",
               display: "flex",
               flexDirection: "column",

--- a/examples/lynx-spa/src/pages/FoundationMonochromeIconPage.tsx
+++ b/examples/lynx-spa/src/pages/FoundationMonochromeIconPage.tsx
@@ -1,642 +1,641 @@
-// Total: 636 icons
-import { vars } from '@seed-design/css/vars';
+import { vars } from "@seed-design/css/vars";
 
-import IconAUppercaseALowercaseFill from '@karrotmarket/lynx-monochrome-icon/IconAUppercaseALowercaseFill';
-import IconAUppercaseALowercaseLine from '@karrotmarket/lynx-monochrome-icon/IconAUppercaseALowercaseLine';
-import IconAUppercaseOutlineFill from '@karrotmarket/lynx-monochrome-icon/IconAUppercaseOutlineFill';
-import IconAUppercaseOutlineLine from '@karrotmarket/lynx-monochrome-icon/IconAUppercaseOutlineLine';
-import IconAUppercaseSquareFill from '@karrotmarket/lynx-monochrome-icon/IconAUppercaseSquareFill';
-import IconAUppercaseSquareLine from '@karrotmarket/lynx-monochrome-icon/IconAUppercaseSquareLine';
-import IconAndroidshareFill from '@karrotmarket/lynx-monochrome-icon/IconAndroidshareFill';
-import IconAndroidshareLine from '@karrotmarket/lynx-monochrome-icon/IconAndroidshareLine';
-import IconAppleFill from '@karrotmarket/lynx-monochrome-icon/IconAppleFill';
-import IconAppleLine from '@karrotmarket/lynx-monochrome-icon/IconAppleLine';
-import IconArrow2ClockwiseCircularFill from '@karrotmarket/lynx-monochrome-icon/IconArrow2ClockwiseCircularFill';
-import IconArrow2ClockwiseCircularLine from '@karrotmarket/lynx-monochrome-icon/IconArrow2ClockwiseCircularLine';
-import IconArrowClockwiseCircularFill from '@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseCircularFill';
-import IconArrowClockwiseCircularLine from '@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseCircularLine';
-import IconArrowClockwiseOvalFill from '@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseOvalFill';
-import IconArrowClockwiseOvalLine from '@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseOvalLine';
-import IconArrowCounterclockwiseCircularFill from '@karrotmarket/lynx-monochrome-icon/IconArrowCounterclockwiseCircularFill';
-import IconArrowCounterclockwiseCircularLine from '@karrotmarket/lynx-monochrome-icon/IconArrowCounterclockwiseCircularLine';
-import IconArrowDownFill from '@karrotmarket/lynx-monochrome-icon/IconArrowDownFill';
-import IconArrowDownHorizlineFill from '@karrotmarket/lynx-monochrome-icon/IconArrowDownHorizlineFill';
-import IconArrowDownHorizlineLine from '@karrotmarket/lynx-monochrome-icon/IconArrowDownHorizlineLine';
-import IconArrowDownLine from '@karrotmarket/lynx-monochrome-icon/IconArrowDownLine';
-import IconArrowDownLineVerticalArrowUpSquareFill from '@karrotmarket/lynx-monochrome-icon/IconArrowDownLineVerticalArrowUpSquareFill';
-import IconArrowDownLineVerticalArrowUpSquareLine from '@karrotmarket/lynx-monochrome-icon/IconArrowDownLineVerticalArrowUpSquareLine';
-import IconArrowDownRightArrowUpLeftFill from '@karrotmarket/lynx-monochrome-icon/IconArrowDownRightArrowUpLeftFill';
-import IconArrowDownRightArrowUpLeftLine from '@karrotmarket/lynx-monochrome-icon/IconArrowDownRightArrowUpLeftLine';
-import IconArrowLeftBracketRightFill from '@karrotmarket/lynx-monochrome-icon/IconArrowLeftBracketRightFill';
-import IconArrowLeftBracketRightLine from '@karrotmarket/lynx-monochrome-icon/IconArrowLeftBracketRightLine';
-import IconArrowLeftFill from '@karrotmarket/lynx-monochrome-icon/IconArrowLeftFill';
-import IconArrowLeftLine from '@karrotmarket/lynx-monochrome-icon/IconArrowLeftLine';
-import IconArrowRightAngledFill from '@karrotmarket/lynx-monochrome-icon/IconArrowRightAngledFill';
-import IconArrowRightAngledLine from '@karrotmarket/lynx-monochrome-icon/IconArrowRightAngledLine';
-import IconArrowRightArrowLeftFill from '@karrotmarket/lynx-monochrome-icon/IconArrowRightArrowLeftFill';
-import IconArrowRightArrowLeftLine from '@karrotmarket/lynx-monochrome-icon/IconArrowRightArrowLeftLine';
-import IconArrowRightFill from '@karrotmarket/lynx-monochrome-icon/IconArrowRightFill';
-import IconArrowRightLine from '@karrotmarket/lynx-monochrome-icon/IconArrowRightLine';
-import IconArrowUpArrowDownFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpArrowDownFill';
-import IconArrowUpArrowDownLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpArrowDownLine';
-import IconArrowUpBracketDownFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpBracketDownFill';
-import IconArrowUpBracketDownLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpBracketDownLine';
-import IconArrowUpFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpFill';
-import IconArrowUpLeftFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpLeftFill';
-import IconArrowUpLeftLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpLeftLine';
-import IconArrowUpLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpLine';
-import IconArrowUpRightArrowDownLeftFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftFill';
-import IconArrowUpRightArrowDownLeftLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftLine';
-import IconArrowUpRightArrowDownLeftSquareFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftSquareFill';
-import IconArrowUpRightArrowDownLeftSquareLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftSquareLine';
-import IconArrowUpRightFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightFill';
-import IconArrowUpRightLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightLine';
-import IconArrowUpRightShoppingbagTiltedFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightShoppingbagTiltedFill';
-import IconArrowUpRightShoppingbagTiltedLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightShoppingbagTiltedLine';
-import IconArrowUturnLeftFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUturnLeftFill';
-import IconArrowUturnLeftLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUturnLeftLine';
-import IconArrowUturnRightFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUturnRightFill';
-import IconArrowUturnRightLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUturnRightLine';
-import IconArticleFill from '@karrotmarket/lynx-monochrome-icon/IconArticleFill';
-import IconArticleLine from '@karrotmarket/lynx-monochrome-icon/IconArticleLine';
-import IconAsteriskHorizrectangleCoolwave3Fill from '@karrotmarket/lynx-monochrome-icon/IconAsteriskHorizrectangleCoolwave3Fill';
-import IconAsteriskHorizrectangleCoolwave3Line from '@karrotmarket/lynx-monochrome-icon/IconAsteriskHorizrectangleCoolwave3Line';
-import IconAtFill from '@karrotmarket/lynx-monochrome-icon/IconAtFill';
-import IconAtLine from '@karrotmarket/lynx-monochrome-icon/IconAtLine';
-import IconBUppercaseFill from '@karrotmarket/lynx-monochrome-icon/IconBUppercaseFill';
-import IconBUppercaseLine from '@karrotmarket/lynx-monochrome-icon/IconBUppercaseLine';
-import IconBackspacekeyFill from '@karrotmarket/lynx-monochrome-icon/IconBackspacekeyFill';
-import IconBackspacekeyLine from '@karrotmarket/lynx-monochrome-icon/IconBackspacekeyLine';
-import IconBarchartBoardFill from '@karrotmarket/lynx-monochrome-icon/IconBarchartBoardFill';
-import IconBarchartBoardLine from '@karrotmarket/lynx-monochrome-icon/IconBarchartBoardLine';
-import IconBarchartSquareFill from '@karrotmarket/lynx-monochrome-icon/IconBarchartSquareFill';
-import IconBarchartSquareLine from '@karrotmarket/lynx-monochrome-icon/IconBarchartSquareLine';
-import IconBedFrontsideFill from '@karrotmarket/lynx-monochrome-icon/IconBedFrontsideFill';
-import IconBedFrontsideLine from '@karrotmarket/lynx-monochrome-icon/IconBedFrontsideLine';
-import IconBellFill from '@karrotmarket/lynx-monochrome-icon/IconBellFill';
-import IconBellLine from '@karrotmarket/lynx-monochrome-icon/IconBellLine';
-import IconBellSlashFill from '@karrotmarket/lynx-monochrome-icon/IconBellSlashFill';
-import IconBellSlashLine from '@karrotmarket/lynx-monochrome-icon/IconBellSlashLine';
-import IconBookFill from '@karrotmarket/lynx-monochrome-icon/IconBookFill';
-import IconBookLine from '@karrotmarket/lynx-monochrome-icon/IconBookLine';
-import IconBookOpenFill from '@karrotmarket/lynx-monochrome-icon/IconBookOpenFill';
-import IconBookOpenLine from '@karrotmarket/lynx-monochrome-icon/IconBookOpenLine';
-import IconBookmarkFill from '@karrotmarket/lynx-monochrome-icon/IconBookmarkFill';
-import IconBookmarkLine from '@karrotmarket/lynx-monochrome-icon/IconBookmarkLine';
-import IconBoxFlapFill from '@karrotmarket/lynx-monochrome-icon/IconBoxFlapFill';
-import IconBoxFlapLine from '@karrotmarket/lynx-monochrome-icon/IconBoxFlapLine';
-import IconBracketLeftArrowRightFill from '@karrotmarket/lynx-monochrome-icon/IconBracketLeftArrowRightFill';
-import IconBracketLeftArrowRightLine from '@karrotmarket/lynx-monochrome-icon/IconBracketLeftArrowRightLine';
-import IconBuilding2Fill from '@karrotmarket/lynx-monochrome-icon/IconBuilding2Fill';
-import IconBuilding2Line from '@karrotmarket/lynx-monochrome-icon/IconBuilding2Line';
-import IconCalendarFill from '@karrotmarket/lynx-monochrome-icon/IconCalendarFill';
-import IconCalendarLine from '@karrotmarket/lynx-monochrome-icon/IconCalendarLine';
-import IconCamcorderFill from '@karrotmarket/lynx-monochrome-icon/IconCamcorderFill';
-import IconCamcorderLine from '@karrotmarket/lynx-monochrome-icon/IconCamcorderLine';
-import IconCameraFill from '@karrotmarket/lynx-monochrome-icon/IconCameraFill';
-import IconCameraLine from '@karrotmarket/lynx-monochrome-icon/IconCameraLine';
-import IconCarFill from '@karrotmarket/lynx-monochrome-icon/IconCarFill';
-import IconCarFrontUpsideWave2ReversedUpFill from '@karrotmarket/lynx-monochrome-icon/IconCarFrontUpsideWave2ReversedUpFill';
-import IconCarFrontUpsideWave2ReversedUpLine from '@karrotmarket/lynx-monochrome-icon/IconCarFrontUpsideWave2ReversedUpLine';
-import IconCarFrontsideFill from '@karrotmarket/lynx-monochrome-icon/IconCarFrontsideFill';
-import IconCarFrontsideLine from '@karrotmarket/lynx-monochrome-icon/IconCarFrontsideLine';
-import IconCarLine from '@karrotmarket/lynx-monochrome-icon/IconCarLine';
-import IconCarRearTrunkOpenLeftsideFill from '@karrotmarket/lynx-monochrome-icon/IconCarRearTrunkOpenLeftsideFill';
-import IconCarRearTrunkOpenLeftsideLine from '@karrotmarket/lynx-monochrome-icon/IconCarRearTrunkOpenLeftsideLine';
-import IconCarRearUpsideSectorDownFill from '@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideSectorDownFill';
-import IconCarRearUpsideSectorDownLine from '@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideSectorDownLine';
-import IconCarRearUpsideWave2ReversedDownFill from '@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownFill';
-import IconCarRearUpsideWave2ReversedDownLeftFill from '@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownLeftFill';
-import IconCarRearUpsideWave2ReversedDownLeftLine from '@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownLeftLine';
-import IconCarRearUpsideWave2ReversedDownLine from '@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownLine';
-import IconCardFill from '@karrotmarket/lynx-monochrome-icon/IconCardFill';
-import IconCardLine from '@karrotmarket/lynx-monochrome-icon/IconCardLine';
-import IconCarrotFill from '@karrotmarket/lynx-monochrome-icon/IconCarrotFill';
-import IconCarrotLine from '@karrotmarket/lynx-monochrome-icon/IconCarrotLine';
-import IconCartFill from '@karrotmarket/lynx-monochrome-icon/IconCartFill';
-import IconCartItemsFill from '@karrotmarket/lynx-monochrome-icon/IconCartItemsFill';
-import IconCartItemsLine from '@karrotmarket/lynx-monochrome-icon/IconCartItemsLine';
-import IconCartLine from '@karrotmarket/lynx-monochrome-icon/IconCartLine';
-import IconCartLoadFill from '@karrotmarket/lynx-monochrome-icon/IconCartLoadFill';
-import IconCartLoadLine from '@karrotmarket/lynx-monochrome-icon/IconCartLoadLine';
-import IconCheckmarkBadgeFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkBadgeFill';
-import IconCheckmarkBadgeLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkBadgeLine';
-import IconCheckmarkBallotboxFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkBallotboxFill';
-import IconCheckmarkBallotboxLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkBallotboxLine';
-import IconCheckmarkCalendarFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkCalendarFill';
-import IconCheckmarkCalendarLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkCalendarLine';
-import IconCheckmarkChatbubbleLeftFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkChatbubbleLeftFill';
-import IconCheckmarkChatbubbleLeftLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkChatbubbleLeftLine';
-import IconCheckmarkCircleFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkCircleFill';
-import IconCheckmarkCircleLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkCircleLine';
-import IconCheckmarkClipboardFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkClipboardFill';
-import IconCheckmarkClipboardLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkClipboardLine';
-import IconCheckmarkCouponFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkCouponFill';
-import IconCheckmarkCouponLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkCouponLine';
-import IconCheckmarkFatFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkFatFill';
-import IconCheckmarkFatLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkFatLine';
-import IconCheckmarkFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkFill';
-import IconCheckmarkFlowerFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkFlowerFill';
-import IconCheckmarkFlowerLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkFlowerLine';
-import IconCheckmarkHorizlineFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkHorizlineFill';
-import IconCheckmarkHorizlineLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkHorizlineLine';
-import IconCheckmarkLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkLine';
-import IconCheckmarkScaleFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkScaleFill';
-import IconCheckmarkScaleLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkScaleLine';
-import IconCheckmarkShieldFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkShieldFill';
-import IconCheckmarkShieldLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkShieldLine';
-import IconCheckmarkhorizline2VerticalFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkhorizline2VerticalFill';
-import IconCheckmarkhorizline2VerticalLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkhorizline2VerticalLine';
-import IconChevronDownFill from '@karrotmarket/lynx-monochrome-icon/IconChevronDownFill';
-import IconChevronDownLine from '@karrotmarket/lynx-monochrome-icon/IconChevronDownLine';
-import IconChevronDownSmallFill from '@karrotmarket/lynx-monochrome-icon/IconChevronDownSmallFill';
-import IconChevronDownSmallLine from '@karrotmarket/lynx-monochrome-icon/IconChevronDownSmallLine';
-import IconChevronLeftFill from '@karrotmarket/lynx-monochrome-icon/IconChevronLeftFill';
-import IconChevronLeftLine from '@karrotmarket/lynx-monochrome-icon/IconChevronLeftLine';
-import IconChevronLeftSmallFill from '@karrotmarket/lynx-monochrome-icon/IconChevronLeftSmallFill';
-import IconChevronLeftSmallLine from '@karrotmarket/lynx-monochrome-icon/IconChevronLeftSmallLine';
-import IconChevronRightFill from '@karrotmarket/lynx-monochrome-icon/IconChevronRightFill';
-import IconChevronRightLine from '@karrotmarket/lynx-monochrome-icon/IconChevronRightLine';
-import IconChevronRightSmallFill from '@karrotmarket/lynx-monochrome-icon/IconChevronRightSmallFill';
-import IconChevronRightSmallLine from '@karrotmarket/lynx-monochrome-icon/IconChevronRightSmallLine';
-import IconChevronUpFill from '@karrotmarket/lynx-monochrome-icon/IconChevronUpFill';
-import IconChevronUpLine from '@karrotmarket/lynx-monochrome-icon/IconChevronUpLine';
-import IconChevronUpSmallFill from '@karrotmarket/lynx-monochrome-icon/IconChevronUpSmallFill';
-import IconChevronUpSmallLine from '@karrotmarket/lynx-monochrome-icon/IconChevronUpSmallLine';
-import IconCircle4SquareFill from '@karrotmarket/lynx-monochrome-icon/IconCircle4SquareFill';
-import IconCircle4SquareLine from '@karrotmarket/lynx-monochrome-icon/IconCircle4SquareLine';
-import IconClockFill from '@karrotmarket/lynx-monochrome-icon/IconClockFill';
-import IconClockLine from '@karrotmarket/lynx-monochrome-icon/IconClockLine';
-import IconCompassFill from '@karrotmarket/lynx-monochrome-icon/IconCompassFill';
-import IconCompassLine from '@karrotmarket/lynx-monochrome-icon/IconCompassLine';
-import IconCorner4InwardFill from '@karrotmarket/lynx-monochrome-icon/IconCorner4InwardFill';
-import IconCorner4InwardLine from '@karrotmarket/lynx-monochrome-icon/IconCorner4InwardLine';
-import IconCorner4OutwardFill from '@karrotmarket/lynx-monochrome-icon/IconCorner4OutwardFill';
-import IconCorner4OutwardLine from '@karrotmarket/lynx-monochrome-icon/IconCorner4OutwardLine';
-import IconCornerDownLeftFill from '@karrotmarket/lynx-monochrome-icon/IconCornerDownLeftFill';
-import IconCornerDownLeftLine from '@karrotmarket/lynx-monochrome-icon/IconCornerDownLeftLine';
-import IconCouponFill from '@karrotmarket/lynx-monochrome-icon/IconCouponFill';
-import IconCouponLine from '@karrotmarket/lynx-monochrome-icon/IconCouponLine';
-import IconCropmarkFill from '@karrotmarket/lynx-monochrome-icon/IconCropmarkFill';
-import IconCropmarkLine from '@karrotmarket/lynx-monochrome-icon/IconCropmarkLine';
-import IconCrosshairFill from '@karrotmarket/lynx-monochrome-icon/IconCrosshairFill';
-import IconCrosshairLine from '@karrotmarket/lynx-monochrome-icon/IconCrosshairLine';
-import IconCrosshairQuestionmarkFill from '@karrotmarket/lynx-monochrome-icon/IconCrosshairQuestionmarkFill';
-import IconCrosshairQuestionmarkLine from '@karrotmarket/lynx-monochrome-icon/IconCrosshairQuestionmarkLine';
-import IconCrownFill from '@karrotmarket/lynx-monochrome-icon/IconCrownFill';
-import IconCrownLine from '@karrotmarket/lynx-monochrome-icon/IconCrownLine';
-import IconCupHeatwaveFill from '@karrotmarket/lynx-monochrome-icon/IconCupHeatwaveFill';
-import IconCupHeatwaveLine from '@karrotmarket/lynx-monochrome-icon/IconCupHeatwaveLine';
-import IconDiamondFill from '@karrotmarket/lynx-monochrome-icon/IconDiamondFill';
-import IconDiamondLine from '@karrotmarket/lynx-monochrome-icon/IconDiamondLine';
-import IconDocumentArrowLeftFill from '@karrotmarket/lynx-monochrome-icon/IconDocumentArrowLeftFill';
-import IconDocumentArrowLeftLine from '@karrotmarket/lynx-monochrome-icon/IconDocumentArrowLeftLine';
-import IconDocumentCheckmarkFill from '@karrotmarket/lynx-monochrome-icon/IconDocumentCheckmarkFill';
-import IconDocumentCheckmarkLine from '@karrotmarket/lynx-monochrome-icon/IconDocumentCheckmarkLine';
-import IconDocumentFill from '@karrotmarket/lynx-monochrome-icon/IconDocumentFill';
-import IconDocumentLine from '@karrotmarket/lynx-monochrome-icon/IconDocumentLine';
-import IconDocumentMagnifyingglassFill from '@karrotmarket/lynx-monochrome-icon/IconDocumentMagnifyingglassFill';
-import IconDocumentMagnifyingglassLine from '@karrotmarket/lynx-monochrome-icon/IconDocumentMagnifyingglassLine';
-import IconDocumentPenFill from '@karrotmarket/lynx-monochrome-icon/IconDocumentPenFill';
-import IconDocumentPenLine from '@karrotmarket/lynx-monochrome-icon/IconDocumentPenLine';
-import IconDocumentPlusFill from '@karrotmarket/lynx-monochrome-icon/IconDocumentPlusFill';
-import IconDocumentPlusLine from '@karrotmarket/lynx-monochrome-icon/IconDocumentPlusLine';
-import IconDollarCircleArrowRightFill from '@karrotmarket/lynx-monochrome-icon/IconDollarCircleArrowRightFill';
-import IconDollarCircleArrowRightLine from '@karrotmarket/lynx-monochrome-icon/IconDollarCircleArrowRightLine';
-import IconDollarCircleFill from '@karrotmarket/lynx-monochrome-icon/IconDollarCircleFill';
-import IconDollarCircleLine from '@karrotmarket/lynx-monochrome-icon/IconDollarCircleLine';
-import IconDollarFill from '@karrotmarket/lynx-monochrome-icon/IconDollarFill';
-import IconDollarLine from '@karrotmarket/lynx-monochrome-icon/IconDollarLine';
-import IconDot3CircleFill from '@karrotmarket/lynx-monochrome-icon/IconDot3CircleFill';
-import IconDot3CircleLine from '@karrotmarket/lynx-monochrome-icon/IconDot3CircleLine';
-import IconDot3HorizontalChatbubbleLeftFill from '@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftFill';
-import IconDot3HorizontalChatbubbleLeftLine from '@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftLine';
-import IconDot3HorizontalChatbubbleLeftSlashFill from '@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftSlashFill';
-import IconDot3HorizontalChatbubbleLeftSlashLine from '@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftSlashLine';
-import IconDot3HorizontalFill from '@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalFill';
-import IconDot3HorizontalLine from '@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalLine';
-import IconDot3VerticalFill from '@karrotmarket/lynx-monochrome-icon/IconDot3VerticalFill';
-import IconDot3VerticalLine from '@karrotmarket/lynx-monochrome-icon/IconDot3VerticalLine';
-import IconDothorizline3VerticalFill from '@karrotmarket/lynx-monochrome-icon/IconDothorizline3VerticalFill';
-import IconDothorizline3VerticalLine from '@karrotmarket/lynx-monochrome-icon/IconDothorizline3VerticalLine';
-import IconDumbbellFill from '@karrotmarket/lynx-monochrome-icon/IconDumbbellFill';
-import IconDumbbellLine from '@karrotmarket/lynx-monochrome-icon/IconDumbbellLine';
-import IconEarthFill from '@karrotmarket/lynx-monochrome-icon/IconEarthFill';
-import IconEarthLine from '@karrotmarket/lynx-monochrome-icon/IconEarthLine';
-import IconEnvelopeFill from '@karrotmarket/lynx-monochrome-icon/IconEnvelopeFill';
-import IconEnvelopeLine from '@karrotmarket/lynx-monochrome-icon/IconEnvelopeLine';
-import IconEpbFill from '@karrotmarket/lynx-monochrome-icon/IconEpbFill';
-import IconEpbLine from '@karrotmarket/lynx-monochrome-icon/IconEpbLine';
-import IconEraserHorizlineFill from '@karrotmarket/lynx-monochrome-icon/IconEraserHorizlineFill';
-import IconEraserHorizlineLine from '@karrotmarket/lynx-monochrome-icon/IconEraserHorizlineLine';
-import IconExclamationmarkChatbubbleRectangularCenterFill from '@karrotmarket/lynx-monochrome-icon/IconExclamationmarkChatbubbleRectangularCenterFill';
-import IconExclamationmarkChatbubbleRectangularCenterLine from '@karrotmarket/lynx-monochrome-icon/IconExclamationmarkChatbubbleRectangularCenterLine';
-import IconExclamationmarkCircleFill from '@karrotmarket/lynx-monochrome-icon/IconExclamationmarkCircleFill';
-import IconExclamationmarkCircleLine from '@karrotmarket/lynx-monochrome-icon/IconExclamationmarkCircleLine';
-import IconEyeFill from '@karrotmarket/lynx-monochrome-icon/IconEyeFill';
-import IconEyeLine from '@karrotmarket/lynx-monochrome-icon/IconEyeLine';
-import IconEyeSlashFill from '@karrotmarket/lynx-monochrome-icon/IconEyeSlashFill';
-import IconEyeSlashLine from '@karrotmarket/lynx-monochrome-icon/IconEyeSlashLine';
-import IconFaceFrustratedCircleFill from '@karrotmarket/lynx-monochrome-icon/IconFaceFrustratedCircleFill';
-import IconFaceFrustratedCircleLine from '@karrotmarket/lynx-monochrome-icon/IconFaceFrustratedCircleLine';
-import IconFaceSadCircleFill from '@karrotmarket/lynx-monochrome-icon/IconFaceSadCircleFill';
-import IconFaceSadCircleLine from '@karrotmarket/lynx-monochrome-icon/IconFaceSadCircleLine';
-import IconFaceSmileCircleFill from '@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleFill';
-import IconFaceSmileCircleFoldedFill from '@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleFoldedFill';
-import IconFaceSmileCircleFoldedLine from '@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleFoldedLine';
-import IconFaceSmileCircleLine from '@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleLine';
-import IconFaceSurprisedCircleFill from '@karrotmarket/lynx-monochrome-icon/IconFaceSurprisedCircleFill';
-import IconFaceSurprisedCircleLine from '@karrotmarket/lynx-monochrome-icon/IconFaceSurprisedCircleLine';
-import IconFaceViewfinderFill from '@karrotmarket/lynx-monochrome-icon/IconFaceViewfinderFill';
-import IconFaceViewfinderLine from '@karrotmarket/lynx-monochrome-icon/IconFaceViewfinderLine';
-import IconFigureBikeFill from '@karrotmarket/lynx-monochrome-icon/IconFigureBikeFill';
-import IconFigureBikeLine from '@karrotmarket/lynx-monochrome-icon/IconFigureBikeLine';
-import IconFigureOvalFill from '@karrotmarket/lynx-monochrome-icon/IconFigureOvalFill';
-import IconFigureOvalLine from '@karrotmarket/lynx-monochrome-icon/IconFigureOvalLine';
-import IconFigureRunFill from '@karrotmarket/lynx-monochrome-icon/IconFigureRunFill';
-import IconFigureRunLine from '@karrotmarket/lynx-monochrome-icon/IconFigureRunLine';
-import IconFigureWalkFill from '@karrotmarket/lynx-monochrome-icon/IconFigureWalkFill';
-import IconFigureWalkLine from '@karrotmarket/lynx-monochrome-icon/IconFigureWalkLine';
-import IconFigureWheelchairFill from '@karrotmarket/lynx-monochrome-icon/IconFigureWheelchairFill';
-import IconFigureWheelchairLine from '@karrotmarket/lynx-monochrome-icon/IconFigureWheelchairLine';
-import IconFingerprintFill from '@karrotmarket/lynx-monochrome-icon/IconFingerprintFill';
-import IconFingerprintLine from '@karrotmarket/lynx-monochrome-icon/IconFingerprintLine';
-import IconFireworkFill from '@karrotmarket/lynx-monochrome-icon/IconFireworkFill';
-import IconFireworkLine from '@karrotmarket/lynx-monochrome-icon/IconFireworkLine';
-import IconFishWave2Fill from '@karrotmarket/lynx-monochrome-icon/IconFishWave2Fill';
-import IconFishWave2Line from '@karrotmarket/lynx-monochrome-icon/IconFishWave2Line';
-import IconFlagFill from '@karrotmarket/lynx-monochrome-icon/IconFlagFill';
-import IconFlagHillFill from '@karrotmarket/lynx-monochrome-icon/IconFlagHillFill';
-import IconFlagHillLine from '@karrotmarket/lynx-monochrome-icon/IconFlagHillLine';
-import IconFlagLine from '@karrotmarket/lynx-monochrome-icon/IconFlagLine';
-import IconFlameFill from '@karrotmarket/lynx-monochrome-icon/IconFlameFill';
-import IconFlameLine from '@karrotmarket/lynx-monochrome-icon/IconFlameLine';
-import IconFlaskFill from '@karrotmarket/lynx-monochrome-icon/IconFlaskFill';
-import IconFlaskLine from '@karrotmarket/lynx-monochrome-icon/IconFlaskLine';
-import IconForkSpoonBagFill from '@karrotmarket/lynx-monochrome-icon/IconForkSpoonBagFill';
-import IconForkSpoonBagLine from '@karrotmarket/lynx-monochrome-icon/IconForkSpoonBagLine';
-import IconForkSpoonFill from '@karrotmarket/lynx-monochrome-icon/IconForkSpoonFill';
-import IconForkSpoonLine from '@karrotmarket/lynx-monochrome-icon/IconForkSpoonLine';
-import IconFridgeFill from '@karrotmarket/lynx-monochrome-icon/IconFridgeFill';
-import IconFridgeLine from '@karrotmarket/lynx-monochrome-icon/IconFridgeLine';
-import IconGearFill from '@karrotmarket/lynx-monochrome-icon/IconGearFill';
-import IconGearLine from '@karrotmarket/lynx-monochrome-icon/IconGearLine';
-import IconGiftFill from '@karrotmarket/lynx-monochrome-icon/IconGiftFill';
-import IconGiftLine from '@karrotmarket/lynx-monochrome-icon/IconGiftLine';
-import IconGlobeFill from '@karrotmarket/lynx-monochrome-icon/IconGlobeFill';
-import IconGlobeLine from '@karrotmarket/lynx-monochrome-icon/IconGlobeLine';
-import IconGraduationcapFill from '@karrotmarket/lynx-monochrome-icon/IconGraduationcapFill';
-import IconGraduationcapLine from '@karrotmarket/lynx-monochrome-icon/IconGraduationcapLine';
-import IconGridDot5Fill from '@karrotmarket/lynx-monochrome-icon/IconGridDot5Fill';
-import IconGridDot5Line from '@karrotmarket/lynx-monochrome-icon/IconGridDot5Line';
-import IconGridFill from '@karrotmarket/lynx-monochrome-icon/IconGridFill';
-import IconGridHeartFill from '@karrotmarket/lynx-monochrome-icon/IconGridHeartFill';
-import IconGridHeartLine from '@karrotmarket/lynx-monochrome-icon/IconGridHeartLine';
-import IconGridLine from '@karrotmarket/lynx-monochrome-icon/IconGridLine';
-import IconHandPointUpFill from '@karrotmarket/lynx-monochrome-icon/IconHandPointUpFill';
-import IconHandPointUpLine from '@karrotmarket/lynx-monochrome-icon/IconHandPointUpLine';
-import IconHandWaveFill from '@karrotmarket/lynx-monochrome-icon/IconHandWaveFill';
-import IconHandWaveLine from '@karrotmarket/lynx-monochrome-icon/IconHandWaveLine';
-import IconHashFill from '@karrotmarket/lynx-monochrome-icon/IconHashFill';
-import IconHashLine from '@karrotmarket/lynx-monochrome-icon/IconHashLine';
-import IconHeadsetFill from '@karrotmarket/lynx-monochrome-icon/IconHeadsetFill';
-import IconHeadsetLine from '@karrotmarket/lynx-monochrome-icon/IconHeadsetLine';
-import IconHeartFill from '@karrotmarket/lynx-monochrome-icon/IconHeartFill';
-import IconHeartLine from '@karrotmarket/lynx-monochrome-icon/IconHeartLine';
-import IconHorizline2VerticalChatbubbleRectangularRightFill from '@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightFill';
-import IconHorizline2VerticalChatbubbleRectangularRightLine from '@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightLine';
-import IconHorizline2VerticalChatbubbleRectangularRightSlashFill from '@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightSlashFill';
-import IconHorizline2VerticalChatbubbleRectangularRightSlashLine from '@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightSlashLine';
-import IconHorizline3VerticalCheckmarkFill from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalCheckmarkFill';
-import IconHorizline3VerticalCheckmarkLine from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalCheckmarkLine';
-import IconHorizline3VerticalFill from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalFill';
-import IconHorizline3VerticalLine from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalLine';
-import IconHorizline3VerticalStarFill from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalStarFill';
-import IconHorizline3VerticalStarLine from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalStarLine';
-import IconHorizline3VerticalTightFill from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalTightFill';
-import IconHorizline3VerticalTightLine from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalTightLine';
-import IconHorizlineViewfinderFill from '@karrotmarket/lynx-monochrome-icon/IconHorizlineViewfinderFill';
-import IconHorizlineViewfinderLine from '@karrotmarket/lynx-monochrome-icon/IconHorizlineViewfinderLine';
-import IconHorizrectangleHorizline2VerticalFill from '@karrotmarket/lynx-monochrome-icon/IconHorizrectangleHorizline2VerticalFill';
-import IconHorizrectangleHorizline2VerticalLine from '@karrotmarket/lynx-monochrome-icon/IconHorizrectangleHorizline2VerticalLine';
-import IconHospitalcrossBuildingFill from '@karrotmarket/lynx-monochrome-icon/IconHospitalcrossBuildingFill';
-import IconHospitalcrossBuildingLine from '@karrotmarket/lynx-monochrome-icon/IconHospitalcrossBuildingLine';
-import IconHospitalcrossSquareFill from '@karrotmarket/lynx-monochrome-icon/IconHospitalcrossSquareFill';
-import IconHospitalcrossSquareLine from '@karrotmarket/lynx-monochrome-icon/IconHospitalcrossSquareLine';
-import IconHouseFill from '@karrotmarket/lynx-monochrome-icon/IconHouseFill';
-import IconHouseLine from '@karrotmarket/lynx-monochrome-icon/IconHouseLine';
-import IconHousePlusFill from '@karrotmarket/lynx-monochrome-icon/IconHousePlusFill';
-import IconHousePlusLine from '@karrotmarket/lynx-monochrome-icon/IconHousePlusLine';
-import IconHouseSquareFill from '@karrotmarket/lynx-monochrome-icon/IconHouseSquareFill';
-import IconHouseSquareLine from '@karrotmarket/lynx-monochrome-icon/IconHouseSquareLine';
-import IconILowercaseSerifCircleFill from '@karrotmarket/lynx-monochrome-icon/IconILowercaseSerifCircleFill';
-import IconILowercaseSerifCircleLine from '@karrotmarket/lynx-monochrome-icon/IconILowercaseSerifCircleLine';
-import IconKeyboardChevronDownFill from '@karrotmarket/lynx-monochrome-icon/IconKeyboardChevronDownFill';
-import IconKeyboardChevronDownLine from '@karrotmarket/lynx-monochrome-icon/IconKeyboardChevronDownLine';
-import IconKeyholeShieldFill from '@karrotmarket/lynx-monochrome-icon/IconKeyholeShieldFill';
-import IconKeyholeShieldLine from '@karrotmarket/lynx-monochrome-icon/IconKeyholeShieldLine';
-import IconLaptopFill from '@karrotmarket/lynx-monochrome-icon/IconLaptopFill';
-import IconLaptopLine from '@karrotmarket/lynx-monochrome-icon/IconLaptopLine';
-import IconLeafFill from '@karrotmarket/lynx-monochrome-icon/IconLeafFill';
-import IconLeafLine from '@karrotmarket/lynx-monochrome-icon/IconLeafLine';
-import IconLightbulbDot5Fill from '@karrotmarket/lynx-monochrome-icon/IconLightbulbDot5Fill';
-import IconLightbulbDot5Line from '@karrotmarket/lynx-monochrome-icon/IconLightbulbDot5Line';
-import IconLightningFill from '@karrotmarket/lynx-monochrome-icon/IconLightningFill';
-import IconLightningLine from '@karrotmarket/lynx-monochrome-icon/IconLightningLine';
-import IconLightningSlashFill from '@karrotmarket/lynx-monochrome-icon/IconLightningSlashFill';
-import IconLightningSlashLine from '@karrotmarket/lynx-monochrome-icon/IconLightningSlashLine';
-import IconLinechartUpXaxisFill from '@karrotmarket/lynx-monochrome-icon/IconLinechartUpXaxisFill';
-import IconLinechartUpXaxisLine from '@karrotmarket/lynx-monochrome-icon/IconLinechartUpXaxisLine';
-import IconLocationpinFill from '@karrotmarket/lynx-monochrome-icon/IconLocationpinFill';
-import IconLocationpinLine from '@karrotmarket/lynx-monochrome-icon/IconLocationpinLine';
-import IconLockFill from '@karrotmarket/lynx-monochrome-icon/IconLockFill';
-import IconLockLine from '@karrotmarket/lynx-monochrome-icon/IconLockLine';
-import IconLockOpenedFill from '@karrotmarket/lynx-monochrome-icon/IconLockOpenedFill';
-import IconLockOpenedLine from '@karrotmarket/lynx-monochrome-icon/IconLockOpenedLine';
-import IconMagnifyingglassFill from '@karrotmarket/lynx-monochrome-icon/IconMagnifyingglassFill';
-import IconMagnifyingglassLine from '@karrotmarket/lynx-monochrome-icon/IconMagnifyingglassLine';
-import IconMalesymbolFemalesymbolFill from '@karrotmarket/lynx-monochrome-icon/IconMalesymbolFemalesymbolFill';
-import IconMalesymbolFemalesymbolLine from '@karrotmarket/lynx-monochrome-icon/IconMalesymbolFemalesymbolLine';
-import IconMapFill from '@karrotmarket/lynx-monochrome-icon/IconMapFill';
-import IconMapLine from '@karrotmarket/lynx-monochrome-icon/IconMapLine';
-import IconMapLocationpinFill from '@karrotmarket/lynx-monochrome-icon/IconMapLocationpinFill';
-import IconMapLocationpinLine from '@karrotmarket/lynx-monochrome-icon/IconMapLocationpinLine';
-import IconMegaphoneFill from '@karrotmarket/lynx-monochrome-icon/IconMegaphoneFill';
-import IconMegaphoneLine from '@karrotmarket/lynx-monochrome-icon/IconMegaphoneLine';
-import IconMegaphoneTiltedFill from '@karrotmarket/lynx-monochrome-icon/IconMegaphoneTiltedFill';
-import IconMegaphoneTiltedLine from '@karrotmarket/lynx-monochrome-icon/IconMegaphoneTiltedLine';
-import IconMetroFrontsideFill from '@karrotmarket/lynx-monochrome-icon/IconMetroFrontsideFill';
-import IconMetroFrontsideLine from '@karrotmarket/lynx-monochrome-icon/IconMetroFrontsideLine';
-import IconMicrophoneFill from '@karrotmarket/lynx-monochrome-icon/IconMicrophoneFill';
-import IconMicrophoneLine from '@karrotmarket/lynx-monochrome-icon/IconMicrophoneLine';
-import IconMicrophoneSlashFill from '@karrotmarket/lynx-monochrome-icon/IconMicrophoneSlashFill';
-import IconMicrophoneSlashLine from '@karrotmarket/lynx-monochrome-icon/IconMicrophoneSlashLine';
-import IconMicrowaveFill from '@karrotmarket/lynx-monochrome-icon/IconMicrowaveFill';
-import IconMicrowaveLine from '@karrotmarket/lynx-monochrome-icon/IconMicrowaveLine';
-import IconMidcutSquareFill from '@karrotmarket/lynx-monochrome-icon/IconMidcutSquareFill';
-import IconMidcutSquareLine from '@karrotmarket/lynx-monochrome-icon/IconMidcutSquareLine';
-import IconMinusCircleFill from '@karrotmarket/lynx-monochrome-icon/IconMinusCircleFill';
-import IconMinusCircleLine from '@karrotmarket/lynx-monochrome-icon/IconMinusCircleLine';
-import IconMinusFatFill from '@karrotmarket/lynx-monochrome-icon/IconMinusFatFill';
-import IconMinusFatLine from '@karrotmarket/lynx-monochrome-icon/IconMinusFatLine';
-import IconMinusFill from '@karrotmarket/lynx-monochrome-icon/IconMinusFill';
-import IconMinusLine from '@karrotmarket/lynx-monochrome-icon/IconMinusLine';
-import IconMobileFill from '@karrotmarket/lynx-monochrome-icon/IconMobileFill';
-import IconMobileLine from '@karrotmarket/lynx-monochrome-icon/IconMobileLine';
-import IconMoonFill from '@karrotmarket/lynx-monochrome-icon/IconMoonFill';
-import IconMoonLine from '@karrotmarket/lynx-monochrome-icon/IconMoonLine';
-import IconMusicalnoteDoubleFill from '@karrotmarket/lynx-monochrome-icon/IconMusicalnoteDoubleFill';
-import IconMusicalnoteDoubleLine from '@karrotmarket/lynx-monochrome-icon/IconMusicalnoteDoubleLine';
-import IconNUppercaseCircleFill from '@karrotmarket/lynx-monochrome-icon/IconNUppercaseCircleFill';
-import IconNUppercaseCircleLine from '@karrotmarket/lynx-monochrome-icon/IconNUppercaseCircleLine';
-import IconNailpolishFill from '@karrotmarket/lynx-monochrome-icon/IconNailpolishFill';
-import IconNailpolishLine from '@karrotmarket/lynx-monochrome-icon/IconNailpolishLine';
-import IconNeedleScaleFill from '@karrotmarket/lynx-monochrome-icon/IconNeedleScaleFill';
-import IconNeedleScaleLine from '@karrotmarket/lynx-monochrome-icon/IconNeedleScaleLine';
-import IconPUppercaseCircleFill from '@karrotmarket/lynx-monochrome-icon/IconPUppercaseCircleFill';
-import IconPUppercaseCircleLine from '@karrotmarket/lynx-monochrome-icon/IconPUppercaseCircleLine';
-import IconPaintrollerFill from '@karrotmarket/lynx-monochrome-icon/IconPaintrollerFill';
-import IconPaintrollerLine from '@karrotmarket/lynx-monochrome-icon/IconPaintrollerLine';
-import IconPaletteFill from '@karrotmarket/lynx-monochrome-icon/IconPaletteFill';
-import IconPaletteLine from '@karrotmarket/lynx-monochrome-icon/IconPaletteLine';
-import IconPaperclipFill from '@karrotmarket/lynx-monochrome-icon/IconPaperclipFill';
-import IconPaperclipLine from '@karrotmarket/lynx-monochrome-icon/IconPaperclipLine';
-import IconPaperplaneFill from '@karrotmarket/lynx-monochrome-icon/IconPaperplaneFill';
-import IconPaperplaneLine from '@karrotmarket/lynx-monochrome-icon/IconPaperplaneLine';
-import IconPaperplaneTiltedFill from '@karrotmarket/lynx-monochrome-icon/IconPaperplaneTiltedFill';
-import IconPaperplaneTiltedLine from '@karrotmarket/lynx-monochrome-icon/IconPaperplaneTiltedLine';
-import IconPawprintFill from '@karrotmarket/lynx-monochrome-icon/IconPawprintFill';
-import IconPawprintLine from '@karrotmarket/lynx-monochrome-icon/IconPawprintLine';
-import IconPenHorizlineFill from '@karrotmarket/lynx-monochrome-icon/IconPenHorizlineFill';
-import IconPenHorizlineLine from '@karrotmarket/lynx-monochrome-icon/IconPenHorizlineLine';
-import IconPencilFill from '@karrotmarket/lynx-monochrome-icon/IconPencilFill';
-import IconPencilLine from '@karrotmarket/lynx-monochrome-icon/IconPencilLine';
-import IconPeople3Fill from '@karrotmarket/lynx-monochrome-icon/IconPeople3Fill';
-import IconPeople3Line from '@karrotmarket/lynx-monochrome-icon/IconPeople3Line';
-import IconPercentFill from '@karrotmarket/lynx-monochrome-icon/IconPercentFill';
-import IconPercentFlowerFill from '@karrotmarket/lynx-monochrome-icon/IconPercentFlowerFill';
-import IconPercentFlowerLine from '@karrotmarket/lynx-monochrome-icon/IconPercentFlowerLine';
-import IconPercentLine from '@karrotmarket/lynx-monochrome-icon/IconPercentLine';
-import IconPerson2Fill from '@karrotmarket/lynx-monochrome-icon/IconPerson2Fill';
-import IconPerson2Line from '@karrotmarket/lynx-monochrome-icon/IconPerson2Line';
-import IconPerson2OpenarmsFill from '@karrotmarket/lynx-monochrome-icon/IconPerson2OpenarmsFill';
-import IconPerson2OpenarmsLine from '@karrotmarket/lynx-monochrome-icon/IconPerson2OpenarmsLine';
-import IconPersonCircleFill from '@karrotmarket/lynx-monochrome-icon/IconPersonCircleFill';
-import IconPersonCircleLine from '@karrotmarket/lynx-monochrome-icon/IconPersonCircleLine';
-import IconPersonFill from '@karrotmarket/lynx-monochrome-icon/IconPersonFill';
-import IconPersonFlowerFill from '@karrotmarket/lynx-monochrome-icon/IconPersonFlowerFill';
-import IconPersonFlowerLine from '@karrotmarket/lynx-monochrome-icon/IconPersonFlowerLine';
-import IconPersonLine from '@karrotmarket/lynx-monochrome-icon/IconPersonLine';
-import IconPersonMagnifyingglassFill from '@karrotmarket/lynx-monochrome-icon/IconPersonMagnifyingglassFill';
-import IconPersonMagnifyingglassLine from '@karrotmarket/lynx-monochrome-icon/IconPersonMagnifyingglassLine';
-import IconPersonPlusFill from '@karrotmarket/lynx-monochrome-icon/IconPersonPlusFill';
-import IconPersonPlusLine from '@karrotmarket/lynx-monochrome-icon/IconPersonPlusLine';
-import IconPersonShieldFill from '@karrotmarket/lynx-monochrome-icon/IconPersonShieldFill';
-import IconPersonShieldLine from '@karrotmarket/lynx-monochrome-icon/IconPersonShieldLine';
-import IconPhoneFill from '@karrotmarket/lynx-monochrome-icon/IconPhoneFill';
-import IconPhoneLine from '@karrotmarket/lynx-monochrome-icon/IconPhoneLine';
-import IconPhoneXmarkFill from '@karrotmarket/lynx-monochrome-icon/IconPhoneXmarkFill';
-import IconPhoneXmarkLine from '@karrotmarket/lynx-monochrome-icon/IconPhoneXmarkLine';
-import IconPicture2StackedFill from '@karrotmarket/lynx-monochrome-icon/IconPicture2StackedFill';
-import IconPicture2StackedLine from '@karrotmarket/lynx-monochrome-icon/IconPicture2StackedLine';
-import IconPictureFill from '@karrotmarket/lynx-monochrome-icon/IconPictureFill';
-import IconPictureLine from '@karrotmarket/lynx-monochrome-icon/IconPictureLine';
-import IconPlusCircleFill from '@karrotmarket/lynx-monochrome-icon/IconPlusCircleFill';
-import IconPlusCircleLine from '@karrotmarket/lynx-monochrome-icon/IconPlusCircleLine';
-import IconPlusFill from '@karrotmarket/lynx-monochrome-icon/IconPlusFill';
-import IconPlusLine from '@karrotmarket/lynx-monochrome-icon/IconPlusLine';
-import IconPlusSmallFill from '@karrotmarket/lynx-monochrome-icon/IconPlusSmallFill';
-import IconPlusSmallLine from '@karrotmarket/lynx-monochrome-icon/IconPlusSmallLine';
-import IconPlusSquareFill from '@karrotmarket/lynx-monochrome-icon/IconPlusSquareFill';
-import IconPlusSquareLine from '@karrotmarket/lynx-monochrome-icon/IconPlusSquareLine';
-import IconPostFill from '@karrotmarket/lynx-monochrome-icon/IconPostFill';
-import IconPostLine from '@karrotmarket/lynx-monochrome-icon/IconPostLine';
-import IconPushpinFill from '@karrotmarket/lynx-monochrome-icon/IconPushpinFill';
-import IconPushpinLine from '@karrotmarket/lynx-monochrome-icon/IconPushpinLine';
-import IconQUppercaseChatbubbleRightFill from '@karrotmarket/lynx-monochrome-icon/IconQUppercaseChatbubbleRightFill';
-import IconQUppercaseChatbubbleRightLine from '@karrotmarket/lynx-monochrome-icon/IconQUppercaseChatbubbleRightLine';
-import IconQuestionmarkCircleFill from '@karrotmarket/lynx-monochrome-icon/IconQuestionmarkCircleFill';
-import IconQuestionmarkCircleLine from '@karrotmarket/lynx-monochrome-icon/IconQuestionmarkCircleLine';
-import IconQuestionmarkSquareFill from '@karrotmarket/lynx-monochrome-icon/IconQuestionmarkSquareFill';
-import IconQuestionmarkSquareLine from '@karrotmarket/lynx-monochrome-icon/IconQuestionmarkSquareLine';
-import IconQuotationmark2LeftFill from '@karrotmarket/lynx-monochrome-icon/IconQuotationmark2LeftFill';
-import IconQuotationmark2LeftLine from '@karrotmarket/lynx-monochrome-icon/IconQuotationmark2LeftLine';
-import IconQuotationmark2RightFill from '@karrotmarket/lynx-monochrome-icon/IconQuotationmark2RightFill';
-import IconQuotationmark2RightLine from '@karrotmarket/lynx-monochrome-icon/IconQuotationmark2RightLine';
-import IconReceiptFill from '@karrotmarket/lynx-monochrome-icon/IconReceiptFill';
-import IconReceiptLine from '@karrotmarket/lynx-monochrome-icon/IconReceiptLine';
-import IconRectangleSplitedLineVerticalFill from '@karrotmarket/lynx-monochrome-icon/IconRectangleSplitedLineVerticalFill';
-import IconRectangleSplitedLineVerticalLine from '@karrotmarket/lynx-monochrome-icon/IconRectangleSplitedLineVerticalLine';
-import IconRoadlaneFill from '@karrotmarket/lynx-monochrome-icon/IconRoadlaneFill';
-import IconRoadlaneLine from '@karrotmarket/lynx-monochrome-icon/IconRoadlaneLine';
-import IconRocketFill from '@karrotmarket/lynx-monochrome-icon/IconRocketFill';
-import IconRocketLine from '@karrotmarket/lynx-monochrome-icon/IconRocketLine';
-import IconRooftoproomFill from '@karrotmarket/lynx-monochrome-icon/IconRooftoproomFill';
-import IconRooftoproomLine from '@karrotmarket/lynx-monochrome-icon/IconRooftoproomLine';
-import IconSUppercaseHorizlineCenterFill from '@karrotmarket/lynx-monochrome-icon/IconSUppercaseHorizlineCenterFill';
-import IconSUppercaseHorizlineCenterLine from '@karrotmarket/lynx-monochrome-icon/IconSUppercaseHorizlineCenterLine';
-import IconScissorsFill from '@karrotmarket/lynx-monochrome-icon/IconScissorsFill';
-import IconScissorsLine from '@karrotmarket/lynx-monochrome-icon/IconScissorsLine';
-import IconScribbleFill from '@karrotmarket/lynx-monochrome-icon/IconScribbleFill';
-import IconScribbleLine from '@karrotmarket/lynx-monochrome-icon/IconScribbleLine';
-import IconSeatLeftFanFill from '@karrotmarket/lynx-monochrome-icon/IconSeatLeftFanFill';
-import IconSeatLeftFanLine from '@karrotmarket/lynx-monochrome-icon/IconSeatLeftFanLine';
-import IconSeatLeftFill from '@karrotmarket/lynx-monochrome-icon/IconSeatLeftFill';
-import IconSeatLeftHeatwave2Fill from '@karrotmarket/lynx-monochrome-icon/IconSeatLeftHeatwave2Fill';
-import IconSeatLeftHeatwave2Line from '@karrotmarket/lynx-monochrome-icon/IconSeatLeftHeatwave2Line';
-import IconSeatLeftLine from '@karrotmarket/lynx-monochrome-icon/IconSeatLeftLine';
-import IconShoppingbag2StackedFill from '@karrotmarket/lynx-monochrome-icon/IconShoppingbag2StackedFill';
-import IconShoppingbag2StackedLine from '@karrotmarket/lynx-monochrome-icon/IconShoppingbag2StackedLine';
-import IconShoppingbagFill from '@karrotmarket/lynx-monochrome-icon/IconShoppingbagFill';
-import IconShoppingbagItemsFill from '@karrotmarket/lynx-monochrome-icon/IconShoppingbagItemsFill';
-import IconShoppingbagItemsLine from '@karrotmarket/lynx-monochrome-icon/IconShoppingbagItemsLine';
-import IconShoppingbagLine from '@karrotmarket/lynx-monochrome-icon/IconShoppingbagLine';
-import IconSidemirrorWaveFill from '@karrotmarket/lynx-monochrome-icon/IconSidemirrorWaveFill';
-import IconSidemirrorWaveLine from '@karrotmarket/lynx-monochrome-icon/IconSidemirrorWaveLine';
-import IconSignboardFill from '@karrotmarket/lynx-monochrome-icon/IconSignboardFill';
-import IconSignboardLine from '@karrotmarket/lynx-monochrome-icon/IconSignboardLine';
-import IconSlashCircleFill from '@karrotmarket/lynx-monochrome-icon/IconSlashCircleFill';
-import IconSlashCircleLine from '@karrotmarket/lynx-monochrome-icon/IconSlashCircleLine';
-import IconSlashSemicircle2Fill from '@karrotmarket/lynx-monochrome-icon/IconSlashSemicircle2Fill';
-import IconSlashSemicircle2Line from '@karrotmarket/lynx-monochrome-icon/IconSlashSemicircle2Line';
-import IconSlider2HorizontalFill from '@karrotmarket/lynx-monochrome-icon/IconSlider2HorizontalFill';
-import IconSlider2HorizontalLine from '@karrotmarket/lynx-monochrome-icon/IconSlider2HorizontalLine';
-import IconSmartkeyFill from '@karrotmarket/lynx-monochrome-icon/IconSmartkeyFill';
-import IconSmartkeyLine from '@karrotmarket/lynx-monochrome-icon/IconSmartkeyLine';
-import IconSneakerLiftedLeftsideFill from '@karrotmarket/lynx-monochrome-icon/IconSneakerLiftedLeftsideFill';
-import IconSneakerLiftedLeftsideLine from '@karrotmarket/lynx-monochrome-icon/IconSneakerLiftedLeftsideLine';
-import IconSofaFill from '@karrotmarket/lynx-monochrome-icon/IconSofaFill';
-import IconSofaLine from '@karrotmarket/lynx-monochrome-icon/IconSofaLine';
-import IconSparkle2Fill from '@karrotmarket/lynx-monochrome-icon/IconSparkle2Fill';
-import IconSparkle2Line from '@karrotmarket/lynx-monochrome-icon/IconSparkle2Line';
-import IconSparkleViewfinderFill from '@karrotmarket/lynx-monochrome-icon/IconSparkleViewfinderFill';
-import IconSparkleViewfinderLine from '@karrotmarket/lynx-monochrome-icon/IconSparkleViewfinderLine';
-import IconSpeakerWave2Fill from '@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2Fill';
-import IconSpeakerWave2Line from '@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2Line';
-import IconSpeakerWave2SlashFill from '@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2SlashFill';
-import IconSpeakerWave2SlashLine from '@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2SlashLine';
-import IconSpeedometerFill from '@karrotmarket/lynx-monochrome-icon/IconSpeedometerFill';
-import IconSpeedometerLine from '@karrotmarket/lynx-monochrome-icon/IconSpeedometerLine';
-import IconSpeedometer_1xFill from '@karrotmarket/lynx-monochrome-icon/IconSpeedometer_1xFill';
-import IconSpeedometer_1xLine from '@karrotmarket/lynx-monochrome-icon/IconSpeedometer_1xLine';
-import IconSpeedometer_2xFill from '@karrotmarket/lynx-monochrome-icon/IconSpeedometer_2xFill';
-import IconSpeedometer_2xLine from '@karrotmarket/lynx-monochrome-icon/IconSpeedometer_2xLine';
-import IconSpeedometer_3xFill from '@karrotmarket/lynx-monochrome-icon/IconSpeedometer_3xFill';
-import IconSpeedometer_3xLine from '@karrotmarket/lynx-monochrome-icon/IconSpeedometer_3xLine';
-import IconSplitedGridSquareFill from '@karrotmarket/lynx-monochrome-icon/IconSplitedGridSquareFill';
-import IconSplitedGridSquareLine from '@karrotmarket/lynx-monochrome-icon/IconSplitedGridSquareLine';
-import IconSpraybottleSpongeFill from '@karrotmarket/lynx-monochrome-icon/IconSpraybottleSpongeFill';
-import IconSpraybottleSpongeLine from '@karrotmarket/lynx-monochrome-icon/IconSpraybottleSpongeLine';
-import IconSquare2StackedFill from '@karrotmarket/lynx-monochrome-icon/IconSquare2StackedFill';
-import IconSquare2StackedLine from '@karrotmarket/lynx-monochrome-icon/IconSquare2StackedLine';
-import IconSquareline2VerticalFill from '@karrotmarket/lynx-monochrome-icon/IconSquareline2VerticalFill';
-import IconSquareline2VerticalLine from '@karrotmarket/lynx-monochrome-icon/IconSquareline2VerticalLine';
-import IconStarFill from '@karrotmarket/lynx-monochrome-icon/IconStarFill';
-import IconStarLine from '@karrotmarket/lynx-monochrome-icon/IconStarLine';
-import IconSteeringwheelHeatwave2Fill from '@karrotmarket/lynx-monochrome-icon/IconSteeringwheelHeatwave2Fill';
-import IconSteeringwheelHeatwave2Line from '@karrotmarket/lynx-monochrome-icon/IconSteeringwheelHeatwave2Line';
-import IconStepsFill from '@karrotmarket/lynx-monochrome-icon/IconStepsFill';
-import IconStepsLine from '@karrotmarket/lynx-monochrome-icon/IconStepsLine';
-import IconStoreCheckmarkFill from '@karrotmarket/lynx-monochrome-icon/IconStoreCheckmarkFill';
-import IconStoreCheckmarkLine from '@karrotmarket/lynx-monochrome-icon/IconStoreCheckmarkLine';
-import IconStoreFill from '@karrotmarket/lynx-monochrome-icon/IconStoreFill';
-import IconStoreLine from '@karrotmarket/lynx-monochrome-icon/IconStoreLine';
-import IconStorePenFill from '@karrotmarket/lynx-monochrome-icon/IconStorePenFill';
-import IconStorePenLine from '@karrotmarket/lynx-monochrome-icon/IconStorePenLine';
-import IconSunFill from '@karrotmarket/lynx-monochrome-icon/IconSunFill';
-import IconSunLine from '@karrotmarket/lynx-monochrome-icon/IconSunLine';
-import IconTUppercaseSerifFill from '@karrotmarket/lynx-monochrome-icon/IconTUppercaseSerifFill';
-import IconTUppercaseSerifLine from '@karrotmarket/lynx-monochrome-icon/IconTUppercaseSerifLine';
-import IconTUppercaseTLowercaseFill from '@karrotmarket/lynx-monochrome-icon/IconTUppercaseTLowercaseFill';
-import IconTUppercaseTLowercaseLine from '@karrotmarket/lynx-monochrome-icon/IconTUppercaseTLowercaseLine';
-import IconTagFill from '@karrotmarket/lynx-monochrome-icon/IconTagFill';
-import IconTagLine from '@karrotmarket/lynx-monochrome-icon/IconTagLine';
-import IconTextAligncenterFill from '@karrotmarket/lynx-monochrome-icon/IconTextAligncenterFill';
-import IconTextAligncenterLine from '@karrotmarket/lynx-monochrome-icon/IconTextAligncenterLine';
-import IconTextAlignleftFill from '@karrotmarket/lynx-monochrome-icon/IconTextAlignleftFill';
-import IconTextAlignleftLine from '@karrotmarket/lynx-monochrome-icon/IconTextAlignleftLine';
-import IconTextAlignrightFill from '@karrotmarket/lynx-monochrome-icon/IconTextAlignrightFill';
-import IconTextAlignrightLine from '@karrotmarket/lynx-monochrome-icon/IconTextAlignrightLine';
-import IconThumbDownFill from '@karrotmarket/lynx-monochrome-icon/IconThumbDownFill';
-import IconThumbDownLine from '@karrotmarket/lynx-monochrome-icon/IconThumbDownLine';
-import IconThumbUpFill from '@karrotmarket/lynx-monochrome-icon/IconThumbUpFill';
-import IconThumbUpLine from '@karrotmarket/lynx-monochrome-icon/IconThumbUpLine';
-import IconTimerFill from '@karrotmarket/lynx-monochrome-icon/IconTimerFill';
-import IconTimerLine from '@karrotmarket/lynx-monochrome-icon/IconTimerLine';
-import IconTimer_10Fill from '@karrotmarket/lynx-monochrome-icon/IconTimer_10Fill';
-import IconTimer_10Line from '@karrotmarket/lynx-monochrome-icon/IconTimer_10Line';
-import IconTimer_3Fill from '@karrotmarket/lynx-monochrome-icon/IconTimer_3Fill';
-import IconTimer_3Line from '@karrotmarket/lynx-monochrome-icon/IconTimer_3Line';
-import IconToolboxFill from '@karrotmarket/lynx-monochrome-icon/IconToolboxFill';
-import IconToolboxLine from '@karrotmarket/lynx-monochrome-icon/IconToolboxLine';
-import IconTranslationFill from '@karrotmarket/lynx-monochrome-icon/IconTranslationFill';
-import IconTranslationLine from '@karrotmarket/lynx-monochrome-icon/IconTranslationLine';
-import IconTrashcanFill from '@karrotmarket/lynx-monochrome-icon/IconTrashcanFill';
-import IconTrashcanLine from '@karrotmarket/lynx-monochrome-icon/IconTrashcanLine';
-import IconTriangleDownSmallFill from '@karrotmarket/lynx-monochrome-icon/IconTriangleDownSmallFill';
-import IconTriangleDownSmallLine from '@karrotmarket/lynx-monochrome-icon/IconTriangleDownSmallLine';
-import IconTriangleRightChatbubbleLeftFill from '@karrotmarket/lynx-monochrome-icon/IconTriangleRightChatbubbleLeftFill';
-import IconTriangleRightChatbubbleLeftLine from '@karrotmarket/lynx-monochrome-icon/IconTriangleRightChatbubbleLeftLine';
-import IconTriangleRightFill from '@karrotmarket/lynx-monochrome-icon/IconTriangleRightFill';
-import IconTriangleRightLine from '@karrotmarket/lynx-monochrome-icon/IconTriangleRightLine';
-import IconTriangleRightRectangleSplitedLineVerticalFill from '@karrotmarket/lynx-monochrome-icon/IconTriangleRightRectangleSplitedLineVerticalFill';
-import IconTriangleRightRectangleSplitedLineVerticalLine from '@karrotmarket/lynx-monochrome-icon/IconTriangleRightRectangleSplitedLineVerticalLine';
-import IconTriangleUpSmallFill from '@karrotmarket/lynx-monochrome-icon/IconTriangleUpSmallFill';
-import IconTriangleUpSmallLine from '@karrotmarket/lynx-monochrome-icon/IconTriangleUpSmallLine';
-import IconTrophyFill from '@karrotmarket/lynx-monochrome-icon/IconTrophyFill';
-import IconTrophyLine from '@karrotmarket/lynx-monochrome-icon/IconTrophyLine';
-import IconTruckFill from '@karrotmarket/lynx-monochrome-icon/IconTruckFill';
-import IconTruckLine from '@karrotmarket/lynx-monochrome-icon/IconTruckLine';
-import IconTshirtBubble2Fill from '@karrotmarket/lynx-monochrome-icon/IconTshirtBubble2Fill';
-import IconTshirtBubble2Line from '@karrotmarket/lynx-monochrome-icon/IconTshirtBubble2Line';
-import IconUUppercaseHorizlineFill from '@karrotmarket/lynx-monochrome-icon/IconUUppercaseHorizlineFill';
-import IconUUppercaseHorizlineLine from '@karrotmarket/lynx-monochrome-icon/IconUUppercaseHorizlineLine';
-import IconVertline3ViewfinderFill from '@karrotmarket/lynx-monochrome-icon/IconVertline3ViewfinderFill';
-import IconVertline3ViewfinderLine from '@karrotmarket/lynx-monochrome-icon/IconVertline3ViewfinderLine';
-import IconVertline4SparkleFill from '@karrotmarket/lynx-monochrome-icon/IconVertline4SparkleFill';
-import IconVertline4SparkleLine from '@karrotmarket/lynx-monochrome-icon/IconVertline4SparkleLine';
-import IconVertlineCouponFill from '@karrotmarket/lynx-monochrome-icon/IconVertlineCouponFill';
-import IconVertlineCouponLine from '@karrotmarket/lynx-monochrome-icon/IconVertlineCouponLine';
-import IconVertrectangle2HorizontalFill from '@karrotmarket/lynx-monochrome-icon/IconVertrectangle2HorizontalFill';
-import IconVertrectangle2HorizontalLine from '@karrotmarket/lynx-monochrome-icon/IconVertrectangle2HorizontalLine';
-import IconVertrectangleFoldedFill from '@karrotmarket/lynx-monochrome-icon/IconVertrectangleFoldedFill';
-import IconVertrectangleFoldedLine from '@karrotmarket/lynx-monochrome-icon/IconVertrectangleFoldedLine';
-import IconVotingstampFill from '@karrotmarket/lynx-monochrome-icon/IconVotingstampFill';
-import IconVotingstampLine from '@karrotmarket/lynx-monochrome-icon/IconVotingstampLine';
-import IconWandFill from '@karrotmarket/lynx-monochrome-icon/IconWandFill';
-import IconWandLine from '@karrotmarket/lynx-monochrome-icon/IconWandLine';
-import IconWashingmachineFill from '@karrotmarket/lynx-monochrome-icon/IconWashingmachineFill';
-import IconWashingmachineLine from '@karrotmarket/lynx-monochrome-icon/IconWashingmachineLine';
-import IconWindow2StoreFill from '@karrotmarket/lynx-monochrome-icon/IconWindow2StoreFill';
-import IconWindow2StoreLine from '@karrotmarket/lynx-monochrome-icon/IconWindow2StoreLine';
-import IconWindow4HouseFill from '@karrotmarket/lynx-monochrome-icon/IconWindow4HouseFill';
-import IconWindow4HouseLine from '@karrotmarket/lynx-monochrome-icon/IconWindow4HouseLine';
-import IconWonArrowClockwiseCircularFill from '@karrotmarket/lynx-monochrome-icon/IconWonArrowClockwiseCircularFill';
-import IconWonArrowClockwiseCircularLine from '@karrotmarket/lynx-monochrome-icon/IconWonArrowClockwiseCircularLine';
-import IconWonCircleArrowLeftFill from '@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowLeftFill';
-import IconWonCircleArrowLeftLine from '@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowLeftLine';
-import IconWonCircleArrowRightFill from '@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowRightFill';
-import IconWonCircleArrowRightLine from '@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowRightLine';
-import IconWonCircleFill from '@karrotmarket/lynx-monochrome-icon/IconWonCircleFill';
-import IconWonCircleLine from '@karrotmarket/lynx-monochrome-icon/IconWonCircleLine';
-import IconWonFill from '@karrotmarket/lynx-monochrome-icon/IconWonFill';
-import IconWonLine from '@karrotmarket/lynx-monochrome-icon/IconWonLine';
-import IconWonShieldFill from '@karrotmarket/lynx-monochrome-icon/IconWonShieldFill';
-import IconWonShieldLine from '@karrotmarket/lynx-monochrome-icon/IconWonShieldLine';
-import IconWrenchFill from '@karrotmarket/lynx-monochrome-icon/IconWrenchFill';
-import IconWrenchLine from '@karrotmarket/lynx-monochrome-icon/IconWrenchLine';
-import IconXmarkCircleFill from '@karrotmarket/lynx-monochrome-icon/IconXmarkCircleFill';
-import IconXmarkCircleLine from '@karrotmarket/lynx-monochrome-icon/IconXmarkCircleLine';
-import IconXmarkFill from '@karrotmarket/lynx-monochrome-icon/IconXmarkFill';
-import IconXmarkLine from '@karrotmarket/lynx-monochrome-icon/IconXmarkLine';
-import IconXmarkScaleFill from '@karrotmarket/lynx-monochrome-icon/IconXmarkScaleFill';
-import IconXmarkScaleLine from '@karrotmarket/lynx-monochrome-icon/IconXmarkScaleLine';
-import IconYenCircleArrowRightFill from '@karrotmarket/lynx-monochrome-icon/IconYenCircleArrowRightFill';
-import IconYenCircleArrowRightLine from '@karrotmarket/lynx-monochrome-icon/IconYenCircleArrowRightLine';
-import IconYenCircleFill from '@karrotmarket/lynx-monochrome-icon/IconYenCircleFill';
-import IconYenCircleLine from '@karrotmarket/lynx-monochrome-icon/IconYenCircleLine';
-import IconYenFill from '@karrotmarket/lynx-monochrome-icon/IconYenFill';
-import IconYenLine from '@karrotmarket/lynx-monochrome-icon/IconYenLine';
+import IconAUppercaseALowercaseFill from "@karrotmarket/lynx-monochrome-icon/IconAUppercaseALowercaseFill";
+import IconAUppercaseALowercaseLine from "@karrotmarket/lynx-monochrome-icon/IconAUppercaseALowercaseLine";
+import IconAUppercaseOutlineFill from "@karrotmarket/lynx-monochrome-icon/IconAUppercaseOutlineFill";
+import IconAUppercaseOutlineLine from "@karrotmarket/lynx-monochrome-icon/IconAUppercaseOutlineLine";
+import IconAUppercaseSquareFill from "@karrotmarket/lynx-monochrome-icon/IconAUppercaseSquareFill";
+import IconAUppercaseSquareLine from "@karrotmarket/lynx-monochrome-icon/IconAUppercaseSquareLine";
+import IconAndroidshareFill from "@karrotmarket/lynx-monochrome-icon/IconAndroidshareFill";
+import IconAndroidshareLine from "@karrotmarket/lynx-monochrome-icon/IconAndroidshareLine";
+import IconAppleFill from "@karrotmarket/lynx-monochrome-icon/IconAppleFill";
+import IconAppleLine from "@karrotmarket/lynx-monochrome-icon/IconAppleLine";
+import IconArrow2ClockwiseCircularFill from "@karrotmarket/lynx-monochrome-icon/IconArrow2ClockwiseCircularFill";
+import IconArrow2ClockwiseCircularLine from "@karrotmarket/lynx-monochrome-icon/IconArrow2ClockwiseCircularLine";
+import IconArrowClockwiseCircularFill from "@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseCircularFill";
+import IconArrowClockwiseCircularLine from "@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseCircularLine";
+import IconArrowClockwiseOvalFill from "@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseOvalFill";
+import IconArrowClockwiseOvalLine from "@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseOvalLine";
+import IconArrowCounterclockwiseCircularFill from "@karrotmarket/lynx-monochrome-icon/IconArrowCounterclockwiseCircularFill";
+import IconArrowCounterclockwiseCircularLine from "@karrotmarket/lynx-monochrome-icon/IconArrowCounterclockwiseCircularLine";
+import IconArrowDownFill from "@karrotmarket/lynx-monochrome-icon/IconArrowDownFill";
+import IconArrowDownHorizlineFill from "@karrotmarket/lynx-monochrome-icon/IconArrowDownHorizlineFill";
+import IconArrowDownHorizlineLine from "@karrotmarket/lynx-monochrome-icon/IconArrowDownHorizlineLine";
+import IconArrowDownLine from "@karrotmarket/lynx-monochrome-icon/IconArrowDownLine";
+import IconArrowDownLineVerticalArrowUpSquareFill from "@karrotmarket/lynx-monochrome-icon/IconArrowDownLineVerticalArrowUpSquareFill";
+import IconArrowDownLineVerticalArrowUpSquareLine from "@karrotmarket/lynx-monochrome-icon/IconArrowDownLineVerticalArrowUpSquareLine";
+import IconArrowDownRightArrowUpLeftFill from "@karrotmarket/lynx-monochrome-icon/IconArrowDownRightArrowUpLeftFill";
+import IconArrowDownRightArrowUpLeftLine from "@karrotmarket/lynx-monochrome-icon/IconArrowDownRightArrowUpLeftLine";
+import IconArrowLeftBracketRightFill from "@karrotmarket/lynx-monochrome-icon/IconArrowLeftBracketRightFill";
+import IconArrowLeftBracketRightLine from "@karrotmarket/lynx-monochrome-icon/IconArrowLeftBracketRightLine";
+import IconArrowLeftFill from "@karrotmarket/lynx-monochrome-icon/IconArrowLeftFill";
+import IconArrowLeftLine from "@karrotmarket/lynx-monochrome-icon/IconArrowLeftLine";
+import IconArrowRightAngledFill from "@karrotmarket/lynx-monochrome-icon/IconArrowRightAngledFill";
+import IconArrowRightAngledLine from "@karrotmarket/lynx-monochrome-icon/IconArrowRightAngledLine";
+import IconArrowRightArrowLeftFill from "@karrotmarket/lynx-monochrome-icon/IconArrowRightArrowLeftFill";
+import IconArrowRightArrowLeftLine from "@karrotmarket/lynx-monochrome-icon/IconArrowRightArrowLeftLine";
+import IconArrowRightFill from "@karrotmarket/lynx-monochrome-icon/IconArrowRightFill";
+import IconArrowRightLine from "@karrotmarket/lynx-monochrome-icon/IconArrowRightLine";
+import IconArrowUpArrowDownFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUpArrowDownFill";
+import IconArrowUpArrowDownLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUpArrowDownLine";
+import IconArrowUpBracketDownFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUpBracketDownFill";
+import IconArrowUpBracketDownLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUpBracketDownLine";
+import IconArrowUpFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUpFill";
+import IconArrowUpLeftFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUpLeftFill";
+import IconArrowUpLeftLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUpLeftLine";
+import IconArrowUpLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUpLine";
+import IconArrowUpRightArrowDownLeftFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftFill";
+import IconArrowUpRightArrowDownLeftLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftLine";
+import IconArrowUpRightArrowDownLeftSquareFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftSquareFill";
+import IconArrowUpRightArrowDownLeftSquareLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftSquareLine";
+import IconArrowUpRightFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUpRightFill";
+import IconArrowUpRightLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUpRightLine";
+import IconArrowUpRightShoppingbagTiltedFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUpRightShoppingbagTiltedFill";
+import IconArrowUpRightShoppingbagTiltedLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUpRightShoppingbagTiltedLine";
+import IconArrowUturnLeftFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUturnLeftFill";
+import IconArrowUturnLeftLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUturnLeftLine";
+import IconArrowUturnRightFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUturnRightFill";
+import IconArrowUturnRightLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUturnRightLine";
+import IconArticleFill from "@karrotmarket/lynx-monochrome-icon/IconArticleFill";
+import IconArticleLine from "@karrotmarket/lynx-monochrome-icon/IconArticleLine";
+import IconAsteriskHorizrectangleCoolwave3Fill from "@karrotmarket/lynx-monochrome-icon/IconAsteriskHorizrectangleCoolwave3Fill";
+import IconAsteriskHorizrectangleCoolwave3Line from "@karrotmarket/lynx-monochrome-icon/IconAsteriskHorizrectangleCoolwave3Line";
+import IconAtFill from "@karrotmarket/lynx-monochrome-icon/IconAtFill";
+import IconAtLine from "@karrotmarket/lynx-monochrome-icon/IconAtLine";
+import IconBUppercaseFill from "@karrotmarket/lynx-monochrome-icon/IconBUppercaseFill";
+import IconBUppercaseLine from "@karrotmarket/lynx-monochrome-icon/IconBUppercaseLine";
+import IconBackspacekeyFill from "@karrotmarket/lynx-monochrome-icon/IconBackspacekeyFill";
+import IconBackspacekeyLine from "@karrotmarket/lynx-monochrome-icon/IconBackspacekeyLine";
+import IconBarchartBoardFill from "@karrotmarket/lynx-monochrome-icon/IconBarchartBoardFill";
+import IconBarchartBoardLine from "@karrotmarket/lynx-monochrome-icon/IconBarchartBoardLine";
+import IconBarchartSquareFill from "@karrotmarket/lynx-monochrome-icon/IconBarchartSquareFill";
+import IconBarchartSquareLine from "@karrotmarket/lynx-monochrome-icon/IconBarchartSquareLine";
+import IconBedFrontsideFill from "@karrotmarket/lynx-monochrome-icon/IconBedFrontsideFill";
+import IconBedFrontsideLine from "@karrotmarket/lynx-monochrome-icon/IconBedFrontsideLine";
+import IconBellFill from "@karrotmarket/lynx-monochrome-icon/IconBellFill";
+import IconBellLine from "@karrotmarket/lynx-monochrome-icon/IconBellLine";
+import IconBellSlashFill from "@karrotmarket/lynx-monochrome-icon/IconBellSlashFill";
+import IconBellSlashLine from "@karrotmarket/lynx-monochrome-icon/IconBellSlashLine";
+import IconBookFill from "@karrotmarket/lynx-monochrome-icon/IconBookFill";
+import IconBookLine from "@karrotmarket/lynx-monochrome-icon/IconBookLine";
+import IconBookOpenFill from "@karrotmarket/lynx-monochrome-icon/IconBookOpenFill";
+import IconBookOpenLine from "@karrotmarket/lynx-monochrome-icon/IconBookOpenLine";
+import IconBookmarkFill from "@karrotmarket/lynx-monochrome-icon/IconBookmarkFill";
+import IconBookmarkLine from "@karrotmarket/lynx-monochrome-icon/IconBookmarkLine";
+import IconBoxFlapFill from "@karrotmarket/lynx-monochrome-icon/IconBoxFlapFill";
+import IconBoxFlapLine from "@karrotmarket/lynx-monochrome-icon/IconBoxFlapLine";
+import IconBracketLeftArrowRightFill from "@karrotmarket/lynx-monochrome-icon/IconBracketLeftArrowRightFill";
+import IconBracketLeftArrowRightLine from "@karrotmarket/lynx-monochrome-icon/IconBracketLeftArrowRightLine";
+import IconBuilding2Fill from "@karrotmarket/lynx-monochrome-icon/IconBuilding2Fill";
+import IconBuilding2Line from "@karrotmarket/lynx-monochrome-icon/IconBuilding2Line";
+import IconCalendarFill from "@karrotmarket/lynx-monochrome-icon/IconCalendarFill";
+import IconCalendarLine from "@karrotmarket/lynx-monochrome-icon/IconCalendarLine";
+import IconCamcorderFill from "@karrotmarket/lynx-monochrome-icon/IconCamcorderFill";
+import IconCamcorderLine from "@karrotmarket/lynx-monochrome-icon/IconCamcorderLine";
+import IconCameraFill from "@karrotmarket/lynx-monochrome-icon/IconCameraFill";
+import IconCameraLine from "@karrotmarket/lynx-monochrome-icon/IconCameraLine";
+import IconCarFill from "@karrotmarket/lynx-monochrome-icon/IconCarFill";
+import IconCarFrontUpsideWave2ReversedUpFill from "@karrotmarket/lynx-monochrome-icon/IconCarFrontUpsideWave2ReversedUpFill";
+import IconCarFrontUpsideWave2ReversedUpLine from "@karrotmarket/lynx-monochrome-icon/IconCarFrontUpsideWave2ReversedUpLine";
+import IconCarFrontsideFill from "@karrotmarket/lynx-monochrome-icon/IconCarFrontsideFill";
+import IconCarFrontsideLine from "@karrotmarket/lynx-monochrome-icon/IconCarFrontsideLine";
+import IconCarLine from "@karrotmarket/lynx-monochrome-icon/IconCarLine";
+import IconCarRearTrunkOpenLeftsideFill from "@karrotmarket/lynx-monochrome-icon/IconCarRearTrunkOpenLeftsideFill";
+import IconCarRearTrunkOpenLeftsideLine from "@karrotmarket/lynx-monochrome-icon/IconCarRearTrunkOpenLeftsideLine";
+import IconCarRearUpsideSectorDownFill from "@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideSectorDownFill";
+import IconCarRearUpsideSectorDownLine from "@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideSectorDownLine";
+import IconCarRearUpsideWave2ReversedDownFill from "@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownFill";
+import IconCarRearUpsideWave2ReversedDownLeftFill from "@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownLeftFill";
+import IconCarRearUpsideWave2ReversedDownLeftLine from "@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownLeftLine";
+import IconCarRearUpsideWave2ReversedDownLine from "@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownLine";
+import IconCardFill from "@karrotmarket/lynx-monochrome-icon/IconCardFill";
+import IconCardLine from "@karrotmarket/lynx-monochrome-icon/IconCardLine";
+import IconCarrotFill from "@karrotmarket/lynx-monochrome-icon/IconCarrotFill";
+import IconCarrotLine from "@karrotmarket/lynx-monochrome-icon/IconCarrotLine";
+import IconCartFill from "@karrotmarket/lynx-monochrome-icon/IconCartFill";
+import IconCartItemsFill from "@karrotmarket/lynx-monochrome-icon/IconCartItemsFill";
+import IconCartItemsLine from "@karrotmarket/lynx-monochrome-icon/IconCartItemsLine";
+import IconCartLine from "@karrotmarket/lynx-monochrome-icon/IconCartLine";
+import IconCartLoadFill from "@karrotmarket/lynx-monochrome-icon/IconCartLoadFill";
+import IconCartLoadLine from "@karrotmarket/lynx-monochrome-icon/IconCartLoadLine";
+import IconCheckmarkBadgeFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkBadgeFill";
+import IconCheckmarkBadgeLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkBadgeLine";
+import IconCheckmarkBallotboxFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkBallotboxFill";
+import IconCheckmarkBallotboxLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkBallotboxLine";
+import IconCheckmarkCalendarFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkCalendarFill";
+import IconCheckmarkCalendarLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkCalendarLine";
+import IconCheckmarkChatbubbleLeftFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkChatbubbleLeftFill";
+import IconCheckmarkChatbubbleLeftLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkChatbubbleLeftLine";
+import IconCheckmarkCircleFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkCircleFill";
+import IconCheckmarkCircleLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkCircleLine";
+import IconCheckmarkClipboardFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkClipboardFill";
+import IconCheckmarkClipboardLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkClipboardLine";
+import IconCheckmarkCouponFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkCouponFill";
+import IconCheckmarkCouponLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkCouponLine";
+import IconCheckmarkFatFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkFatFill";
+import IconCheckmarkFatLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkFatLine";
+import IconCheckmarkFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkFill";
+import IconCheckmarkFlowerFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkFlowerFill";
+import IconCheckmarkFlowerLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkFlowerLine";
+import IconCheckmarkHorizlineFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkHorizlineFill";
+import IconCheckmarkHorizlineLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkHorizlineLine";
+import IconCheckmarkLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkLine";
+import IconCheckmarkScaleFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkScaleFill";
+import IconCheckmarkScaleLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkScaleLine";
+import IconCheckmarkShieldFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkShieldFill";
+import IconCheckmarkShieldLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkShieldLine";
+import IconCheckmarkhorizline2VerticalFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkhorizline2VerticalFill";
+import IconCheckmarkhorizline2VerticalLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkhorizline2VerticalLine";
+import IconChevronDownFill from "@karrotmarket/lynx-monochrome-icon/IconChevronDownFill";
+import IconChevronDownLine from "@karrotmarket/lynx-monochrome-icon/IconChevronDownLine";
+import IconChevronDownSmallFill from "@karrotmarket/lynx-monochrome-icon/IconChevronDownSmallFill";
+import IconChevronDownSmallLine from "@karrotmarket/lynx-monochrome-icon/IconChevronDownSmallLine";
+import IconChevronLeftFill from "@karrotmarket/lynx-monochrome-icon/IconChevronLeftFill";
+import IconChevronLeftLine from "@karrotmarket/lynx-monochrome-icon/IconChevronLeftLine";
+import IconChevronLeftSmallFill from "@karrotmarket/lynx-monochrome-icon/IconChevronLeftSmallFill";
+import IconChevronLeftSmallLine from "@karrotmarket/lynx-monochrome-icon/IconChevronLeftSmallLine";
+import IconChevronRightFill from "@karrotmarket/lynx-monochrome-icon/IconChevronRightFill";
+import IconChevronRightLine from "@karrotmarket/lynx-monochrome-icon/IconChevronRightLine";
+import IconChevronRightSmallFill from "@karrotmarket/lynx-monochrome-icon/IconChevronRightSmallFill";
+import IconChevronRightSmallLine from "@karrotmarket/lynx-monochrome-icon/IconChevronRightSmallLine";
+import IconChevronUpFill from "@karrotmarket/lynx-monochrome-icon/IconChevronUpFill";
+import IconChevronUpLine from "@karrotmarket/lynx-monochrome-icon/IconChevronUpLine";
+import IconChevronUpSmallFill from "@karrotmarket/lynx-monochrome-icon/IconChevronUpSmallFill";
+import IconChevronUpSmallLine from "@karrotmarket/lynx-monochrome-icon/IconChevronUpSmallLine";
+import IconCircle4SquareFill from "@karrotmarket/lynx-monochrome-icon/IconCircle4SquareFill";
+import IconCircle4SquareLine from "@karrotmarket/lynx-monochrome-icon/IconCircle4SquareLine";
+import IconClockFill from "@karrotmarket/lynx-monochrome-icon/IconClockFill";
+import IconClockLine from "@karrotmarket/lynx-monochrome-icon/IconClockLine";
+import IconCompassFill from "@karrotmarket/lynx-monochrome-icon/IconCompassFill";
+import IconCompassLine from "@karrotmarket/lynx-monochrome-icon/IconCompassLine";
+import IconCorner4InwardFill from "@karrotmarket/lynx-monochrome-icon/IconCorner4InwardFill";
+import IconCorner4InwardLine from "@karrotmarket/lynx-monochrome-icon/IconCorner4InwardLine";
+import IconCorner4OutwardFill from "@karrotmarket/lynx-monochrome-icon/IconCorner4OutwardFill";
+import IconCorner4OutwardLine from "@karrotmarket/lynx-monochrome-icon/IconCorner4OutwardLine";
+import IconCornerDownLeftFill from "@karrotmarket/lynx-monochrome-icon/IconCornerDownLeftFill";
+import IconCornerDownLeftLine from "@karrotmarket/lynx-monochrome-icon/IconCornerDownLeftLine";
+import IconCouponFill from "@karrotmarket/lynx-monochrome-icon/IconCouponFill";
+import IconCouponLine from "@karrotmarket/lynx-monochrome-icon/IconCouponLine";
+import IconCropmarkFill from "@karrotmarket/lynx-monochrome-icon/IconCropmarkFill";
+import IconCropmarkLine from "@karrotmarket/lynx-monochrome-icon/IconCropmarkLine";
+import IconCrosshairFill from "@karrotmarket/lynx-monochrome-icon/IconCrosshairFill";
+import IconCrosshairLine from "@karrotmarket/lynx-monochrome-icon/IconCrosshairLine";
+import IconCrosshairQuestionmarkFill from "@karrotmarket/lynx-monochrome-icon/IconCrosshairQuestionmarkFill";
+import IconCrosshairQuestionmarkLine from "@karrotmarket/lynx-monochrome-icon/IconCrosshairQuestionmarkLine";
+import IconCrownFill from "@karrotmarket/lynx-monochrome-icon/IconCrownFill";
+import IconCrownLine from "@karrotmarket/lynx-monochrome-icon/IconCrownLine";
+import IconCupHeatwaveFill from "@karrotmarket/lynx-monochrome-icon/IconCupHeatwaveFill";
+import IconCupHeatwaveLine from "@karrotmarket/lynx-monochrome-icon/IconCupHeatwaveLine";
+import IconDiamondFill from "@karrotmarket/lynx-monochrome-icon/IconDiamondFill";
+import IconDiamondLine from "@karrotmarket/lynx-monochrome-icon/IconDiamondLine";
+import IconDocumentArrowLeftFill from "@karrotmarket/lynx-monochrome-icon/IconDocumentArrowLeftFill";
+import IconDocumentArrowLeftLine from "@karrotmarket/lynx-monochrome-icon/IconDocumentArrowLeftLine";
+import IconDocumentCheckmarkFill from "@karrotmarket/lynx-monochrome-icon/IconDocumentCheckmarkFill";
+import IconDocumentCheckmarkLine from "@karrotmarket/lynx-monochrome-icon/IconDocumentCheckmarkLine";
+import IconDocumentFill from "@karrotmarket/lynx-monochrome-icon/IconDocumentFill";
+import IconDocumentLine from "@karrotmarket/lynx-monochrome-icon/IconDocumentLine";
+import IconDocumentMagnifyingglassFill from "@karrotmarket/lynx-monochrome-icon/IconDocumentMagnifyingglassFill";
+import IconDocumentMagnifyingglassLine from "@karrotmarket/lynx-monochrome-icon/IconDocumentMagnifyingglassLine";
+import IconDocumentPenFill from "@karrotmarket/lynx-monochrome-icon/IconDocumentPenFill";
+import IconDocumentPenLine from "@karrotmarket/lynx-monochrome-icon/IconDocumentPenLine";
+import IconDocumentPlusFill from "@karrotmarket/lynx-monochrome-icon/IconDocumentPlusFill";
+import IconDocumentPlusLine from "@karrotmarket/lynx-monochrome-icon/IconDocumentPlusLine";
+import IconDollarCircleArrowRightFill from "@karrotmarket/lynx-monochrome-icon/IconDollarCircleArrowRightFill";
+import IconDollarCircleArrowRightLine from "@karrotmarket/lynx-monochrome-icon/IconDollarCircleArrowRightLine";
+import IconDollarCircleFill from "@karrotmarket/lynx-monochrome-icon/IconDollarCircleFill";
+import IconDollarCircleLine from "@karrotmarket/lynx-monochrome-icon/IconDollarCircleLine";
+import IconDollarFill from "@karrotmarket/lynx-monochrome-icon/IconDollarFill";
+import IconDollarLine from "@karrotmarket/lynx-monochrome-icon/IconDollarLine";
+import IconDot3CircleFill from "@karrotmarket/lynx-monochrome-icon/IconDot3CircleFill";
+import IconDot3CircleLine from "@karrotmarket/lynx-monochrome-icon/IconDot3CircleLine";
+import IconDot3HorizontalChatbubbleLeftFill from "@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftFill";
+import IconDot3HorizontalChatbubbleLeftLine from "@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftLine";
+import IconDot3HorizontalChatbubbleLeftSlashFill from "@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftSlashFill";
+import IconDot3HorizontalChatbubbleLeftSlashLine from "@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftSlashLine";
+import IconDot3HorizontalFill from "@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalFill";
+import IconDot3HorizontalLine from "@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalLine";
+import IconDot3VerticalFill from "@karrotmarket/lynx-monochrome-icon/IconDot3VerticalFill";
+import IconDot3VerticalLine from "@karrotmarket/lynx-monochrome-icon/IconDot3VerticalLine";
+import IconDothorizline3VerticalFill from "@karrotmarket/lynx-monochrome-icon/IconDothorizline3VerticalFill";
+import IconDothorizline3VerticalLine from "@karrotmarket/lynx-monochrome-icon/IconDothorizline3VerticalLine";
+import IconDumbbellFill from "@karrotmarket/lynx-monochrome-icon/IconDumbbellFill";
+import IconDumbbellLine from "@karrotmarket/lynx-monochrome-icon/IconDumbbellLine";
+import IconEarthFill from "@karrotmarket/lynx-monochrome-icon/IconEarthFill";
+import IconEarthLine from "@karrotmarket/lynx-monochrome-icon/IconEarthLine";
+import IconEnvelopeFill from "@karrotmarket/lynx-monochrome-icon/IconEnvelopeFill";
+import IconEnvelopeLine from "@karrotmarket/lynx-monochrome-icon/IconEnvelopeLine";
+import IconEpbFill from "@karrotmarket/lynx-monochrome-icon/IconEpbFill";
+import IconEpbLine from "@karrotmarket/lynx-monochrome-icon/IconEpbLine";
+import IconEraserHorizlineFill from "@karrotmarket/lynx-monochrome-icon/IconEraserHorizlineFill";
+import IconEraserHorizlineLine from "@karrotmarket/lynx-monochrome-icon/IconEraserHorizlineLine";
+import IconExclamationmarkChatbubbleRectangularCenterFill from "@karrotmarket/lynx-monochrome-icon/IconExclamationmarkChatbubbleRectangularCenterFill";
+import IconExclamationmarkChatbubbleRectangularCenterLine from "@karrotmarket/lynx-monochrome-icon/IconExclamationmarkChatbubbleRectangularCenterLine";
+import IconExclamationmarkCircleFill from "@karrotmarket/lynx-monochrome-icon/IconExclamationmarkCircleFill";
+import IconExclamationmarkCircleLine from "@karrotmarket/lynx-monochrome-icon/IconExclamationmarkCircleLine";
+import IconEyeFill from "@karrotmarket/lynx-monochrome-icon/IconEyeFill";
+import IconEyeLine from "@karrotmarket/lynx-monochrome-icon/IconEyeLine";
+import IconEyeSlashFill from "@karrotmarket/lynx-monochrome-icon/IconEyeSlashFill";
+import IconEyeSlashLine from "@karrotmarket/lynx-monochrome-icon/IconEyeSlashLine";
+import IconFaceFrustratedCircleFill from "@karrotmarket/lynx-monochrome-icon/IconFaceFrustratedCircleFill";
+import IconFaceFrustratedCircleLine from "@karrotmarket/lynx-monochrome-icon/IconFaceFrustratedCircleLine";
+import IconFaceSadCircleFill from "@karrotmarket/lynx-monochrome-icon/IconFaceSadCircleFill";
+import IconFaceSadCircleLine from "@karrotmarket/lynx-monochrome-icon/IconFaceSadCircleLine";
+import IconFaceSmileCircleFill from "@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleFill";
+import IconFaceSmileCircleFoldedFill from "@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleFoldedFill";
+import IconFaceSmileCircleFoldedLine from "@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleFoldedLine";
+import IconFaceSmileCircleLine from "@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleLine";
+import IconFaceSurprisedCircleFill from "@karrotmarket/lynx-monochrome-icon/IconFaceSurprisedCircleFill";
+import IconFaceSurprisedCircleLine from "@karrotmarket/lynx-monochrome-icon/IconFaceSurprisedCircleLine";
+import IconFaceViewfinderFill from "@karrotmarket/lynx-monochrome-icon/IconFaceViewfinderFill";
+import IconFaceViewfinderLine from "@karrotmarket/lynx-monochrome-icon/IconFaceViewfinderLine";
+import IconFigureBikeFill from "@karrotmarket/lynx-monochrome-icon/IconFigureBikeFill";
+import IconFigureBikeLine from "@karrotmarket/lynx-monochrome-icon/IconFigureBikeLine";
+import IconFigureOvalFill from "@karrotmarket/lynx-monochrome-icon/IconFigureOvalFill";
+import IconFigureOvalLine from "@karrotmarket/lynx-monochrome-icon/IconFigureOvalLine";
+import IconFigureRunFill from "@karrotmarket/lynx-monochrome-icon/IconFigureRunFill";
+import IconFigureRunLine from "@karrotmarket/lynx-monochrome-icon/IconFigureRunLine";
+import IconFigureWalkFill from "@karrotmarket/lynx-monochrome-icon/IconFigureWalkFill";
+import IconFigureWalkLine from "@karrotmarket/lynx-monochrome-icon/IconFigureWalkLine";
+import IconFigureWheelchairFill from "@karrotmarket/lynx-monochrome-icon/IconFigureWheelchairFill";
+import IconFigureWheelchairLine from "@karrotmarket/lynx-monochrome-icon/IconFigureWheelchairLine";
+import IconFingerprintFill from "@karrotmarket/lynx-monochrome-icon/IconFingerprintFill";
+import IconFingerprintLine from "@karrotmarket/lynx-monochrome-icon/IconFingerprintLine";
+import IconFireworkFill from "@karrotmarket/lynx-monochrome-icon/IconFireworkFill";
+import IconFireworkLine from "@karrotmarket/lynx-monochrome-icon/IconFireworkLine";
+import IconFishWave2Fill from "@karrotmarket/lynx-monochrome-icon/IconFishWave2Fill";
+import IconFishWave2Line from "@karrotmarket/lynx-monochrome-icon/IconFishWave2Line";
+import IconFlagFill from "@karrotmarket/lynx-monochrome-icon/IconFlagFill";
+import IconFlagHillFill from "@karrotmarket/lynx-monochrome-icon/IconFlagHillFill";
+import IconFlagHillLine from "@karrotmarket/lynx-monochrome-icon/IconFlagHillLine";
+import IconFlagLine from "@karrotmarket/lynx-monochrome-icon/IconFlagLine";
+import IconFlameFill from "@karrotmarket/lynx-monochrome-icon/IconFlameFill";
+import IconFlameLine from "@karrotmarket/lynx-monochrome-icon/IconFlameLine";
+import IconFlaskFill from "@karrotmarket/lynx-monochrome-icon/IconFlaskFill";
+import IconFlaskLine from "@karrotmarket/lynx-monochrome-icon/IconFlaskLine";
+import IconForkSpoonBagFill from "@karrotmarket/lynx-monochrome-icon/IconForkSpoonBagFill";
+import IconForkSpoonBagLine from "@karrotmarket/lynx-monochrome-icon/IconForkSpoonBagLine";
+import IconForkSpoonFill from "@karrotmarket/lynx-monochrome-icon/IconForkSpoonFill";
+import IconForkSpoonLine from "@karrotmarket/lynx-monochrome-icon/IconForkSpoonLine";
+import IconFridgeFill from "@karrotmarket/lynx-monochrome-icon/IconFridgeFill";
+import IconFridgeLine from "@karrotmarket/lynx-monochrome-icon/IconFridgeLine";
+import IconGearFill from "@karrotmarket/lynx-monochrome-icon/IconGearFill";
+import IconGearLine from "@karrotmarket/lynx-monochrome-icon/IconGearLine";
+import IconGiftFill from "@karrotmarket/lynx-monochrome-icon/IconGiftFill";
+import IconGiftLine from "@karrotmarket/lynx-monochrome-icon/IconGiftLine";
+import IconGlobeFill from "@karrotmarket/lynx-monochrome-icon/IconGlobeFill";
+import IconGlobeLine from "@karrotmarket/lynx-monochrome-icon/IconGlobeLine";
+import IconGraduationcapFill from "@karrotmarket/lynx-monochrome-icon/IconGraduationcapFill";
+import IconGraduationcapLine from "@karrotmarket/lynx-monochrome-icon/IconGraduationcapLine";
+import IconGridDot5Fill from "@karrotmarket/lynx-monochrome-icon/IconGridDot5Fill";
+import IconGridDot5Line from "@karrotmarket/lynx-monochrome-icon/IconGridDot5Line";
+import IconGridFill from "@karrotmarket/lynx-monochrome-icon/IconGridFill";
+import IconGridHeartFill from "@karrotmarket/lynx-monochrome-icon/IconGridHeartFill";
+import IconGridHeartLine from "@karrotmarket/lynx-monochrome-icon/IconGridHeartLine";
+import IconGridLine from "@karrotmarket/lynx-monochrome-icon/IconGridLine";
+import IconHandPointUpFill from "@karrotmarket/lynx-monochrome-icon/IconHandPointUpFill";
+import IconHandPointUpLine from "@karrotmarket/lynx-monochrome-icon/IconHandPointUpLine";
+import IconHandWaveFill from "@karrotmarket/lynx-monochrome-icon/IconHandWaveFill";
+import IconHandWaveLine from "@karrotmarket/lynx-monochrome-icon/IconHandWaveLine";
+import IconHashFill from "@karrotmarket/lynx-monochrome-icon/IconHashFill";
+import IconHashLine from "@karrotmarket/lynx-monochrome-icon/IconHashLine";
+import IconHeadsetFill from "@karrotmarket/lynx-monochrome-icon/IconHeadsetFill";
+import IconHeadsetLine from "@karrotmarket/lynx-monochrome-icon/IconHeadsetLine";
+import IconHeartFill from "@karrotmarket/lynx-monochrome-icon/IconHeartFill";
+import IconHeartLine from "@karrotmarket/lynx-monochrome-icon/IconHeartLine";
+import IconHorizline2VerticalChatbubbleRectangularRightFill from "@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightFill";
+import IconHorizline2VerticalChatbubbleRectangularRightLine from "@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightLine";
+import IconHorizline2VerticalChatbubbleRectangularRightSlashFill from "@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightSlashFill";
+import IconHorizline2VerticalChatbubbleRectangularRightSlashLine from "@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightSlashLine";
+import IconHorizline3VerticalCheckmarkFill from "@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalCheckmarkFill";
+import IconHorizline3VerticalCheckmarkLine from "@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalCheckmarkLine";
+import IconHorizline3VerticalFill from "@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalFill";
+import IconHorizline3VerticalLine from "@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalLine";
+import IconHorizline3VerticalStarFill from "@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalStarFill";
+import IconHorizline3VerticalStarLine from "@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalStarLine";
+import IconHorizline3VerticalTightFill from "@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalTightFill";
+import IconHorizline3VerticalTightLine from "@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalTightLine";
+import IconHorizlineViewfinderFill from "@karrotmarket/lynx-monochrome-icon/IconHorizlineViewfinderFill";
+import IconHorizlineViewfinderLine from "@karrotmarket/lynx-monochrome-icon/IconHorizlineViewfinderLine";
+import IconHorizrectangleHorizline2VerticalFill from "@karrotmarket/lynx-monochrome-icon/IconHorizrectangleHorizline2VerticalFill";
+import IconHorizrectangleHorizline2VerticalLine from "@karrotmarket/lynx-monochrome-icon/IconHorizrectangleHorizline2VerticalLine";
+import IconHospitalcrossBuildingFill from "@karrotmarket/lynx-monochrome-icon/IconHospitalcrossBuildingFill";
+import IconHospitalcrossBuildingLine from "@karrotmarket/lynx-monochrome-icon/IconHospitalcrossBuildingLine";
+import IconHospitalcrossSquareFill from "@karrotmarket/lynx-monochrome-icon/IconHospitalcrossSquareFill";
+import IconHospitalcrossSquareLine from "@karrotmarket/lynx-monochrome-icon/IconHospitalcrossSquareLine";
+import IconHouseFill from "@karrotmarket/lynx-monochrome-icon/IconHouseFill";
+import IconHouseLine from "@karrotmarket/lynx-monochrome-icon/IconHouseLine";
+import IconHousePlusFill from "@karrotmarket/lynx-monochrome-icon/IconHousePlusFill";
+import IconHousePlusLine from "@karrotmarket/lynx-monochrome-icon/IconHousePlusLine";
+import IconHouseSquareFill from "@karrotmarket/lynx-monochrome-icon/IconHouseSquareFill";
+import IconHouseSquareLine from "@karrotmarket/lynx-monochrome-icon/IconHouseSquareLine";
+import IconILowercaseSerifCircleFill from "@karrotmarket/lynx-monochrome-icon/IconILowercaseSerifCircleFill";
+import IconILowercaseSerifCircleLine from "@karrotmarket/lynx-monochrome-icon/IconILowercaseSerifCircleLine";
+import IconKeyboardChevronDownFill from "@karrotmarket/lynx-monochrome-icon/IconKeyboardChevronDownFill";
+import IconKeyboardChevronDownLine from "@karrotmarket/lynx-monochrome-icon/IconKeyboardChevronDownLine";
+import IconKeyholeShieldFill from "@karrotmarket/lynx-monochrome-icon/IconKeyholeShieldFill";
+import IconKeyholeShieldLine from "@karrotmarket/lynx-monochrome-icon/IconKeyholeShieldLine";
+import IconLaptopFill from "@karrotmarket/lynx-monochrome-icon/IconLaptopFill";
+import IconLaptopLine from "@karrotmarket/lynx-monochrome-icon/IconLaptopLine";
+import IconLeafFill from "@karrotmarket/lynx-monochrome-icon/IconLeafFill";
+import IconLeafLine from "@karrotmarket/lynx-monochrome-icon/IconLeafLine";
+import IconLightbulbDot5Fill from "@karrotmarket/lynx-monochrome-icon/IconLightbulbDot5Fill";
+import IconLightbulbDot5Line from "@karrotmarket/lynx-monochrome-icon/IconLightbulbDot5Line";
+import IconLightningFill from "@karrotmarket/lynx-monochrome-icon/IconLightningFill";
+import IconLightningLine from "@karrotmarket/lynx-monochrome-icon/IconLightningLine";
+import IconLightningSlashFill from "@karrotmarket/lynx-monochrome-icon/IconLightningSlashFill";
+import IconLightningSlashLine from "@karrotmarket/lynx-monochrome-icon/IconLightningSlashLine";
+import IconLinechartUpXaxisFill from "@karrotmarket/lynx-monochrome-icon/IconLinechartUpXaxisFill";
+import IconLinechartUpXaxisLine from "@karrotmarket/lynx-monochrome-icon/IconLinechartUpXaxisLine";
+import IconLocationpinFill from "@karrotmarket/lynx-monochrome-icon/IconLocationpinFill";
+import IconLocationpinLine from "@karrotmarket/lynx-monochrome-icon/IconLocationpinLine";
+import IconLockFill from "@karrotmarket/lynx-monochrome-icon/IconLockFill";
+import IconLockLine from "@karrotmarket/lynx-monochrome-icon/IconLockLine";
+import IconLockOpenedFill from "@karrotmarket/lynx-monochrome-icon/IconLockOpenedFill";
+import IconLockOpenedLine from "@karrotmarket/lynx-monochrome-icon/IconLockOpenedLine";
+import IconMagnifyingglassFill from "@karrotmarket/lynx-monochrome-icon/IconMagnifyingglassFill";
+import IconMagnifyingglassLine from "@karrotmarket/lynx-monochrome-icon/IconMagnifyingglassLine";
+import IconMalesymbolFemalesymbolFill from "@karrotmarket/lynx-monochrome-icon/IconMalesymbolFemalesymbolFill";
+import IconMalesymbolFemalesymbolLine from "@karrotmarket/lynx-monochrome-icon/IconMalesymbolFemalesymbolLine";
+import IconMapFill from "@karrotmarket/lynx-monochrome-icon/IconMapFill";
+import IconMapLine from "@karrotmarket/lynx-monochrome-icon/IconMapLine";
+import IconMapLocationpinFill from "@karrotmarket/lynx-monochrome-icon/IconMapLocationpinFill";
+import IconMapLocationpinLine from "@karrotmarket/lynx-monochrome-icon/IconMapLocationpinLine";
+import IconMegaphoneFill from "@karrotmarket/lynx-monochrome-icon/IconMegaphoneFill";
+import IconMegaphoneLine from "@karrotmarket/lynx-monochrome-icon/IconMegaphoneLine";
+import IconMegaphoneTiltedFill from "@karrotmarket/lynx-monochrome-icon/IconMegaphoneTiltedFill";
+import IconMegaphoneTiltedLine from "@karrotmarket/lynx-monochrome-icon/IconMegaphoneTiltedLine";
+import IconMetroFrontsideFill from "@karrotmarket/lynx-monochrome-icon/IconMetroFrontsideFill";
+import IconMetroFrontsideLine from "@karrotmarket/lynx-monochrome-icon/IconMetroFrontsideLine";
+import IconMicrophoneFill from "@karrotmarket/lynx-monochrome-icon/IconMicrophoneFill";
+import IconMicrophoneLine from "@karrotmarket/lynx-monochrome-icon/IconMicrophoneLine";
+import IconMicrophoneSlashFill from "@karrotmarket/lynx-monochrome-icon/IconMicrophoneSlashFill";
+import IconMicrophoneSlashLine from "@karrotmarket/lynx-monochrome-icon/IconMicrophoneSlashLine";
+import IconMicrowaveFill from "@karrotmarket/lynx-monochrome-icon/IconMicrowaveFill";
+import IconMicrowaveLine from "@karrotmarket/lynx-monochrome-icon/IconMicrowaveLine";
+import IconMidcutSquareFill from "@karrotmarket/lynx-monochrome-icon/IconMidcutSquareFill";
+import IconMidcutSquareLine from "@karrotmarket/lynx-monochrome-icon/IconMidcutSquareLine";
+import IconMinusCircleFill from "@karrotmarket/lynx-monochrome-icon/IconMinusCircleFill";
+import IconMinusCircleLine from "@karrotmarket/lynx-monochrome-icon/IconMinusCircleLine";
+import IconMinusFatFill from "@karrotmarket/lynx-monochrome-icon/IconMinusFatFill";
+import IconMinusFatLine from "@karrotmarket/lynx-monochrome-icon/IconMinusFatLine";
+import IconMinusFill from "@karrotmarket/lynx-monochrome-icon/IconMinusFill";
+import IconMinusLine from "@karrotmarket/lynx-monochrome-icon/IconMinusLine";
+import IconMobileFill from "@karrotmarket/lynx-monochrome-icon/IconMobileFill";
+import IconMobileLine from "@karrotmarket/lynx-monochrome-icon/IconMobileLine";
+import IconMoonFill from "@karrotmarket/lynx-monochrome-icon/IconMoonFill";
+import IconMoonLine from "@karrotmarket/lynx-monochrome-icon/IconMoonLine";
+import IconMusicalnoteDoubleFill from "@karrotmarket/lynx-monochrome-icon/IconMusicalnoteDoubleFill";
+import IconMusicalnoteDoubleLine from "@karrotmarket/lynx-monochrome-icon/IconMusicalnoteDoubleLine";
+import IconNUppercaseCircleFill from "@karrotmarket/lynx-monochrome-icon/IconNUppercaseCircleFill";
+import IconNUppercaseCircleLine from "@karrotmarket/lynx-monochrome-icon/IconNUppercaseCircleLine";
+import IconNailpolishFill from "@karrotmarket/lynx-monochrome-icon/IconNailpolishFill";
+import IconNailpolishLine from "@karrotmarket/lynx-monochrome-icon/IconNailpolishLine";
+import IconNeedleScaleFill from "@karrotmarket/lynx-monochrome-icon/IconNeedleScaleFill";
+import IconNeedleScaleLine from "@karrotmarket/lynx-monochrome-icon/IconNeedleScaleLine";
+import IconPUppercaseCircleFill from "@karrotmarket/lynx-monochrome-icon/IconPUppercaseCircleFill";
+import IconPUppercaseCircleLine from "@karrotmarket/lynx-monochrome-icon/IconPUppercaseCircleLine";
+import IconPaintrollerFill from "@karrotmarket/lynx-monochrome-icon/IconPaintrollerFill";
+import IconPaintrollerLine from "@karrotmarket/lynx-monochrome-icon/IconPaintrollerLine";
+import IconPaletteFill from "@karrotmarket/lynx-monochrome-icon/IconPaletteFill";
+import IconPaletteLine from "@karrotmarket/lynx-monochrome-icon/IconPaletteLine";
+import IconPaperclipFill from "@karrotmarket/lynx-monochrome-icon/IconPaperclipFill";
+import IconPaperclipLine from "@karrotmarket/lynx-monochrome-icon/IconPaperclipLine";
+import IconPaperplaneFill from "@karrotmarket/lynx-monochrome-icon/IconPaperplaneFill";
+import IconPaperplaneLine from "@karrotmarket/lynx-monochrome-icon/IconPaperplaneLine";
+import IconPaperplaneTiltedFill from "@karrotmarket/lynx-monochrome-icon/IconPaperplaneTiltedFill";
+import IconPaperplaneTiltedLine from "@karrotmarket/lynx-monochrome-icon/IconPaperplaneTiltedLine";
+import IconPawprintFill from "@karrotmarket/lynx-monochrome-icon/IconPawprintFill";
+import IconPawprintLine from "@karrotmarket/lynx-monochrome-icon/IconPawprintLine";
+import IconPenHorizlineFill from "@karrotmarket/lynx-monochrome-icon/IconPenHorizlineFill";
+import IconPenHorizlineLine from "@karrotmarket/lynx-monochrome-icon/IconPenHorizlineLine";
+import IconPencilFill from "@karrotmarket/lynx-monochrome-icon/IconPencilFill";
+import IconPencilLine from "@karrotmarket/lynx-monochrome-icon/IconPencilLine";
+import IconPeople3Fill from "@karrotmarket/lynx-monochrome-icon/IconPeople3Fill";
+import IconPeople3Line from "@karrotmarket/lynx-monochrome-icon/IconPeople3Line";
+import IconPercentFill from "@karrotmarket/lynx-monochrome-icon/IconPercentFill";
+import IconPercentFlowerFill from "@karrotmarket/lynx-monochrome-icon/IconPercentFlowerFill";
+import IconPercentFlowerLine from "@karrotmarket/lynx-monochrome-icon/IconPercentFlowerLine";
+import IconPercentLine from "@karrotmarket/lynx-monochrome-icon/IconPercentLine";
+import IconPerson2Fill from "@karrotmarket/lynx-monochrome-icon/IconPerson2Fill";
+import IconPerson2Line from "@karrotmarket/lynx-monochrome-icon/IconPerson2Line";
+import IconPerson2OpenarmsFill from "@karrotmarket/lynx-monochrome-icon/IconPerson2OpenarmsFill";
+import IconPerson2OpenarmsLine from "@karrotmarket/lynx-monochrome-icon/IconPerson2OpenarmsLine";
+import IconPersonCircleFill from "@karrotmarket/lynx-monochrome-icon/IconPersonCircleFill";
+import IconPersonCircleLine from "@karrotmarket/lynx-monochrome-icon/IconPersonCircleLine";
+import IconPersonFill from "@karrotmarket/lynx-monochrome-icon/IconPersonFill";
+import IconPersonFlowerFill from "@karrotmarket/lynx-monochrome-icon/IconPersonFlowerFill";
+import IconPersonFlowerLine from "@karrotmarket/lynx-monochrome-icon/IconPersonFlowerLine";
+import IconPersonLine from "@karrotmarket/lynx-monochrome-icon/IconPersonLine";
+import IconPersonMagnifyingglassFill from "@karrotmarket/lynx-monochrome-icon/IconPersonMagnifyingglassFill";
+import IconPersonMagnifyingglassLine from "@karrotmarket/lynx-monochrome-icon/IconPersonMagnifyingglassLine";
+import IconPersonPlusFill from "@karrotmarket/lynx-monochrome-icon/IconPersonPlusFill";
+import IconPersonPlusLine from "@karrotmarket/lynx-monochrome-icon/IconPersonPlusLine";
+import IconPersonShieldFill from "@karrotmarket/lynx-monochrome-icon/IconPersonShieldFill";
+import IconPersonShieldLine from "@karrotmarket/lynx-monochrome-icon/IconPersonShieldLine";
+import IconPhoneFill from "@karrotmarket/lynx-monochrome-icon/IconPhoneFill";
+import IconPhoneLine from "@karrotmarket/lynx-monochrome-icon/IconPhoneLine";
+import IconPhoneXmarkFill from "@karrotmarket/lynx-monochrome-icon/IconPhoneXmarkFill";
+import IconPhoneXmarkLine from "@karrotmarket/lynx-monochrome-icon/IconPhoneXmarkLine";
+import IconPicture2StackedFill from "@karrotmarket/lynx-monochrome-icon/IconPicture2StackedFill";
+import IconPicture2StackedLine from "@karrotmarket/lynx-monochrome-icon/IconPicture2StackedLine";
+import IconPictureFill from "@karrotmarket/lynx-monochrome-icon/IconPictureFill";
+import IconPictureLine from "@karrotmarket/lynx-monochrome-icon/IconPictureLine";
+import IconPlusCircleFill from "@karrotmarket/lynx-monochrome-icon/IconPlusCircleFill";
+import IconPlusCircleLine from "@karrotmarket/lynx-monochrome-icon/IconPlusCircleLine";
+import IconPlusFill from "@karrotmarket/lynx-monochrome-icon/IconPlusFill";
+import IconPlusLine from "@karrotmarket/lynx-monochrome-icon/IconPlusLine";
+import IconPlusSmallFill from "@karrotmarket/lynx-monochrome-icon/IconPlusSmallFill";
+import IconPlusSmallLine from "@karrotmarket/lynx-monochrome-icon/IconPlusSmallLine";
+import IconPlusSquareFill from "@karrotmarket/lynx-monochrome-icon/IconPlusSquareFill";
+import IconPlusSquareLine from "@karrotmarket/lynx-monochrome-icon/IconPlusSquareLine";
+import IconPostFill from "@karrotmarket/lynx-monochrome-icon/IconPostFill";
+import IconPostLine from "@karrotmarket/lynx-monochrome-icon/IconPostLine";
+import IconPushpinFill from "@karrotmarket/lynx-monochrome-icon/IconPushpinFill";
+import IconPushpinLine from "@karrotmarket/lynx-monochrome-icon/IconPushpinLine";
+import IconQUppercaseChatbubbleRightFill from "@karrotmarket/lynx-monochrome-icon/IconQUppercaseChatbubbleRightFill";
+import IconQUppercaseChatbubbleRightLine from "@karrotmarket/lynx-monochrome-icon/IconQUppercaseChatbubbleRightLine";
+import IconQuestionmarkCircleFill from "@karrotmarket/lynx-monochrome-icon/IconQuestionmarkCircleFill";
+import IconQuestionmarkCircleLine from "@karrotmarket/lynx-monochrome-icon/IconQuestionmarkCircleLine";
+import IconQuestionmarkSquareFill from "@karrotmarket/lynx-monochrome-icon/IconQuestionmarkSquareFill";
+import IconQuestionmarkSquareLine from "@karrotmarket/lynx-monochrome-icon/IconQuestionmarkSquareLine";
+import IconQuotationmark2LeftFill from "@karrotmarket/lynx-monochrome-icon/IconQuotationmark2LeftFill";
+import IconQuotationmark2LeftLine from "@karrotmarket/lynx-monochrome-icon/IconQuotationmark2LeftLine";
+import IconQuotationmark2RightFill from "@karrotmarket/lynx-monochrome-icon/IconQuotationmark2RightFill";
+import IconQuotationmark2RightLine from "@karrotmarket/lynx-monochrome-icon/IconQuotationmark2RightLine";
+import IconReceiptFill from "@karrotmarket/lynx-monochrome-icon/IconReceiptFill";
+import IconReceiptLine from "@karrotmarket/lynx-monochrome-icon/IconReceiptLine";
+import IconRectangleSplitedLineVerticalFill from "@karrotmarket/lynx-monochrome-icon/IconRectangleSplitedLineVerticalFill";
+import IconRectangleSplitedLineVerticalLine from "@karrotmarket/lynx-monochrome-icon/IconRectangleSplitedLineVerticalLine";
+import IconRoadlaneFill from "@karrotmarket/lynx-monochrome-icon/IconRoadlaneFill";
+import IconRoadlaneLine from "@karrotmarket/lynx-monochrome-icon/IconRoadlaneLine";
+import IconRocketFill from "@karrotmarket/lynx-monochrome-icon/IconRocketFill";
+import IconRocketLine from "@karrotmarket/lynx-monochrome-icon/IconRocketLine";
+import IconRooftoproomFill from "@karrotmarket/lynx-monochrome-icon/IconRooftoproomFill";
+import IconRooftoproomLine from "@karrotmarket/lynx-monochrome-icon/IconRooftoproomLine";
+import IconSUppercaseHorizlineCenterFill from "@karrotmarket/lynx-monochrome-icon/IconSUppercaseHorizlineCenterFill";
+import IconSUppercaseHorizlineCenterLine from "@karrotmarket/lynx-monochrome-icon/IconSUppercaseHorizlineCenterLine";
+import IconScissorsFill from "@karrotmarket/lynx-monochrome-icon/IconScissorsFill";
+import IconScissorsLine from "@karrotmarket/lynx-monochrome-icon/IconScissorsLine";
+import IconScribbleFill from "@karrotmarket/lynx-monochrome-icon/IconScribbleFill";
+import IconScribbleLine from "@karrotmarket/lynx-monochrome-icon/IconScribbleLine";
+import IconSeatLeftFanFill from "@karrotmarket/lynx-monochrome-icon/IconSeatLeftFanFill";
+import IconSeatLeftFanLine from "@karrotmarket/lynx-monochrome-icon/IconSeatLeftFanLine";
+import IconSeatLeftFill from "@karrotmarket/lynx-monochrome-icon/IconSeatLeftFill";
+import IconSeatLeftHeatwave2Fill from "@karrotmarket/lynx-monochrome-icon/IconSeatLeftHeatwave2Fill";
+import IconSeatLeftHeatwave2Line from "@karrotmarket/lynx-monochrome-icon/IconSeatLeftHeatwave2Line";
+import IconSeatLeftLine from "@karrotmarket/lynx-monochrome-icon/IconSeatLeftLine";
+import IconShoppingbag2StackedFill from "@karrotmarket/lynx-monochrome-icon/IconShoppingbag2StackedFill";
+import IconShoppingbag2StackedLine from "@karrotmarket/lynx-monochrome-icon/IconShoppingbag2StackedLine";
+import IconShoppingbagFill from "@karrotmarket/lynx-monochrome-icon/IconShoppingbagFill";
+import IconShoppingbagItemsFill from "@karrotmarket/lynx-monochrome-icon/IconShoppingbagItemsFill";
+import IconShoppingbagItemsLine from "@karrotmarket/lynx-monochrome-icon/IconShoppingbagItemsLine";
+import IconShoppingbagLine from "@karrotmarket/lynx-monochrome-icon/IconShoppingbagLine";
+import IconSidemirrorWaveFill from "@karrotmarket/lynx-monochrome-icon/IconSidemirrorWaveFill";
+import IconSidemirrorWaveLine from "@karrotmarket/lynx-monochrome-icon/IconSidemirrorWaveLine";
+import IconSignboardFill from "@karrotmarket/lynx-monochrome-icon/IconSignboardFill";
+import IconSignboardLine from "@karrotmarket/lynx-monochrome-icon/IconSignboardLine";
+import IconSlashCircleFill from "@karrotmarket/lynx-monochrome-icon/IconSlashCircleFill";
+import IconSlashCircleLine from "@karrotmarket/lynx-monochrome-icon/IconSlashCircleLine";
+import IconSlashSemicircle2Fill from "@karrotmarket/lynx-monochrome-icon/IconSlashSemicircle2Fill";
+import IconSlashSemicircle2Line from "@karrotmarket/lynx-monochrome-icon/IconSlashSemicircle2Line";
+import IconSlider2HorizontalFill from "@karrotmarket/lynx-monochrome-icon/IconSlider2HorizontalFill";
+import IconSlider2HorizontalLine from "@karrotmarket/lynx-monochrome-icon/IconSlider2HorizontalLine";
+import IconSmartkeyFill from "@karrotmarket/lynx-monochrome-icon/IconSmartkeyFill";
+import IconSmartkeyLine from "@karrotmarket/lynx-monochrome-icon/IconSmartkeyLine";
+import IconSneakerLiftedLeftsideFill from "@karrotmarket/lynx-monochrome-icon/IconSneakerLiftedLeftsideFill";
+import IconSneakerLiftedLeftsideLine from "@karrotmarket/lynx-monochrome-icon/IconSneakerLiftedLeftsideLine";
+import IconSofaFill from "@karrotmarket/lynx-monochrome-icon/IconSofaFill";
+import IconSofaLine from "@karrotmarket/lynx-monochrome-icon/IconSofaLine";
+import IconSparkle2Fill from "@karrotmarket/lynx-monochrome-icon/IconSparkle2Fill";
+import IconSparkle2Line from "@karrotmarket/lynx-monochrome-icon/IconSparkle2Line";
+import IconSparkleViewfinderFill from "@karrotmarket/lynx-monochrome-icon/IconSparkleViewfinderFill";
+import IconSparkleViewfinderLine from "@karrotmarket/lynx-monochrome-icon/IconSparkleViewfinderLine";
+import IconSpeakerWave2Fill from "@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2Fill";
+import IconSpeakerWave2Line from "@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2Line";
+import IconSpeakerWave2SlashFill from "@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2SlashFill";
+import IconSpeakerWave2SlashLine from "@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2SlashLine";
+import IconSpeedometerFill from "@karrotmarket/lynx-monochrome-icon/IconSpeedometerFill";
+import IconSpeedometerLine from "@karrotmarket/lynx-monochrome-icon/IconSpeedometerLine";
+import IconSpeedometer_1xFill from "@karrotmarket/lynx-monochrome-icon/IconSpeedometer_1xFill";
+import IconSpeedometer_1xLine from "@karrotmarket/lynx-monochrome-icon/IconSpeedometer_1xLine";
+import IconSpeedometer_2xFill from "@karrotmarket/lynx-monochrome-icon/IconSpeedometer_2xFill";
+import IconSpeedometer_2xLine from "@karrotmarket/lynx-monochrome-icon/IconSpeedometer_2xLine";
+import IconSpeedometer_3xFill from "@karrotmarket/lynx-monochrome-icon/IconSpeedometer_3xFill";
+import IconSpeedometer_3xLine from "@karrotmarket/lynx-monochrome-icon/IconSpeedometer_3xLine";
+import IconSplitedGridSquareFill from "@karrotmarket/lynx-monochrome-icon/IconSplitedGridSquareFill";
+import IconSplitedGridSquareLine from "@karrotmarket/lynx-monochrome-icon/IconSplitedGridSquareLine";
+import IconSpraybottleSpongeFill from "@karrotmarket/lynx-monochrome-icon/IconSpraybottleSpongeFill";
+import IconSpraybottleSpongeLine from "@karrotmarket/lynx-monochrome-icon/IconSpraybottleSpongeLine";
+import IconSquare2StackedFill from "@karrotmarket/lynx-monochrome-icon/IconSquare2StackedFill";
+import IconSquare2StackedLine from "@karrotmarket/lynx-monochrome-icon/IconSquare2StackedLine";
+import IconSquareline2VerticalFill from "@karrotmarket/lynx-monochrome-icon/IconSquareline2VerticalFill";
+import IconSquareline2VerticalLine from "@karrotmarket/lynx-monochrome-icon/IconSquareline2VerticalLine";
+import IconStarFill from "@karrotmarket/lynx-monochrome-icon/IconStarFill";
+import IconStarLine from "@karrotmarket/lynx-monochrome-icon/IconStarLine";
+import IconSteeringwheelHeatwave2Fill from "@karrotmarket/lynx-monochrome-icon/IconSteeringwheelHeatwave2Fill";
+import IconSteeringwheelHeatwave2Line from "@karrotmarket/lynx-monochrome-icon/IconSteeringwheelHeatwave2Line";
+import IconStepsFill from "@karrotmarket/lynx-monochrome-icon/IconStepsFill";
+import IconStepsLine from "@karrotmarket/lynx-monochrome-icon/IconStepsLine";
+import IconStoreCheckmarkFill from "@karrotmarket/lynx-monochrome-icon/IconStoreCheckmarkFill";
+import IconStoreCheckmarkLine from "@karrotmarket/lynx-monochrome-icon/IconStoreCheckmarkLine";
+import IconStoreFill from "@karrotmarket/lynx-monochrome-icon/IconStoreFill";
+import IconStoreLine from "@karrotmarket/lynx-monochrome-icon/IconStoreLine";
+import IconStorePenFill from "@karrotmarket/lynx-monochrome-icon/IconStorePenFill";
+import IconStorePenLine from "@karrotmarket/lynx-monochrome-icon/IconStorePenLine";
+import IconSunFill from "@karrotmarket/lynx-monochrome-icon/IconSunFill";
+import IconSunLine from "@karrotmarket/lynx-monochrome-icon/IconSunLine";
+import IconTUppercaseSerifFill from "@karrotmarket/lynx-monochrome-icon/IconTUppercaseSerifFill";
+import IconTUppercaseSerifLine from "@karrotmarket/lynx-monochrome-icon/IconTUppercaseSerifLine";
+import IconTUppercaseTLowercaseFill from "@karrotmarket/lynx-monochrome-icon/IconTUppercaseTLowercaseFill";
+import IconTUppercaseTLowercaseLine from "@karrotmarket/lynx-monochrome-icon/IconTUppercaseTLowercaseLine";
+import IconTagFill from "@karrotmarket/lynx-monochrome-icon/IconTagFill";
+import IconTagLine from "@karrotmarket/lynx-monochrome-icon/IconTagLine";
+import IconTextAligncenterFill from "@karrotmarket/lynx-monochrome-icon/IconTextAligncenterFill";
+import IconTextAligncenterLine from "@karrotmarket/lynx-monochrome-icon/IconTextAligncenterLine";
+import IconTextAlignleftFill from "@karrotmarket/lynx-monochrome-icon/IconTextAlignleftFill";
+import IconTextAlignleftLine from "@karrotmarket/lynx-monochrome-icon/IconTextAlignleftLine";
+import IconTextAlignrightFill from "@karrotmarket/lynx-monochrome-icon/IconTextAlignrightFill";
+import IconTextAlignrightLine from "@karrotmarket/lynx-monochrome-icon/IconTextAlignrightLine";
+import IconThumbDownFill from "@karrotmarket/lynx-monochrome-icon/IconThumbDownFill";
+import IconThumbDownLine from "@karrotmarket/lynx-monochrome-icon/IconThumbDownLine";
+import IconThumbUpFill from "@karrotmarket/lynx-monochrome-icon/IconThumbUpFill";
+import IconThumbUpLine from "@karrotmarket/lynx-monochrome-icon/IconThumbUpLine";
+import IconTimerFill from "@karrotmarket/lynx-monochrome-icon/IconTimerFill";
+import IconTimerLine from "@karrotmarket/lynx-monochrome-icon/IconTimerLine";
+import IconTimer_10Fill from "@karrotmarket/lynx-monochrome-icon/IconTimer_10Fill";
+import IconTimer_10Line from "@karrotmarket/lynx-monochrome-icon/IconTimer_10Line";
+import IconTimer_3Fill from "@karrotmarket/lynx-monochrome-icon/IconTimer_3Fill";
+import IconTimer_3Line from "@karrotmarket/lynx-monochrome-icon/IconTimer_3Line";
+import IconToolboxFill from "@karrotmarket/lynx-monochrome-icon/IconToolboxFill";
+import IconToolboxLine from "@karrotmarket/lynx-monochrome-icon/IconToolboxLine";
+import IconTranslationFill from "@karrotmarket/lynx-monochrome-icon/IconTranslationFill";
+import IconTranslationLine from "@karrotmarket/lynx-monochrome-icon/IconTranslationLine";
+import IconTrashcanFill from "@karrotmarket/lynx-monochrome-icon/IconTrashcanFill";
+import IconTrashcanLine from "@karrotmarket/lynx-monochrome-icon/IconTrashcanLine";
+import IconTriangleDownSmallFill from "@karrotmarket/lynx-monochrome-icon/IconTriangleDownSmallFill";
+import IconTriangleDownSmallLine from "@karrotmarket/lynx-monochrome-icon/IconTriangleDownSmallLine";
+import IconTriangleRightChatbubbleLeftFill from "@karrotmarket/lynx-monochrome-icon/IconTriangleRightChatbubbleLeftFill";
+import IconTriangleRightChatbubbleLeftLine from "@karrotmarket/lynx-monochrome-icon/IconTriangleRightChatbubbleLeftLine";
+import IconTriangleRightFill from "@karrotmarket/lynx-monochrome-icon/IconTriangleRightFill";
+import IconTriangleRightLine from "@karrotmarket/lynx-monochrome-icon/IconTriangleRightLine";
+import IconTriangleRightRectangleSplitedLineVerticalFill from "@karrotmarket/lynx-monochrome-icon/IconTriangleRightRectangleSplitedLineVerticalFill";
+import IconTriangleRightRectangleSplitedLineVerticalLine from "@karrotmarket/lynx-monochrome-icon/IconTriangleRightRectangleSplitedLineVerticalLine";
+import IconTriangleUpSmallFill from "@karrotmarket/lynx-monochrome-icon/IconTriangleUpSmallFill";
+import IconTriangleUpSmallLine from "@karrotmarket/lynx-monochrome-icon/IconTriangleUpSmallLine";
+import IconTrophyFill from "@karrotmarket/lynx-monochrome-icon/IconTrophyFill";
+import IconTrophyLine from "@karrotmarket/lynx-monochrome-icon/IconTrophyLine";
+import IconTruckFill from "@karrotmarket/lynx-monochrome-icon/IconTruckFill";
+import IconTruckLine from "@karrotmarket/lynx-monochrome-icon/IconTruckLine";
+import IconTshirtBubble2Fill from "@karrotmarket/lynx-monochrome-icon/IconTshirtBubble2Fill";
+import IconTshirtBubble2Line from "@karrotmarket/lynx-monochrome-icon/IconTshirtBubble2Line";
+import IconUUppercaseHorizlineFill from "@karrotmarket/lynx-monochrome-icon/IconUUppercaseHorizlineFill";
+import IconUUppercaseHorizlineLine from "@karrotmarket/lynx-monochrome-icon/IconUUppercaseHorizlineLine";
+import IconVertline3ViewfinderFill from "@karrotmarket/lynx-monochrome-icon/IconVertline3ViewfinderFill";
+import IconVertline3ViewfinderLine from "@karrotmarket/lynx-monochrome-icon/IconVertline3ViewfinderLine";
+import IconVertline4SparkleFill from "@karrotmarket/lynx-monochrome-icon/IconVertline4SparkleFill";
+import IconVertline4SparkleLine from "@karrotmarket/lynx-monochrome-icon/IconVertline4SparkleLine";
+import IconVertlineCouponFill from "@karrotmarket/lynx-monochrome-icon/IconVertlineCouponFill";
+import IconVertlineCouponLine from "@karrotmarket/lynx-monochrome-icon/IconVertlineCouponLine";
+import IconVertrectangle2HorizontalFill from "@karrotmarket/lynx-monochrome-icon/IconVertrectangle2HorizontalFill";
+import IconVertrectangle2HorizontalLine from "@karrotmarket/lynx-monochrome-icon/IconVertrectangle2HorizontalLine";
+import IconVertrectangleFoldedFill from "@karrotmarket/lynx-monochrome-icon/IconVertrectangleFoldedFill";
+import IconVertrectangleFoldedLine from "@karrotmarket/lynx-monochrome-icon/IconVertrectangleFoldedLine";
+import IconVotingstampFill from "@karrotmarket/lynx-monochrome-icon/IconVotingstampFill";
+import IconVotingstampLine from "@karrotmarket/lynx-monochrome-icon/IconVotingstampLine";
+import IconWandFill from "@karrotmarket/lynx-monochrome-icon/IconWandFill";
+import IconWandLine from "@karrotmarket/lynx-monochrome-icon/IconWandLine";
+import IconWashingmachineFill from "@karrotmarket/lynx-monochrome-icon/IconWashingmachineFill";
+import IconWashingmachineLine from "@karrotmarket/lynx-monochrome-icon/IconWashingmachineLine";
+import IconWindow2StoreFill from "@karrotmarket/lynx-monochrome-icon/IconWindow2StoreFill";
+import IconWindow2StoreLine from "@karrotmarket/lynx-monochrome-icon/IconWindow2StoreLine";
+import IconWindow4HouseFill from "@karrotmarket/lynx-monochrome-icon/IconWindow4HouseFill";
+import IconWindow4HouseLine from "@karrotmarket/lynx-monochrome-icon/IconWindow4HouseLine";
+import IconWonArrowClockwiseCircularFill from "@karrotmarket/lynx-monochrome-icon/IconWonArrowClockwiseCircularFill";
+import IconWonArrowClockwiseCircularLine from "@karrotmarket/lynx-monochrome-icon/IconWonArrowClockwiseCircularLine";
+import IconWonCircleArrowLeftFill from "@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowLeftFill";
+import IconWonCircleArrowLeftLine from "@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowLeftLine";
+import IconWonCircleArrowRightFill from "@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowRightFill";
+import IconWonCircleArrowRightLine from "@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowRightLine";
+import IconWonCircleFill from "@karrotmarket/lynx-monochrome-icon/IconWonCircleFill";
+import IconWonCircleLine from "@karrotmarket/lynx-monochrome-icon/IconWonCircleLine";
+import IconWonFill from "@karrotmarket/lynx-monochrome-icon/IconWonFill";
+import IconWonLine from "@karrotmarket/lynx-monochrome-icon/IconWonLine";
+import IconWonShieldFill from "@karrotmarket/lynx-monochrome-icon/IconWonShieldFill";
+import IconWonShieldLine from "@karrotmarket/lynx-monochrome-icon/IconWonShieldLine";
+import IconWrenchFill from "@karrotmarket/lynx-monochrome-icon/IconWrenchFill";
+import IconWrenchLine from "@karrotmarket/lynx-monochrome-icon/IconWrenchLine";
+import IconXmarkCircleFill from "@karrotmarket/lynx-monochrome-icon/IconXmarkCircleFill";
+import IconXmarkCircleLine from "@karrotmarket/lynx-monochrome-icon/IconXmarkCircleLine";
+import IconXmarkFill from "@karrotmarket/lynx-monochrome-icon/IconXmarkFill";
+import IconXmarkLine from "@karrotmarket/lynx-monochrome-icon/IconXmarkLine";
+import IconXmarkScaleFill from "@karrotmarket/lynx-monochrome-icon/IconXmarkScaleFill";
+import IconXmarkScaleLine from "@karrotmarket/lynx-monochrome-icon/IconXmarkScaleLine";
+import IconYenCircleArrowRightFill from "@karrotmarket/lynx-monochrome-icon/IconYenCircleArrowRightFill";
+import IconYenCircleArrowRightLine from "@karrotmarket/lynx-monochrome-icon/IconYenCircleArrowRightLine";
+import IconYenCircleFill from "@karrotmarket/lynx-monochrome-icon/IconYenCircleFill";
+import IconYenCircleLine from "@karrotmarket/lynx-monochrome-icon/IconYenCircleLine";
+import IconYenFill from "@karrotmarket/lynx-monochrome-icon/IconYenFill";
+import IconYenLine from "@karrotmarket/lynx-monochrome-icon/IconYenLine";
 
 const { $color } = vars;
 
@@ -646,934 +645,653 @@ interface IconEntry {
 }
 
 const icons: IconEntry[] = [
-  { component: IconAUppercaseALowercaseFill, name: 'AUppercaseALowercaseFill' },
-  { component: IconAUppercaseALowercaseLine, name: 'AUppercaseALowercaseLine' },
-  { component: IconAUppercaseOutlineFill, name: 'AUppercaseOutlineFill' },
-  { component: IconAUppercaseOutlineLine, name: 'AUppercaseOutlineLine' },
-  { component: IconAUppercaseSquareFill, name: 'AUppercaseSquareFill' },
-  { component: IconAUppercaseSquareLine, name: 'AUppercaseSquareLine' },
-  { component: IconAndroidshareFill, name: 'AndroidshareFill' },
-  { component: IconAndroidshareLine, name: 'AndroidshareLine' },
-  { component: IconAppleFill, name: 'AppleFill' },
-  { component: IconAppleLine, name: 'AppleLine' },
-  {
-    component: IconArrow2ClockwiseCircularFill,
-    name: 'Arrow2ClockwiseCircularFill',
-  },
-  {
-    component: IconArrow2ClockwiseCircularLine,
-    name: 'Arrow2ClockwiseCircularLine',
-  },
-  {
-    component: IconArrowClockwiseCircularFill,
-    name: 'ArrowClockwiseCircularFill',
-  },
-  {
-    component: IconArrowClockwiseCircularLine,
-    name: 'ArrowClockwiseCircularLine',
-  },
-  { component: IconArrowClockwiseOvalFill, name: 'ArrowClockwiseOvalFill' },
-  { component: IconArrowClockwiseOvalLine, name: 'ArrowClockwiseOvalLine' },
-  {
-    component: IconArrowCounterclockwiseCircularFill,
-    name: 'ArrowCounterclockwiseCircularFill',
-  },
-  {
-    component: IconArrowCounterclockwiseCircularLine,
-    name: 'ArrowCounterclockwiseCircularLine',
-  },
-  { component: IconArrowDownFill, name: 'ArrowDownFill' },
-  { component: IconArrowDownHorizlineFill, name: 'ArrowDownHorizlineFill' },
-  { component: IconArrowDownHorizlineLine, name: 'ArrowDownHorizlineLine' },
-  { component: IconArrowDownLine, name: 'ArrowDownLine' },
-  {
-    component: IconArrowDownLineVerticalArrowUpSquareFill,
-    name: 'ArrowDownLineVerticalArrowUpSquareFill',
-  },
-  {
-    component: IconArrowDownLineVerticalArrowUpSquareLine,
-    name: 'ArrowDownLineVerticalArrowUpSquareLine',
-  },
-  {
-    component: IconArrowDownRightArrowUpLeftFill,
-    name: 'ArrowDownRightArrowUpLeftFill',
-  },
-  {
-    component: IconArrowDownRightArrowUpLeftLine,
-    name: 'ArrowDownRightArrowUpLeftLine',
-  },
-  {
-    component: IconArrowLeftBracketRightFill,
-    name: 'ArrowLeftBracketRightFill',
-  },
-  {
-    component: IconArrowLeftBracketRightLine,
-    name: 'ArrowLeftBracketRightLine',
-  },
-  { component: IconArrowLeftFill, name: 'ArrowLeftFill' },
-  { component: IconArrowLeftLine, name: 'ArrowLeftLine' },
-  { component: IconArrowRightAngledFill, name: 'ArrowRightAngledFill' },
-  { component: IconArrowRightAngledLine, name: 'ArrowRightAngledLine' },
-  { component: IconArrowRightArrowLeftFill, name: 'ArrowRightArrowLeftFill' },
-  { component: IconArrowRightArrowLeftLine, name: 'ArrowRightArrowLeftLine' },
-  { component: IconArrowRightFill, name: 'ArrowRightFill' },
-  { component: IconArrowRightLine, name: 'ArrowRightLine' },
-  { component: IconArrowUpArrowDownFill, name: 'ArrowUpArrowDownFill' },
-  { component: IconArrowUpArrowDownLine, name: 'ArrowUpArrowDownLine' },
-  { component: IconArrowUpBracketDownFill, name: 'ArrowUpBracketDownFill' },
-  { component: IconArrowUpBracketDownLine, name: 'ArrowUpBracketDownLine' },
-  { component: IconArrowUpFill, name: 'ArrowUpFill' },
-  { component: IconArrowUpLeftFill, name: 'ArrowUpLeftFill' },
-  { component: IconArrowUpLeftLine, name: 'ArrowUpLeftLine' },
-  { component: IconArrowUpLine, name: 'ArrowUpLine' },
-  {
-    component: IconArrowUpRightArrowDownLeftFill,
-    name: 'ArrowUpRightArrowDownLeftFill',
-  },
-  {
-    component: IconArrowUpRightArrowDownLeftLine,
-    name: 'ArrowUpRightArrowDownLeftLine',
-  },
-  {
-    component: IconArrowUpRightArrowDownLeftSquareFill,
-    name: 'ArrowUpRightArrowDownLeftSquareFill',
-  },
-  {
-    component: IconArrowUpRightArrowDownLeftSquareLine,
-    name: 'ArrowUpRightArrowDownLeftSquareLine',
-  },
-  { component: IconArrowUpRightFill, name: 'ArrowUpRightFill' },
-  { component: IconArrowUpRightLine, name: 'ArrowUpRightLine' },
-  {
-    component: IconArrowUpRightShoppingbagTiltedFill,
-    name: 'ArrowUpRightShoppingbagTiltedFill',
-  },
-  {
-    component: IconArrowUpRightShoppingbagTiltedLine,
-    name: 'ArrowUpRightShoppingbagTiltedLine',
-  },
-  { component: IconArrowUturnLeftFill, name: 'ArrowUturnLeftFill' },
-  { component: IconArrowUturnLeftLine, name: 'ArrowUturnLeftLine' },
-  { component: IconArrowUturnRightFill, name: 'ArrowUturnRightFill' },
-  { component: IconArrowUturnRightLine, name: 'ArrowUturnRightLine' },
-  { component: IconArticleFill, name: 'ArticleFill' },
-  { component: IconArticleLine, name: 'ArticleLine' },
-  {
-    component: IconAsteriskHorizrectangleCoolwave3Fill,
-    name: 'AsteriskHorizrectangleCoolwave3Fill',
-  },
-  {
-    component: IconAsteriskHorizrectangleCoolwave3Line,
-    name: 'AsteriskHorizrectangleCoolwave3Line',
-  },
-  { component: IconAtFill, name: 'AtFill' },
-  { component: IconAtLine, name: 'AtLine' },
-  { component: IconBUppercaseFill, name: 'BUppercaseFill' },
-  { component: IconBUppercaseLine, name: 'BUppercaseLine' },
-  { component: IconBackspacekeyFill, name: 'BackspacekeyFill' },
-  { component: IconBackspacekeyLine, name: 'BackspacekeyLine' },
-  { component: IconBarchartBoardFill, name: 'BarchartBoardFill' },
-  { component: IconBarchartBoardLine, name: 'BarchartBoardLine' },
-  { component: IconBarchartSquareFill, name: 'BarchartSquareFill' },
-  { component: IconBarchartSquareLine, name: 'BarchartSquareLine' },
-  { component: IconBedFrontsideFill, name: 'BedFrontsideFill' },
-  { component: IconBedFrontsideLine, name: 'BedFrontsideLine' },
-  { component: IconBellFill, name: 'BellFill' },
-  { component: IconBellLine, name: 'BellLine' },
-  { component: IconBellSlashFill, name: 'BellSlashFill' },
-  { component: IconBellSlashLine, name: 'BellSlashLine' },
-  { component: IconBookFill, name: 'BookFill' },
-  { component: IconBookLine, name: 'BookLine' },
-  { component: IconBookOpenFill, name: 'BookOpenFill' },
-  { component: IconBookOpenLine, name: 'BookOpenLine' },
-  { component: IconBookmarkFill, name: 'BookmarkFill' },
-  { component: IconBookmarkLine, name: 'BookmarkLine' },
-  { component: IconBoxFlapFill, name: 'BoxFlapFill' },
-  { component: IconBoxFlapLine, name: 'BoxFlapLine' },
-  {
-    component: IconBracketLeftArrowRightFill,
-    name: 'BracketLeftArrowRightFill',
-  },
-  {
-    component: IconBracketLeftArrowRightLine,
-    name: 'BracketLeftArrowRightLine',
-  },
-  { component: IconBuilding2Fill, name: 'Building2Fill' },
-  { component: IconBuilding2Line, name: 'Building2Line' },
-  { component: IconCalendarFill, name: 'CalendarFill' },
-  { component: IconCalendarLine, name: 'CalendarLine' },
-  { component: IconCamcorderFill, name: 'CamcorderFill' },
-  { component: IconCamcorderLine, name: 'CamcorderLine' },
-  { component: IconCameraFill, name: 'CameraFill' },
-  { component: IconCameraLine, name: 'CameraLine' },
-  { component: IconCarFill, name: 'CarFill' },
-  {
-    component: IconCarFrontUpsideWave2ReversedUpFill,
-    name: 'CarFrontUpsideWave2ReversedUpFill',
-  },
-  {
-    component: IconCarFrontUpsideWave2ReversedUpLine,
-    name: 'CarFrontUpsideWave2ReversedUpLine',
-  },
-  { component: IconCarFrontsideFill, name: 'CarFrontsideFill' },
-  { component: IconCarFrontsideLine, name: 'CarFrontsideLine' },
-  { component: IconCarLine, name: 'CarLine' },
-  {
-    component: IconCarRearTrunkOpenLeftsideFill,
-    name: 'CarRearTrunkOpenLeftsideFill',
-  },
-  {
-    component: IconCarRearTrunkOpenLeftsideLine,
-    name: 'CarRearTrunkOpenLeftsideLine',
-  },
-  {
-    component: IconCarRearUpsideSectorDownFill,
-    name: 'CarRearUpsideSectorDownFill',
-  },
-  {
-    component: IconCarRearUpsideSectorDownLine,
-    name: 'CarRearUpsideSectorDownLine',
-  },
-  {
-    component: IconCarRearUpsideWave2ReversedDownFill,
-    name: 'CarRearUpsideWave2ReversedDownFill',
-  },
-  {
-    component: IconCarRearUpsideWave2ReversedDownLeftFill,
-    name: 'CarRearUpsideWave2ReversedDownLeftFill',
-  },
-  {
-    component: IconCarRearUpsideWave2ReversedDownLeftLine,
-    name: 'CarRearUpsideWave2ReversedDownLeftLine',
-  },
-  {
-    component: IconCarRearUpsideWave2ReversedDownLine,
-    name: 'CarRearUpsideWave2ReversedDownLine',
-  },
-  { component: IconCardFill, name: 'CardFill' },
-  { component: IconCardLine, name: 'CardLine' },
-  { component: IconCarrotFill, name: 'CarrotFill' },
-  { component: IconCarrotLine, name: 'CarrotLine' },
-  { component: IconCartFill, name: 'CartFill' },
-  { component: IconCartItemsFill, name: 'CartItemsFill' },
-  { component: IconCartItemsLine, name: 'CartItemsLine' },
-  { component: IconCartLine, name: 'CartLine' },
-  { component: IconCartLoadFill, name: 'CartLoadFill' },
-  { component: IconCartLoadLine, name: 'CartLoadLine' },
-  { component: IconCheckmarkBadgeFill, name: 'CheckmarkBadgeFill' },
-  { component: IconCheckmarkBadgeLine, name: 'CheckmarkBadgeLine' },
-  { component: IconCheckmarkBallotboxFill, name: 'CheckmarkBallotboxFill' },
-  { component: IconCheckmarkBallotboxLine, name: 'CheckmarkBallotboxLine' },
-  { component: IconCheckmarkCalendarFill, name: 'CheckmarkCalendarFill' },
-  { component: IconCheckmarkCalendarLine, name: 'CheckmarkCalendarLine' },
-  {
-    component: IconCheckmarkChatbubbleLeftFill,
-    name: 'CheckmarkChatbubbleLeftFill',
-  },
-  {
-    component: IconCheckmarkChatbubbleLeftLine,
-    name: 'CheckmarkChatbubbleLeftLine',
-  },
-  { component: IconCheckmarkCircleFill, name: 'CheckmarkCircleFill' },
-  { component: IconCheckmarkCircleLine, name: 'CheckmarkCircleLine' },
-  { component: IconCheckmarkClipboardFill, name: 'CheckmarkClipboardFill' },
-  { component: IconCheckmarkClipboardLine, name: 'CheckmarkClipboardLine' },
-  { component: IconCheckmarkCouponFill, name: 'CheckmarkCouponFill' },
-  { component: IconCheckmarkCouponLine, name: 'CheckmarkCouponLine' },
-  { component: IconCheckmarkFatFill, name: 'CheckmarkFatFill' },
-  { component: IconCheckmarkFatLine, name: 'CheckmarkFatLine' },
-  { component: IconCheckmarkFill, name: 'CheckmarkFill' },
-  { component: IconCheckmarkFlowerFill, name: 'CheckmarkFlowerFill' },
-  { component: IconCheckmarkFlowerLine, name: 'CheckmarkFlowerLine' },
-  { component: IconCheckmarkHorizlineFill, name: 'CheckmarkHorizlineFill' },
-  { component: IconCheckmarkHorizlineLine, name: 'CheckmarkHorizlineLine' },
-  { component: IconCheckmarkLine, name: 'CheckmarkLine' },
-  { component: IconCheckmarkScaleFill, name: 'CheckmarkScaleFill' },
-  { component: IconCheckmarkScaleLine, name: 'CheckmarkScaleLine' },
-  { component: IconCheckmarkShieldFill, name: 'CheckmarkShieldFill' },
-  { component: IconCheckmarkShieldLine, name: 'CheckmarkShieldLine' },
-  {
-    component: IconCheckmarkhorizline2VerticalFill,
-    name: 'Checkmarkhorizline2VerticalFill',
-  },
-  {
-    component: IconCheckmarkhorizline2VerticalLine,
-    name: 'Checkmarkhorizline2VerticalLine',
-  },
-  { component: IconChevronDownFill, name: 'ChevronDownFill' },
-  { component: IconChevronDownLine, name: 'ChevronDownLine' },
-  { component: IconChevronDownSmallFill, name: 'ChevronDownSmallFill' },
-  { component: IconChevronDownSmallLine, name: 'ChevronDownSmallLine' },
-  { component: IconChevronLeftFill, name: 'ChevronLeftFill' },
-  { component: IconChevronLeftLine, name: 'ChevronLeftLine' },
-  { component: IconChevronLeftSmallFill, name: 'ChevronLeftSmallFill' },
-  { component: IconChevronLeftSmallLine, name: 'ChevronLeftSmallLine' },
-  { component: IconChevronRightFill, name: 'ChevronRightFill' },
-  { component: IconChevronRightLine, name: 'ChevronRightLine' },
-  { component: IconChevronRightSmallFill, name: 'ChevronRightSmallFill' },
-  { component: IconChevronRightSmallLine, name: 'ChevronRightSmallLine' },
-  { component: IconChevronUpFill, name: 'ChevronUpFill' },
-  { component: IconChevronUpLine, name: 'ChevronUpLine' },
-  { component: IconChevronUpSmallFill, name: 'ChevronUpSmallFill' },
-  { component: IconChevronUpSmallLine, name: 'ChevronUpSmallLine' },
-  { component: IconCircle4SquareFill, name: 'Circle4SquareFill' },
-  { component: IconCircle4SquareLine, name: 'Circle4SquareLine' },
-  { component: IconClockFill, name: 'ClockFill' },
-  { component: IconClockLine, name: 'ClockLine' },
-  { component: IconCompassFill, name: 'CompassFill' },
-  { component: IconCompassLine, name: 'CompassLine' },
-  { component: IconCorner4InwardFill, name: 'Corner4InwardFill' },
-  { component: IconCorner4InwardLine, name: 'Corner4InwardLine' },
-  { component: IconCorner4OutwardFill, name: 'Corner4OutwardFill' },
-  { component: IconCorner4OutwardLine, name: 'Corner4OutwardLine' },
-  { component: IconCornerDownLeftFill, name: 'CornerDownLeftFill' },
-  { component: IconCornerDownLeftLine, name: 'CornerDownLeftLine' },
-  { component: IconCouponFill, name: 'CouponFill' },
-  { component: IconCouponLine, name: 'CouponLine' },
-  { component: IconCropmarkFill, name: 'CropmarkFill' },
-  { component: IconCropmarkLine, name: 'CropmarkLine' },
-  { component: IconCrosshairFill, name: 'CrosshairFill' },
-  { component: IconCrosshairLine, name: 'CrosshairLine' },
-  {
-    component: IconCrosshairQuestionmarkFill,
-    name: 'CrosshairQuestionmarkFill',
-  },
-  {
-    component: IconCrosshairQuestionmarkLine,
-    name: 'CrosshairQuestionmarkLine',
-  },
-  { component: IconCrownFill, name: 'CrownFill' },
-  { component: IconCrownLine, name: 'CrownLine' },
-  { component: IconCupHeatwaveFill, name: 'CupHeatwaveFill' },
-  { component: IconCupHeatwaveLine, name: 'CupHeatwaveLine' },
-  { component: IconDiamondFill, name: 'DiamondFill' },
-  { component: IconDiamondLine, name: 'DiamondLine' },
-  { component: IconDocumentArrowLeftFill, name: 'DocumentArrowLeftFill' },
-  { component: IconDocumentArrowLeftLine, name: 'DocumentArrowLeftLine' },
-  { component: IconDocumentCheckmarkFill, name: 'DocumentCheckmarkFill' },
-  { component: IconDocumentCheckmarkLine, name: 'DocumentCheckmarkLine' },
-  { component: IconDocumentFill, name: 'DocumentFill' },
-  { component: IconDocumentLine, name: 'DocumentLine' },
-  {
-    component: IconDocumentMagnifyingglassFill,
-    name: 'DocumentMagnifyingglassFill',
-  },
-  {
-    component: IconDocumentMagnifyingglassLine,
-    name: 'DocumentMagnifyingglassLine',
-  },
-  { component: IconDocumentPenFill, name: 'DocumentPenFill' },
-  { component: IconDocumentPenLine, name: 'DocumentPenLine' },
-  { component: IconDocumentPlusFill, name: 'DocumentPlusFill' },
-  { component: IconDocumentPlusLine, name: 'DocumentPlusLine' },
-  {
-    component: IconDollarCircleArrowRightFill,
-    name: 'DollarCircleArrowRightFill',
-  },
-  {
-    component: IconDollarCircleArrowRightLine,
-    name: 'DollarCircleArrowRightLine',
-  },
-  { component: IconDollarCircleFill, name: 'DollarCircleFill' },
-  { component: IconDollarCircleLine, name: 'DollarCircleLine' },
-  { component: IconDollarFill, name: 'DollarFill' },
-  { component: IconDollarLine, name: 'DollarLine' },
-  { component: IconDot3CircleFill, name: 'Dot3CircleFill' },
-  { component: IconDot3CircleLine, name: 'Dot3CircleLine' },
-  {
-    component: IconDot3HorizontalChatbubbleLeftFill,
-    name: 'Dot3HorizontalChatbubbleLeftFill',
-  },
-  {
-    component: IconDot3HorizontalChatbubbleLeftLine,
-    name: 'Dot3HorizontalChatbubbleLeftLine',
-  },
-  {
-    component: IconDot3HorizontalChatbubbleLeftSlashFill,
-    name: 'Dot3HorizontalChatbubbleLeftSlashFill',
-  },
-  {
-    component: IconDot3HorizontalChatbubbleLeftSlashLine,
-    name: 'Dot3HorizontalChatbubbleLeftSlashLine',
-  },
-  { component: IconDot3HorizontalFill, name: 'Dot3HorizontalFill' },
-  { component: IconDot3HorizontalLine, name: 'Dot3HorizontalLine' },
-  { component: IconDot3VerticalFill, name: 'Dot3VerticalFill' },
-  { component: IconDot3VerticalLine, name: 'Dot3VerticalLine' },
-  {
-    component: IconDothorizline3VerticalFill,
-    name: 'Dothorizline3VerticalFill',
-  },
-  {
-    component: IconDothorizline3VerticalLine,
-    name: 'Dothorizline3VerticalLine',
-  },
-  { component: IconDumbbellFill, name: 'DumbbellFill' },
-  { component: IconDumbbellLine, name: 'DumbbellLine' },
-  { component: IconEarthFill, name: 'EarthFill' },
-  { component: IconEarthLine, name: 'EarthLine' },
-  { component: IconEnvelopeFill, name: 'EnvelopeFill' },
-  { component: IconEnvelopeLine, name: 'EnvelopeLine' },
-  { component: IconEpbFill, name: 'EpbFill' },
-  { component: IconEpbLine, name: 'EpbLine' },
-  { component: IconEraserHorizlineFill, name: 'EraserHorizlineFill' },
-  { component: IconEraserHorizlineLine, name: 'EraserHorizlineLine' },
-  {
-    component: IconExclamationmarkChatbubbleRectangularCenterFill,
-    name: 'ExclamationmarkChatbubbleRectangularCenterFill',
-  },
-  {
-    component: IconExclamationmarkChatbubbleRectangularCenterLine,
-    name: 'ExclamationmarkChatbubbleRectangularCenterLine',
-  },
-  {
-    component: IconExclamationmarkCircleFill,
-    name: 'ExclamationmarkCircleFill',
-  },
-  {
-    component: IconExclamationmarkCircleLine,
-    name: 'ExclamationmarkCircleLine',
-  },
-  { component: IconEyeFill, name: 'EyeFill' },
-  { component: IconEyeLine, name: 'EyeLine' },
-  { component: IconEyeSlashFill, name: 'EyeSlashFill' },
-  { component: IconEyeSlashLine, name: 'EyeSlashLine' },
-  { component: IconFaceFrustratedCircleFill, name: 'FaceFrustratedCircleFill' },
-  { component: IconFaceFrustratedCircleLine, name: 'FaceFrustratedCircleLine' },
-  { component: IconFaceSadCircleFill, name: 'FaceSadCircleFill' },
-  { component: IconFaceSadCircleLine, name: 'FaceSadCircleLine' },
-  { component: IconFaceSmileCircleFill, name: 'FaceSmileCircleFill' },
-  {
-    component: IconFaceSmileCircleFoldedFill,
-    name: 'FaceSmileCircleFoldedFill',
-  },
-  {
-    component: IconFaceSmileCircleFoldedLine,
-    name: 'FaceSmileCircleFoldedLine',
-  },
-  { component: IconFaceSmileCircleLine, name: 'FaceSmileCircleLine' },
-  { component: IconFaceSurprisedCircleFill, name: 'FaceSurprisedCircleFill' },
-  { component: IconFaceSurprisedCircleLine, name: 'FaceSurprisedCircleLine' },
-  { component: IconFaceViewfinderFill, name: 'FaceViewfinderFill' },
-  { component: IconFaceViewfinderLine, name: 'FaceViewfinderLine' },
-  { component: IconFigureBikeFill, name: 'FigureBikeFill' },
-  { component: IconFigureBikeLine, name: 'FigureBikeLine' },
-  { component: IconFigureOvalFill, name: 'FigureOvalFill' },
-  { component: IconFigureOvalLine, name: 'FigureOvalLine' },
-  { component: IconFigureRunFill, name: 'FigureRunFill' },
-  { component: IconFigureRunLine, name: 'FigureRunLine' },
-  { component: IconFigureWalkFill, name: 'FigureWalkFill' },
-  { component: IconFigureWalkLine, name: 'FigureWalkLine' },
-  { component: IconFigureWheelchairFill, name: 'FigureWheelchairFill' },
-  { component: IconFigureWheelchairLine, name: 'FigureWheelchairLine' },
-  { component: IconFingerprintFill, name: 'FingerprintFill' },
-  { component: IconFingerprintLine, name: 'FingerprintLine' },
-  { component: IconFireworkFill, name: 'FireworkFill' },
-  { component: IconFireworkLine, name: 'FireworkLine' },
-  { component: IconFishWave2Fill, name: 'FishWave2Fill' },
-  { component: IconFishWave2Line, name: 'FishWave2Line' },
-  { component: IconFlagFill, name: 'FlagFill' },
-  { component: IconFlagHillFill, name: 'FlagHillFill' },
-  { component: IconFlagHillLine, name: 'FlagHillLine' },
-  { component: IconFlagLine, name: 'FlagLine' },
-  { component: IconFlameFill, name: 'FlameFill' },
-  { component: IconFlameLine, name: 'FlameLine' },
-  { component: IconFlaskFill, name: 'FlaskFill' },
-  { component: IconFlaskLine, name: 'FlaskLine' },
-  { component: IconForkSpoonBagFill, name: 'ForkSpoonBagFill' },
-  { component: IconForkSpoonBagLine, name: 'ForkSpoonBagLine' },
-  { component: IconForkSpoonFill, name: 'ForkSpoonFill' },
-  { component: IconForkSpoonLine, name: 'ForkSpoonLine' },
-  { component: IconFridgeFill, name: 'FridgeFill' },
-  { component: IconFridgeLine, name: 'FridgeLine' },
-  { component: IconGearFill, name: 'GearFill' },
-  { component: IconGearLine, name: 'GearLine' },
-  { component: IconGiftFill, name: 'GiftFill' },
-  { component: IconGiftLine, name: 'GiftLine' },
-  { component: IconGlobeFill, name: 'GlobeFill' },
-  { component: IconGlobeLine, name: 'GlobeLine' },
-  { component: IconGraduationcapFill, name: 'GraduationcapFill' },
-  { component: IconGraduationcapLine, name: 'GraduationcapLine' },
-  { component: IconGridDot5Fill, name: 'GridDot5Fill' },
-  { component: IconGridDot5Line, name: 'GridDot5Line' },
-  { component: IconGridFill, name: 'GridFill' },
-  { component: IconGridHeartFill, name: 'GridHeartFill' },
-  { component: IconGridHeartLine, name: 'GridHeartLine' },
-  { component: IconGridLine, name: 'GridLine' },
-  { component: IconHandPointUpFill, name: 'HandPointUpFill' },
-  { component: IconHandPointUpLine, name: 'HandPointUpLine' },
-  { component: IconHandWaveFill, name: 'HandWaveFill' },
-  { component: IconHandWaveLine, name: 'HandWaveLine' },
-  { component: IconHashFill, name: 'HashFill' },
-  { component: IconHashLine, name: 'HashLine' },
-  { component: IconHeadsetFill, name: 'HeadsetFill' },
-  { component: IconHeadsetLine, name: 'HeadsetLine' },
-  { component: IconHeartFill, name: 'HeartFill' },
-  { component: IconHeartLine, name: 'HeartLine' },
-  {
-    component: IconHorizline2VerticalChatbubbleRectangularRightFill,
-    name: 'Horizline2VerticalChatbubbleRectangularRightFill',
-  },
-  {
-    component: IconHorizline2VerticalChatbubbleRectangularRightLine,
-    name: 'Horizline2VerticalChatbubbleRectangularRightLine',
-  },
-  {
-    component: IconHorizline2VerticalChatbubbleRectangularRightSlashFill,
-    name: 'Horizline2VerticalChatbubbleRectangularRightSlashFill',
-  },
-  {
-    component: IconHorizline2VerticalChatbubbleRectangularRightSlashLine,
-    name: 'Horizline2VerticalChatbubbleRectangularRightSlashLine',
-  },
-  {
-    component: IconHorizline3VerticalCheckmarkFill,
-    name: 'Horizline3VerticalCheckmarkFill',
-  },
-  {
-    component: IconHorizline3VerticalCheckmarkLine,
-    name: 'Horizline3VerticalCheckmarkLine',
-  },
-  { component: IconHorizline3VerticalFill, name: 'Horizline3VerticalFill' },
-  { component: IconHorizline3VerticalLine, name: 'Horizline3VerticalLine' },
-  {
-    component: IconHorizline3VerticalStarFill,
-    name: 'Horizline3VerticalStarFill',
-  },
-  {
-    component: IconHorizline3VerticalStarLine,
-    name: 'Horizline3VerticalStarLine',
-  },
-  {
-    component: IconHorizline3VerticalTightFill,
-    name: 'Horizline3VerticalTightFill',
-  },
-  {
-    component: IconHorizline3VerticalTightLine,
-    name: 'Horizline3VerticalTightLine',
-  },
-  { component: IconHorizlineViewfinderFill, name: 'HorizlineViewfinderFill' },
-  { component: IconHorizlineViewfinderLine, name: 'HorizlineViewfinderLine' },
-  {
-    component: IconHorizrectangleHorizline2VerticalFill,
-    name: 'HorizrectangleHorizline2VerticalFill',
-  },
-  {
-    component: IconHorizrectangleHorizline2VerticalLine,
-    name: 'HorizrectangleHorizline2VerticalLine',
-  },
-  {
-    component: IconHospitalcrossBuildingFill,
-    name: 'HospitalcrossBuildingFill',
-  },
-  {
-    component: IconHospitalcrossBuildingLine,
-    name: 'HospitalcrossBuildingLine',
-  },
-  { component: IconHospitalcrossSquareFill, name: 'HospitalcrossSquareFill' },
-  { component: IconHospitalcrossSquareLine, name: 'HospitalcrossSquareLine' },
-  { component: IconHouseFill, name: 'HouseFill' },
-  { component: IconHouseLine, name: 'HouseLine' },
-  { component: IconHousePlusFill, name: 'HousePlusFill' },
-  { component: IconHousePlusLine, name: 'HousePlusLine' },
-  { component: IconHouseSquareFill, name: 'HouseSquareFill' },
-  { component: IconHouseSquareLine, name: 'HouseSquareLine' },
-  {
-    component: IconILowercaseSerifCircleFill,
-    name: 'ILowercaseSerifCircleFill',
-  },
-  {
-    component: IconILowercaseSerifCircleLine,
-    name: 'ILowercaseSerifCircleLine',
-  },
-  { component: IconKeyboardChevronDownFill, name: 'KeyboardChevronDownFill' },
-  { component: IconKeyboardChevronDownLine, name: 'KeyboardChevronDownLine' },
-  { component: IconKeyholeShieldFill, name: 'KeyholeShieldFill' },
-  { component: IconKeyholeShieldLine, name: 'KeyholeShieldLine' },
-  { component: IconLaptopFill, name: 'LaptopFill' },
-  { component: IconLaptopLine, name: 'LaptopLine' },
-  { component: IconLeafFill, name: 'LeafFill' },
-  { component: IconLeafLine, name: 'LeafLine' },
-  { component: IconLightbulbDot5Fill, name: 'LightbulbDot5Fill' },
-  { component: IconLightbulbDot5Line, name: 'LightbulbDot5Line' },
-  { component: IconLightningFill, name: 'LightningFill' },
-  { component: IconLightningLine, name: 'LightningLine' },
-  { component: IconLightningSlashFill, name: 'LightningSlashFill' },
-  { component: IconLightningSlashLine, name: 'LightningSlashLine' },
-  { component: IconLinechartUpXaxisFill, name: 'LinechartUpXaxisFill' },
-  { component: IconLinechartUpXaxisLine, name: 'LinechartUpXaxisLine' },
-  { component: IconLocationpinFill, name: 'LocationpinFill' },
-  { component: IconLocationpinLine, name: 'LocationpinLine' },
-  { component: IconLockFill, name: 'LockFill' },
-  { component: IconLockLine, name: 'LockLine' },
-  { component: IconLockOpenedFill, name: 'LockOpenedFill' },
-  { component: IconLockOpenedLine, name: 'LockOpenedLine' },
-  { component: IconMagnifyingglassFill, name: 'MagnifyingglassFill' },
-  { component: IconMagnifyingglassLine, name: 'MagnifyingglassLine' },
-  {
-    component: IconMalesymbolFemalesymbolFill,
-    name: 'MalesymbolFemalesymbolFill',
-  },
-  {
-    component: IconMalesymbolFemalesymbolLine,
-    name: 'MalesymbolFemalesymbolLine',
-  },
-  { component: IconMapFill, name: 'MapFill' },
-  { component: IconMapLine, name: 'MapLine' },
-  { component: IconMapLocationpinFill, name: 'MapLocationpinFill' },
-  { component: IconMapLocationpinLine, name: 'MapLocationpinLine' },
-  { component: IconMegaphoneFill, name: 'MegaphoneFill' },
-  { component: IconMegaphoneLine, name: 'MegaphoneLine' },
-  { component: IconMegaphoneTiltedFill, name: 'MegaphoneTiltedFill' },
-  { component: IconMegaphoneTiltedLine, name: 'MegaphoneTiltedLine' },
-  { component: IconMetroFrontsideFill, name: 'MetroFrontsideFill' },
-  { component: IconMetroFrontsideLine, name: 'MetroFrontsideLine' },
-  { component: IconMicrophoneFill, name: 'MicrophoneFill' },
-  { component: IconMicrophoneLine, name: 'MicrophoneLine' },
-  { component: IconMicrophoneSlashFill, name: 'MicrophoneSlashFill' },
-  { component: IconMicrophoneSlashLine, name: 'MicrophoneSlashLine' },
-  { component: IconMicrowaveFill, name: 'MicrowaveFill' },
-  { component: IconMicrowaveLine, name: 'MicrowaveLine' },
-  { component: IconMidcutSquareFill, name: 'MidcutSquareFill' },
-  { component: IconMidcutSquareLine, name: 'MidcutSquareLine' },
-  { component: IconMinusCircleFill, name: 'MinusCircleFill' },
-  { component: IconMinusCircleLine, name: 'MinusCircleLine' },
-  { component: IconMinusFatFill, name: 'MinusFatFill' },
-  { component: IconMinusFatLine, name: 'MinusFatLine' },
-  { component: IconMinusFill, name: 'MinusFill' },
-  { component: IconMinusLine, name: 'MinusLine' },
-  { component: IconMobileFill, name: 'MobileFill' },
-  { component: IconMobileLine, name: 'MobileLine' },
-  { component: IconMoonFill, name: 'MoonFill' },
-  { component: IconMoonLine, name: 'MoonLine' },
-  { component: IconMusicalnoteDoubleFill, name: 'MusicalnoteDoubleFill' },
-  { component: IconMusicalnoteDoubleLine, name: 'MusicalnoteDoubleLine' },
-  { component: IconNUppercaseCircleFill, name: 'NUppercaseCircleFill' },
-  { component: IconNUppercaseCircleLine, name: 'NUppercaseCircleLine' },
-  { component: IconNailpolishFill, name: 'NailpolishFill' },
-  { component: IconNailpolishLine, name: 'NailpolishLine' },
-  { component: IconNeedleScaleFill, name: 'NeedleScaleFill' },
-  { component: IconNeedleScaleLine, name: 'NeedleScaleLine' },
-  { component: IconPUppercaseCircleFill, name: 'PUppercaseCircleFill' },
-  { component: IconPUppercaseCircleLine, name: 'PUppercaseCircleLine' },
-  { component: IconPaintrollerFill, name: 'PaintrollerFill' },
-  { component: IconPaintrollerLine, name: 'PaintrollerLine' },
-  { component: IconPaletteFill, name: 'PaletteFill' },
-  { component: IconPaletteLine, name: 'PaletteLine' },
-  { component: IconPaperclipFill, name: 'PaperclipFill' },
-  { component: IconPaperclipLine, name: 'PaperclipLine' },
-  { component: IconPaperplaneFill, name: 'PaperplaneFill' },
-  { component: IconPaperplaneLine, name: 'PaperplaneLine' },
-  { component: IconPaperplaneTiltedFill, name: 'PaperplaneTiltedFill' },
-  { component: IconPaperplaneTiltedLine, name: 'PaperplaneTiltedLine' },
-  { component: IconPawprintFill, name: 'PawprintFill' },
-  { component: IconPawprintLine, name: 'PawprintLine' },
-  { component: IconPenHorizlineFill, name: 'PenHorizlineFill' },
-  { component: IconPenHorizlineLine, name: 'PenHorizlineLine' },
-  { component: IconPencilFill, name: 'PencilFill' },
-  { component: IconPencilLine, name: 'PencilLine' },
-  { component: IconPeople3Fill, name: 'People3Fill' },
-  { component: IconPeople3Line, name: 'People3Line' },
-  { component: IconPercentFill, name: 'PercentFill' },
-  { component: IconPercentFlowerFill, name: 'PercentFlowerFill' },
-  { component: IconPercentFlowerLine, name: 'PercentFlowerLine' },
-  { component: IconPercentLine, name: 'PercentLine' },
-  { component: IconPerson2Fill, name: 'Person2Fill' },
-  { component: IconPerson2Line, name: 'Person2Line' },
-  { component: IconPerson2OpenarmsFill, name: 'Person2OpenarmsFill' },
-  { component: IconPerson2OpenarmsLine, name: 'Person2OpenarmsLine' },
-  { component: IconPersonCircleFill, name: 'PersonCircleFill' },
-  { component: IconPersonCircleLine, name: 'PersonCircleLine' },
-  { component: IconPersonFill, name: 'PersonFill' },
-  { component: IconPersonFlowerFill, name: 'PersonFlowerFill' },
-  { component: IconPersonFlowerLine, name: 'PersonFlowerLine' },
-  { component: IconPersonLine, name: 'PersonLine' },
-  {
-    component: IconPersonMagnifyingglassFill,
-    name: 'PersonMagnifyingglassFill',
-  },
-  {
-    component: IconPersonMagnifyingglassLine,
-    name: 'PersonMagnifyingglassLine',
-  },
-  { component: IconPersonPlusFill, name: 'PersonPlusFill' },
-  { component: IconPersonPlusLine, name: 'PersonPlusLine' },
-  { component: IconPersonShieldFill, name: 'PersonShieldFill' },
-  { component: IconPersonShieldLine, name: 'PersonShieldLine' },
-  { component: IconPhoneFill, name: 'PhoneFill' },
-  { component: IconPhoneLine, name: 'PhoneLine' },
-  { component: IconPhoneXmarkFill, name: 'PhoneXmarkFill' },
-  { component: IconPhoneXmarkLine, name: 'PhoneXmarkLine' },
-  { component: IconPicture2StackedFill, name: 'Picture2StackedFill' },
-  { component: IconPicture2StackedLine, name: 'Picture2StackedLine' },
-  { component: IconPictureFill, name: 'PictureFill' },
-  { component: IconPictureLine, name: 'PictureLine' },
-  { component: IconPlusCircleFill, name: 'PlusCircleFill' },
-  { component: IconPlusCircleLine, name: 'PlusCircleLine' },
-  { component: IconPlusFill, name: 'PlusFill' },
-  { component: IconPlusLine, name: 'PlusLine' },
-  { component: IconPlusSmallFill, name: 'PlusSmallFill' },
-  { component: IconPlusSmallLine, name: 'PlusSmallLine' },
-  { component: IconPlusSquareFill, name: 'PlusSquareFill' },
-  { component: IconPlusSquareLine, name: 'PlusSquareLine' },
-  { component: IconPostFill, name: 'PostFill' },
-  { component: IconPostLine, name: 'PostLine' },
-  { component: IconPushpinFill, name: 'PushpinFill' },
-  { component: IconPushpinLine, name: 'PushpinLine' },
-  {
-    component: IconQUppercaseChatbubbleRightFill,
-    name: 'QUppercaseChatbubbleRightFill',
-  },
-  {
-    component: IconQUppercaseChatbubbleRightLine,
-    name: 'QUppercaseChatbubbleRightLine',
-  },
-  { component: IconQuestionmarkCircleFill, name: 'QuestionmarkCircleFill' },
-  { component: IconQuestionmarkCircleLine, name: 'QuestionmarkCircleLine' },
-  { component: IconQuestionmarkSquareFill, name: 'QuestionmarkSquareFill' },
-  { component: IconQuestionmarkSquareLine, name: 'QuestionmarkSquareLine' },
-  { component: IconQuotationmark2LeftFill, name: 'Quotationmark2LeftFill' },
-  { component: IconQuotationmark2LeftLine, name: 'Quotationmark2LeftLine' },
-  { component: IconQuotationmark2RightFill, name: 'Quotationmark2RightFill' },
-  { component: IconQuotationmark2RightLine, name: 'Quotationmark2RightLine' },
-  { component: IconReceiptFill, name: 'ReceiptFill' },
-  { component: IconReceiptLine, name: 'ReceiptLine' },
-  {
-    component: IconRectangleSplitedLineVerticalFill,
-    name: 'RectangleSplitedLineVerticalFill',
-  },
-  {
-    component: IconRectangleSplitedLineVerticalLine,
-    name: 'RectangleSplitedLineVerticalLine',
-  },
-  { component: IconRoadlaneFill, name: 'RoadlaneFill' },
-  { component: IconRoadlaneLine, name: 'RoadlaneLine' },
-  { component: IconRocketFill, name: 'RocketFill' },
-  { component: IconRocketLine, name: 'RocketLine' },
-  { component: IconRooftoproomFill, name: 'RooftoproomFill' },
-  { component: IconRooftoproomLine, name: 'RooftoproomLine' },
-  {
-    component: IconSUppercaseHorizlineCenterFill,
-    name: 'SUppercaseHorizlineCenterFill',
-  },
-  {
-    component: IconSUppercaseHorizlineCenterLine,
-    name: 'SUppercaseHorizlineCenterLine',
-  },
-  { component: IconScissorsFill, name: 'ScissorsFill' },
-  { component: IconScissorsLine, name: 'ScissorsLine' },
-  { component: IconScribbleFill, name: 'ScribbleFill' },
-  { component: IconScribbleLine, name: 'ScribbleLine' },
-  { component: IconSeatLeftFanFill, name: 'SeatLeftFanFill' },
-  { component: IconSeatLeftFanLine, name: 'SeatLeftFanLine' },
-  { component: IconSeatLeftFill, name: 'SeatLeftFill' },
-  { component: IconSeatLeftHeatwave2Fill, name: 'SeatLeftHeatwave2Fill' },
-  { component: IconSeatLeftHeatwave2Line, name: 'SeatLeftHeatwave2Line' },
-  { component: IconSeatLeftLine, name: 'SeatLeftLine' },
-  { component: IconShoppingbag2StackedFill, name: 'Shoppingbag2StackedFill' },
-  { component: IconShoppingbag2StackedLine, name: 'Shoppingbag2StackedLine' },
-  { component: IconShoppingbagFill, name: 'ShoppingbagFill' },
-  { component: IconShoppingbagItemsFill, name: 'ShoppingbagItemsFill' },
-  { component: IconShoppingbagItemsLine, name: 'ShoppingbagItemsLine' },
-  { component: IconShoppingbagLine, name: 'ShoppingbagLine' },
-  { component: IconSidemirrorWaveFill, name: 'SidemirrorWaveFill' },
-  { component: IconSidemirrorWaveLine, name: 'SidemirrorWaveLine' },
-  { component: IconSignboardFill, name: 'SignboardFill' },
-  { component: IconSignboardLine, name: 'SignboardLine' },
-  { component: IconSlashCircleFill, name: 'SlashCircleFill' },
-  { component: IconSlashCircleLine, name: 'SlashCircleLine' },
-  { component: IconSlashSemicircle2Fill, name: 'SlashSemicircle2Fill' },
-  { component: IconSlashSemicircle2Line, name: 'SlashSemicircle2Line' },
-  { component: IconSlider2HorizontalFill, name: 'Slider2HorizontalFill' },
-  { component: IconSlider2HorizontalLine, name: 'Slider2HorizontalLine' },
-  { component: IconSmartkeyFill, name: 'SmartkeyFill' },
-  { component: IconSmartkeyLine, name: 'SmartkeyLine' },
-  {
-    component: IconSneakerLiftedLeftsideFill,
-    name: 'SneakerLiftedLeftsideFill',
-  },
-  {
-    component: IconSneakerLiftedLeftsideLine,
-    name: 'SneakerLiftedLeftsideLine',
-  },
-  { component: IconSofaFill, name: 'SofaFill' },
-  { component: IconSofaLine, name: 'SofaLine' },
-  { component: IconSparkle2Fill, name: 'Sparkle2Fill' },
-  { component: IconSparkle2Line, name: 'Sparkle2Line' },
-  { component: IconSparkleViewfinderFill, name: 'SparkleViewfinderFill' },
-  { component: IconSparkleViewfinderLine, name: 'SparkleViewfinderLine' },
-  { component: IconSpeakerWave2Fill, name: 'SpeakerWave2Fill' },
-  { component: IconSpeakerWave2Line, name: 'SpeakerWave2Line' },
-  { component: IconSpeakerWave2SlashFill, name: 'SpeakerWave2SlashFill' },
-  { component: IconSpeakerWave2SlashLine, name: 'SpeakerWave2SlashLine' },
-  { component: IconSpeedometerFill, name: 'SpeedometerFill' },
-  { component: IconSpeedometerLine, name: 'SpeedometerLine' },
-  { component: IconSpeedometer_1xFill, name: 'Speedometer_1xFill' },
-  { component: IconSpeedometer_1xLine, name: 'Speedometer_1xLine' },
-  { component: IconSpeedometer_2xFill, name: 'Speedometer_2xFill' },
-  { component: IconSpeedometer_2xLine, name: 'Speedometer_2xLine' },
-  { component: IconSpeedometer_3xFill, name: 'Speedometer_3xFill' },
-  { component: IconSpeedometer_3xLine, name: 'Speedometer_3xLine' },
-  { component: IconSplitedGridSquareFill, name: 'SplitedGridSquareFill' },
-  { component: IconSplitedGridSquareLine, name: 'SplitedGridSquareLine' },
-  { component: IconSpraybottleSpongeFill, name: 'SpraybottleSpongeFill' },
-  { component: IconSpraybottleSpongeLine, name: 'SpraybottleSpongeLine' },
-  { component: IconSquare2StackedFill, name: 'Square2StackedFill' },
-  { component: IconSquare2StackedLine, name: 'Square2StackedLine' },
-  { component: IconSquareline2VerticalFill, name: 'Squareline2VerticalFill' },
-  { component: IconSquareline2VerticalLine, name: 'Squareline2VerticalLine' },
-  { component: IconStarFill, name: 'StarFill' },
-  { component: IconStarLine, name: 'StarLine' },
-  {
-    component: IconSteeringwheelHeatwave2Fill,
-    name: 'SteeringwheelHeatwave2Fill',
-  },
-  {
-    component: IconSteeringwheelHeatwave2Line,
-    name: 'SteeringwheelHeatwave2Line',
-  },
-  { component: IconStepsFill, name: 'StepsFill' },
-  { component: IconStepsLine, name: 'StepsLine' },
-  { component: IconStoreCheckmarkFill, name: 'StoreCheckmarkFill' },
-  { component: IconStoreCheckmarkLine, name: 'StoreCheckmarkLine' },
-  { component: IconStoreFill, name: 'StoreFill' },
-  { component: IconStoreLine, name: 'StoreLine' },
-  { component: IconStorePenFill, name: 'StorePenFill' },
-  { component: IconStorePenLine, name: 'StorePenLine' },
-  { component: IconSunFill, name: 'SunFill' },
-  { component: IconSunLine, name: 'SunLine' },
-  { component: IconTUppercaseSerifFill, name: 'TUppercaseSerifFill' },
-  { component: IconTUppercaseSerifLine, name: 'TUppercaseSerifLine' },
-  { component: IconTUppercaseTLowercaseFill, name: 'TUppercaseTLowercaseFill' },
-  { component: IconTUppercaseTLowercaseLine, name: 'TUppercaseTLowercaseLine' },
-  { component: IconTagFill, name: 'TagFill' },
-  { component: IconTagLine, name: 'TagLine' },
-  { component: IconTextAligncenterFill, name: 'TextAligncenterFill' },
-  { component: IconTextAligncenterLine, name: 'TextAligncenterLine' },
-  { component: IconTextAlignleftFill, name: 'TextAlignleftFill' },
-  { component: IconTextAlignleftLine, name: 'TextAlignleftLine' },
-  { component: IconTextAlignrightFill, name: 'TextAlignrightFill' },
-  { component: IconTextAlignrightLine, name: 'TextAlignrightLine' },
-  { component: IconThumbDownFill, name: 'ThumbDownFill' },
-  { component: IconThumbDownLine, name: 'ThumbDownLine' },
-  { component: IconThumbUpFill, name: 'ThumbUpFill' },
-  { component: IconThumbUpLine, name: 'ThumbUpLine' },
-  { component: IconTimerFill, name: 'TimerFill' },
-  { component: IconTimerLine, name: 'TimerLine' },
-  { component: IconTimer_10Fill, name: 'Timer_10Fill' },
-  { component: IconTimer_10Line, name: 'Timer_10Line' },
-  { component: IconTimer_3Fill, name: 'Timer_3Fill' },
-  { component: IconTimer_3Line, name: 'Timer_3Line' },
-  { component: IconToolboxFill, name: 'ToolboxFill' },
-  { component: IconToolboxLine, name: 'ToolboxLine' },
-  { component: IconTranslationFill, name: 'TranslationFill' },
-  { component: IconTranslationLine, name: 'TranslationLine' },
-  { component: IconTrashcanFill, name: 'TrashcanFill' },
-  { component: IconTrashcanLine, name: 'TrashcanLine' },
-  { component: IconTriangleDownSmallFill, name: 'TriangleDownSmallFill' },
-  { component: IconTriangleDownSmallLine, name: 'TriangleDownSmallLine' },
-  {
-    component: IconTriangleRightChatbubbleLeftFill,
-    name: 'TriangleRightChatbubbleLeftFill',
-  },
-  {
-    component: IconTriangleRightChatbubbleLeftLine,
-    name: 'TriangleRightChatbubbleLeftLine',
-  },
-  { component: IconTriangleRightFill, name: 'TriangleRightFill' },
-  { component: IconTriangleRightLine, name: 'TriangleRightLine' },
-  {
-    component: IconTriangleRightRectangleSplitedLineVerticalFill,
-    name: 'TriangleRightRectangleSplitedLineVerticalFill',
-  },
-  {
-    component: IconTriangleRightRectangleSplitedLineVerticalLine,
-    name: 'TriangleRightRectangleSplitedLineVerticalLine',
-  },
-  { component: IconTriangleUpSmallFill, name: 'TriangleUpSmallFill' },
-  { component: IconTriangleUpSmallLine, name: 'TriangleUpSmallLine' },
-  { component: IconTrophyFill, name: 'TrophyFill' },
-  { component: IconTrophyLine, name: 'TrophyLine' },
-  { component: IconTruckFill, name: 'TruckFill' },
-  { component: IconTruckLine, name: 'TruckLine' },
-  { component: IconTshirtBubble2Fill, name: 'TshirtBubble2Fill' },
-  { component: IconTshirtBubble2Line, name: 'TshirtBubble2Line' },
-  { component: IconUUppercaseHorizlineFill, name: 'UUppercaseHorizlineFill' },
-  { component: IconUUppercaseHorizlineLine, name: 'UUppercaseHorizlineLine' },
-  { component: IconVertline3ViewfinderFill, name: 'Vertline3ViewfinderFill' },
-  { component: IconVertline3ViewfinderLine, name: 'Vertline3ViewfinderLine' },
-  { component: IconVertline4SparkleFill, name: 'Vertline4SparkleFill' },
-  { component: IconVertline4SparkleLine, name: 'Vertline4SparkleLine' },
-  { component: IconVertlineCouponFill, name: 'VertlineCouponFill' },
-  { component: IconVertlineCouponLine, name: 'VertlineCouponLine' },
-  {
-    component: IconVertrectangle2HorizontalFill,
-    name: 'Vertrectangle2HorizontalFill',
-  },
-  {
-    component: IconVertrectangle2HorizontalLine,
-    name: 'Vertrectangle2HorizontalLine',
-  },
-  { component: IconVertrectangleFoldedFill, name: 'VertrectangleFoldedFill' },
-  { component: IconVertrectangleFoldedLine, name: 'VertrectangleFoldedLine' },
-  { component: IconVotingstampFill, name: 'VotingstampFill' },
-  { component: IconVotingstampLine, name: 'VotingstampLine' },
-  { component: IconWandFill, name: 'WandFill' },
-  { component: IconWandLine, name: 'WandLine' },
-  { component: IconWashingmachineFill, name: 'WashingmachineFill' },
-  { component: IconWashingmachineLine, name: 'WashingmachineLine' },
-  { component: IconWindow2StoreFill, name: 'Window2StoreFill' },
-  { component: IconWindow2StoreLine, name: 'Window2StoreLine' },
-  { component: IconWindow4HouseFill, name: 'Window4HouseFill' },
-  { component: IconWindow4HouseLine, name: 'Window4HouseLine' },
-  {
-    component: IconWonArrowClockwiseCircularFill,
-    name: 'WonArrowClockwiseCircularFill',
-  },
-  {
-    component: IconWonArrowClockwiseCircularLine,
-    name: 'WonArrowClockwiseCircularLine',
-  },
-  { component: IconWonCircleArrowLeftFill, name: 'WonCircleArrowLeftFill' },
-  { component: IconWonCircleArrowLeftLine, name: 'WonCircleArrowLeftLine' },
-  { component: IconWonCircleArrowRightFill, name: 'WonCircleArrowRightFill' },
-  { component: IconWonCircleArrowRightLine, name: 'WonCircleArrowRightLine' },
-  { component: IconWonCircleFill, name: 'WonCircleFill' },
-  { component: IconWonCircleLine, name: 'WonCircleLine' },
-  { component: IconWonFill, name: 'WonFill' },
-  { component: IconWonLine, name: 'WonLine' },
-  { component: IconWonShieldFill, name: 'WonShieldFill' },
-  { component: IconWonShieldLine, name: 'WonShieldLine' },
-  { component: IconWrenchFill, name: 'WrenchFill' },
-  { component: IconWrenchLine, name: 'WrenchLine' },
-  { component: IconXmarkCircleFill, name: 'XmarkCircleFill' },
-  { component: IconXmarkCircleLine, name: 'XmarkCircleLine' },
-  { component: IconXmarkFill, name: 'XmarkFill' },
-  { component: IconXmarkLine, name: 'XmarkLine' },
-  { component: IconXmarkScaleFill, name: 'XmarkScaleFill' },
-  { component: IconXmarkScaleLine, name: 'XmarkScaleLine' },
-  { component: IconYenCircleArrowRightFill, name: 'YenCircleArrowRightFill' },
-  { component: IconYenCircleArrowRightLine, name: 'YenCircleArrowRightLine' },
-  { component: IconYenCircleFill, name: 'YenCircleFill' },
-  { component: IconYenCircleLine, name: 'YenCircleLine' },
-  { component: IconYenFill, name: 'YenFill' },
-  { component: IconYenLine, name: 'YenLine' },
+  { component: IconAUppercaseALowercaseFill, name: "AUppercaseALowercaseFill" },
+  { component: IconAUppercaseALowercaseLine, name: "AUppercaseALowercaseLine" },
+  { component: IconAUppercaseOutlineFill, name: "AUppercaseOutlineFill" },
+  { component: IconAUppercaseOutlineLine, name: "AUppercaseOutlineLine" },
+  { component: IconAUppercaseSquareFill, name: "AUppercaseSquareFill" },
+  { component: IconAUppercaseSquareLine, name: "AUppercaseSquareLine" },
+  { component: IconAndroidshareFill, name: "AndroidshareFill" },
+  { component: IconAndroidshareLine, name: "AndroidshareLine" },
+  { component: IconAppleFill, name: "AppleFill" },
+  { component: IconAppleLine, name: "AppleLine" },
+  { component: IconArrow2ClockwiseCircularFill, name: "Arrow2ClockwiseCircularFill" },
+  { component: IconArrow2ClockwiseCircularLine, name: "Arrow2ClockwiseCircularLine" },
+  { component: IconArrowClockwiseCircularFill, name: "ArrowClockwiseCircularFill" },
+  { component: IconArrowClockwiseCircularLine, name: "ArrowClockwiseCircularLine" },
+  { component: IconArrowClockwiseOvalFill, name: "ArrowClockwiseOvalFill" },
+  { component: IconArrowClockwiseOvalLine, name: "ArrowClockwiseOvalLine" },
+  { component: IconArrowCounterclockwiseCircularFill, name: "ArrowCounterclockwiseCircularFill" },
+  { component: IconArrowCounterclockwiseCircularLine, name: "ArrowCounterclockwiseCircularLine" },
+  { component: IconArrowDownFill, name: "ArrowDownFill" },
+  { component: IconArrowDownHorizlineFill, name: "ArrowDownHorizlineFill" },
+  { component: IconArrowDownHorizlineLine, name: "ArrowDownHorizlineLine" },
+  { component: IconArrowDownLine, name: "ArrowDownLine" },
+  { component: IconArrowDownLineVerticalArrowUpSquareFill, name: "ArrowDownLineVerticalArrowUpSquareFill" },
+  { component: IconArrowDownLineVerticalArrowUpSquareLine, name: "ArrowDownLineVerticalArrowUpSquareLine" },
+  { component: IconArrowDownRightArrowUpLeftFill, name: "ArrowDownRightArrowUpLeftFill" },
+  { component: IconArrowDownRightArrowUpLeftLine, name: "ArrowDownRightArrowUpLeftLine" },
+  { component: IconArrowLeftBracketRightFill, name: "ArrowLeftBracketRightFill" },
+  { component: IconArrowLeftBracketRightLine, name: "ArrowLeftBracketRightLine" },
+  { component: IconArrowLeftFill, name: "ArrowLeftFill" },
+  { component: IconArrowLeftLine, name: "ArrowLeftLine" },
+  { component: IconArrowRightAngledFill, name: "ArrowRightAngledFill" },
+  { component: IconArrowRightAngledLine, name: "ArrowRightAngledLine" },
+  { component: IconArrowRightArrowLeftFill, name: "ArrowRightArrowLeftFill" },
+  { component: IconArrowRightArrowLeftLine, name: "ArrowRightArrowLeftLine" },
+  { component: IconArrowRightFill, name: "ArrowRightFill" },
+  { component: IconArrowRightLine, name: "ArrowRightLine" },
+  { component: IconArrowUpArrowDownFill, name: "ArrowUpArrowDownFill" },
+  { component: IconArrowUpArrowDownLine, name: "ArrowUpArrowDownLine" },
+  { component: IconArrowUpBracketDownFill, name: "ArrowUpBracketDownFill" },
+  { component: IconArrowUpBracketDownLine, name: "ArrowUpBracketDownLine" },
+  { component: IconArrowUpFill, name: "ArrowUpFill" },
+  { component: IconArrowUpLeftFill, name: "ArrowUpLeftFill" },
+  { component: IconArrowUpLeftLine, name: "ArrowUpLeftLine" },
+  { component: IconArrowUpLine, name: "ArrowUpLine" },
+  { component: IconArrowUpRightArrowDownLeftFill, name: "ArrowUpRightArrowDownLeftFill" },
+  { component: IconArrowUpRightArrowDownLeftLine, name: "ArrowUpRightArrowDownLeftLine" },
+  { component: IconArrowUpRightArrowDownLeftSquareFill, name: "ArrowUpRightArrowDownLeftSquareFill" },
+  { component: IconArrowUpRightArrowDownLeftSquareLine, name: "ArrowUpRightArrowDownLeftSquareLine" },
+  { component: IconArrowUpRightFill, name: "ArrowUpRightFill" },
+  { component: IconArrowUpRightLine, name: "ArrowUpRightLine" },
+  { component: IconArrowUpRightShoppingbagTiltedFill, name: "ArrowUpRightShoppingbagTiltedFill" },
+  { component: IconArrowUpRightShoppingbagTiltedLine, name: "ArrowUpRightShoppingbagTiltedLine" },
+  { component: IconArrowUturnLeftFill, name: "ArrowUturnLeftFill" },
+  { component: IconArrowUturnLeftLine, name: "ArrowUturnLeftLine" },
+  { component: IconArrowUturnRightFill, name: "ArrowUturnRightFill" },
+  { component: IconArrowUturnRightLine, name: "ArrowUturnRightLine" },
+  { component: IconArticleFill, name: "ArticleFill" },
+  { component: IconArticleLine, name: "ArticleLine" },
+  { component: IconAsteriskHorizrectangleCoolwave3Fill, name: "AsteriskHorizrectangleCoolwave3Fill" },
+  { component: IconAsteriskHorizrectangleCoolwave3Line, name: "AsteriskHorizrectangleCoolwave3Line" },
+  { component: IconAtFill, name: "AtFill" },
+  { component: IconAtLine, name: "AtLine" },
+  { component: IconBUppercaseFill, name: "BUppercaseFill" },
+  { component: IconBUppercaseLine, name: "BUppercaseLine" },
+  { component: IconBackspacekeyFill, name: "BackspacekeyFill" },
+  { component: IconBackspacekeyLine, name: "BackspacekeyLine" },
+  { component: IconBarchartBoardFill, name: "BarchartBoardFill" },
+  { component: IconBarchartBoardLine, name: "BarchartBoardLine" },
+  { component: IconBarchartSquareFill, name: "BarchartSquareFill" },
+  { component: IconBarchartSquareLine, name: "BarchartSquareLine" },
+  { component: IconBedFrontsideFill, name: "BedFrontsideFill" },
+  { component: IconBedFrontsideLine, name: "BedFrontsideLine" },
+  { component: IconBellFill, name: "BellFill" },
+  { component: IconBellLine, name: "BellLine" },
+  { component: IconBellSlashFill, name: "BellSlashFill" },
+  { component: IconBellSlashLine, name: "BellSlashLine" },
+  { component: IconBookFill, name: "BookFill" },
+  { component: IconBookLine, name: "BookLine" },
+  { component: IconBookOpenFill, name: "BookOpenFill" },
+  { component: IconBookOpenLine, name: "BookOpenLine" },
+  { component: IconBookmarkFill, name: "BookmarkFill" },
+  { component: IconBookmarkLine, name: "BookmarkLine" },
+  { component: IconBoxFlapFill, name: "BoxFlapFill" },
+  { component: IconBoxFlapLine, name: "BoxFlapLine" },
+  { component: IconBracketLeftArrowRightFill, name: "BracketLeftArrowRightFill" },
+  { component: IconBracketLeftArrowRightLine, name: "BracketLeftArrowRightLine" },
+  { component: IconBuilding2Fill, name: "Building2Fill" },
+  { component: IconBuilding2Line, name: "Building2Line" },
+  { component: IconCalendarFill, name: "CalendarFill" },
+  { component: IconCalendarLine, name: "CalendarLine" },
+  { component: IconCamcorderFill, name: "CamcorderFill" },
+  { component: IconCamcorderLine, name: "CamcorderLine" },
+  { component: IconCameraFill, name: "CameraFill" },
+  { component: IconCameraLine, name: "CameraLine" },
+  { component: IconCarFill, name: "CarFill" },
+  { component: IconCarFrontUpsideWave2ReversedUpFill, name: "CarFrontUpsideWave2ReversedUpFill" },
+  { component: IconCarFrontUpsideWave2ReversedUpLine, name: "CarFrontUpsideWave2ReversedUpLine" },
+  { component: IconCarFrontsideFill, name: "CarFrontsideFill" },
+  { component: IconCarFrontsideLine, name: "CarFrontsideLine" },
+  { component: IconCarLine, name: "CarLine" },
+  { component: IconCarRearTrunkOpenLeftsideFill, name: "CarRearTrunkOpenLeftsideFill" },
+  { component: IconCarRearTrunkOpenLeftsideLine, name: "CarRearTrunkOpenLeftsideLine" },
+  { component: IconCarRearUpsideSectorDownFill, name: "CarRearUpsideSectorDownFill" },
+  { component: IconCarRearUpsideSectorDownLine, name: "CarRearUpsideSectorDownLine" },
+  { component: IconCarRearUpsideWave2ReversedDownFill, name: "CarRearUpsideWave2ReversedDownFill" },
+  { component: IconCarRearUpsideWave2ReversedDownLeftFill, name: "CarRearUpsideWave2ReversedDownLeftFill" },
+  { component: IconCarRearUpsideWave2ReversedDownLeftLine, name: "CarRearUpsideWave2ReversedDownLeftLine" },
+  { component: IconCarRearUpsideWave2ReversedDownLine, name: "CarRearUpsideWave2ReversedDownLine" },
+  { component: IconCardFill, name: "CardFill" },
+  { component: IconCardLine, name: "CardLine" },
+  { component: IconCarrotFill, name: "CarrotFill" },
+  { component: IconCarrotLine, name: "CarrotLine" },
+  { component: IconCartFill, name: "CartFill" },
+  { component: IconCartItemsFill, name: "CartItemsFill" },
+  { component: IconCartItemsLine, name: "CartItemsLine" },
+  { component: IconCartLine, name: "CartLine" },
+  { component: IconCartLoadFill, name: "CartLoadFill" },
+  { component: IconCartLoadLine, name: "CartLoadLine" },
+  { component: IconCheckmarkBadgeFill, name: "CheckmarkBadgeFill" },
+  { component: IconCheckmarkBadgeLine, name: "CheckmarkBadgeLine" },
+  { component: IconCheckmarkBallotboxFill, name: "CheckmarkBallotboxFill" },
+  { component: IconCheckmarkBallotboxLine, name: "CheckmarkBallotboxLine" },
+  { component: IconCheckmarkCalendarFill, name: "CheckmarkCalendarFill" },
+  { component: IconCheckmarkCalendarLine, name: "CheckmarkCalendarLine" },
+  { component: IconCheckmarkChatbubbleLeftFill, name: "CheckmarkChatbubbleLeftFill" },
+  { component: IconCheckmarkChatbubbleLeftLine, name: "CheckmarkChatbubbleLeftLine" },
+  { component: IconCheckmarkCircleFill, name: "CheckmarkCircleFill" },
+  { component: IconCheckmarkCircleLine, name: "CheckmarkCircleLine" },
+  { component: IconCheckmarkClipboardFill, name: "CheckmarkClipboardFill" },
+  { component: IconCheckmarkClipboardLine, name: "CheckmarkClipboardLine" },
+  { component: IconCheckmarkCouponFill, name: "CheckmarkCouponFill" },
+  { component: IconCheckmarkCouponLine, name: "CheckmarkCouponLine" },
+  { component: IconCheckmarkFatFill, name: "CheckmarkFatFill" },
+  { component: IconCheckmarkFatLine, name: "CheckmarkFatLine" },
+  { component: IconCheckmarkFill, name: "CheckmarkFill" },
+  { component: IconCheckmarkFlowerFill, name: "CheckmarkFlowerFill" },
+  { component: IconCheckmarkFlowerLine, name: "CheckmarkFlowerLine" },
+  { component: IconCheckmarkHorizlineFill, name: "CheckmarkHorizlineFill" },
+  { component: IconCheckmarkHorizlineLine, name: "CheckmarkHorizlineLine" },
+  { component: IconCheckmarkLine, name: "CheckmarkLine" },
+  { component: IconCheckmarkScaleFill, name: "CheckmarkScaleFill" },
+  { component: IconCheckmarkScaleLine, name: "CheckmarkScaleLine" },
+  { component: IconCheckmarkShieldFill, name: "CheckmarkShieldFill" },
+  { component: IconCheckmarkShieldLine, name: "CheckmarkShieldLine" },
+  { component: IconCheckmarkhorizline2VerticalFill, name: "Checkmarkhorizline2VerticalFill" },
+  { component: IconCheckmarkhorizline2VerticalLine, name: "Checkmarkhorizline2VerticalLine" },
+  { component: IconChevronDownFill, name: "ChevronDownFill" },
+  { component: IconChevronDownLine, name: "ChevronDownLine" },
+  { component: IconChevronDownSmallFill, name: "ChevronDownSmallFill" },
+  { component: IconChevronDownSmallLine, name: "ChevronDownSmallLine" },
+  { component: IconChevronLeftFill, name: "ChevronLeftFill" },
+  { component: IconChevronLeftLine, name: "ChevronLeftLine" },
+  { component: IconChevronLeftSmallFill, name: "ChevronLeftSmallFill" },
+  { component: IconChevronLeftSmallLine, name: "ChevronLeftSmallLine" },
+  { component: IconChevronRightFill, name: "ChevronRightFill" },
+  { component: IconChevronRightLine, name: "ChevronRightLine" },
+  { component: IconChevronRightSmallFill, name: "ChevronRightSmallFill" },
+  { component: IconChevronRightSmallLine, name: "ChevronRightSmallLine" },
+  { component: IconChevronUpFill, name: "ChevronUpFill" },
+  { component: IconChevronUpLine, name: "ChevronUpLine" },
+  { component: IconChevronUpSmallFill, name: "ChevronUpSmallFill" },
+  { component: IconChevronUpSmallLine, name: "ChevronUpSmallLine" },
+  { component: IconCircle4SquareFill, name: "Circle4SquareFill" },
+  { component: IconCircle4SquareLine, name: "Circle4SquareLine" },
+  { component: IconClockFill, name: "ClockFill" },
+  { component: IconClockLine, name: "ClockLine" },
+  { component: IconCompassFill, name: "CompassFill" },
+  { component: IconCompassLine, name: "CompassLine" },
+  { component: IconCorner4InwardFill, name: "Corner4InwardFill" },
+  { component: IconCorner4InwardLine, name: "Corner4InwardLine" },
+  { component: IconCorner4OutwardFill, name: "Corner4OutwardFill" },
+  { component: IconCorner4OutwardLine, name: "Corner4OutwardLine" },
+  { component: IconCornerDownLeftFill, name: "CornerDownLeftFill" },
+  { component: IconCornerDownLeftLine, name: "CornerDownLeftLine" },
+  { component: IconCouponFill, name: "CouponFill" },
+  { component: IconCouponLine, name: "CouponLine" },
+  { component: IconCropmarkFill, name: "CropmarkFill" },
+  { component: IconCropmarkLine, name: "CropmarkLine" },
+  { component: IconCrosshairFill, name: "CrosshairFill" },
+  { component: IconCrosshairLine, name: "CrosshairLine" },
+  { component: IconCrosshairQuestionmarkFill, name: "CrosshairQuestionmarkFill" },
+  { component: IconCrosshairQuestionmarkLine, name: "CrosshairQuestionmarkLine" },
+  { component: IconCrownFill, name: "CrownFill" },
+  { component: IconCrownLine, name: "CrownLine" },
+  { component: IconCupHeatwaveFill, name: "CupHeatwaveFill" },
+  { component: IconCupHeatwaveLine, name: "CupHeatwaveLine" },
+  { component: IconDiamondFill, name: "DiamondFill" },
+  { component: IconDiamondLine, name: "DiamondLine" },
+  { component: IconDocumentArrowLeftFill, name: "DocumentArrowLeftFill" },
+  { component: IconDocumentArrowLeftLine, name: "DocumentArrowLeftLine" },
+  { component: IconDocumentCheckmarkFill, name: "DocumentCheckmarkFill" },
+  { component: IconDocumentCheckmarkLine, name: "DocumentCheckmarkLine" },
+  { component: IconDocumentFill, name: "DocumentFill" },
+  { component: IconDocumentLine, name: "DocumentLine" },
+  { component: IconDocumentMagnifyingglassFill, name: "DocumentMagnifyingglassFill" },
+  { component: IconDocumentMagnifyingglassLine, name: "DocumentMagnifyingglassLine" },
+  { component: IconDocumentPenFill, name: "DocumentPenFill" },
+  { component: IconDocumentPenLine, name: "DocumentPenLine" },
+  { component: IconDocumentPlusFill, name: "DocumentPlusFill" },
+  { component: IconDocumentPlusLine, name: "DocumentPlusLine" },
+  { component: IconDollarCircleArrowRightFill, name: "DollarCircleArrowRightFill" },
+  { component: IconDollarCircleArrowRightLine, name: "DollarCircleArrowRightLine" },
+  { component: IconDollarCircleFill, name: "DollarCircleFill" },
+  { component: IconDollarCircleLine, name: "DollarCircleLine" },
+  { component: IconDollarFill, name: "DollarFill" },
+  { component: IconDollarLine, name: "DollarLine" },
+  { component: IconDot3CircleFill, name: "Dot3CircleFill" },
+  { component: IconDot3CircleLine, name: "Dot3CircleLine" },
+  { component: IconDot3HorizontalChatbubbleLeftFill, name: "Dot3HorizontalChatbubbleLeftFill" },
+  { component: IconDot3HorizontalChatbubbleLeftLine, name: "Dot3HorizontalChatbubbleLeftLine" },
+  { component: IconDot3HorizontalChatbubbleLeftSlashFill, name: "Dot3HorizontalChatbubbleLeftSlashFill" },
+  { component: IconDot3HorizontalChatbubbleLeftSlashLine, name: "Dot3HorizontalChatbubbleLeftSlashLine" },
+  { component: IconDot3HorizontalFill, name: "Dot3HorizontalFill" },
+  { component: IconDot3HorizontalLine, name: "Dot3HorizontalLine" },
+  { component: IconDot3VerticalFill, name: "Dot3VerticalFill" },
+  { component: IconDot3VerticalLine, name: "Dot3VerticalLine" },
+  { component: IconDothorizline3VerticalFill, name: "Dothorizline3VerticalFill" },
+  { component: IconDothorizline3VerticalLine, name: "Dothorizline3VerticalLine" },
+  { component: IconDumbbellFill, name: "DumbbellFill" },
+  { component: IconDumbbellLine, name: "DumbbellLine" },
+  { component: IconEarthFill, name: "EarthFill" },
+  { component: IconEarthLine, name: "EarthLine" },
+  { component: IconEnvelopeFill, name: "EnvelopeFill" },
+  { component: IconEnvelopeLine, name: "EnvelopeLine" },
+  { component: IconEpbFill, name: "EpbFill" },
+  { component: IconEpbLine, name: "EpbLine" },
+  { component: IconEraserHorizlineFill, name: "EraserHorizlineFill" },
+  { component: IconEraserHorizlineLine, name: "EraserHorizlineLine" },
+  { component: IconExclamationmarkChatbubbleRectangularCenterFill, name: "ExclamationmarkChatbubbleRectangularCenterFill" },
+  { component: IconExclamationmarkChatbubbleRectangularCenterLine, name: "ExclamationmarkChatbubbleRectangularCenterLine" },
+  { component: IconExclamationmarkCircleFill, name: "ExclamationmarkCircleFill" },
+  { component: IconExclamationmarkCircleLine, name: "ExclamationmarkCircleLine" },
+  { component: IconEyeFill, name: "EyeFill" },
+  { component: IconEyeLine, name: "EyeLine" },
+  { component: IconEyeSlashFill, name: "EyeSlashFill" },
+  { component: IconEyeSlashLine, name: "EyeSlashLine" },
+  { component: IconFaceFrustratedCircleFill, name: "FaceFrustratedCircleFill" },
+  { component: IconFaceFrustratedCircleLine, name: "FaceFrustratedCircleLine" },
+  { component: IconFaceSadCircleFill, name: "FaceSadCircleFill" },
+  { component: IconFaceSadCircleLine, name: "FaceSadCircleLine" },
+  { component: IconFaceSmileCircleFill, name: "FaceSmileCircleFill" },
+  { component: IconFaceSmileCircleFoldedFill, name: "FaceSmileCircleFoldedFill" },
+  { component: IconFaceSmileCircleFoldedLine, name: "FaceSmileCircleFoldedLine" },
+  { component: IconFaceSmileCircleLine, name: "FaceSmileCircleLine" },
+  { component: IconFaceSurprisedCircleFill, name: "FaceSurprisedCircleFill" },
+  { component: IconFaceSurprisedCircleLine, name: "FaceSurprisedCircleLine" },
+  { component: IconFaceViewfinderFill, name: "FaceViewfinderFill" },
+  { component: IconFaceViewfinderLine, name: "FaceViewfinderLine" },
+  { component: IconFigureBikeFill, name: "FigureBikeFill" },
+  { component: IconFigureBikeLine, name: "FigureBikeLine" },
+  { component: IconFigureOvalFill, name: "FigureOvalFill" },
+  { component: IconFigureOvalLine, name: "FigureOvalLine" },
+  { component: IconFigureRunFill, name: "FigureRunFill" },
+  { component: IconFigureRunLine, name: "FigureRunLine" },
+  { component: IconFigureWalkFill, name: "FigureWalkFill" },
+  { component: IconFigureWalkLine, name: "FigureWalkLine" },
+  { component: IconFigureWheelchairFill, name: "FigureWheelchairFill" },
+  { component: IconFigureWheelchairLine, name: "FigureWheelchairLine" },
+  { component: IconFingerprintFill, name: "FingerprintFill" },
+  { component: IconFingerprintLine, name: "FingerprintLine" },
+  { component: IconFireworkFill, name: "FireworkFill" },
+  { component: IconFireworkLine, name: "FireworkLine" },
+  { component: IconFishWave2Fill, name: "FishWave2Fill" },
+  { component: IconFishWave2Line, name: "FishWave2Line" },
+  { component: IconFlagFill, name: "FlagFill" },
+  { component: IconFlagHillFill, name: "FlagHillFill" },
+  { component: IconFlagHillLine, name: "FlagHillLine" },
+  { component: IconFlagLine, name: "FlagLine" },
+  { component: IconFlameFill, name: "FlameFill" },
+  { component: IconFlameLine, name: "FlameLine" },
+  { component: IconFlaskFill, name: "FlaskFill" },
+  { component: IconFlaskLine, name: "FlaskLine" },
+  { component: IconForkSpoonBagFill, name: "ForkSpoonBagFill" },
+  { component: IconForkSpoonBagLine, name: "ForkSpoonBagLine" },
+  { component: IconForkSpoonFill, name: "ForkSpoonFill" },
+  { component: IconForkSpoonLine, name: "ForkSpoonLine" },
+  { component: IconFridgeFill, name: "FridgeFill" },
+  { component: IconFridgeLine, name: "FridgeLine" },
+  { component: IconGearFill, name: "GearFill" },
+  { component: IconGearLine, name: "GearLine" },
+  { component: IconGiftFill, name: "GiftFill" },
+  { component: IconGiftLine, name: "GiftLine" },
+  { component: IconGlobeFill, name: "GlobeFill" },
+  { component: IconGlobeLine, name: "GlobeLine" },
+  { component: IconGraduationcapFill, name: "GraduationcapFill" },
+  { component: IconGraduationcapLine, name: "GraduationcapLine" },
+  { component: IconGridDot5Fill, name: "GridDot5Fill" },
+  { component: IconGridDot5Line, name: "GridDot5Line" },
+  { component: IconGridFill, name: "GridFill" },
+  { component: IconGridHeartFill, name: "GridHeartFill" },
+  { component: IconGridHeartLine, name: "GridHeartLine" },
+  { component: IconGridLine, name: "GridLine" },
+  { component: IconHandPointUpFill, name: "HandPointUpFill" },
+  { component: IconHandPointUpLine, name: "HandPointUpLine" },
+  { component: IconHandWaveFill, name: "HandWaveFill" },
+  { component: IconHandWaveLine, name: "HandWaveLine" },
+  { component: IconHashFill, name: "HashFill" },
+  { component: IconHashLine, name: "HashLine" },
+  { component: IconHeadsetFill, name: "HeadsetFill" },
+  { component: IconHeadsetLine, name: "HeadsetLine" },
+  { component: IconHeartFill, name: "HeartFill" },
+  { component: IconHeartLine, name: "HeartLine" },
+  { component: IconHorizline2VerticalChatbubbleRectangularRightFill, name: "Horizline2VerticalChatbubbleRectangularRightFill" },
+  { component: IconHorizline2VerticalChatbubbleRectangularRightLine, name: "Horizline2VerticalChatbubbleRectangularRightLine" },
+  { component: IconHorizline2VerticalChatbubbleRectangularRightSlashFill, name: "Horizline2VerticalChatbubbleRectangularRightSlashFill" },
+  { component: IconHorizline2VerticalChatbubbleRectangularRightSlashLine, name: "Horizline2VerticalChatbubbleRectangularRightSlashLine" },
+  { component: IconHorizline3VerticalCheckmarkFill, name: "Horizline3VerticalCheckmarkFill" },
+  { component: IconHorizline3VerticalCheckmarkLine, name: "Horizline3VerticalCheckmarkLine" },
+  { component: IconHorizline3VerticalFill, name: "Horizline3VerticalFill" },
+  { component: IconHorizline3VerticalLine, name: "Horizline3VerticalLine" },
+  { component: IconHorizline3VerticalStarFill, name: "Horizline3VerticalStarFill" },
+  { component: IconHorizline3VerticalStarLine, name: "Horizline3VerticalStarLine" },
+  { component: IconHorizline3VerticalTightFill, name: "Horizline3VerticalTightFill" },
+  { component: IconHorizline3VerticalTightLine, name: "Horizline3VerticalTightLine" },
+  { component: IconHorizlineViewfinderFill, name: "HorizlineViewfinderFill" },
+  { component: IconHorizlineViewfinderLine, name: "HorizlineViewfinderLine" },
+  { component: IconHorizrectangleHorizline2VerticalFill, name: "HorizrectangleHorizline2VerticalFill" },
+  { component: IconHorizrectangleHorizline2VerticalLine, name: "HorizrectangleHorizline2VerticalLine" },
+  { component: IconHospitalcrossBuildingFill, name: "HospitalcrossBuildingFill" },
+  { component: IconHospitalcrossBuildingLine, name: "HospitalcrossBuildingLine" },
+  { component: IconHospitalcrossSquareFill, name: "HospitalcrossSquareFill" },
+  { component: IconHospitalcrossSquareLine, name: "HospitalcrossSquareLine" },
+  { component: IconHouseFill, name: "HouseFill" },
+  { component: IconHouseLine, name: "HouseLine" },
+  { component: IconHousePlusFill, name: "HousePlusFill" },
+  { component: IconHousePlusLine, name: "HousePlusLine" },
+  { component: IconHouseSquareFill, name: "HouseSquareFill" },
+  { component: IconHouseSquareLine, name: "HouseSquareLine" },
+  { component: IconILowercaseSerifCircleFill, name: "ILowercaseSerifCircleFill" },
+  { component: IconILowercaseSerifCircleLine, name: "ILowercaseSerifCircleLine" },
+  { component: IconKeyboardChevronDownFill, name: "KeyboardChevronDownFill" },
+  { component: IconKeyboardChevronDownLine, name: "KeyboardChevronDownLine" },
+  { component: IconKeyholeShieldFill, name: "KeyholeShieldFill" },
+  { component: IconKeyholeShieldLine, name: "KeyholeShieldLine" },
+  { component: IconLaptopFill, name: "LaptopFill" },
+  { component: IconLaptopLine, name: "LaptopLine" },
+  { component: IconLeafFill, name: "LeafFill" },
+  { component: IconLeafLine, name: "LeafLine" },
+  { component: IconLightbulbDot5Fill, name: "LightbulbDot5Fill" },
+  { component: IconLightbulbDot5Line, name: "LightbulbDot5Line" },
+  { component: IconLightningFill, name: "LightningFill" },
+  { component: IconLightningLine, name: "LightningLine" },
+  { component: IconLightningSlashFill, name: "LightningSlashFill" },
+  { component: IconLightningSlashLine, name: "LightningSlashLine" },
+  { component: IconLinechartUpXaxisFill, name: "LinechartUpXaxisFill" },
+  { component: IconLinechartUpXaxisLine, name: "LinechartUpXaxisLine" },
+  { component: IconLocationpinFill, name: "LocationpinFill" },
+  { component: IconLocationpinLine, name: "LocationpinLine" },
+  { component: IconLockFill, name: "LockFill" },
+  { component: IconLockLine, name: "LockLine" },
+  { component: IconLockOpenedFill, name: "LockOpenedFill" },
+  { component: IconLockOpenedLine, name: "LockOpenedLine" },
+  { component: IconMagnifyingglassFill, name: "MagnifyingglassFill" },
+  { component: IconMagnifyingglassLine, name: "MagnifyingglassLine" },
+  { component: IconMalesymbolFemalesymbolFill, name: "MalesymbolFemalesymbolFill" },
+  { component: IconMalesymbolFemalesymbolLine, name: "MalesymbolFemalesymbolLine" },
+  { component: IconMapFill, name: "MapFill" },
+  { component: IconMapLine, name: "MapLine" },
+  { component: IconMapLocationpinFill, name: "MapLocationpinFill" },
+  { component: IconMapLocationpinLine, name: "MapLocationpinLine" },
+  { component: IconMegaphoneFill, name: "MegaphoneFill" },
+  { component: IconMegaphoneLine, name: "MegaphoneLine" },
+  { component: IconMegaphoneTiltedFill, name: "MegaphoneTiltedFill" },
+  { component: IconMegaphoneTiltedLine, name: "MegaphoneTiltedLine" },
+  { component: IconMetroFrontsideFill, name: "MetroFrontsideFill" },
+  { component: IconMetroFrontsideLine, name: "MetroFrontsideLine" },
+  { component: IconMicrophoneFill, name: "MicrophoneFill" },
+  { component: IconMicrophoneLine, name: "MicrophoneLine" },
+  { component: IconMicrophoneSlashFill, name: "MicrophoneSlashFill" },
+  { component: IconMicrophoneSlashLine, name: "MicrophoneSlashLine" },
+  { component: IconMicrowaveFill, name: "MicrowaveFill" },
+  { component: IconMicrowaveLine, name: "MicrowaveLine" },
+  { component: IconMidcutSquareFill, name: "MidcutSquareFill" },
+  { component: IconMidcutSquareLine, name: "MidcutSquareLine" },
+  { component: IconMinusCircleFill, name: "MinusCircleFill" },
+  { component: IconMinusCircleLine, name: "MinusCircleLine" },
+  { component: IconMinusFatFill, name: "MinusFatFill" },
+  { component: IconMinusFatLine, name: "MinusFatLine" },
+  { component: IconMinusFill, name: "MinusFill" },
+  { component: IconMinusLine, name: "MinusLine" },
+  { component: IconMobileFill, name: "MobileFill" },
+  { component: IconMobileLine, name: "MobileLine" },
+  { component: IconMoonFill, name: "MoonFill" },
+  { component: IconMoonLine, name: "MoonLine" },
+  { component: IconMusicalnoteDoubleFill, name: "MusicalnoteDoubleFill" },
+  { component: IconMusicalnoteDoubleLine, name: "MusicalnoteDoubleLine" },
+  { component: IconNUppercaseCircleFill, name: "NUppercaseCircleFill" },
+  { component: IconNUppercaseCircleLine, name: "NUppercaseCircleLine" },
+  { component: IconNailpolishFill, name: "NailpolishFill" },
+  { component: IconNailpolishLine, name: "NailpolishLine" },
+  { component: IconNeedleScaleFill, name: "NeedleScaleFill" },
+  { component: IconNeedleScaleLine, name: "NeedleScaleLine" },
+  { component: IconPUppercaseCircleFill, name: "PUppercaseCircleFill" },
+  { component: IconPUppercaseCircleLine, name: "PUppercaseCircleLine" },
+  { component: IconPaintrollerFill, name: "PaintrollerFill" },
+  { component: IconPaintrollerLine, name: "PaintrollerLine" },
+  { component: IconPaletteFill, name: "PaletteFill" },
+  { component: IconPaletteLine, name: "PaletteLine" },
+  { component: IconPaperclipFill, name: "PaperclipFill" },
+  { component: IconPaperclipLine, name: "PaperclipLine" },
+  { component: IconPaperplaneFill, name: "PaperplaneFill" },
+  { component: IconPaperplaneLine, name: "PaperplaneLine" },
+  { component: IconPaperplaneTiltedFill, name: "PaperplaneTiltedFill" },
+  { component: IconPaperplaneTiltedLine, name: "PaperplaneTiltedLine" },
+  { component: IconPawprintFill, name: "PawprintFill" },
+  { component: IconPawprintLine, name: "PawprintLine" },
+  { component: IconPenHorizlineFill, name: "PenHorizlineFill" },
+  { component: IconPenHorizlineLine, name: "PenHorizlineLine" },
+  { component: IconPencilFill, name: "PencilFill" },
+  { component: IconPencilLine, name: "PencilLine" },
+  { component: IconPeople3Fill, name: "People3Fill" },
+  { component: IconPeople3Line, name: "People3Line" },
+  { component: IconPercentFill, name: "PercentFill" },
+  { component: IconPercentFlowerFill, name: "PercentFlowerFill" },
+  { component: IconPercentFlowerLine, name: "PercentFlowerLine" },
+  { component: IconPercentLine, name: "PercentLine" },
+  { component: IconPerson2Fill, name: "Person2Fill" },
+  { component: IconPerson2Line, name: "Person2Line" },
+  { component: IconPerson2OpenarmsFill, name: "Person2OpenarmsFill" },
+  { component: IconPerson2OpenarmsLine, name: "Person2OpenarmsLine" },
+  { component: IconPersonCircleFill, name: "PersonCircleFill" },
+  { component: IconPersonCircleLine, name: "PersonCircleLine" },
+  { component: IconPersonFill, name: "PersonFill" },
+  { component: IconPersonFlowerFill, name: "PersonFlowerFill" },
+  { component: IconPersonFlowerLine, name: "PersonFlowerLine" },
+  { component: IconPersonLine, name: "PersonLine" },
+  { component: IconPersonMagnifyingglassFill, name: "PersonMagnifyingglassFill" },
+  { component: IconPersonMagnifyingglassLine, name: "PersonMagnifyingglassLine" },
+  { component: IconPersonPlusFill, name: "PersonPlusFill" },
+  { component: IconPersonPlusLine, name: "PersonPlusLine" },
+  { component: IconPersonShieldFill, name: "PersonShieldFill" },
+  { component: IconPersonShieldLine, name: "PersonShieldLine" },
+  { component: IconPhoneFill, name: "PhoneFill" },
+  { component: IconPhoneLine, name: "PhoneLine" },
+  { component: IconPhoneXmarkFill, name: "PhoneXmarkFill" },
+  { component: IconPhoneXmarkLine, name: "PhoneXmarkLine" },
+  { component: IconPicture2StackedFill, name: "Picture2StackedFill" },
+  { component: IconPicture2StackedLine, name: "Picture2StackedLine" },
+  { component: IconPictureFill, name: "PictureFill" },
+  { component: IconPictureLine, name: "PictureLine" },
+  { component: IconPlusCircleFill, name: "PlusCircleFill" },
+  { component: IconPlusCircleLine, name: "PlusCircleLine" },
+  { component: IconPlusFill, name: "PlusFill" },
+  { component: IconPlusLine, name: "PlusLine" },
+  { component: IconPlusSmallFill, name: "PlusSmallFill" },
+  { component: IconPlusSmallLine, name: "PlusSmallLine" },
+  { component: IconPlusSquareFill, name: "PlusSquareFill" },
+  { component: IconPlusSquareLine, name: "PlusSquareLine" },
+  { component: IconPostFill, name: "PostFill" },
+  { component: IconPostLine, name: "PostLine" },
+  { component: IconPushpinFill, name: "PushpinFill" },
+  { component: IconPushpinLine, name: "PushpinLine" },
+  { component: IconQUppercaseChatbubbleRightFill, name: "QUppercaseChatbubbleRightFill" },
+  { component: IconQUppercaseChatbubbleRightLine, name: "QUppercaseChatbubbleRightLine" },
+  { component: IconQuestionmarkCircleFill, name: "QuestionmarkCircleFill" },
+  { component: IconQuestionmarkCircleLine, name: "QuestionmarkCircleLine" },
+  { component: IconQuestionmarkSquareFill, name: "QuestionmarkSquareFill" },
+  { component: IconQuestionmarkSquareLine, name: "QuestionmarkSquareLine" },
+  { component: IconQuotationmark2LeftFill, name: "Quotationmark2LeftFill" },
+  { component: IconQuotationmark2LeftLine, name: "Quotationmark2LeftLine" },
+  { component: IconQuotationmark2RightFill, name: "Quotationmark2RightFill" },
+  { component: IconQuotationmark2RightLine, name: "Quotationmark2RightLine" },
+  { component: IconReceiptFill, name: "ReceiptFill" },
+  { component: IconReceiptLine, name: "ReceiptLine" },
+  { component: IconRectangleSplitedLineVerticalFill, name: "RectangleSplitedLineVerticalFill" },
+  { component: IconRectangleSplitedLineVerticalLine, name: "RectangleSplitedLineVerticalLine" },
+  { component: IconRoadlaneFill, name: "RoadlaneFill" },
+  { component: IconRoadlaneLine, name: "RoadlaneLine" },
+  { component: IconRocketFill, name: "RocketFill" },
+  { component: IconRocketLine, name: "RocketLine" },
+  { component: IconRooftoproomFill, name: "RooftoproomFill" },
+  { component: IconRooftoproomLine, name: "RooftoproomLine" },
+  { component: IconSUppercaseHorizlineCenterFill, name: "SUppercaseHorizlineCenterFill" },
+  { component: IconSUppercaseHorizlineCenterLine, name: "SUppercaseHorizlineCenterLine" },
+  { component: IconScissorsFill, name: "ScissorsFill" },
+  { component: IconScissorsLine, name: "ScissorsLine" },
+  { component: IconScribbleFill, name: "ScribbleFill" },
+  { component: IconScribbleLine, name: "ScribbleLine" },
+  { component: IconSeatLeftFanFill, name: "SeatLeftFanFill" },
+  { component: IconSeatLeftFanLine, name: "SeatLeftFanLine" },
+  { component: IconSeatLeftFill, name: "SeatLeftFill" },
+  { component: IconSeatLeftHeatwave2Fill, name: "SeatLeftHeatwave2Fill" },
+  { component: IconSeatLeftHeatwave2Line, name: "SeatLeftHeatwave2Line" },
+  { component: IconSeatLeftLine, name: "SeatLeftLine" },
+  { component: IconShoppingbag2StackedFill, name: "Shoppingbag2StackedFill" },
+  { component: IconShoppingbag2StackedLine, name: "Shoppingbag2StackedLine" },
+  { component: IconShoppingbagFill, name: "ShoppingbagFill" },
+  { component: IconShoppingbagItemsFill, name: "ShoppingbagItemsFill" },
+  { component: IconShoppingbagItemsLine, name: "ShoppingbagItemsLine" },
+  { component: IconShoppingbagLine, name: "ShoppingbagLine" },
+  { component: IconSidemirrorWaveFill, name: "SidemirrorWaveFill" },
+  { component: IconSidemirrorWaveLine, name: "SidemirrorWaveLine" },
+  { component: IconSignboardFill, name: "SignboardFill" },
+  { component: IconSignboardLine, name: "SignboardLine" },
+  { component: IconSlashCircleFill, name: "SlashCircleFill" },
+  { component: IconSlashCircleLine, name: "SlashCircleLine" },
+  { component: IconSlashSemicircle2Fill, name: "SlashSemicircle2Fill" },
+  { component: IconSlashSemicircle2Line, name: "SlashSemicircle2Line" },
+  { component: IconSlider2HorizontalFill, name: "Slider2HorizontalFill" },
+  { component: IconSlider2HorizontalLine, name: "Slider2HorizontalLine" },
+  { component: IconSmartkeyFill, name: "SmartkeyFill" },
+  { component: IconSmartkeyLine, name: "SmartkeyLine" },
+  { component: IconSneakerLiftedLeftsideFill, name: "SneakerLiftedLeftsideFill" },
+  { component: IconSneakerLiftedLeftsideLine, name: "SneakerLiftedLeftsideLine" },
+  { component: IconSofaFill, name: "SofaFill" },
+  { component: IconSofaLine, name: "SofaLine" },
+  { component: IconSparkle2Fill, name: "Sparkle2Fill" },
+  { component: IconSparkle2Line, name: "Sparkle2Line" },
+  { component: IconSparkleViewfinderFill, name: "SparkleViewfinderFill" },
+  { component: IconSparkleViewfinderLine, name: "SparkleViewfinderLine" },
+  { component: IconSpeakerWave2Fill, name: "SpeakerWave2Fill" },
+  { component: IconSpeakerWave2Line, name: "SpeakerWave2Line" },
+  { component: IconSpeakerWave2SlashFill, name: "SpeakerWave2SlashFill" },
+  { component: IconSpeakerWave2SlashLine, name: "SpeakerWave2SlashLine" },
+  { component: IconSpeedometerFill, name: "SpeedometerFill" },
+  { component: IconSpeedometerLine, name: "SpeedometerLine" },
+  { component: IconSpeedometer_1xFill, name: "Speedometer_1xFill" },
+  { component: IconSpeedometer_1xLine, name: "Speedometer_1xLine" },
+  { component: IconSpeedometer_2xFill, name: "Speedometer_2xFill" },
+  { component: IconSpeedometer_2xLine, name: "Speedometer_2xLine" },
+  { component: IconSpeedometer_3xFill, name: "Speedometer_3xFill" },
+  { component: IconSpeedometer_3xLine, name: "Speedometer_3xLine" },
+  { component: IconSplitedGridSquareFill, name: "SplitedGridSquareFill" },
+  { component: IconSplitedGridSquareLine, name: "SplitedGridSquareLine" },
+  { component: IconSpraybottleSpongeFill, name: "SpraybottleSpongeFill" },
+  { component: IconSpraybottleSpongeLine, name: "SpraybottleSpongeLine" },
+  { component: IconSquare2StackedFill, name: "Square2StackedFill" },
+  { component: IconSquare2StackedLine, name: "Square2StackedLine" },
+  { component: IconSquareline2VerticalFill, name: "Squareline2VerticalFill" },
+  { component: IconSquareline2VerticalLine, name: "Squareline2VerticalLine" },
+  { component: IconStarFill, name: "StarFill" },
+  { component: IconStarLine, name: "StarLine" },
+  { component: IconSteeringwheelHeatwave2Fill, name: "SteeringwheelHeatwave2Fill" },
+  { component: IconSteeringwheelHeatwave2Line, name: "SteeringwheelHeatwave2Line" },
+  { component: IconStepsFill, name: "StepsFill" },
+  { component: IconStepsLine, name: "StepsLine" },
+  { component: IconStoreCheckmarkFill, name: "StoreCheckmarkFill" },
+  { component: IconStoreCheckmarkLine, name: "StoreCheckmarkLine" },
+  { component: IconStoreFill, name: "StoreFill" },
+  { component: IconStoreLine, name: "StoreLine" },
+  { component: IconStorePenFill, name: "StorePenFill" },
+  { component: IconStorePenLine, name: "StorePenLine" },
+  { component: IconSunFill, name: "SunFill" },
+  { component: IconSunLine, name: "SunLine" },
+  { component: IconTUppercaseSerifFill, name: "TUppercaseSerifFill" },
+  { component: IconTUppercaseSerifLine, name: "TUppercaseSerifLine" },
+  { component: IconTUppercaseTLowercaseFill, name: "TUppercaseTLowercaseFill" },
+  { component: IconTUppercaseTLowercaseLine, name: "TUppercaseTLowercaseLine" },
+  { component: IconTagFill, name: "TagFill" },
+  { component: IconTagLine, name: "TagLine" },
+  { component: IconTextAligncenterFill, name: "TextAligncenterFill" },
+  { component: IconTextAligncenterLine, name: "TextAligncenterLine" },
+  { component: IconTextAlignleftFill, name: "TextAlignleftFill" },
+  { component: IconTextAlignleftLine, name: "TextAlignleftLine" },
+  { component: IconTextAlignrightFill, name: "TextAlignrightFill" },
+  { component: IconTextAlignrightLine, name: "TextAlignrightLine" },
+  { component: IconThumbDownFill, name: "ThumbDownFill" },
+  { component: IconThumbDownLine, name: "ThumbDownLine" },
+  { component: IconThumbUpFill, name: "ThumbUpFill" },
+  { component: IconThumbUpLine, name: "ThumbUpLine" },
+  { component: IconTimerFill, name: "TimerFill" },
+  { component: IconTimerLine, name: "TimerLine" },
+  { component: IconTimer_10Fill, name: "Timer_10Fill" },
+  { component: IconTimer_10Line, name: "Timer_10Line" },
+  { component: IconTimer_3Fill, name: "Timer_3Fill" },
+  { component: IconTimer_3Line, name: "Timer_3Line" },
+  { component: IconToolboxFill, name: "ToolboxFill" },
+  { component: IconToolboxLine, name: "ToolboxLine" },
+  { component: IconTranslationFill, name: "TranslationFill" },
+  { component: IconTranslationLine, name: "TranslationLine" },
+  { component: IconTrashcanFill, name: "TrashcanFill" },
+  { component: IconTrashcanLine, name: "TrashcanLine" },
+  { component: IconTriangleDownSmallFill, name: "TriangleDownSmallFill" },
+  { component: IconTriangleDownSmallLine, name: "TriangleDownSmallLine" },
+  { component: IconTriangleRightChatbubbleLeftFill, name: "TriangleRightChatbubbleLeftFill" },
+  { component: IconTriangleRightChatbubbleLeftLine, name: "TriangleRightChatbubbleLeftLine" },
+  { component: IconTriangleRightFill, name: "TriangleRightFill" },
+  { component: IconTriangleRightLine, name: "TriangleRightLine" },
+  { component: IconTriangleRightRectangleSplitedLineVerticalFill, name: "TriangleRightRectangleSplitedLineVerticalFill" },
+  { component: IconTriangleRightRectangleSplitedLineVerticalLine, name: "TriangleRightRectangleSplitedLineVerticalLine" },
+  { component: IconTriangleUpSmallFill, name: "TriangleUpSmallFill" },
+  { component: IconTriangleUpSmallLine, name: "TriangleUpSmallLine" },
+  { component: IconTrophyFill, name: "TrophyFill" },
+  { component: IconTrophyLine, name: "TrophyLine" },
+  { component: IconTruckFill, name: "TruckFill" },
+  { component: IconTruckLine, name: "TruckLine" },
+  { component: IconTshirtBubble2Fill, name: "TshirtBubble2Fill" },
+  { component: IconTshirtBubble2Line, name: "TshirtBubble2Line" },
+  { component: IconUUppercaseHorizlineFill, name: "UUppercaseHorizlineFill" },
+  { component: IconUUppercaseHorizlineLine, name: "UUppercaseHorizlineLine" },
+  { component: IconVertline3ViewfinderFill, name: "Vertline3ViewfinderFill" },
+  { component: IconVertline3ViewfinderLine, name: "Vertline3ViewfinderLine" },
+  { component: IconVertline4SparkleFill, name: "Vertline4SparkleFill" },
+  { component: IconVertline4SparkleLine, name: "Vertline4SparkleLine" },
+  { component: IconVertlineCouponFill, name: "VertlineCouponFill" },
+  { component: IconVertlineCouponLine, name: "VertlineCouponLine" },
+  { component: IconVertrectangle2HorizontalFill, name: "Vertrectangle2HorizontalFill" },
+  { component: IconVertrectangle2HorizontalLine, name: "Vertrectangle2HorizontalLine" },
+  { component: IconVertrectangleFoldedFill, name: "VertrectangleFoldedFill" },
+  { component: IconVertrectangleFoldedLine, name: "VertrectangleFoldedLine" },
+  { component: IconVotingstampFill, name: "VotingstampFill" },
+  { component: IconVotingstampLine, name: "VotingstampLine" },
+  { component: IconWandFill, name: "WandFill" },
+  { component: IconWandLine, name: "WandLine" },
+  { component: IconWashingmachineFill, name: "WashingmachineFill" },
+  { component: IconWashingmachineLine, name: "WashingmachineLine" },
+  { component: IconWindow2StoreFill, name: "Window2StoreFill" },
+  { component: IconWindow2StoreLine, name: "Window2StoreLine" },
+  { component: IconWindow4HouseFill, name: "Window4HouseFill" },
+  { component: IconWindow4HouseLine, name: "Window4HouseLine" },
+  { component: IconWonArrowClockwiseCircularFill, name: "WonArrowClockwiseCircularFill" },
+  { component: IconWonArrowClockwiseCircularLine, name: "WonArrowClockwiseCircularLine" },
+  { component: IconWonCircleArrowLeftFill, name: "WonCircleArrowLeftFill" },
+  { component: IconWonCircleArrowLeftLine, name: "WonCircleArrowLeftLine" },
+  { component: IconWonCircleArrowRightFill, name: "WonCircleArrowRightFill" },
+  { component: IconWonCircleArrowRightLine, name: "WonCircleArrowRightLine" },
+  { component: IconWonCircleFill, name: "WonCircleFill" },
+  { component: IconWonCircleLine, name: "WonCircleLine" },
+  { component: IconWonFill, name: "WonFill" },
+  { component: IconWonLine, name: "WonLine" },
+  { component: IconWonShieldFill, name: "WonShieldFill" },
+  { component: IconWonShieldLine, name: "WonShieldLine" },
+  { component: IconWrenchFill, name: "WrenchFill" },
+  { component: IconWrenchLine, name: "WrenchLine" },
+  { component: IconXmarkCircleFill, name: "XmarkCircleFill" },
+  { component: IconXmarkCircleLine, name: "XmarkCircleLine" },
+  { component: IconXmarkFill, name: "XmarkFill" },
+  { component: IconXmarkLine, name: "XmarkLine" },
+  { component: IconXmarkScaleFill, name: "XmarkScaleFill" },
+  { component: IconXmarkScaleLine, name: "XmarkScaleLine" },
+  { component: IconYenCircleArrowRightFill, name: "YenCircleArrowRightFill" },
+  { component: IconYenCircleArrowRightLine, name: "YenCircleArrowRightLine" },
+  { component: IconYenCircleFill, name: "YenCircleFill" },
+  { component: IconYenCircleLine, name: "YenCircleLine" },
+  { component: IconYenFill, name: "YenFill" },
+  { component: IconYenLine, name: "YenLine" },
 ];
 
 export function FoundationMonochromeIconPage() {
   return (
-    <scroll-view
-      scroll-y
-      style={{ display: 'flex', flexDirection: 'column', flex: 1 }}
-    >
-      <text style={{ fontSize: '20px', fontWeight: 'bold' }}>
-        Monochrome Icon
-      </text>
+    <scroll-view scroll-y style={{ display: "flex", flexDirection: "column", flex: 1 }}>
+      <text style={{ fontSize: "20px", fontWeight: "bold" }}>Monochrome Icon</text>
       <text
         style={{
-          fontSize: '13px',
+          fontSize: "13px",
           color: $color.fg.neutralSubtle,
-          marginBottom: '8px',
+          marginBottom: "8px",
         }}
       >
         @karrotmarket/lynx-monochrome-icon — {icons.length} icons
@@ -1581,31 +1299,31 @@ export function FoundationMonochromeIconPage() {
 
       <view
         style={{
-          display: 'flex',
-          flexDirection: 'row',
-          flexWrap: 'wrap',
-          gap: '4px',
+          display: "flex",
+          flexDirection: "row",
+          flexWrap: "wrap",
+          gap: "4px",
         }}
       >
         {icons.map(({ component: IconComp, name }) => (
           <view
             key={name}
             style={{
-              width: '80px',
-              padding: '8px 4px',
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              gap: '4px',
+              width: "80px",
+              padding: "8px 4px",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "4px",
             }}
           >
             <IconComp size={24} color={$color.fg.neutral} />
             <text
               style={{
-                fontSize: '9px',
+                fontSize: "9px",
                 color: $color.fg.neutralMuted,
-                textAlign: 'center',
-                wordBreak: 'break-all',
+                textAlign: "center",
+                wordBreak: "break-all",
               }}
             >
               {name}

--- a/examples/lynx-spa/src/pages/FoundationMulticolorIconPage.tsx
+++ b/examples/lynx-spa/src/pages/FoundationMulticolorIconPage.tsx
@@ -1,0 +1,207 @@
+import { vars } from "@seed-design/css/vars";
+
+import IconAnimalFace from "@karrotmarket/lynx-multicolor-icon/IconAnimalFace";
+import IconApple from "@karrotmarket/lynx-multicolor-icon/IconApple";
+import IconArrowUpRightShoppingbagTilted from "@karrotmarket/lynx-multicolor-icon/IconArrowUpRightShoppingbagTilted";
+import IconAsteriskHorizrectangleCoolwave3 from "@karrotmarket/lynx-multicolor-icon/IconAsteriskHorizrectangleCoolwave3";
+import IconBoxFlap from "@karrotmarket/lynx-multicolor-icon/IconBoxFlap";
+import IconBuilding2 from "@karrotmarket/lynx-multicolor-icon/IconBuilding2";
+import IconBuilding2Twosize from "@karrotmarket/lynx-multicolor-icon/IconBuilding2Twosize";
+import IconCamera from "@karrotmarket/lynx-multicolor-icon/IconCamera";
+import IconCarFrontside from "@karrotmarket/lynx-multicolor-icon/IconCarFrontside";
+import IconCarFrontsideBubble from "@karrotmarket/lynx-multicolor-icon/IconCarFrontsideBubble";
+import IconCard from "@karrotmarket/lynx-multicolor-icon/IconCard";
+import IconCart from "@karrotmarket/lynx-multicolor-icon/IconCart";
+import IconCartItems from "@karrotmarket/lynx-multicolor-icon/IconCartItems";
+import IconCartLoad from "@karrotmarket/lynx-multicolor-icon/IconCartLoad";
+import IconCheckmarkCalendar from "@karrotmarket/lynx-multicolor-icon/IconCheckmarkCalendar";
+import IconClover4 from "@karrotmarket/lynx-multicolor-icon/IconClover4";
+import IconCupHeatwave from "@karrotmarket/lynx-multicolor-icon/IconCupHeatwave";
+import IconDiamond from "@karrotmarket/lynx-multicolor-icon/IconDiamond";
+import IconDomePillar3 from "@karrotmarket/lynx-multicolor-icon/IconDomePillar3";
+import IconDonut from "@karrotmarket/lynx-multicolor-icon/IconDonut";
+import IconDuckLeftside from "@karrotmarket/lynx-multicolor-icon/IconDuckLeftside";
+import IconDumbbell from "@karrotmarket/lynx-multicolor-icon/IconDumbbell";
+import IconEnvelope from "@karrotmarket/lynx-multicolor-icon/IconEnvelope";
+import IconFaceSmileCircle from "@karrotmarket/lynx-multicolor-icon/IconFaceSmileCircle";
+import IconFigureWalk from "@karrotmarket/lynx-multicolor-icon/IconFigureWalk";
+import IconFishWave2 from "@karrotmarket/lynx-multicolor-icon/IconFishWave2";
+import IconForkSpoon from "@karrotmarket/lynx-multicolor-icon/IconForkSpoon";
+import IconForkSpoonBag from "@karrotmarket/lynx-multicolor-icon/IconForkSpoonBag";
+import IconFraction_1NUppercase from "@karrotmarket/lynx-multicolor-icon/IconFraction_1NUppercase";
+import IconGamepad from "@karrotmarket/lynx-multicolor-icon/IconGamepad";
+import IconGift from "@karrotmarket/lynx-multicolor-icon/IconGift";
+import IconGridDot5 from "@karrotmarket/lynx-multicolor-icon/IconGridDot5";
+import IconHorizlineViewfinder from "@karrotmarket/lynx-multicolor-icon/IconHorizlineViewfinder";
+import IconHospital from "@karrotmarket/lynx-multicolor-icon/IconHospital";
+import IconIcecreamcone from "@karrotmarket/lynx-multicolor-icon/IconIcecreamcone";
+import IconLinechartUpXaxis from "@karrotmarket/lynx-multicolor-icon/IconLinechartUpXaxis";
+import IconMagnifyingglass from "@karrotmarket/lynx-multicolor-icon/IconMagnifyingglass";
+import IconMask2SmileStacked from "@karrotmarket/lynx-multicolor-icon/IconMask2SmileStacked";
+import IconMegaphoneTilted from "@karrotmarket/lynx-multicolor-icon/IconMegaphoneTilted";
+import IconMonitor from "@karrotmarket/lynx-multicolor-icon/IconMonitor";
+import IconNailpolish from "@karrotmarket/lynx-multicolor-icon/IconNailpolish";
+import IconPaintroller from "@karrotmarket/lynx-multicolor-icon/IconPaintroller";
+import IconPalette from "@karrotmarket/lynx-multicolor-icon/IconPalette";
+import IconPencil from "@karrotmarket/lynx-multicolor-icon/IconPencil";
+import IconPerson2Openarms from "@karrotmarket/lynx-multicolor-icon/IconPerson2Openarms";
+import IconPersonMagnifyingglass from "@karrotmarket/lynx-multicolor-icon/IconPersonMagnifyingglass";
+import IconPizzaSlice from "@karrotmarket/lynx-multicolor-icon/IconPizzaSlice";
+import IconPlateCovered from "@karrotmarket/lynx-multicolor-icon/IconPlateCovered";
+import IconPost from "@karrotmarket/lynx-multicolor-icon/IconPost";
+import IconRocket from "@karrotmarket/lynx-multicolor-icon/IconRocket";
+import IconRoundmeatBottombone from "@karrotmarket/lynx-multicolor-icon/IconRoundmeatBottombone";
+import IconScissors from "@karrotmarket/lynx-multicolor-icon/IconScissors";
+import IconShoppingbag2Stacked from "@karrotmarket/lynx-multicolor-icon/IconShoppingbag2Stacked";
+import IconShoppingbagItems from "@karrotmarket/lynx-multicolor-icon/IconShoppingbagItems";
+import IconSneakerLiftedLeftside from "@karrotmarket/lynx-multicolor-icon/IconSneakerLiftedLeftside";
+import IconSofa from "@karrotmarket/lynx-multicolor-icon/IconSofa";
+import IconSparkle2 from "@karrotmarket/lynx-multicolor-icon/IconSparkle2";
+import IconSpraybottleSponge from "@karrotmarket/lynx-multicolor-icon/IconSpraybottleSponge";
+import IconTree from "@karrotmarket/lynx-multicolor-icon/IconTree";
+import IconTriangleRightChatbubbleLeft from "@karrotmarket/lynx-multicolor-icon/IconTriangleRightChatbubbleLeft";
+import IconTruck from "@karrotmarket/lynx-multicolor-icon/IconTruck";
+import IconTshirtBubble2 from "@karrotmarket/lynx-multicolor-icon/IconTshirtBubble2";
+import IconVertrectangleTiltedstacked from "@karrotmarket/lynx-multicolor-icon/IconVertrectangleTiltedstacked";
+import IconVestHorizstripe from "@karrotmarket/lynx-multicolor-icon/IconVestHorizstripe";
+import IconWarninglight from "@karrotmarket/lynx-multicolor-icon/IconWarninglight";
+import IconWindow2Store from "@karrotmarket/lynx-multicolor-icon/IconWindow2Store";
+import IconWindow2StoreDoubleband from "@karrotmarket/lynx-multicolor-icon/IconWindow2StoreDoubleband";
+import IconWindow4House from "@karrotmarket/lynx-multicolor-icon/IconWindow4House";
+import IconWonCircle from "@karrotmarket/lynx-multicolor-icon/IconWonCircle";
+import IconWonShield from "@karrotmarket/lynx-multicolor-icon/IconWonShield";
+import IconWrench from "@karrotmarket/lynx-multicolor-icon/IconWrench";
+
+const { $color } = vars;
+
+interface IconEntry {
+  component: (props: { size?: number }) => JSX.Element;
+  name: string;
+}
+
+const icons: IconEntry[] = [
+  { component: IconAnimalFace, name: "AnimalFace" },
+  { component: IconApple, name: "Apple" },
+  { component: IconArrowUpRightShoppingbagTilted, name: "ArrowUpRightShoppingbagTilted" },
+  { component: IconAsteriskHorizrectangleCoolwave3, name: "AsteriskHorizrectangleCoolwave3" },
+  { component: IconBoxFlap, name: "BoxFlap" },
+  { component: IconBuilding2, name: "Building2" },
+  { component: IconBuilding2Twosize, name: "Building2Twosize" },
+  { component: IconCamera, name: "Camera" },
+  { component: IconCarFrontside, name: "CarFrontside" },
+  { component: IconCarFrontsideBubble, name: "CarFrontsideBubble" },
+  { component: IconCard, name: "Card" },
+  { component: IconCart, name: "Cart" },
+  { component: IconCartItems, name: "CartItems" },
+  { component: IconCartLoad, name: "CartLoad" },
+  { component: IconCheckmarkCalendar, name: "CheckmarkCalendar" },
+  { component: IconClover4, name: "Clover4" },
+  { component: IconCupHeatwave, name: "CupHeatwave" },
+  { component: IconDiamond, name: "Diamond" },
+  { component: IconDomePillar3, name: "DomePillar3" },
+  { component: IconDonut, name: "Donut" },
+  { component: IconDuckLeftside, name: "DuckLeftside" },
+  { component: IconDumbbell, name: "Dumbbell" },
+  { component: IconEnvelope, name: "Envelope" },
+  { component: IconFaceSmileCircle, name: "FaceSmileCircle" },
+  { component: IconFigureWalk, name: "FigureWalk" },
+  { component: IconFishWave2, name: "FishWave2" },
+  { component: IconForkSpoon, name: "ForkSpoon" },
+  { component: IconForkSpoonBag, name: "ForkSpoonBag" },
+  { component: IconFraction_1NUppercase, name: "Fraction_1NUppercase" },
+  { component: IconGamepad, name: "Gamepad" },
+  { component: IconGift, name: "Gift" },
+  { component: IconGridDot5, name: "GridDot5" },
+  { component: IconHorizlineViewfinder, name: "HorizlineViewfinder" },
+  { component: IconHospital, name: "Hospital" },
+  { component: IconIcecreamcone, name: "Icecreamcone" },
+  { component: IconLinechartUpXaxis, name: "LinechartUpXaxis" },
+  { component: IconMagnifyingglass, name: "Magnifyingglass" },
+  { component: IconMask2SmileStacked, name: "Mask2SmileStacked" },
+  { component: IconMegaphoneTilted, name: "MegaphoneTilted" },
+  { component: IconMonitor, name: "Monitor" },
+  { component: IconNailpolish, name: "Nailpolish" },
+  { component: IconPaintroller, name: "Paintroller" },
+  { component: IconPalette, name: "Palette" },
+  { component: IconPencil, name: "Pencil" },
+  { component: IconPerson2Openarms, name: "Person2Openarms" },
+  { component: IconPersonMagnifyingglass, name: "PersonMagnifyingglass" },
+  { component: IconPizzaSlice, name: "PizzaSlice" },
+  { component: IconPlateCovered, name: "PlateCovered" },
+  { component: IconPost, name: "Post" },
+  { component: IconRocket, name: "Rocket" },
+  { component: IconRoundmeatBottombone, name: "RoundmeatBottombone" },
+  { component: IconScissors, name: "Scissors" },
+  { component: IconShoppingbag2Stacked, name: "Shoppingbag2Stacked" },
+  { component: IconShoppingbagItems, name: "ShoppingbagItems" },
+  { component: IconSneakerLiftedLeftside, name: "SneakerLiftedLeftside" },
+  { component: IconSofa, name: "Sofa" },
+  { component: IconSparkle2, name: "Sparkle2" },
+  { component: IconSpraybottleSponge, name: "SpraybottleSponge" },
+  { component: IconTree, name: "Tree" },
+  { component: IconTriangleRightChatbubbleLeft, name: "TriangleRightChatbubbleLeft" },
+  { component: IconTruck, name: "Truck" },
+  { component: IconTshirtBubble2, name: "TshirtBubble2" },
+  { component: IconVertrectangleTiltedstacked, name: "VertrectangleTiltedstacked" },
+  { component: IconVestHorizstripe, name: "VestHorizstripe" },
+  { component: IconWarninglight, name: "Warninglight" },
+  { component: IconWindow2Store, name: "Window2Store" },
+  { component: IconWindow2StoreDoubleband, name: "Window2StoreDoubleband" },
+  { component: IconWindow4House, name: "Window4House" },
+  { component: IconWonCircle, name: "WonCircle" },
+  { component: IconWonShield, name: "WonShield" },
+  { component: IconWrench, name: "Wrench" },
+];
+
+export function FoundationMulticolorIconPage() {
+  return (
+    <scroll-view scroll-y style={{ display: "flex", flexDirection: "column", flex: 1 }}>
+      <text style={{ fontSize: "20px", fontWeight: "bold" }}>Multicolor Icon</text>
+      <text
+        style={{
+          fontSize: "13px",
+          color: $color.fg.neutralSubtle,
+          marginBottom: "8px",
+        }}
+      >
+        @karrotmarket/lynx-multicolor-icon — {icons.length} icons
+      </text>
+
+      <view
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          flexWrap: "wrap",
+          gap: "4px",
+        }}
+      >
+        {icons.map(({ component: IconComp, name }) => (
+          <view
+            key={name}
+            style={{
+              width: "80px",
+              padding: "8px 4px",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "4px",
+            }}
+          >
+            <IconComp size={24} />
+            <text
+              style={{
+                fontSize: "9px",
+                color: $color.fg.neutralMuted,
+                textAlign: "center",
+                wordBreak: "break-all",
+              }}
+            >
+              {name}
+            </text>
+          </view>
+        ))}
+      </view>
+    </scroll-view>
+  );
+}
+

--- a/examples/lynx-spa/src/pages/FoundationMulticolorIconPage.tsx
+++ b/examples/lynx-spa/src/pages/FoundationMulticolorIconPage.tsx
@@ -204,4 +204,3 @@ export function FoundationMulticolorIconPage() {
     </scroll-view>
   );
 }
-

--- a/examples/lynx-spa/src/pages/FoundationMulticolorIconPage.tsx
+++ b/examples/lynx-spa/src/pages/FoundationMulticolorIconPage.tsx
@@ -172,14 +172,13 @@ export function FoundationMulticolorIconPage() {
           display: "flex",
           flexDirection: "row",
           flexWrap: "wrap",
-          gap: "4px",
         }}
       >
         {icons.map(({ component: IconComp, name }) => (
           <view
             key={name}
             style={{
-              width: "80px",
+              width: "25%",
               padding: "8px 4px",
               display: "flex",
               flexDirection: "column",

--- a/examples/lynx-spa/src/pages/HomePage.tsx
+++ b/examples/lynx-spa/src/pages/HomePage.tsx
@@ -59,6 +59,8 @@ export function HomePage({ navigate }: { navigate: (page: Page) => void }) {
 
       <SectionHeader>Foundation</SectionHeader>
       <ListItem title="Color" onTap={() => navigate('foundation-color')} />
+      <ListItem title="Monochrome Icon" onTap={() => navigate('foundation-monochrome-icon')} />
+      <ListItem title="Multicolor Icon" onTap={() => navigate('foundation-multicolor-icon')} />
       <ListItem title="Typography" onTap={() => navigate('foundation-typography')} />
 
       <SectionHeader>Components</SectionHeader>


### PR DESCRIPTION
## Summary
- lynx-spa에 모노크롬 아이콘(636개), 멀티컬러 아이콘(71개) 페이지 2개 추가
- SVG → WebP 변환 icon-loader 설정 추가
- docs의 `icon.mdx`를 `foundation/iconography.mdx`로 이동하여 Foundation 섹션 구성

## Test plan
- [ ] `cd examples/lynx-spa && bun dev`로 빌드 확인
- [ ] Home → Monochrome Icon 페이지에서 아이콘 렌더링 확인
- [ ] Home → Multicolor Icon 페이지에서 아이콘 렌더링 확인
- [ ] docs 사이트에서 Lynx > Foundation > Iconography 페이지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)