### PR TITLE
docs(mcp): add multi-tool quick install commands

### DIFF
--- a/docs/content/ai-integration/(mcp)/docs-mcp.mdx
+++ b/docs/content/ai-integration/(mcp)/docs-mcp.mdx
@@ -19,9 +19,27 @@ Figma 연결 없이 독립적으로 실행되며, SEED Design을 사용하는 �
 
 ## 설치
 
-<Tabs items={['Claude Desktop', 'Cursor', 'Claude Code']}>
-  <Tab value="Claude Desktop">
-`~/Library/Application Support/Claude/claude_desktop_config.json` 파일에 다음을 추가합니다:
+<Tabs items={['Claude Code', 'Codex CLI', 'Gemini CLI', 'Cursor', 'Claude Desktop']}>
+
+<Tab value="Claude Code">
+
+```sh
+claude mcp add seed-docs -- npx -y @seed-design/docs-mcp
+```
+
+</Tab>
+
+<Tab value="Codex CLI">
+
+```sh
+codex mcp add seed-docs -- npx -y @seed-design/docs-mcp
+```
+
+</Tab>
+
+<Tab value="Gemini CLI">
+
+`~/.gemini/settings.json` 파일에 다음을 추가합니다:
 
 ```json
 {
@@ -33,8 +51,11 @@ Figma 연결 없이 독립적으로 실행되며, SEED Design을 사용하는 �
   }
 }
 ```
