### PR TITLE
fix(docs): add changelog-page class to enable prose padding override

### DIFF
--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -95,7 +95,7 @@ article .prose {
   padding-bottom: 3rem;
 }
 
-.changelog-page article .prose {
+.changelog-page .prose {
   padding-bottom: 0;
 }
 

--- a/docs/components/changelog-viewer.tsx
+++ b/docs/components/changelog-viewer.tsx
@@ -24,7 +24,7 @@ export function ChangelogViewer({
 
   return (
     <SnackbarProvider>
-      <div className="flex flex-col gap-6 lg:grid lg:grid-cols-[220px_minmax(0,1fr)] lg:items-start">
+      <div className="changelog-page flex flex-col gap-6 lg:grid lg:grid-cols-[220px_minmax(0,1fr)] lg:items-start">
         <ChangelogPackageRail
           selectedPackage={state.selectedPackage}
           packages={state.packages}


### PR DESCRIPTION
- Changelog page 에서 변경사항에 들어가는 아이템의 패딩 바텀 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 변경 로그 뷰어의 최상위 레이아웃에 `changelog-page` 클래스가 추가되어 관련 스타일이 적용됩니다.
  * 변경 로그 페이지의 본문 요소(.prose)에 대한 CSS 선택자가 조정되어, 본문 패딩 하단(padding-bottom: 0)이 페이지 내 모든 `.prose` 후손에 일관되게 적용됩니다.
  * 레이아웃 및 여백 처리 개선으로 표시 일관성이 향상됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->