### PR TITLE
docs(agents): remove forwardRef rule from root AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,6 @@ SEED Design은 당근의 디자인 시스템이다. 기술적 상세는 @TECH.md
 - ✅ **Always:**
   - `bun generate:all` 실행 후 변경사항 확인
   - 테스트 실행 후 커밋 (`bun test:all`)
-  - `forwardRef` + `displayName` 사용 (React 컴포넌트)
 
 - ⚠️ **Ask first:**
   - 새 패키지 추가


### PR DESCRIPTION
## Summary
- 루트 `AGENTS.md`의 Boundaries "Always" 섹션에서 `forwardRef + displayName` 룰 제거
- 해당 룰은 `packages/react`에만 해당하며, `packages/react/AGENTS.md`에 이미 명시되어 있음
- 폴더 스코프 룰은 해당 폴더의 AGENTS.md에서만 관리하는 원칙 적용

## Test plan
- [x] `packages/react/AGENTS.md`에 `forwardRef + displayName 필수` 룰 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 개발 가이드라인에서 React 컴포넌트 관련 지침이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->