-  </Tab>
-  <Tab value="Cursor">
+
+</Tab>
+
+<Tab value="Cursor">
+
 ```json
 {
   "mcpServers": {
@@ -48,12 +69,26 @@ Figma 연결 없이 독립적으로 실행되며, SEED Design을 사용하는 �
 ```
 
 [Cursor MCP에 대해 자세히 알아보기](https://docs.cursor.com/context/model-context-protocol)
-  </Tab>
-  <Tab value="Claude Code">
-```sh
-claude mcp add seed-docs npx @seed-design/docs-mcp
+
+</Tab>
+
+<Tab value="Claude Desktop">
+
+`~/Library/Application Support/Claude/claude_desktop_config.json` 파일에 다음을 추가합니다:
+
+```json
+{
+  "mcpServers": {
+    "seed-docs": {
+      "command": "npx",
+      "args": ["-y", "@seed-design/docs-mcp"]
+    }
+  }
+}
 ```
-  </Tab>
+
+</Tab>
+
 </Tabs>
 
 ## 사용 가능한 도구

--- a/docs/content/ai-integration/(mcp)/figma-mcp.mdx
+++ b/docs/content/ai-integration/(mcp)/figma-mcp.mdx
@@ -3,6 +3,161 @@ title: Figma MCP
 description: AI Agent를 활용해 Figma 디자인을 React 코드로 변환하는 Model Context Protocol(MCP)를 제공합니다.
 ---
 
+## 빠른 설치
+
+[Figma 설정](https://www.figma.com/settings)에서 **Personal Access Token(PAT)**을 발급받을 수 있습니다.
+
+- **PAT가 있는 경우**: Figma URL을 복사해서 AI Agent에게 전달하는 **REST API** 방식으로 사용할 수 있습니다.
+- **PAT가 없는 경우**: Figma 플러그인을 통해 실시간으로 선택한 레이어를 가져오는 **WebSocket** 방식을 사용해야 합니다.
+
+각 방식의 상세한 차이점은 아래 [설치](#설치) 섹션을 참고하세요.
+
+<Tabs groupId="figma-quick-install" persist items={['REST API (PAT 필요)', 'WebSocket (PAT 불필요)']}>
+
+<Tab value="REST API (PAT 필요)">
+
+<Tabs items={['Claude Code', 'Codex CLI', 'Gemini CLI', 'Claude Desktop']}>
+
+<Tab value="Claude Code">
+
+```bash
+claude mcp add seed-design-figma \
+  --env FIGMA_PERSONAL_ACCESS_TOKEN=${FIGMA_PERSONAL_ACCESS_TOKEN} \
+  -- bunx -y @seed-design/mcp@latest
+```
+
+</Tab>
+
+<Tab value="Codex CLI">
+
+```bash
+codex mcp add seed-design-figma \
+  --env FIGMA_PERSONAL_ACCESS_TOKEN=${FIGMA_PERSONAL_ACCESS_TOKEN} \
+  -- bunx -y @seed-design/mcp@latest
+```
+
+</Tab>
+
+<Tab value="Gemini CLI">
+
+`~/.gemini/settings.json` 파일에 다음을 추가합니다:
+
+```json
+{
+  "mcpServers": {
+    "seed-design-figma": {
+      "command": "bunx",
+      "args": ["-y", "@seed-design/mcp@latest"],
+      "env": {
+        "FIGMA_PERSONAL_ACCESS_TOKEN": "<YOUR_FIGMA_PERSONAL_ACCESS_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+</Tab>
+
+<Tab value="Claude Desktop">
+
+`~/Library/Application Support/Claude/claude_desktop_config.json` 파일에 다음을 추가합니다:
+
+```json
+{
+  "mcpServers": {
+    "seed-design-figma": {
+      "command": "bunx",
+      "args": ["-y", "@seed-design/mcp@latest"],
+      "env": {
+        "FIGMA_PERSONAL_ACCESS_TOKEN": "<YOUR_FIGMA_PERSONAL_ACCESS_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+</Tab>
+
+</Tabs>
+
+</Tab>
+
+<Tab value="WebSocket (PAT 불필요)">
+
+먼저 백그라운드에서 WebSocket 서버를 실행하고, Figma에서 [MCP 플러그인](https://www.figma.com/community/plugin/1496384010980477154)을 설치합니다.
+
+<Callout>
+
+WebSocket 서버 실행을 위해 Bun 런타임이 필요합니다. `--bun` flag를 사용해주세요.
+
+</Callout>
+
+```bash
+bunx --bun @seed-design/mcp@latest socket
+```
+
+그 다음 MCP 서버를 등록합니다.
+
+<Tabs items={['Claude Code', 'Codex CLI', 'Gemini CLI', 'Claude Desktop']}>
+
+<Tab value="Claude Code">
+
+```bash
+claude mcp add seed-design-figma \
+  -- bunx -y @seed-design/mcp@latest
+```
+
+</Tab>
+
+<Tab value="Codex CLI">
+
+```bash
+codex mcp add seed-design-figma \
+  -- bunx -y @seed-design/mcp@latest
+```
+
+</Tab>
+
+<Tab value="Gemini CLI">
+
+`~/.gemini/settings.json` 파일에 다음을 추가합니다:
+
+```json
+{
+  "mcpServers": {
+    "seed-design-figma": {
+      "command": "bunx",
+      "args": ["-y", "@seed-design/mcp@latest"]
+    }
+  }
+}
+```
+
+</Tab>
+
+<Tab value="Claude Desktop">
+
+`~/Library/Application Support/Claude/claude_desktop_config.json` 파일에 다음을 추가합니다:
+
+```json
+{
+  "mcpServers": {
+    "seed-design-figma": {
+      "command": "bunx",
+      "args": ["-y", "@seed-design/mcp@latest"]
+    }
+  }
+}
+```
+
+</Tab>
+
+</Tabs>
+
+</Tab>
+
+</Tabs>
+
 ## 설치
 
 <Steps>
@@ -60,6 +215,12 @@ bunx --bun @seed-design/mcp@latest socket
 
 </Tabs>
 
+</Step>
+
+<Step>
+
+### MCP 서버 등록
+
 #### `--mode` 옵션으로 도구 범위 제한하기
 
 MCP 서버 실행 시 `--mode` 옵션을 명시하면 해당 모드에서 사용 가능한 도구만 등록하여 context 크기를 줄일 수 있습니다.
@@ -71,12 +232,6 @@ MCP 서버 실행 시 `--mode` 옵션을 명시하면 해당 모드에서 사용
 | `all` (기본값) | 모든 도구 등록        | PAT 있으면 REST 우선, WS 전용 도구는 WS 사용   |
 | `rest`         | REST API 도구만 등록  | `get_selection` 등 WS 전용 도구 미등록         |
 | `websocket`    | WebSocket 도구만 등록 | 현재 모든 도구가 WebSocket 동작 가능, PAT 무시 |
-
-</Step>
-
-<Step>
-
-### MCP 서버 등록
 
 <Tabs groupId="figma-access-method" persist items={['REST API', 'WebSocket']}>
 

--- a/docs/content/ai-integration/(mcp)/figma-mcp.mdx
+++ b/docs/content/ai-integration/(mcp)/figma-mcp.mdx
@@ -5,7 +5,7 @@ description: AI Agent를 활용해 Figma 디자인을 React 코드로 변환하�
 
 ## 빠른 설치
 
-[Figma 설정](https://www.figma.com/settings)에서 **Personal Access Token(PAT)**을 발급받을 수 있습니다.
+[Figma 설정](https://www.figma.com/settings)에서 **Personal Access Token** (PAT)을 발급받을 수 있습니다.
 
 - **PAT가 있는 경우**: Figma URL을 복사해서 AI Agent에게 전달하는 **REST API** 방식으로 사용할 수 있습니다.
 - **PAT가 없는 경우**: Figma 플러그인을 통해 실시간으로 선택한 레이어를 가져오는 **WebSocket** 방식을 사용해야 합니다.


### PR DESCRIPTION
## Summary

- Figma MCP 문서에 "빠른 설치" 섹션 추가 — PAT 유무에 따른 REST API/WebSocket 안내와 함께 Claude Code, Codex CLI, Gemini CLI, Claude Desktop 4개 도구별 복사-붙여넣기 명령어 제공
- Docs MCP 문서의 설치 탭을 3개에서 5개로 확장 (Codex CLI, Gemini CLI 추가)
- Figma MCP의 `--mode` 옵션 설명을 "접근 방식 선택" 단계에서 "MCP 서버 등록" 단계로 이동
- WebSocket 빠른 설치에 Bun 런타임 요구사항 Callout 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **문서화**
  * MCP 설정 지침이 Claude Code, Codex CLI, Gemini CLI, Cursor, Claude Desktop에 맞춰 재구성 및 업데이트되었습니다.
  * 설치 명령 및 클라이언트별 설정 예시(JSON)가 더 명확하게 갱신되었습니다.
  * 빠른 설치 섹션이 추가되어 REST API(토큰 필요)와 WebSocket(토큰 불필요) 흐름을 선택할 수 있습니다.
  * 설치 단계 구성이 재정렬되어 설정 흐름이 더 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->