### PR TITLE
feat(docs): add footer-1 block preset

### DIFF
--- a/docs/content/react/blocks/footer.mdx
+++ b/docs/content/react/blocks/footer.mdx
@@ -1,0 +1,11 @@
+---
+title: Footer
+description: 페이지 하단에 사이트 정보, 링크, 법적 고지 등을 표시하는 블록입니다.
+full: true
+---
+
+<BlockPreview name="footer-1">
+```json doc-gen:file
+{"file": "registry/block/footer-1.tsx", "codeblock": true}
+```
+</BlockPreview>

--- a/docs/content/react/blocks/meta.json
+++ b/docs/content/react/blocks/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Blocks",
+  "description": "바로 사용할 수 있는 UI 블록 프리셋",
+  "pages": ["footer"]
+}

--- a/docs/content/react/meta.json
+++ b/docs/content/react/meta.json
@@ -7,6 +7,8 @@
     "---Getting Started---",
     "...getting-started",
     "...components",
+    "---Blocks---",
+    "...blocks",
     "---Stackflow---",
     "...stackflow",
     "---Developer Tools---",

--- a/docs/public/__registry__/block/footer-1.json
+++ b/docs/public/__registry__/block/footer-1.json
@@ -1,0 +1,17 @@
+{
+  "id": "footer-1",
+  "description": "심플 텍스트형 Footer (회사정보 + 링크 + 저작권)",
+  "dependencies": [
+    "@seed-design/react"
+  ],
+  "snippets": [
+    {
+      "path": "footer-1.tsx",
+      "content": "/**\n * @file block:footer-1\n * @requires @seed-design/react@~1.0.0\n * @requires @seed-design/css@~1.0.0\n **/\n\n\"use client\";\n\nimport { Box, HStack, Text, VStack } from \"@seed-design/react\";\nimport * as React from \"react\";\n\nfunction FooterLink({ href, children }: { href: string; children: React.ReactNode }) {\n  return (\n    <a href={href} style={{ textDecoration: \"none\" }}>\n      <Text textStyle=\"t4Regular\" color=\"fg.neutralSubtle\">\n        {children}\n      </Text>\n    </a>\n  );\n}\n\nfunction FooterInfo({ children }: { children: React.ReactNode }) {\n  return (\n    <Text textStyle=\"t4Regular\" color=\"fg.neutralMuted\">\n      {children}\n    </Text>\n  );\n}\n\nexport function Footer1() {\n  return (\n    <Box\n      as=\"footer\"\n      width=\"100%\"\n      style={{ maxWidth: \"1040px\", marginInline: \"auto\" }}\n      paddingX=\"x8\"\n      paddingY=\"x10\"\n    >\n      <VStack gap=\"x4\" align=\"flex-start\">\n        <HStack gap=\"x4\" wrap>\n          <FooterLink href=\"#\">이용약관</FooterLink>\n          <FooterLink href=\"#\">개인정보처리방침</FooterLink>\n          <FooterLink href=\"#\">위치기반서비스 이용약관</FooterLink>\n          <FooterLink href=\"#\">광고주센터</FooterLink>\n          <FooterLink href=\"#\">고객센터</FooterLink>\n        </HStack>\n\n        <VStack gap=\"x1\" align=\"flex-start\">\n          <FooterInfo>주식회사 당근마켓 | 대표 김용현 | 사업자등록번호 000-00-00000</FooterInfo>\n          <FooterInfo>\n            직업정보제공사업 신고번호 J0000000000000 | 통신판매업 신고번호 제2000-서울서초-0000호\n          </FooterInfo>\n          <FooterInfo>서울특별시 서초구 강남대로 000, 0층 (서초동, 당근빌딩)</FooterInfo>\n        </VStack>\n\n        <HStack gap=\"x3\" wrap>\n          <FooterLink href=\"mailto:cs@daangn.com\">cs@daangn.com</FooterLink>\n        </HStack>\n\n        <Text textStyle=\"t4Regular\" color=\"fg.neutralMuted\">\n          © 2026 Danggeun Market Inc.\n        </Text>\n      </VStack>\n    </Box>\n  );\n}\n\n/**\n * This file is a snippet from SEED Design, helping you get started quickly with @seed-design/* packages.\n * You can extend this snippet however you want.\n */\n",
+      "dependencies": {
+        "@seed-design/react": "~1.0.0",
+        "@seed-design/css": "~1.0.0"
+      }
+    }
+  ]
+}

