### PR TITLE
feat(mcp): add find_nodes tool for name-based layer search

### DIFF
--- a/.changeset/find-nodes-tool.md
+++ b/.changeset/find-nodes-tool.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/mcp": patch
+---
+
+SEED Figma MCP에 `find_nodes` 도구를 추가합니다. 하위 레이어를 이름(정규식)으로 검색하여 목록을 반환합니다.

--- a/docs/content/ai-integration/(mcp)/figma-mcp.mdx
+++ b/docs/content/ai-integration/(mcp)/figma-mcp.mdx
@@ -171,6 +171,7 @@ Figma URL 또는 `fileKey` + `nodeId`를 전달하면 REST API로, `nodeId`만 �
 | `get_nodes_info`                | 여러 레이어의 구조 정보를 한 번에 반환합니다. |
 | `get_node_react_code`           | 레이어의 React 코드를 생성합니다.             |
 | `get_component_info`            | 컴포넌트의 key와 속성 정의를 반환합니다.      |
+| `find_nodes`                   | 하위 레이어를 이름(정규식)으로 검색하여 ID 목록을 반환합니다. |
 | `retrieve_color_variable_names` | SEED Design 색상 변수 이름 목록을 반환합니다. |
 
 ### WebSocket 전용

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1,5 +1,11 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { createRestNormalizer, figma, getFigmaColorVariableNames, react } from "@seed-design/figma";
+import {
+  createRestNormalizer,
+  figma,
+  getFigmaColorVariableNames,
+  react,
+  type NormalizedSceneNode,
+} from "@seed-design/figma";
 import { z } from "zod";
 import type { McpConfig } from "./config";
 import { parseFigmaUrl } from "./figma-rest-client";
@@ -324,6 +330,36 @@ export function registerTools(
     },
   );
 
+  // Find Layers Tool (REST API + WebSocket)
+  server.registerTool(
+    "find_nodes",
+    {
+      description: getSingleNodeDescription(
+        "Find layers by name within a Figma node's subtree. Returns a flat array of matching nodes with their IDs.",
+        mode,
+      ),
+      inputSchema: singleNodeBaseSchema.extend({
+        name: z.string().describe("Regex pattern to match layer names (e.g., 'Usage', 'Do$')."),
+      }),
+    },
+    async (params: z.infer<typeof singleNodeBaseSchema> & { name: string }) => {
+      try {
+        const { fileKey, nodeId, personalAccessToken } = resolveSingleNodeParams(params);
+        const result = await fetchNodeData({ fileKey, nodeId, personalAccessToken }, context);
+
+        const normalizer = createRestNormalizer(result);
+        const node = normalizer(result.document);
+
+        const pattern = new RegExp(params.name);
+        const matches = collectMatchingNodes(node, pattern);
+
+        return formatObjectResponse(matches);
+      } catch (error) {
+        return formatErrorResponse("find_nodes", error);
+      }
+    },
+  );
+
   // Utility Tools (No Figma connection required)
 
   // Retrieve Color Variable Names Tool
@@ -504,6 +540,25 @@ export function registerTools(
       },
     );
   }
+}
+
+function collectMatchingNodes(
+  node: NormalizedSceneNode,
+  pattern: RegExp,
+): Array<{ id: string; name: string; type: string }> {
+  const results: Array<{ id: string; name: string; type: string }> = [];
+
+  if ("name" in node && pattern.test(node.name)) {
+    results.push({ id: node.id, name: node.name, type: node.type });
+  }
+
+  if ("children" in node && node.children) {
+    for (const child of node.children) {
+      results.push(...collectMatchingNodes(child, pattern));
+    }
+  }
+
+  return results;
 }
 
 // editing tools require WebSocket client

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -338,7 +338,7 @@ export function registerTools(
         "Find layers by name within a Figma node's subtree. Returns a flat array of matching nodes with their IDs.",
         mode,
       ),
-      inputSchema: singleNodeBaseSchema.extend({
+      inputSchema: singleNodeParamsSchema.extend({
         name: z.string().describe("Regex pattern to match layer names (e.g., 'Usage', 'Do$')."),
       }),
     },
@@ -350,7 +350,15 @@ export function registerTools(
         const normalizer = createRestNormalizer(result);
         const node = normalizer(result.document);
 
-        const pattern = new RegExp(params.name);
+        let pattern: RegExp;
+        try {
+          pattern = new RegExp(params.name);
+        } catch {
+          return formatErrorResponse(
+            "find_nodes",
+            new Error(`Invalid regex pattern: ${params.name}`),
+          );
+        }
         const matches = collectMatchingNodes(node, pattern);
 
         return formatObjectResponse(matches);


### PR DESCRIPTION
## Summary
- Figma 노드의 하위 트리에서 이름(정규식)으로 레이어를 검색하여 `{ id, name, type }` flat 배열을 반환하는 `find_nodes` MCP 도구 추가
- normalizer만 사용하고 codegen 파이프라인을 건너뛰어 가벼운 응답 제공
- 문서 도구 목록에 `find_nodes` 추가

## Test plan
- [ ] `bun packages:build` 빌드 통과 확인
- [ ] MCP 서버 재시작 후 `find_nodes(figmaUrl: "...", name: "Usage")` 호출 시 매칭 결과 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SEED Figma MCP에 `find_nodes` 도구 추가: 정규표현식을 사용하여 하위 레이어를 이름으로 검색하고 일치하는 노드 목록 반환

* **Documentation**
  * Figma MCP 도구 문서 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->