### PR TITLE
feat(ci): add changelog link to release Slack notification

### DIFF
--- a/.github/scripts/notify-release.js
+++ b/.github/scripts/notify-release.js
@@ -221,7 +221,7 @@ function main() {
           ]
         : [];
 
-    const changelogUrl = `https://seed-design.io/react/updates/changelog?package=${encodeURIComponent(release.packageName)}&version=${release.version}`;
+    const changelogUrl = `https://seed-design.io/react/updates/changelog?package=${encodeURIComponent(release.packageName)}&version=${encodeURIComponent(release.version)}`;
     const text = [
       `${emoji} *<${changelogUrl}|${release.packageName}@${release.version}>*`,
       "",

--- a/.github/scripts/notify-release.js
+++ b/.github/scripts/notify-release.js
@@ -221,8 +221,9 @@ function main() {
           ]
         : [];
 
+    const changelogUrl = `https://seed-design.io/react/updates/changelog?package=${encodeURIComponent(release.packageName)}&version=${release.version}`;
     const text = [
-      `${emoji} *${release.packageName}@${release.version}*`,
+      `${emoji} *<${changelogUrl}|${release.packageName}@${release.version}>*`,
       "",
       ...allItems.slice(0, 10).map((item) => `• ${item.replace(/^- /, "")}`),
       ...dependencySection,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
* 릴리스 알림 메시지에서 패키지@버전 표기를 클릭 가능한 변경로그 링크로 표시되도록 개선했습니다.  
* 이로 인해 릴리스 메시지에서 버전명을 클릭하면 해당 변경로그 페이지로 바로 이동할 수 있어, 릴리스 정보 확인이 더 편리해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->