### PR TITLE
fix(ci): replace workflow_dispatch with issue_comment trigger for renovate review

### DIFF
--- a/.github/workflows/renovate-dependency-review.yml
+++ b/.github/workflows/renovate-dependency-review.yml
@@ -41,7 +41,13 @@ jobs:
 
             const headRef = pr.data.head.ref;
             const baseRef = pr.data.base.ref;
+            const headRepo = pr.data.head.repo?.full_name;
+            const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
 
+            if (headRepo !== baseRepo) {
+              core.setFailed(`This command only works on same-repository PRs. Got: ${headRepo}`);
+              return;
+            }
             if (!headRef.startsWith('renovate/')) {
               core.setFailed(`This command only works on Renovate PRs (renovate/* branch). Got: ${headRef}`);
               return;

--- a/.github/workflows/renovate-dependency-review.yml
+++ b/.github/workflows/renovate-dependency-review.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ steps.pr-info.outputs.ref || github.head_ref }}
+          ref: ${{ steps.pr-info.outputs.sha || github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Run Claude Dependency Analysis

--- a/.github/workflows/renovate-dependency-review.yml
+++ b/.github/workflows/renovate-dependency-review.yml
@@ -4,42 +4,61 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches: [dev]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: "PR number to analyze"
-        required: true
-        type: number
+  issue_comment:
+    types: [created]
 
 jobs:
   analyze-dependencies:
     concurrency:
-      group: renovate-dependency-review-${{ github.event.pull_request.number || inputs.pr_number }}
+      group: renovate-dependency-review-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: true
     if: >-
-      github.event_name == 'workflow_dispatch'
-      || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
+      (github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
+      || (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && startsWith(github.event.comment.body, '/renovate-review')
+        && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
     steps:
-      - name: Resolve PR metadata
-        if: github.event_name == 'workflow_dispatch'
+      - name: Get PR details
+        if: github.event_name == 'issue_comment'
         id: pr-info
-        run: |
-          PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${{ inputs.pr_number }} \
-            --jq '{head_ref: .head.ref, base_sha: .base.sha}')
-          echo "head_ref=$(echo "$PR_DATA" | jq -r '.head_ref')" >> "$GITHUB_OUTPUT"
-          echo "base_sha=$(echo "$PR_DATA" | jq -r '.base_sha')" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ github.token }}
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('number', pr.data.number);
+            core.setOutput('ref', pr.data.head.ref);
+            core.setOutput('sha', pr.data.head.sha);
+            core.setOutput('base_sha', pr.data.base.sha);
+
+      - name: Add reaction
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes'
+            });
 
       - name: Checkout PR branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ steps.pr-info.outputs.head_ref || github.head_ref }}
+          ref: ${{ steps.pr-info.outputs.ref || github.head_ref }}
           fetch-depth: 0
 
       - name: Run Claude Dependency Analysis
@@ -50,7 +69,7 @@ jobs:
           use_sticky_comment: true
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+            PR NUMBER: ${{ steps.pr-info.outputs.number || github.event.pull_request.number }}
 
             한국어로 분석 결과를 작성하세요.
 
@@ -154,3 +173,27 @@ jobs:
               Read,
               mcp__github_comment__update_claude_comment
             "
+
+      - name: Add success reaction
+        if: success() && github.event_name == 'issue_comment'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'hooray'
+            });
+
+      - name: Add failure reaction
+        if: failure() && github.event_name == 'issue_comment'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '-1'
+            });

--- a/.github/workflows/renovate-dependency-review.yml
+++ b/.github/workflows/renovate-dependency-review.yml
@@ -13,7 +13,11 @@ jobs:
       group: renovate-dependency-review-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: true
     if: >-
-      (github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))
+      (
+        github.event_name == 'pull_request'
+        && startsWith(github.head_ref, 'renovate/')
+        && github.event.pull_request.head.repo.full_name == github.repository
+      )
       || (
         github.event_name == 'issue_comment'
         && github.event.issue.pull_request

--- a/.github/workflows/renovate-dependency-review.yml
+++ b/.github/workflows/renovate-dependency-review.yml
@@ -38,6 +38,19 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number
             });
+
+            const headRef = pr.data.head.ref;
+            const baseRef = pr.data.base.ref;
+
+            if (!headRef.startsWith('renovate/')) {
+              core.setFailed(`This command only works on Renovate PRs (renovate/* branch). Got: ${headRef}`);
+              return;
+            }
+            if (baseRef !== 'dev') {
+              core.setFailed(`This command only works on PRs targeting dev. Got: ${baseRef}`);
+              return;
+            }
+
             core.setOutput('number', pr.data.number);
             core.setOutput('ref', pr.data.head.ref);
             core.setOutput('sha', pr.data.head.sha);
@@ -48,7 +61,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            github.rest.reactions.createForIssueComment({
+            await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               comment_id: context.payload.comment.id,
@@ -179,7 +192,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            github.rest.reactions.createForIssueComment({
+            await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               comment_id: context.payload.comment.id,
@@ -191,7 +204,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            github.rest.reactions.createForIssueComment({
+            await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               comment_id: context.payload.comment.id,


### PR DESCRIPTION
## Summary

- `workflow_dispatch` 트리거를 제거하고 `issue_comment` 트리거(`/renovate-review`)로 교체
- `claude-code-action`의 `track_progress`가 `workflow_dispatch` 이벤트를 지원하지 않아 발생하던 실패 해결
- `claude-code-review.yml`과 동일한 패턴 적용 (PR details 조회, reaction 추가, 권한 체크)

## Test plan

- [ ] Renovate PR이 열릴 때 자동으로 워크플로우가 트리거되는지 확인
- [ ] PR 코멘트에 `/renovate-review` 입력 시 워크플로우가 트리거되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 워크플로우 트리거를 이슈 댓글 명령으로 전환해 댓글로 자동 검토를 시작할 수 있습니다.
  * 댓글 기반 실행에서 동시성 키 및 PR 참조 방식을 개선해 충돌 가능성을 줄였습니다.
  * 댓글로부터 PR 정보를 직접 조회해 해당 커밋(sha) 기준으로 체크아웃하도록 변경했습니다.
  * 동일 저장소·renovate 브랜치·base 브랜치 조건과 댓글 작성자 권한을 검증하도록 검증 로직을 추가했습니다.
  * 실행 상태를 표시하는 GitHub 리액션(시작·성공·실패)이 추가되었습니다.
  * 작업 권한이 확장(id-token 포함)되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->