### PR TITLE
fix(docs): unify changelog URL params and centralize href generation

### DIFF
--- a/docs/app/api/search/route.ts
+++ b/docs/app/api/search/route.ts
@@ -3,6 +3,7 @@ import { AdvancedIndex, createSearchAPI } from "fumadocs-core/search/server";
 import { tokenize } from "@/components/search/tokenizer";
 import { TAGS } from "@/app/api/search/constants";
 import { getEntrySearchText } from "@/lib/changelog-entry";
+import { getChangelogHref } from "@/components/changelog-viewer/utils";
 import { parseChangelog } from "@/lib/parse-changelog";
 
 // it should be cached forever
@@ -24,7 +25,7 @@ async function getChangelogIndexes(): Promise<AdvancedIndex[]> {
     const label = packageName.replace("@seed-design/", "");
 
     return [...versions.entries()].map(([version, items]) => {
-      const versionUrl = `/react/updates/changelog?tab=${encodeURIComponent(packageName)}&from=${encodeURIComponent(version)}`;
+      const versionUrl = getChangelogHref(packageName, version);
 
       return {
         id: versionUrl,

--- a/docs/components/changelog-viewer/changelog-groups.tsx
+++ b/docs/components/changelog-viewer/changelog-groups.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChangelogEntryItem } from "@/components/changelog-entry-item";
-import { getGroupAnchorId } from "@/components/changelog-viewer/utils";
+import { getChangelogHref, getGroupAnchorId } from "@/components/changelog-viewer/utils";
 import { IconSquare2StackedLine } from "@karrotmarket/react-monochrome-icon";
 import type {
   GroupedChangelogEntry,
@@ -73,7 +73,7 @@ function RelatedPackageEntries({
             className="rounded-lg border border-fd-border/80 bg-fd-card/40 px-3 py-2"
           >
             <a
-              href={`/react/updates/changelog?tab=${encodeURIComponent(pkg.name)}&from=${encodeURIComponent(pkg.version)}`}
+              href={getChangelogHref(pkg.name, pkg.version)}
               className="inline-flex items-center rounded-md border border-fd-border px-2 py-0.5 text-[11px] font-mono text-fd-muted-foreground hover:text-fd-foreground hover:bg-fd-accent/60 transition-colors"
             >
               {pkg.name}@{pkg.version}
@@ -119,13 +119,12 @@ export function ChangelogGroups({
     <div className="flex flex-col gap-6">
       {groupedEntries.map((group) => {
         const groupAnchorId = getGroupAnchorId(group.packageName, group.version);
-        const groupQueryHref = `/react/updates/changelog?tab=${encodeURIComponent(group.packageName)}&from=${encodeURIComponent(group.version)}`;
-        const groupAnchorHref = `${groupQueryHref}#${groupAnchorId}`;
+        const groupQueryHref = getChangelogHref(group.packageName, group.version);
         const groupKey = `${group.packageName}@${group.version}`;
         const absoluteGroupHref =
           typeof window === "undefined"
-            ? groupAnchorHref
-            : `${window.location.origin}${groupAnchorHref}`;
+            ? groupQueryHref
+            : `${window.location.origin}${groupQueryHref}`;
 
         return (
           <section

--- a/docs/components/changelog-viewer/utils.ts
+++ b/docs/components/changelog-viewer/utils.ts
@@ -14,6 +14,10 @@ export function compareSemver(a: string, b: string): number {
   return a.localeCompare(b);
 }
 
+export function getChangelogHref(packageName: string, version: string): string {
+  return `/react/updates/changelog?package=${encodeURIComponent(packageName)}&version=${encodeURIComponent(version)}`;
+}
+
 export function getGroupAnchorId(packageName: string, version: string): string {
   const normalizedPackage = packageName
     .toLowerCase()


### PR DESCRIPTION
Replace scattered inline URL construction (tab/from params, hash fragments) with a single getChangelogHref utility using package/version params.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 변경 로그 링크 URL 생성 로직을 통일하여 일관성 있는 URL 처리 개선
  * 여러 위치에서 수동으로 구성된 URL 생성 방식을 중앙화된 유틸리티 함수로 대체

<!-- end of auto-generated comment: release notes by coderabbit.ai -->