### PR TITLE
feat(docs): `BlockPreview`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -85,6 +85,7 @@
         "react-dom": "^19.2.3",
         "react-error-boundary": "^6.0.0",
         "react-hook-form": "^7.53.2",
+        "react-resizable-panels": "^4.7.3",
         "recast": "^0.23.11",
         "rehype-stringify": "^10.0.1",
         "remark": "^15.0.1",
@@ -4737,6 +4738,8 @@
     "react-remove-scroll": ["react-remove-scroll@2.7.1", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
+
+    "react-resizable-panels": ["react-resizable-panels@4.7.3", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-PYcYMLtvJD+Pr0TQNeMvddcnLOwUa/Yb4iNwU7ThNLlHaQYEEC9MIBWHaBGODzYuXIkPRZ/OWe5sbzG1Rzq5ew=="],
 
     "react-rx": ["react-rx@4.2.2", "", { "dependencies": { "observable-callback": "^1.0.3", "react-compiler-runtime": "1.0.0", "use-effect-event": "^2.0.3" }, "peerDependencies": { "react": "^18.3 || >=19.0.0-0", "rxjs": "^7" } }, "sha512-L0M51QxRnb5RndopV3lGPtG+O2rGVZl6aIzH1Fyx5ieOog/E947Xu00JERxksPJ9Lxn7kdME2wFtsWpiKTgI+A=="],
 

--- a/docs/app/blocks/[name]/block-renderer.tsx
+++ b/docs/app/blocks/[name]/block-renderer.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import * as React from "react";
+import { notFound } from "next/navigation";
+
+export function BlockRenderer({ name }: { name: string }) {
+  const Block = React.useMemo(() => {
+    return React.lazy(() =>
+      import(`../../../registry/block/${name}`).catch(() => ({
+        default: () => notFound(),
+      })),
+    );
+  }, [name]);
+
+  return (
+    <React.Suspense fallback={null}>
+      <Block />
+    </React.Suspense>
+  );
+}

--- a/docs/app/blocks/[name]/page.tsx
+++ b/docs/app/blocks/[name]/page.tsx
@@ -1,15 +1,21 @@
+"use client";
+
 import * as React from "react";
 import { notFound } from "next/navigation";
+import { use } from "react";
 
-const blocks: Record<string, React.LazyExoticComponent<React.ComponentType>> = {};
+import { registryBlock } from "../../../registry/registry-block";
 
-export default async function BlockPage({ params }: { params: Promise<{ name: string }> }) {
-  const { name } = await params;
-  const Block = blocks[name];
+export default function BlockPage({ params }: { params: Promise<{ name: string }> }) {
+  const { name } = use(params);
 
-  if (!Block) {
-    notFound();
-  }
+  const Block = React.useMemo(() => {
+    return React.lazy(() =>
+      import(`../../../registry/block/${name}`).catch(() => ({
+        default: () => notFound(),
+      })),
+    );
+  }, [name]);
 
   return (
     <React.Suspense fallback={null}>
@@ -19,7 +25,7 @@ export default async function BlockPage({ params }: { params: Promise<{ name: st
 }
 
 export function generateStaticParams() {
-  const params = Object.keys(blocks).map((name) => ({ name }));
+  const params = registryBlock.items.map((item) => ({ name: item.id }));
 
   // output: export requires at least one param for dynamic routes
   if (params.length === 0) {

--- a/docs/app/blocks/[name]/page.tsx
+++ b/docs/app/blocks/[name]/page.tsx
@@ -1,11 +1,7 @@
 import * as React from "react";
 import { notFound } from "next/navigation";
 
-const blocks: Record<string, React.LazyExoticComponent<React.ComponentType>> = {
-  "footer-1": React.lazy(() =>
-    import("../../../registry/block/footer-1").then((mod) => ({ default: mod.Footer1 })),
-  ),
-};
+const blocks: Record<string, React.LazyExoticComponent<React.ComponentType>> = {};
 
 export default async function BlockPage({ params }: { params: Promise<{ name: string }> }) {
   const { name } = await params;

--- a/docs/app/blocks/[name]/page.tsx
+++ b/docs/app/blocks/[name]/page.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { notFound } from "next/navigation";
+
+const blocks: Record<string, React.LazyExoticComponent<React.ComponentType>> = {
+  "footer-1": React.lazy(() =>
+    import("../../../registry/block/footer-1").then((mod) => ({ default: mod.Footer1 })),
+  ),
+};
+
+export default async function BlockPage({ params }: { params: Promise<{ name: string }> }) {
+  const { name } = await params;
+  const Block = blocks[name];
+
+  if (!Block) {
+    notFound();
+  }
+
+  return (
+    <React.Suspense fallback={null}>
+      <Block />
+    </React.Suspense>
+  );
+}
+
+export function generateStaticParams() {
+  return Object.keys(blocks).map((name) => ({ name }));
+}

--- a/docs/app/blocks/[name]/page.tsx
+++ b/docs/app/blocks/[name]/page.tsx
@@ -1,27 +1,10 @@
-"use client";
-
-import * as React from "react";
-import { notFound } from "next/navigation";
-import { use } from "react";
-
 import { registryBlock } from "../../../registry/registry-block";
+import { BlockRenderer } from "./block-renderer";
 
-export default function BlockPage({ params }: { params: Promise<{ name: string }> }) {
-  const { name } = use(params);
+export default async function BlockPage({ params }: { params: Promise<{ name: string }> }) {
+  const { name } = await params;
 
-  const Block = React.useMemo(() => {
-    return React.lazy(() =>
-      import(`../../../registry/block/${name}`).catch(() => ({
-        default: () => notFound(),
-      })),
-    );
-  }, [name]);
-
-  return (
-    <React.Suspense fallback={null}>
-      <Block />
-    </React.Suspense>
-  );
+  return <BlockRenderer name={name} />;
 }
 
 export function generateStaticParams() {

--- a/docs/app/blocks/[name]/page.tsx
+++ b/docs/app/blocks/[name]/page.tsx
@@ -19,5 +19,12 @@ export default async function BlockPage({ params }: { params: Promise<{ name: st
 }
 
 export function generateStaticParams() {
-  return Object.keys(blocks).map((name) => ({ name }));
+  const params = Object.keys(blocks).map((name) => ({ name }));
+
+  // output: export requires at least one param for dynamic routes
+  if (params.length === 0) {
+    return [{ name: "__placeholder__" }];
+  }
+
+  return params;
 }

--- a/docs/app/blocks/layout.tsx
+++ b/docs/app/blocks/layout.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react";
+
+/**
+ * Minimal layout for block iframe previews.
+ * Root layout already provides CSS + theme sync.
+ * This layout intentionally adds nothing — no docs navigation, no sidebar.
+ */
+export default function BlockLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/docs/components/block-preview.tsx
+++ b/docs/components/block-preview.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import {
+  IconArrowUpRightArrowDownLeftLine,
+  IconCheckmarkFill,
+  IconLaptopLine,
+  IconMobileLine,
+  IconSquare2StackedLine,
+} from "@karrotmarket/react-monochrome-icon";
+import * as React from "react";
+import { Group, Panel, Separator, type GroupImperativeHandle } from "react-resizable-panels";
+
+import ErrorBoundary from "./error-boundary";
+
+interface BlockPreviewProps {
+  name: string;
+  iframeHeight?: number;
+  children?: React.ReactNode;
+}
+
+type View = "preview" | "code";
+type Viewport = "desktop" | "tablet" | "mobile";
+
+const VIEWPORT_WIDTHS: Record<Viewport, number> = {
+  desktop: 1200,
+  tablet: 768,
+  mobile: 375,
+};
+
+export function BlockPreview({ name, iframeHeight = 400, children }: BlockPreviewProps) {
+  const [view, setView] = React.useState<View>("preview");
+  const [viewport, setViewport] = React.useState<Viewport>("desktop");
+  const [isLoaded, setIsLoaded] = React.useState(false);
+  const [copied, setCopied] = React.useState(false);
+  const groupRef = React.useRef<GroupImperativeHandle>(null);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    setIsLoaded(false);
+  }, [name]);
+
+  const handleViewportChange = (v: Viewport) => {
+    setViewport(v);
+    requestAnimationFrame(() => {
+      if (!containerRef.current || !groupRef.current) return;
+      const containerWidth = containerRef.current.offsetWidth;
+      if (containerWidth === 0) return;
+      const targetWidth = VIEWPORT_WIDTHS[v];
+      const percentage = Math.min((targetWidth / containerWidth) * 100, 100);
+      groupRef.current.setLayout({ preview: percentage, spacer: 100 - percentage });
+    });
+  };
+
+  const cliCommand = `npx @seed-design/cli@latest add block:${name}`;
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(cliCommand);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const iframeSrc = `/blocks/${name}`;
+
+  return (
+    <ErrorBoundary>
+      <div className="not-prose my-6 space-y-3">
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="flex items-center gap-2 rounded-lg border border-fd-border px-3 py-1.5 font-mono text-sm text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+        >
+          <span className="text-fd-foreground">{">"}_</span>
+          {cliCommand}
+          {copied ? <IconCheckmarkFill size={14} /> : <IconSquare2StackedLine size={14} />}
+        </button>
+
+        <div className="overflow-hidden rounded-lg border border-fd-border">
+          <div className="flex items-center justify-between border-b border-fd-border px-4">
+            <div className="flex items-center">
+              <TabButton active={view === "preview"} onClick={() => setView("preview")}>
+                미리보기
+              </TabButton>
+              {children && (
+                <TabButton active={view === "code"} onClick={() => setView("code")}>
+                  코드
+                </TabButton>
+              )}
+            </div>
+            {view === "preview" && (
+              <div className="flex items-center gap-1">
+                <ViewportButton
+                  active={viewport === "desktop"}
+                  onClick={() => handleViewportChange("desktop")}
+                  label="Desktop"
+                >
+                  <IconLaptopLine size={16} />
+                </ViewportButton>
+                <ViewportButton
+                  active={viewport === "tablet"}
+                  onClick={() => handleViewportChange("tablet")}
+                  label="Tablet"
+                >
+                  <TabletIcon />
+                </ViewportButton>
+                <ViewportButton
+                  active={viewport === "mobile"}
+                  onClick={() => handleViewportChange("mobile")}
+                  label="Mobile"
+                >
+                  <IconMobileLine size={16} />
+                </ViewportButton>
+                <div className="mx-0.5 h-4 w-px bg-fd-border" />
+                <ViewportButton
+                  active={false}
+                  onClick={() => window.open(iframeSrc, "_blank")}
+                  label="새 탭에서 열기"
+                >
+                  <IconArrowUpRightArrowDownLeftLine size={16} />
+                </ViewportButton>
+              </div>
+            )}
+          </div>
+          {view === "preview" ? (
+            <div ref={containerRef}>
+              <Group groupRef={groupRef} orientation="horizontal">
+                <Panel id="preview" defaultSize={100} minSize={20}>
+                  <div className="relative" style={{ height: iframeHeight }}>
+                    <iframe
+                      src={iframeSrc}
+                      title="Block Preview"
+                      onLoad={() => setIsLoaded(true)}
+                      className="h-full w-full border-none bg-white dark:bg-neutral-950"
+                    />
+                    {!isLoaded && (
+                      <div className="absolute inset-0 flex items-center justify-center bg-white dark:bg-neutral-950">
+                        <div className="h-6 w-6 animate-spin rounded-full border-2 border-neutral-300 border-t-neutral-900 dark:border-neutral-700 dark:border-t-neutral-100" />
+                      </div>
+                    )}
+                  </div>
+                </Panel>
+                <Separator className="w-2 bg-fd-secondary transition-colors hover:bg-fd-accent" />
+                <Panel id="spacer" defaultSize={0} minSize={0} />
+              </Group>
+            </div>
+          ) : (
+            <div className="[&_figure]:my-0 [&_figure]:rounded-none [&_figure]:border-0">
+              {children}
+            </div>
+          )}
+        </div>
+      </div>
+    </ErrorBoundary>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`border-b-2 px-3 py-2 text-sm font-medium transition-colors ${
+        active
+          ? "border-fd-primary text-fd-primary"
+          : "border-transparent text-fd-muted-foreground hover:text-fd-accent-foreground"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function ViewportButton({
+  active,
+  onClick,
+  label,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-md p-1.5 transition-colors ${
+        active
+          ? "bg-fd-accent text-fd-accent-foreground"
+          : "text-fd-muted-foreground hover:text-fd-foreground"
+      }`}
+      title={label}
+    >
+      {children}
+    </button>
+  );
+}
+
+function TabletIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="4" y="2" width="16" height="20" rx="2" ry="2" />
+      <line x1="12" y1="18" x2="12.01" y2="18" />
+    </svg>
+  );
+}

--- a/docs/components/block-preview.tsx
+++ b/docs/components/block-preview.tsx
@@ -24,7 +24,7 @@ type Viewport = "desktop" | "tablet" | "mobile";
 const VIEWPORT_WIDTHS: Record<Viewport, number> = {
   desktop: 1200,
   tablet: 768,
-  mobile: 375,
+  mobile: 390,
 };
 
 export function BlockPreview({ name, iframeHeight = 400, children }: BlockPreviewProps) {

--- a/docs/components/block-preview.tsx
+++ b/docs/components/block-preview.tsx
@@ -53,10 +53,14 @@ export function BlockPreview({ name, iframeHeight = 400, children }: BlockPrevie
 
   const cliCommand = `npx @seed-design/cli@latest add block:${name}`;
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(cliCommand);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(cliCommand);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      console.error("Failed to copy to clipboard");
+    }
   };
 
   const iframeSrc = `/blocks/${name}`;

--- a/docs/components/mdx-components.tsx
+++ b/docs/components/mdx-components.tsx
@@ -1,4 +1,5 @@
 import { ColorGrid } from "@/components/color-grid";
+import { BlockPreview } from "@/components/block-preview";
 import { ComponentExample } from "@/components/component-example";
 import { ComponentGrid } from "@/components/component-grid";
 import { ComponentSpecBlock } from "@/components/component-spec-block";
@@ -61,6 +62,7 @@ export const mdxComponents: MDXComponents = {
 
   // Components
   ManualInstallation,
+  BlockPreview,
   ComponentExample,
   ComponentGrid,
   TokenReference,

--- a/docs/package.json
+++ b/docs/package.json
@@ -62,6 +62,7 @@
     "react-dom": "^19.2.3",
     "react-error-boundary": "^6.0.0",
     "react-hook-form": "^7.53.2",
+    "react-resizable-panels": "^4.7.3",
     "recast": "^0.23.11",
     "rehype-stringify": "^10.0.1",
     "remark": "^15.0.1",


### PR DESCRIPTION
## Summary
- BlockPreview 컴포넌트 추가: 리사이즈 가능한 viewport (desktop/tablet/mobile) + 미리보기/코드 탭 전환
- Block용 iframe 라우트 (`/blocks/[name]`) 추가
- CLI 복사 버튼 (`npx @seed-design/cli@latest add block:xxx`)
- `react-resizable-panels` 의존성 추가

## Test plan
- [ ] docs dev 서버에서 BlockPreview 렌더링 확인
- [ ] desktop/tablet/mobile 버튼 클릭 시 viewport 리사이즈 확인
- [ ] 미리보기/코드 탭 전환 확인
- [ ] CLI 복사 버튼 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 개별 블록별 동적 페이지로 블록을 직접 열람 가능(알 수 없는 블록은 404 처리)
  * 블록 미리보기 UI 추가 — 미리보기/코드 토글, 뷰포트 전환(데스크톱/태블릿/모바일), 로딩 표시, 가로 리사이즈 지원
  * 설치 명령 복사 및 새 탭 열기 기능, 복사 성공 피드백 및 실패 처리
  * 간단한 블록 전용 레이아웃 및 에러 경계 적용

* **문서**
  * MDX에서 미리보기 컴포넌트 사용 가능하도록 등록 완료
<!-- end of auto-generated comment: release notes by coderabbit.ai -->