--- a/docs/public/__registry__/block/index.json
+++ b/docs/public/__registry__/block/index.json
@@ -1,4 +1,21 @@
 {
   "id": "block",
-  "items": []
+  "items": [
+    {
+      "snippets": [
+        {
+          "path": "footer-1.tsx",
+          "dependencies": {
+            "@seed-design/react": "~1.0.0",
+            "@seed-design/css": "~1.0.0"
+          }
+        }
+      ],
+      "id": "footer-1",
+      "description": "심플 텍스트형 Footer (회사정보 + 링크 + 저작권)",
+      "dependencies": [
+        "@seed-design/react"
+      ]
+    }
+  ]
 }

--- a/docs/registry/block/footer-1.tsx
+++ b/docs/registry/block/footer-1.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Box, HStack, Text, VStack } from "@seed-design/react";
+import * as React from "react";
+
+function FooterLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <a href={href} style={{ textDecoration: "none" }}>
+      <Text textStyle="t4Regular" color="fg.neutralSubtle">
+        {children}
+      </Text>
+    </a>
+  );
+}
+
+function FooterInfo({ children }: { children: React.ReactNode }) {
+  return (
+    <Text textStyle="t4Regular" color="fg.neutralMuted">
+      {children}
+    </Text>
+  );
+}
+
+export function Footer1() {
+  return (
+    <Box
+      as="footer"
+      width="100%"
+      style={{ maxWidth: "1040px", marginInline: "auto" }}
+      paddingX="x8"
+      paddingY="x10"
+    >
+      <VStack gap="x4" align="flex-start">
+        <HStack gap="x4" wrap>
+          <FooterLink href="#">이용약관</FooterLink>
+          <FooterLink href="#">개인정보처리방침</FooterLink>
+          <FooterLink href="#">위치기반서비스 이용약관</FooterLink>
+          <FooterLink href="#">광고주센터</FooterLink>
+          <FooterLink href="#">고객센터</FooterLink>
+        </HStack>
+
+        <VStack gap="x1" align="flex-start">
+          <FooterInfo>주식회사 당근마켓 | 대표 김용현 | 사업자등록번호 000-00-00000</FooterInfo>
+          <FooterInfo>
+            직업정보제공사업 신고번호 J0000000000000 | 통신판매업 신고번호 제2000-서울서초-0000호
+          </FooterInfo>
+          <FooterInfo>서울특별시 서초구 강남대로 000, 0층 (서초동, 당근빌딩)</FooterInfo>
+        </VStack>
+
+        <HStack gap="x3" wrap>
+          <FooterLink href="mailto:cs@daangn.com">cs@daangn.com</FooterLink>
+        </HStack>
+
+        <Text textStyle="t4Regular" color="fg.neutralMuted">
+          © 2026 Danggeun Market Inc.
+        </Text>
+      </VStack>
+    </Box>
+  );
+}

--- a/docs/registry/registry-block.ts
+++ b/docs/registry/registry-block.ts
@@ -2,5 +2,16 @@ import type { Registry } from "./schema";
 
 export const registryBlock: Registry = {
   id: "block",
-  items: [],
+  items: [
+    {
+      id: "footer-1",
+      description: "심플 텍스트형 Footer (회사정보 + 링크 + 저작권)",
+      snippets: [
+        {
+          path: "footer-1.tsx",
+          dependencies: { "@seed-design/react": "~1.0.0", "@seed-design/css": "~1.0.0" },
+        },
+      ],
+    },
+  ],
 };


### PR DESCRIPTION
## Summary
- footer-1 블록 프리셋 추가 (회사정보 + 네비게이션 링크 + 저작권)
- block 레지스트리에 footer-1 등록
- Footer 문서 페이지 추가 (react/blocks/footer)

> **Depends on**: #1376 (BlockPreview component)

## Test plan
- [ ] Footer 문서 페이지에서 footer-1 미리보기 확인
- [ ] 코드 탭에서 footer-1 소스 확인
- [ ] `npx @seed-design/cli@latest add block:footer-1` CLI 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>