### PR TITLE
feat(stackflow): support callback pattern for seedPlugin options

### DIFF
--- a/.changeset/seedplugin-callback-pattern.md
+++ b/.changeset/seedplugin-callback-pattern.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/stackflow": patch
+---
+
+Stackflow 플러그인 `seedPlugin`이 콜백 형태의 옵션을 지원하도록 수정합니다. Stack에 제공하는 `initialContext`를 통해 theme을 동적으로 결정할 수 있습니다.

--- a/docs/content/react/stackflow/getting-started.mdx
+++ b/docs/content/react/stackflow/getting-started.mdx
@@ -45,7 +45,37 @@ export const { Stack, actions } = stackflow({
 
 ### Options
 
-<react-type-table path="../packages/stackflow/src/plugin.tsx" name="SeedPluginOptions" />
+<react-type-table
+  path="../packages/stackflow/src/plugin.tsx"
+  name="SeedPluginOptions"
+/>
+
+### Dynamic Options
+
+SSR 환경 등에서 theme을 동적으로 결정해야 하는 경우, Stack에 제공한 `initialContext`를 통해 `seedPlugin` 옵션을 설정할 수 있습니다.
+
+```tsx title="stackflow.ts"
+import { stackflow } from "@stackflow/react/future";
+import { seedPlugin } from "@seed-design/stackflow";
+
+export const { Stack, actions } = stackflow({
+  plugins: [
+    seedPlugin(({ initialContext }) => ({
+      theme: initialContext?.theme ?? "cupertino",
+    })),
+    // ...
+  ],
+  // ...
+});
+```
+
+`<Stack>` 렌더링 시 `initialContext`로 theme을 전달합니다.
+
+```tsx title="App.tsx"
+import type { SeedPluginOptions } from "@seed-design/stackflow";
+
+<Stack initialContext={{ theme } satisfies SeedPluginOptions} />;
+```
 
 ## What It Provides
 
@@ -59,12 +89,8 @@ export const { Stack, actions } = stackflow({
 // seedPlugin에 옵션으로 제공한 theme이 `AppScreen`에 기본적으로 적용됩니다.
 // `AppScreen`의 `theme` prop을 통해 오버라이드할 수 있습니다.
 <AppScreen>
-  <AppBar>
-    {/* ... */}
-  </AppBar>
-  <AppScreenContent>
-    {/* ... */}
-  </AppScreenContent>
+  <AppBar>{/* ... */}</AppBar>
+  <AppScreenContent>{/* ... */}</AppScreenContent>
 </AppScreen>
 ```
 

--- a/packages/stackflow/src/plugin.tsx
+++ b/packages/stackflow/src/plugin.tsx
@@ -7,12 +7,19 @@ export interface SeedPluginOptions {
 }
 
 export const seedPlugin =
-  (options: SeedPluginOptions): StackflowReactPlugin =>
+  (
+    options:
+      | SeedPluginOptions
+      // biome-ignore lint/suspicious/noExplicitAny: matches upstream @stackflow/react's `initialContext: any`
+      | ((args: { initialContext?: any }) => SeedPluginOptions),
+  ): StackflowReactPlugin =>
   () => ({
     key: "seed-design",
-    wrapStack({ stack }) {
+    wrapStack({ stack, initialContext }) {
+      const resolved = typeof options === "function" ? options({ initialContext }) : options;
+
       return (
-        <AppScreenPropsProvider value={options}>
+        <AppScreenPropsProvider value={resolved}>
           <GlobalInteraction>{stack.render()}</GlobalInteraction>
         </AppScreenPropsProvider>
       );


### PR DESCRIPTION
## Summary

- `seedPlugin`이 `initialContext`를 받는 콜백 형태도 지원하도록 변경
- SSR 환경에서 서버의 user-agent 또는 클라이언트 브릿지를 통해 동적으로 theme을 결정할 수 있음
- 기존 정적 사용법 `seedPlugin({ theme: 'cupertino' })`은 그대로 유지 (비파괴적 변경)

## Test plan

- [x] `bun packages:build` passes
- [x] `bun test:all` passes (585 tests, 0 failures)
- [ ] Verify static usage typechecks: `seedPlugin({ theme: 'cupertino' })`
- [ ] Verify callback usage typechecks: `seedPlugin(({ initialContext }) => ({ theme: initialContext?.theme ?? 'cupertino' }))`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * seedPlugin이 초기화 컨텍스트(initialContext)를 활용한 함수형 옵션 전달을 지원해, 실행 시점에 동적으로 옵션을 생성할 수 있습니다.
  * 생성된(해결된) 옵션이 화면 제공자에 전달되어 의도한 구성대로 동작합니다.

* **문서**
  * 동적 옵션 사용 예제와 초기 컨텍스트 전달 방법이 가이드에 추가되고 예제 형식이 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->