### PR TITLE
docs(identity-placeholder): document usage and a11y notes

### DIFF
--- a/docs/content/react/components/identity-placeholder.mdx
+++ b/docs/content/react/components/identity-placeholder.mdx
@@ -48,7 +48,7 @@ import { IdentityPlaceholder } from "seed-design/ui/identity-placeholder";
 내부 SVG(`IdentityPlaceholder.Image`)에는 기본으로 `role="img"`와 `aria-label="Identity placeholder"`(영문)가 설정되어 있습니다. 스크린 리더는 플레이스홀더 그래픽을 이미지로 인식합니다.
 
 - **`Avatar` 안에서 사용할 때**: 접근성은 주로 `Avatar`와 상위 맥락(목록 항목 이름, 버튼 레이블 등)에 맡기는 패턴이 일반적입니다. 자세한 내용은 [Avatar](/react/components/avatar) 문서를 참고하세요.
-- **단독으로 쓰는 경우**: 주변에 동일한 정보를 텍스트로 이미 제공하고 있다면, 중복 안내를 피하기 위해 상위 요소에 `aria-hidden`을 검토할 수 있습니다. 앱의 정보 구조에 맞게 선택하세요.
+- **단독으로 쓰는 경우**: 주변에 동일한 정보를 텍스트로 이미 제공하고 있다면, 중복 안내를 피하기 위해 **장식용 플레이스홀더 요소 자체**에 `aria-hidden="true"` 적용을 검토할 수 있습니다. 포커스 가능한 요소나 인터랙티브 컨테이너에는 적용하지 마세요. 앱의 정보 구조에 맞게 선택하세요.
 
 ## Props
 

--- a/docs/content/react/components/identity-placeholder.mdx
+++ b/docs/content/react/components/identity-placeholder.mdx
@@ -20,6 +20,36 @@ npx @seed-design/cli@latest add ui:identity-placeholder
 
 <ManualInstallation name="identity-placeholder" />
 
+## Usage
+
+스니펫을 설치했다면 `seed-design/ui`에서 import합니다.
+
+```tsx
+import { IdentityPlaceholder } from "seed-design/ui/identity-placeholder";
+
+export function Example() {
+  return <IdentityPlaceholder identity="person" />;
+}
+```
+
+[`Avatar`](/react/components/avatar)의 `fallback`으로 자주 씁니다. 이미지가 없을 때 프로필 자리를 시각적으로 채우는 용도입니다.
+
+```tsx
+import { Avatar } from "seed-design/ui/avatar";
+import { IdentityPlaceholder } from "seed-design/ui/identity-placeholder";
+
+<Avatar size="48" fallback={<IdentityPlaceholder />} />
+```
+
+`@seed-design/react`의 컴파운드 API(`IdentityPlaceholder.Root`, `IdentityPlaceholder.Image`)로 동일한 UI를 조합할 수 있습니다. 스니펫은 이 조합을 한 컴포넌트로 감싼 형태입니다.
+
+## Accessibility
+
+내부 SVG(`IdentityPlaceholder.Image`)에는 기본으로 `role="img"`와 `aria-label="Identity placeholder"`(영문)가 설정되어 있습니다. 스크린 리더는 플레이스홀더 그래픽을 이미지로 인식합니다.
+
+- **`Avatar` 안에서 사용할 때**: 접근성은 주로 `Avatar`와 상위 맥락(목록 항목 이름, 버튼 레이블 등)에 맡기는 패턴이 일반적입니다. 자세한 내용은 [Avatar](/react/components/avatar) 문서를 참고하세요.
+- **단독으로 쓰는 경우**: 주변에 동일한 정보를 텍스트로 이미 제공하고 있다면, 중복 안내를 피하기 위해 상위 요소에 `aria-hidden`을 검토할 수 있습니다. 앱의 정보 구조에 맞게 선택하세요.
+
 ## Props
 
 <react-type-table


### PR DESCRIPTION
## Summary
- Document snippet import path and a typical `Avatar` `fallback` pattern.
- Describe default screen reader behavior (`role="img"`, fixed English `aria-label`) and when to consider `aria-hidden` for standalone use.

## Test plan
- [x] `bun docs:test` (or `bun test:all`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * IdentityPlaceholder 컴포넌트 사용법 문서 추가: 컴포넌트 임포트 및 렌더링 예시, Avatar의 폴백으로 활용하는 방법 및 React 복합 구성 요소와의 조합 예시 포함
  * 접근성 가이드 추가: 기본 SVG 접근성 속성(예: role, aria-label) 설명과 장식용으로 사용할 경우 aria-hidden 추가 권장 사항 포함
<!-- end of auto-generated comment: release notes by coderabbit.ai -->