### PR TITLE
fix(mcp): always send connection confirmation in WebSocket join handler

### DIFF
--- a/.changeset/red-rooms-tease.md
+++ b/.changeset/red-rooms-tease.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/mcp": patch
+---
+
+Figma MCP 플러그인이 MCP 웹소켓 서버에 연결할 수 없던 문제를 해결합니다.

--- a/packages/mcp/src/bin/websocket-server.ts
+++ b/packages/mcp/src/bin/websocket-server.ts
@@ -64,16 +64,13 @@ function handleJoin(ws: ServerWebSocket<unknown>, data: JoinMessage): void {
     channel: channelName,
   });
 
-  // Send connection confirmation with ID if provided
-  if (id) {
-    console.log("Sending message to client:", id);
-
-    sendJson(ws, {
-      type: "system",
-      message: { id, result: `Connected to channel: ${channelName}` },
-      channel: channelName,
-    });
-  }
+  // Send connection confirmation
+  console.log("Sending message to client:", id);
+  sendJson(ws, {
+    type: "system",
+    message: { id, result: `Connected to channel: ${channelName}` },
+    channel: channelName,
+  });
 
   // Notify other clients in channel
   broadcastToChannel(


### PR DESCRIPTION
## Summary
- Figma MCP 플러그인이 WebSocket 서버에 연결할 때 "연결 중..." 상태에서 멈추는 문제를 수정
- `423d604b9`에서 `websocket-server.ts` 리팩토링 시 `if (id)` 가드가 추가되면서, `id` 없이 join하는 Figma 플러그인에 connection confirmation 응답이 전송되지 않았음
- 가드를 제거하여 원래 동작(항상 confirmation 전송)을 복원

## Test plan
- [ ] `bunx --bun @seed-design/mcp@latest socket`으로 서버 시작
- [ ] Figma에서 SEED Design MCP 플러그인 실행 후 Connect 클릭
- [ ] "연결 중..." 대신 "연결되었어요" 상태로 전환되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 웹소켓 서버의 연결 관리가 개선되어, 모든 연결 시 일관되게 확인 메시지가 전송됩니다. 연결 상태 확인이 보다 안정적이고 예측 가능하게 동작합니다.

* **잡일(변경 기록)**
  * 패치 릴리스용 변경 기록이 추가되어 관련 수정 사항이 릴리스 내역에 반영됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->