### PR TITLE
feat: add missing variant type=singleLine in text-input rootage

### DIFF
--- a/.changeset/deep-zebras-reply.md
+++ b/.changeset/deep-zebras-reply.md
@@ -1,0 +1,6 @@
+---
+"@seed-design/rootage-artifacts": patch
+"@seed-design/css": patch
+---
+
+(사용자 변경사항 없음) Rootage `text-input`에 `type=singleLine` variant 정의를 추가합니다.

--- a/docs/public/rootage/components/text-input.json
+++ b/docs/public/rootage/components/text-input.json
@@ -153,9 +153,10 @@
         },
         "type": {
           "values": {
+            "singleline": {},
             "multiline": {}
           },
-          "defaultValue": "multiline"
+          "defaultValue": "singleline"
         }
       }
     },
@@ -676,6 +677,12 @@
             }
           }
         ]
+      },
+      {
+        "variants": {
+          "type": "singleline"
+        },
+        "definitions": []
       },
       {
         "variants": {

--- a/packages/css/vars/component/text-input.d.ts
+++ b/packages/css/vars/component/text-input.d.ts
@@ -204,6 +204,7 @@ export declare const vars: {
       }
     }
   },
+  "typeSingleline": {},
   "typeMultilineSizeLarge": {
     "enabled": {
       "root": {

--- a/packages/css/vars/component/text-input.mjs
+++ b/packages/css/vars/component/text-input.mjs
@@ -191,6 +191,7 @@ export const vars = {
       }
     }
   },
+  "typeSingleline": {},
   "typeMultilineSizeLarge": {
     "enabled": {
       "root": {

--- a/packages/qvism-preset/src/vars/component/text-input.d.ts
+++ b/packages/qvism-preset/src/vars/component/text-input.d.ts
@@ -204,6 +204,7 @@ export declare const vars: {
       }
     }
   },
+  "typeSingleline": {},
   "typeMultilineSizeLarge": {
     "enabled": {
       "root": {

--- a/packages/qvism-preset/src/vars/component/text-input.mjs
+++ b/packages/qvism-preset/src/vars/component/text-input.mjs
@@ -191,6 +191,7 @@ export const vars = {
       }
     }
   },
+  "typeSingleline": {},
   "typeMultilineSizeLarge": {
     "enabled": {
       "root": {

--- a/packages/rootage/components/text-input.yaml
+++ b/packages/rootage/components/text-input.yaml
@@ -221,6 +221,7 @@ data:
           color: $color.fg.neutral-muted
         placeholder:
           color: $color.fg.neutral-muted
+    type=singleline: {}
     type=multiline,size=large:
       enabled:
         root:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* Rootage text-input 컴포넌트에 새로운 singleLine variant가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->