### PR TITLE
fix(figma): guard against missing styleOverrideTable entry in text node normalizer

### DIFF
--- a/.changeset/fix-text-style-crash.md
+++ b/.changeset/fix-text-style-crash.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/figma": patch
+---
+
+Figma 레이어 normalizer 과정에서, 일부 텍스트 레이어에서 `fontFamily` 관련 크래시가 발생할 수 있는 문제를 수정합니다.

--- a/packages/figma/src/normalizer/from-rest.ts
+++ b/packages/figma/src/normalizer/from-rest.ts
@@ -349,7 +349,7 @@ export function createRestNormalizer(
             characters: "",
             start: i,
             end: 0,
-            style: styleId ? normalizeSegmentStyle(styleTable[styleId]) : {},
+            style: styleId && styleTable[styleId] ? normalizeSegmentStyle(styleTable[styleId]) : {},
           };
         }
       }


### PR DESCRIPTION
## Summary
- `characterStyleOverrides`에 있는 `styleId`가 `styleOverrideTable`에 존재하지 않을 때 `normalizeSegmentStyle(undefined)`가 호출되어 `Cannot read properties of undefined (reading 'fontFamily')` 크래시가 발생하는 문제 수정
- `styleTable[styleId]` 존재 여부를 체크한 뒤 `normalizeSegmentStyle`에 전달하도록 변경

## Test plan
- [ ] `bun packages:build` 빌드 통과 확인
- [ ] Mixed styles 텍스트 노드가 포함된 Figma URL로 `get_node_info` 호출 시 크래시 없이 정상 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * Figma 문서의 텍스트 스타일 처리 로직을 개선해 특정 텍스트 레이어에서 발생하던 폰트/스타일 관련 오류(크래시)를 방지했습니다.
* **Chores**
  * 해당 수정사항을 반영한 패치 릴리스(Changeset)를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->