### PR TITLE
docs: update identity-placeholder assetstorage URLs

### DIFF
--- a/docs/content/docs/components/(display)/identity-placeholder.mdx
+++ b/docs/content/docs/components/(display)/identity-placeholder.mdx
@@ -22,8 +22,8 @@ Person과 Business 두 가지 타입을 제공합니다. 두 타입 모두 [Avat
 
 라이트/다크 모드 이미지 분기가 어려운 레거시 환경에서 Identity Placeholder 컴포넌트 구현체를 fallback으로 활용하기 어려운 상황에서 임시로 활용할 수 있는 에셋을 제공합니다. 에셋스토리지 URL을 통해 접근 가능합니다. (640x640, webp, 각각 약 2.5kb)
 
-- [Identity=Person](https://assetstorage.krrt.io/1404718620223529089/8d36a6da-7a9b-435e-bdc7-6d67e5f48fb0/width_640_height_640.webp)
-- [Identity=Business](https://assetstorage.krrt.io/1404718620223529089/45fb62b8-e3cf-45fb-a011-b7fc4bf46a95/width_640_height_640.webp)
+- [Identity=Person](https://assetstorage.krrt.io/1404718620223529089/5e6a8a2e-9f1d-49fe-a088-215becea1dc0/width_640_height_640.png)
+- [Identity=Business](https://assetstorage.krrt.io/1404718620223529089/eb2a174d-989f-4781-96ff-5b92690e7a2d/width_640_height_640.png)
 
 <FigmaImage
   id="424:2324"

--- a/docs/content/docs/components/(display)/identity-placeholder.mdx
+++ b/docs/content/docs/components/(display)/identity-placeholder.mdx
@@ -22,8 +22,8 @@ Person과 Business 두 가지 타입을 제공합니다. 두 타입 모두 [Avat
 
 라이트/다크 모드 이미지 분기가 어려운 레거시 환경에서 Identity Placeholder 컴포넌트 구현체를 fallback으로 활용하기 어려운 상황에서 임시로 활용할 수 있는 에셋을 제공합니다. 에셋스토리지 URL을 통해 접근 가능합니다. (640x640, webp, 각각 약 2.5kb)
 
-- [Identity=Person](https://assetstorage.krrt.io/1404718620223529089/6df022fd-00dd-4f51-b6ad-cfb285da6bc7/width_640_height_640.webp)
-- [Identity=Business](https://assetstorage.krrt.io/1404718620223529089/ddec04bf-7e8e-45f8-a7c4-76585a6894c8/width_640_height_640.webp)
+- [Identity=Person](https://assetstorage.krrt.io/1404718620223529089/8d36a6da-7a9b-435e-bdc7-6d67e5f48fb0/width_640_height_640.webp)
+- [Identity=Business](https://assetstorage.krrt.io/1404718620223529089/45fb62b8-e3cf-45fb-a011-b7fc4bf46a95/width_640_height_640.webp)
 
 <FigmaImage
   id="424:2324"


### PR DESCRIPTION
docs: identity-placeholder 컴포넌트 문서의 assetstorage URL 업데이트

- Identity=Person URL 변경
- Identity=Business URL 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **문서**
  * Identity Placeholder 컴포넌트 문서를 업데이트했습니다. 'Person' 및 'Business' 예제에 사용되는 외부 이미지 링크를 .webp에서 .png로 교체했고, 링크 레이블과 표시 크기는 유지됩니다. 컴포넌트 동작이나 API에는 변경이 없으며, 시각적 표시가 최신 이미지로 갱신됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->