### PR TITLE
feat(snackbar): add immediate/queued strategy for multi-snackbar behavior

### DIFF
--- a/docs/content/react/components/snackbar.mdx
+++ b/docs/content/react/components/snackbar.mdx
@@ -83,6 +83,22 @@ npx @seed-design/cli@latest add ui:snackbar
   ```
 </ComponentExample>
 
+### Strategy
+
+Snackbar가 이미 표시 중일 때 새로운 Snackbar를 생성하면, 기본적으로 기존 Snackbar를 즉시 교체합니다 (`immediate`).
+큐에 넣고 순차적으로 보여주려면 `strategy: "queued"`를 사용합니다.
+
+`strategy`는 `SnackbarProvider`에서 기본값을 설정하거나, `create()` 호출 시 개별적으로 지정할 수 있습니다.
+
+<ComponentExample name="react/snackbar/strategy">
+  ```json doc-gen:file
+  {
+    "file": "examples/react/snackbar/strategy.tsx",
+    "codeblock": true
+  }
+  ```
+</ComponentExample>
+
 ### Avoid Overlap
 
 `<SnackbarAvoidOverlap />` 컴포넌트를 사용하여 스낵바가 겹치지 않아야 하는 영역을 지정할 수 있습니다.

--- a/docs/examples/react/snackbar/strategy.tsx
+++ b/docs/examples/react/snackbar/strategy.tsx
@@ -1,59 +1,32 @@
-import { VStack } from "@seed-design/react";
-import { useRef, useState } from "react";
 import { ActionButton } from "seed-design/ui/action-button";
-import { SegmentedControl, SegmentedControlItem } from "seed-design/ui/segmented-control";
-import {
-  Snackbar,
-  SnackbarProvider,
-  useSnackbarAdapter,
-  type SnackbarProviderProps,
-} from "seed-design/ui/snackbar";
+import { Snackbar, useSnackbarAdapter } from "seed-design/ui/snackbar";
 
-function Component() {
+export default function SnackbarStrategy() {
   const adapter = useSnackbarAdapter();
-  const countRef = useRef(0);
 
   return (
     <div style={{ display: "flex", gap: 8 }}>
       <ActionButton
+        variant="neutralSolid"
         onClick={() =>
           adapter.create({
-            render: () => <Snackbar message={`Snackbar #${++countRef.current}`} />,
+            render: () => <Snackbar variant="positive" message="저장되었습니다" />,
           })
         }
       >
-        Create
+        Immediate (positive)
       </ActionButton>
       <ActionButton
         variant="neutralSolid"
         onClick={() =>
           adapter.create({
-            render: () => <Snackbar message={`Snackbar #${++countRef.current}`} />,
+            strategy: "queued",
+            render: () => <Snackbar variant="critical" message="오류가 발생했습니다" />,
           })
         }
       >
-        Create Another
+        Queued (critical)
       </ActionButton>
     </div>
-  );
-}
-
-export default function SnackbarStrategy() {
-  const [strategy, setStrategy] = useState<SnackbarProviderProps["strategy"]>("immediate");
-
-  return (
-    <VStack gap="spacingY.componentDefault" alignItems="center">
-      <SnackbarProvider strategy={strategy}>
-        <Component />
-      </SnackbarProvider>
-      <SegmentedControl
-        aria-label="Strategy"
-        value={strategy}
-        onValueChange={(value) => setStrategy(value as typeof strategy)}
-      >
-        <SegmentedControlItem value="immediate">Immediate</SegmentedControlItem>
-        <SegmentedControlItem value="queued">Queued</SegmentedControlItem>
-      </SegmentedControl>
-    </VStack>
   );
 }

--- a/docs/examples/react/snackbar/strategy.tsx
+++ b/docs/examples/react/snackbar/strategy.tsx
@@ -1,0 +1,59 @@
+import { VStack } from "@seed-design/react";
+import { useRef, useState } from "react";
+import { ActionButton } from "seed-design/ui/action-button";
+import { SegmentedControl, SegmentedControlItem } from "seed-design/ui/segmented-control";
+import {
+  Snackbar,
+  SnackbarProvider,
+  useSnackbarAdapter,
+  type SnackbarProviderProps,
+} from "seed-design/ui/snackbar";
+
+function Component() {
+  const adapter = useSnackbarAdapter();
+  const countRef = useRef(0);
+
+  return (
+    <div style={{ display: "flex", gap: 8 }}>
+      <ActionButton
+        onClick={() =>
+          adapter.create({
+            render: () => <Snackbar message={`Snackbar #${++countRef.current}`} />,
+          })
+        }
+      >
+        Create
+      </ActionButton>
+      <ActionButton
+        variant="neutralSolid"
+        onClick={() =>
+          adapter.create({
+            render: () => <Snackbar message={`Snackbar #${++countRef.current}`} />,
+          })
+        }
+      >
+        Create Another
+      </ActionButton>
+    </div>
+  );
+}
+
+export default function SnackbarStrategy() {
+  const [strategy, setStrategy] = useState<SnackbarProviderProps["strategy"]>("immediate");
+
+  return (
+    <VStack gap="spacingY.componentDefault" alignItems="center">
+      <SnackbarProvider strategy={strategy}>
+        <Component />
+      </SnackbarProvider>
+      <SegmentedControl
+        aria-label="Strategy"
+        value={strategy}
+        onValueChange={(value) => setStrategy(value as typeof strategy)}
+      >
+        <SegmentedControlItem value="immediate">Immediate</SegmentedControlItem>
+        <SegmentedControlItem value="queued">Queued</SegmentedControlItem>
+      </SegmentedControl>
+    </VStack>
+  );
+}

--- a/docs/examples/react/snackbar/strategy.tsx
+++ b/docs/examples/react/snackbar/strategy.tsx
@@ -1,7 +1,7 @@
 import { ActionButton } from "seed-design/ui/action-button";
-import { Snackbar, useSnackbarAdapter } from "seed-design/ui/snackbar";
+import { Snackbar, SnackbarProvider, useSnackbarAdapter } from "seed-design/ui/snackbar";
 
-export default function SnackbarStrategy() {
+function Component() {
   const adapter = useSnackbarAdapter();
 
   return (
@@ -28,5 +28,13 @@ export default function SnackbarStrategy() {
         Queued (critical)
       </ActionButton>
     </div>
+  );
+}
+
+export default function SnackbarStrategy() {
+  return (
+    <SnackbarProvider>
+      <Component />
+    </SnackbarProvider>
   );
 }

--- a/examples/stackflow-spa/src/activities/ActivityHome.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityHome.tsx
@@ -220,6 +220,14 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
               ),
             }),
         },
+        {
+          title: "Snackbar (queued)",
+          onClick: () =>
+            snackbarAdapter.create({
+              strategy: "queued",
+              render: () => <Snackbar message="Queued Snackbar" />,
+            }),
+        },
       ],
     },
     {

--- a/examples/stackflow-spa/src/activities/ActivityHome.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityHome.tsx
@@ -228,6 +228,17 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
               render: () => <Snackbar message="Queued Snackbar" />,
             }),
         },
+        {
+          title: "Snackbar (dismiss+setTimeout workaround)",
+          onClick: () => {
+            snackbarAdapter.dismiss();
+            setTimeout(() => {
+              snackbarAdapter.create({
+                render: () => <Snackbar message="Workaround Snackbar" />,
+              });
+            });
+          },
+        },
       ],
     },
     {

--- a/examples/stackflow-spa/src/activities/ActivityHome.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityHome.tsx
@@ -229,6 +229,9 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
             }),
         },
         {
+          // 기존 스낵바를 먼저 닫고 다음 tick에 새 스낵바를 띄우는 패턴.
+          // dismiss 상태 전이가 적용된 뒤에 create가 실행되므로
+          // 항상 새 스낵바부터 활성화되는 것을 보장한다.
           title: "Snackbar (dismiss+setTimeout workaround)",
           onClick: () => {
             snackbarAdapter.dismiss();
@@ -236,7 +239,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
               snackbarAdapter.create({
                 render: () => <Snackbar message="Workaround Snackbar" />,
               });
-            });
+            }, 0);
           },
         },
       ],

--- a/packages/react-headless/snackbar/src/Snackbar.tsx
+++ b/packages/react-headless/snackbar/src/Snackbar.tsx
@@ -12,11 +12,8 @@ export interface SnackbarRootProviderProps extends UseSnackbarProps {
   children: React.ReactNode;
 }
 
-export const SnackbarRootProvider = ({
-  children,
-  pauseOnInteraction,
-}: SnackbarRootProviderProps) => {
-  const api = useSnackbar({ pauseOnInteraction });
+export const SnackbarRootProvider = ({ children, ...props }: SnackbarRootProviderProps) => {
+  const api = useSnackbar(props);
   return <SnackbarProvider value={api}>{children}</SnackbarProvider>;
 };
 

--- a/packages/react-headless/snackbar/src/useSnackbar.test.tsx
+++ b/packages/react-headless/snackbar/src/useSnackbar.test.tsx
@@ -1,6 +1,7 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterAll, beforeEach, describe, expect, it, jest, mock } from "bun:test";
+import { StrictMode } from "react";
 
 import {
   SnackbarRegion,
@@ -50,6 +51,19 @@ function setUp(providerProps: Omit<SnackbarRootProviderProps, "children"> = {}) 
       <SnackbarRootProvider {...providerProps}>
         <SnackbarControls />
       </SnackbarRootProvider>,
+    ),
+  };
+}
+
+function setUpStrict(providerProps: Omit<SnackbarRootProviderProps, "children"> = {}) {
+  return {
+    user: userEvent.setup({ advanceTimers: (ms) => jest.advanceTimersByTime(ms) }),
+    ...render(
+      <StrictMode>
+        <SnackbarRootProvider {...providerProps}>
+          <SnackbarControls />
+        </SnackbarRootProvider>
+      </StrictMode>,
     ),
   };
 }
@@ -113,6 +127,35 @@ describe("useSnackbar", () => {
       act(() => jest.advanceTimersByTime(100));
 
       expect(screen.queryByText("Dismiss me")).not.toBeInTheDocument();
+    });
+
+    it("should call onClose exactly once when dismiss() is invoked", () => {
+      const onClose = mock(() => {});
+      setUp();
+
+      act(() => {
+        snackbarApi.create(createSnackbar("Bye", { onClose, removeDelay: 100 }));
+      });
+
+      act(() => snackbarApi.dismiss());
+      act(() => jest.advanceTimersByTime(100));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("StrictMode safety", () => {
+    it("should not lose queued items under StrictMode double-invocation", () => {
+      setUpStrict({ strategy: "queued" });
+
+      act(() => {
+        snackbarApi.create(createSnackbar("A", { timeout: 10000, removeDelay: 1000 }));
+        snackbarApi.create(createSnackbar("B", { timeout: 10000, removeDelay: 1000 }));
+        snackbarApi.create(createSnackbar("C", { timeout: 10000, removeDelay: 1000 }));
+      });
+
+      expect(screen.getByText("A")).toBeInTheDocument();
+      expect(snackbarApi.queue.length).toBe(2);
     });
   });
 

--- a/packages/react-headless/snackbar/src/useSnackbar.test.tsx
+++ b/packages/react-headless/snackbar/src/useSnackbar.test.tsx
@@ -218,38 +218,81 @@ describe("useSnackbar", () => {
   });
 
   describe("per-snackbar strategy override", () => {
-    it("should allow per-snackbar queued override in immediate provider", () => {
+    it("should mix queued and immediate overrides in immediate provider", () => {
       setUp(); // default: immediate
 
+      // 1. First shows immediately
       act(() => snackbarApi.create(createSnackbar("First", { timeout: 1000, removeDelay: 100 })));
-      act(() => snackbarApi.create(createSnackbar("Queued", { strategy: "queued" })));
-
-      // First is showing, Queued is waiting in queue
       expect(screen.getByText("First")).toBeInTheDocument();
-      expect(screen.queryByText("Queued")).not.toBeInTheDocument();
+
+      // 2. Queued-A waits in queue
+      act(() =>
+        snackbarApi.create(
+          createSnackbar("Queued-A", { strategy: "queued", timeout: 1000, removeDelay: 100 }),
+        ),
+      );
+      expect(screen.getByText("First")).toBeInTheDocument();
       expect(snackbarApi.queue.length).toBe(1);
 
-      // Dismiss first → queued one shows
-      act(() => jest.advanceTimersByTime(1000));
-      act(() => jest.advanceTimersByTime(100));
-
-      expect(screen.getByText("Queued")).toBeInTheDocument();
-    });
-
-    it("should allow per-snackbar immediate override in queued provider", () => {
-      setUp({ strategy: "queued" });
-
-      act(() => {
-        snackbarApi.create(createSnackbar("First"));
-      });
+      // 3. Queued-B also waits in queue
+      act(() =>
+        snackbarApi.create(
+          createSnackbar("Queued-B", { strategy: "queued", timeout: 1000, removeDelay: 100 }),
+        ),
+      );
       expect(screen.getByText("First")).toBeInTheDocument();
+      expect(snackbarApi.queue.length).toBe(2);
 
-      act(() => {
-        snackbarApi.create(createSnackbar("Urgent", { strategy: "immediate" }));
-      });
-
+      // 4. Urgent replaces First immediately and clears queue
+      act(() => snackbarApi.create(createSnackbar("Urgent", { timeout: 1000, removeDelay: 100 })));
       expect(screen.queryByText("First")).not.toBeInTheDocument();
       expect(screen.getByText("Urgent")).toBeInTheDocument();
+      expect(snackbarApi.queue.length).toBe(0);
+
+      // 5. After Urgent times out, nothing left
+      act(() => jest.advanceTimersByTime(1000));
+      act(() => jest.advanceTimersByTime(100));
+      expect(screen.queryByText("Urgent")).not.toBeInTheDocument();
+    });
+
+    it("should mix queued and immediate overrides in queued provider", () => {
+      setUp({ strategy: "queued" }); // default: queued
+
+      // 1. First shows (queued default, but nothing active → shows immediately)
+      act(() => snackbarApi.create(createSnackbar("First", { timeout: 1000, removeDelay: 100 })));
+      expect(screen.getByText("First")).toBeInTheDocument();
+
+      // 2. Second queues behind First
+      act(() => snackbarApi.create(createSnackbar("Second", { timeout: 1000, removeDelay: 100 })));
+      expect(screen.getByText("First")).toBeInTheDocument();
+      expect(snackbarApi.queue.length).toBe(1);
+
+      // 3. Third queues behind Second
+      act(() => snackbarApi.create(createSnackbar("Third", { timeout: 1000, removeDelay: 100 })));
+      expect(snackbarApi.queue.length).toBe(2);
+
+      // 4. Urgent with immediate override replaces First and clears queue
+      act(() =>
+        snackbarApi.create(
+          createSnackbar("Urgent", { strategy: "immediate", timeout: 1000, removeDelay: 100 }),
+        ),
+      );
+      expect(screen.queryByText("First")).not.toBeInTheDocument();
+      expect(screen.getByText("Urgent")).toBeInTheDocument();
+      expect(snackbarApi.queue.length).toBe(0);
+
+      // 5. While Urgent is showing, queue a new one (default queued)
+      act(() =>
+        snackbarApi.create(createSnackbar("After-Urgent", { timeout: 1000, removeDelay: 100 })),
+      );
+      expect(screen.getByText("Urgent")).toBeInTheDocument();
+      expect(snackbarApi.queue.length).toBe(1);
+
+      // 6. Urgent times out → After-Urgent shows from queue
+      act(() => jest.advanceTimersByTime(1000));
+      act(() => jest.advanceTimersByTime(100));
+      expect(screen.queryByText("Urgent")).not.toBeInTheDocument();
+      expect(screen.getByText("After-Urgent")).toBeInTheDocument();
     });
   });
 });

--- a/packages/react-headless/snackbar/src/useSnackbar.test.tsx
+++ b/packages/react-headless/snackbar/src/useSnackbar.test.tsx
@@ -1,0 +1,255 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterAll, beforeEach, describe, expect, it, jest, mock } from "bun:test";
+
+import {
+  SnackbarRegion,
+  SnackbarRenderer,
+  SnackbarRoot,
+  SnackbarRootProvider,
+  type SnackbarRootProviderProps,
+} from "./Snackbar";
+import { useSnackbarContext, type UseSnackbarContext } from "./useSnackbarContext";
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const originalResizeObserver = window.ResizeObserver;
+window.ResizeObserver = ResizeObserver;
+
+afterAll(() => {
+  window.ResizeObserver = originalResizeObserver;
+});
+
+let snackbarApi: UseSnackbarContext;
+
+function SnackbarControls() {
+  const api = useSnackbarContext();
+  snackbarApi = api;
+
+  return (
+    <div>
+      <SnackbarRegion>
+        {api.currentSnackbar && (
+          <SnackbarRoot>
+            <SnackbarRenderer />
+          </SnackbarRoot>
+        )}
+      </SnackbarRegion>
+    </div>
+  );
+}
+
+function setUp(providerProps: Omit<SnackbarRootProviderProps, "children"> = {}) {
+  return {
+    user: userEvent.setup({ advanceTimers: (ms) => jest.advanceTimersByTime(ms) }),
+    ...render(
+      <SnackbarRootProvider {...providerProps}>
+        <SnackbarControls />
+      </SnackbarRootProvider>,
+    ),
+  };
+}
+
+function createSnackbar(message: string, options: Record<string, unknown> = {}) {
+  return {
+    render: () => <span>{message}</span>,
+    timeout: 5000,
+    removeDelay: 200,
+    ...options,
+  };
+}
+
+describe("useSnackbar", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  describe("common", () => {
+    it("should display a single snackbar", () => {
+      setUp();
+
+      act(() => {
+        snackbarApi.create(createSnackbar("Hello"));
+      });
+
+      expect(screen.getByText("Hello")).toBeInTheDocument();
+    });
+
+    it("should auto-dismiss after timeout", () => {
+      setUp();
+
+      act(() => {
+        snackbarApi.create(createSnackbar("Auto dismiss", { timeout: 1000, removeDelay: 100 }));
+      });
+
+      expect(screen.getByText("Auto dismiss")).toBeInTheDocument();
+
+      // timeout fires → dismissing state
+      act(() => jest.advanceTimersByTime(1000));
+      // removeDelay fires → inactive state
+      act(() => jest.advanceTimersByTime(100));
+
+      expect(screen.queryByText("Auto dismiss")).not.toBeInTheDocument();
+    });
+
+    it("should dismiss on dismiss() call", () => {
+      setUp();
+
+      act(() => {
+        snackbarApi.create(createSnackbar("Dismiss me", { removeDelay: 100 }));
+      });
+
+      expect(screen.getByText("Dismiss me")).toBeInTheDocument();
+
+      act(() => snackbarApi.dismiss());
+      act(() => jest.advanceTimersByTime(100));
+
+      expect(screen.queryByText("Dismiss me")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("immediate (default)", () => {
+    it("should replace current snackbar with new one", () => {
+      setUp();
+
+      act(() => {
+        snackbarApi.create(createSnackbar("First"));
+      });
+      expect(screen.getByText("First")).toBeInTheDocument();
+
+      act(() => {
+        snackbarApi.create(createSnackbar("Second"));
+      });
+      expect(screen.queryByText("First")).not.toBeInTheDocument();
+      expect(screen.getByText("Second")).toBeInTheDocument();
+    });
+
+    it("should call onClose of replaced snackbar", () => {
+      const onClose = mock(() => {});
+      setUp();
+
+      act(() => {
+        snackbarApi.create(createSnackbar("First", { onClose }));
+      });
+
+      act(() => {
+        snackbarApi.create(createSnackbar("Second"));
+      });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("should clear queue on replacement", () => {
+      setUp({ strategy: "queued" });
+
+      // Queue up 3 snackbars in queued mode
+      act(() => snackbarApi.create(createSnackbar("First")));
+      act(() => {
+        snackbarApi.create(createSnackbar("Queued A", { strategy: "queued" }));
+        snackbarApi.create(createSnackbar("Queued B", { strategy: "queued" }));
+      });
+
+      expect(screen.getByText("First")).toBeInTheDocument();
+      expect(snackbarApi.queue.length).toBe(2);
+
+      // Immediate snackbar clears queue and replaces
+      act(() => {
+        snackbarApi.create(createSnackbar("Urgent", { strategy: "immediate" }));
+      });
+
+      expect(screen.getByText("Urgent")).toBeInTheDocument();
+      expect(snackbarApi.queue.length).toBe(0);
+    });
+
+    it("should restart timeout after replacement", () => {
+      setUp();
+
+      act(() => {
+        snackbarApi.create(createSnackbar("First", { timeout: 1000, removeDelay: 100 }));
+      });
+
+      // Advance 800ms (not yet dismissed)
+      act(() => jest.advanceTimersByTime(800));
+      expect(screen.getByText("First")).toBeInTheDocument();
+
+      // Replace with new snackbar (timeout resets)
+      act(() => {
+        snackbarApi.create(createSnackbar("Second", { timeout: 1000, removeDelay: 100 }));
+      });
+
+      // Advance 800ms again — Second should still be visible (fresh timeout)
+      act(() => jest.advanceTimersByTime(800));
+      expect(screen.getByText("Second")).toBeInTheDocument();
+
+      // Advance remaining 200ms + removeDelay → gone
+      act(() => jest.advanceTimersByTime(200));
+      act(() => jest.advanceTimersByTime(100));
+      expect(screen.queryByText("Second")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("queued", () => {
+    it("should queue snackbars when strategy is queued", () => {
+      setUp({ strategy: "queued" });
+
+      act(() => snackbarApi.create(createSnackbar("First", { timeout: 1000, removeDelay: 100 })));
+      act(() => snackbarApi.create(createSnackbar("Second")));
+
+      // First is showing, Second is in queue
+      expect(screen.getByText("First")).toBeInTheDocument();
+      expect(screen.queryByText("Second")).not.toBeInTheDocument();
+      expect(snackbarApi.queue.length).toBe(1);
+
+      // Dismiss first → second shows
+      act(() => jest.advanceTimersByTime(1000));
+      act(() => jest.advanceTimersByTime(100));
+
+      expect(screen.queryByText("First")).not.toBeInTheDocument();
+      expect(screen.getByText("Second")).toBeInTheDocument();
+    });
+  });
+
+  describe("per-snackbar strategy override", () => {
+    it("should allow per-snackbar queued override in immediate provider", () => {
+      setUp(); // default: immediate
+
+      act(() => snackbarApi.create(createSnackbar("First", { timeout: 1000, removeDelay: 100 })));
+      act(() => snackbarApi.create(createSnackbar("Queued", { strategy: "queued" })));
+
+      // First is showing, Queued is waiting in queue
+      expect(screen.getByText("First")).toBeInTheDocument();
+      expect(screen.queryByText("Queued")).not.toBeInTheDocument();
+      expect(snackbarApi.queue.length).toBe(1);
+
+      // Dismiss first → queued one shows
+      act(() => jest.advanceTimersByTime(1000));
+      act(() => jest.advanceTimersByTime(100));
+
+      expect(screen.getByText("Queued")).toBeInTheDocument();
+    });
+
+    it("should allow per-snackbar immediate override in queued provider", () => {
+      setUp({ strategy: "queued" });
+
+      act(() => {
+        snackbarApi.create(createSnackbar("First"));
+      });
+      expect(screen.getByText("First")).toBeInTheDocument();
+
+      act(() => {
+        snackbarApi.create(createSnackbar("Urgent", { strategy: "immediate" }));
+      });
+
+      expect(screen.queryByText("First")).not.toBeInTheDocument();
+      expect(screen.getByText("Urgent")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/react-headless/snackbar/src/useSnackbar.test.tsx
+++ b/packages/react-headless/snackbar/src/useSnackbar.test.tsx
@@ -201,8 +201,10 @@ describe("useSnackbar", () => {
     it("should queue snackbars when strategy is queued", () => {
       setUp({ strategy: "queued" });
 
-      act(() => snackbarApi.create(createSnackbar("First", { timeout: 1000, removeDelay: 100 })));
-      act(() => snackbarApi.create(createSnackbar("Second")));
+      act(() => {
+        snackbarApi.create(createSnackbar("First", { timeout: 1000, removeDelay: 100 }));
+        snackbarApi.create(createSnackbar("Second"));
+      });
 
       // First is showing, Second is in queue
       expect(screen.getByText("First")).toBeInTheDocument();
@@ -222,25 +224,17 @@ describe("useSnackbar", () => {
     it("should mix queued and immediate overrides in immediate provider", () => {
       setUp(); // default: immediate
 
-      // 1. First shows immediately
-      act(() => snackbarApi.create(createSnackbar("First", { timeout: 1000, removeDelay: 100 })));
-      expect(screen.getByText("First")).toBeInTheDocument();
-
-      // 2. Queued-A waits in queue
-      act(() =>
+      // 1. First shows, then Queued-A and Queued-B are created in same act
+      act(() => {
+        snackbarApi.create(createSnackbar("First", { timeout: 1000, removeDelay: 100 }));
         snackbarApi.create(
           createSnackbar("Queued-A", { strategy: "queued", timeout: 1000, removeDelay: 100 }),
-        ),
-      );
-      expect(screen.getByText("First")).toBeInTheDocument();
-      expect(snackbarApi.queue.length).toBe(1);
-
-      // 3. Queued-B also waits in queue
-      act(() =>
+        );
         snackbarApi.create(
           createSnackbar("Queued-B", { strategy: "queued", timeout: 1000, removeDelay: 100 }),
-        ),
-      );
+        );
+      });
+
       expect(screen.getByText("First")).toBeInTheDocument();
       expect(snackbarApi.queue.length).toBe(2);
 
@@ -263,17 +257,14 @@ describe("useSnackbar", () => {
     it("should mix queued and immediate overrides in queued provider", () => {
       setUp({ strategy: "queued" }); // default: queued
 
-      // 1. First shows (queued default, but nothing active → shows immediately)
-      act(() => snackbarApi.create(createSnackbar("First", { timeout: 1000, removeDelay: 100 })));
-      expect(screen.getByText("First")).toBeInTheDocument();
+      // 1. First shows, Second and Third queue — all in same act
+      act(() => {
+        snackbarApi.create(createSnackbar("First", { timeout: 1000, removeDelay: 100 }));
+        snackbarApi.create(createSnackbar("Second", { timeout: 1000, removeDelay: 100 }));
+        snackbarApi.create(createSnackbar("Third", { timeout: 1000, removeDelay: 100 }));
+      });
 
-      // 2. Second queues behind First
-      act(() => snackbarApi.create(createSnackbar("Second", { timeout: 1000, removeDelay: 100 })));
       expect(screen.getByText("First")).toBeInTheDocument();
-      expect(snackbarApi.queue.length).toBe(1);
-
-      // 3. Third queues behind Second
-      act(() => snackbarApi.create(createSnackbar("Third", { timeout: 1000, removeDelay: 100 })));
       expect(snackbarApi.queue.length).toBe(2);
 
       // 4. Urgent with immediate override: dismiss First, queue only Urgent

--- a/packages/react-headless/snackbar/src/useSnackbar.test.tsx
+++ b/packages/react-headless/snackbar/src/useSnackbar.test.tsx
@@ -120,14 +120,15 @@ describe("useSnackbar", () => {
     it("should replace current snackbar with new one", () => {
       setUp();
 
-      act(() => {
-        snackbarApi.create(createSnackbar("First"));
-      });
+      act(() => snackbarApi.create(createSnackbar("First", { removeDelay: 100 })));
       expect(screen.getByText("First")).toBeInTheDocument();
 
-      act(() => {
-        snackbarApi.create(createSnackbar("Second"));
-      });
+      act(() => snackbarApi.create(createSnackbar("Second")));
+
+      // First is in dismissing state (exit animation)
+      // Advance removeDelay to complete exit, then new one enters
+      act(() => jest.advanceTimersByTime(100));
+
       expect(screen.queryByText("First")).not.toBeInTheDocument();
       expect(screen.getByText("Second")).toBeInTheDocument();
     });
@@ -136,13 +137,12 @@ describe("useSnackbar", () => {
       const onClose = mock(() => {});
       setUp();
 
-      act(() => {
-        snackbarApi.create(createSnackbar("First", { onClose }));
-      });
+      act(() => snackbarApi.create(createSnackbar("First", { onClose, removeDelay: 100 })));
 
-      act(() => {
-        snackbarApi.create(createSnackbar("Second"));
-      });
+      act(() => snackbarApi.create(createSnackbar("Second")));
+
+      // onClose fires during dismissing → inactive transition
+      act(() => jest.advanceTimersByTime(100));
 
       expect(onClose).toHaveBeenCalledTimes(1);
     });
@@ -151,7 +151,7 @@ describe("useSnackbar", () => {
       setUp({ strategy: "queued" });
 
       // Queue up 3 snackbars in queued mode
-      act(() => snackbarApi.create(createSnackbar("First")));
+      act(() => snackbarApi.create(createSnackbar("First", { removeDelay: 100 })));
       act(() => {
         snackbarApi.create(createSnackbar("Queued A", { strategy: "queued" }));
         snackbarApi.create(createSnackbar("Queued B", { strategy: "queued" }));
@@ -160,10 +160,11 @@ describe("useSnackbar", () => {
       expect(screen.getByText("First")).toBeInTheDocument();
       expect(snackbarApi.queue.length).toBe(2);
 
-      // Immediate snackbar clears queue and replaces
-      act(() => {
-        snackbarApi.create(createSnackbar("Urgent", { strategy: "immediate" }));
-      });
+      // Immediate snackbar clears queue, triggers dismiss of First
+      act(() => snackbarApi.create(createSnackbar("Urgent", { strategy: "immediate" })));
+
+      // Advance removeDelay for First to exit, then Urgent enters
+      act(() => jest.advanceTimersByTime(100));
 
       expect(screen.getByText("Urgent")).toBeInTheDocument();
       expect(snackbarApi.queue.length).toBe(0);
@@ -172,24 +173,24 @@ describe("useSnackbar", () => {
     it("should restart timeout after replacement", () => {
       setUp();
 
-      act(() => {
-        snackbarApi.create(createSnackbar("First", { timeout: 1000, removeDelay: 100 }));
-      });
+      act(() => snackbarApi.create(createSnackbar("First", { timeout: 1000, removeDelay: 100 })));
 
       // Advance 800ms (not yet dismissed)
       act(() => jest.advanceTimersByTime(800));
       expect(screen.getByText("First")).toBeInTheDocument();
 
-      // Replace with new snackbar (timeout resets)
-      act(() => {
-        snackbarApi.create(createSnackbar("Second", { timeout: 1000, removeDelay: 100 }));
-      });
+      // Replace: triggers dismiss of First
+      act(() => snackbarApi.create(createSnackbar("Second", { timeout: 1000, removeDelay: 100 })));
 
-      // Advance 800ms again — Second should still be visible (fresh timeout)
+      // Advance 100ms removeDelay for First exit → Second enters with fresh timeout
+      act(() => jest.advanceTimersByTime(100));
+      expect(screen.getByText("Second")).toBeInTheDocument();
+
+      // Advance 800ms — Second should still be visible (fresh timeout = 1000ms)
       act(() => jest.advanceTimersByTime(800));
       expect(screen.getByText("Second")).toBeInTheDocument();
 
-      // Advance remaining 200ms + removeDelay → gone
+      // Advance remaining 200ms → dismissing, then 100ms removeDelay → gone
       act(() => jest.advanceTimersByTime(200));
       act(() => jest.advanceTimersByTime(100));
       expect(screen.queryByText("Second")).not.toBeInTheDocument();
@@ -243,8 +244,12 @@ describe("useSnackbar", () => {
       expect(screen.getByText("First")).toBeInTheDocument();
       expect(snackbarApi.queue.length).toBe(2);
 
-      // 4. Urgent replaces First immediately and clears queue
+      // 4. Urgent replaces First: dismiss First, queue only Urgent
       act(() => snackbarApi.create(createSnackbar("Urgent", { timeout: 1000, removeDelay: 100 })));
+
+      // First exit animation
+      act(() => jest.advanceTimersByTime(100));
+
       expect(screen.queryByText("First")).not.toBeInTheDocument();
       expect(screen.getByText("Urgent")).toBeInTheDocument();
       expect(snackbarApi.queue.length).toBe(0);
@@ -271,12 +276,16 @@ describe("useSnackbar", () => {
       act(() => snackbarApi.create(createSnackbar("Third", { timeout: 1000, removeDelay: 100 })));
       expect(snackbarApi.queue.length).toBe(2);
 
-      // 4. Urgent with immediate override replaces First and clears queue
+      // 4. Urgent with immediate override: dismiss First, queue only Urgent
       act(() =>
         snackbarApi.create(
           createSnackbar("Urgent", { strategy: "immediate", timeout: 1000, removeDelay: 100 }),
         ),
       );
+
+      // First exit animation
+      act(() => jest.advanceTimersByTime(100));
+
       expect(screen.queryByText("First")).not.toBeInTheDocument();
       expect(screen.getByText("Urgent")).toBeInTheDocument();
       expect(snackbarApi.queue.length).toBe(0);

--- a/packages/react-headless/snackbar/src/useSnackbar.test.tsx
+++ b/packages/react-headless/snackbar/src/useSnackbar.test.tsx
@@ -213,6 +213,37 @@ describe("useSnackbar", () => {
       expect(snackbarApi.queue.length).toBe(0);
     });
 
+    it("should not call onClose of queued snackbars that were dropped without being shown", () => {
+      const onCloseFirst = mock(() => {});
+      const onCloseQueuedA = mock(() => {});
+      const onCloseQueuedB = mock(() => {});
+      setUp({ strategy: "queued" });
+
+      act(() =>
+        snackbarApi.create(createSnackbar("First", { onClose: onCloseFirst, removeDelay: 100 })),
+      );
+      act(() => {
+        snackbarApi.create(
+          createSnackbar("Queued A", { strategy: "queued", onClose: onCloseQueuedA }),
+        );
+        snackbarApi.create(
+          createSnackbar("Queued B", { strategy: "queued", onClose: onCloseQueuedB }),
+        );
+      });
+
+      expect(snackbarApi.queue.length).toBe(2);
+
+      // Immediate snackbar drops the queue (Queued A, B were never shown)
+      act(() => snackbarApi.create(createSnackbar("Urgent", { strategy: "immediate" })));
+      act(() => jest.advanceTimersByTime(100));
+
+      // First was shown → its onClose fires once
+      expect(onCloseFirst).toHaveBeenCalledTimes(1);
+      // Queued A, B never became currentSnackbar → their onClose must not fire
+      expect(onCloseQueuedA).not.toHaveBeenCalled();
+      expect(onCloseQueuedB).not.toHaveBeenCalled();
+    });
+
     it("should restart timeout after replacement", () => {
       setUp();
 

--- a/packages/react-headless/snackbar/src/useSnackbar.ts
+++ b/packages/react-headless/snackbar/src/useSnackbar.ts
@@ -11,6 +11,14 @@ interface UseSnackbarStateProps {
    * @default true
    */
   pauseOnInteraction?: boolean;
+
+  /**
+   * How to handle multiple snackbars.
+   * - `"immediate"`: New snackbar replaces the current one instantly.
+   * - `"queued"`: New snackbar waits in a queue until the current one is dismissed.
+   * @default "immediate"
+   */
+  strategy?: "immediate" | "queued";
 }
 
 export interface CreateSnackbarOptions {
@@ -34,12 +42,23 @@ export interface CreateSnackbarOptions {
    * The content to render in the snackbar region
    */
   render: () => React.ReactNode;
+
+  /**
+   * Override the provider-level strategy for this specific snackbar.
+   * - `"immediate"`: Replace the current snackbar instantly.
+   * - `"queued"`: Wait in the queue until the current one is dismissed.
+   */
+  strategy?: "immediate" | "queued";
 }
 
-function useSnackbarState({ pauseOnInteraction = true }: UseSnackbarStateProps) {
+function useSnackbarState({
+  pauseOnInteraction = true,
+  strategy = "immediate",
+}: UseSnackbarStateProps) {
   const [state, setState] = useState<SnackbarState>("inactive");
   const [queue, setQueue] = useState<CreateSnackbarOptions[]>([]);
   const [currentSnackbar, setCurrentSnackbar] = useState<CreateSnackbarOptions | null>(null);
+  const [generation, setGeneration] = useState(0);
 
   const visibleDuration = currentSnackbar?.timeout ?? 4000;
   const removeDelay = currentSnackbar?.removeDelay ?? 200;
@@ -91,16 +110,40 @@ function useSnackbarState({ pauseOnInteraction = true }: UseSnackbarStateProps) 
       }, removeDelay);
       return () => clearTimeout(timeout);
     }
-  }, [state, queue, visibleDuration, removeDelay, pop, invokeOnClose, removeCurrentSnackbar]);
+  }, [
+    state,
+    queue,
+    generation,
+    visibleDuration,
+    removeDelay,
+    pop,
+    invokeOnClose,
+    removeCurrentSnackbar,
+  ]);
 
   // events
   const events = useMemo(
     () => ({
       push: (option: CreateSnackbarOptions) => {
-        push(option);
-        if (state === "inactive") {
-          pop();
-          setState("active");
+        const effectiveStrategy = option.strategy ?? strategy;
+
+        if (effectiveStrategy === "immediate") {
+          if (state === "inactive") {
+            setCurrentSnackbar(option);
+            setState("active");
+          } else {
+            invokeOnClose();
+            setQueue([]);
+            setCurrentSnackbar(option);
+            setState("active");
+            setGeneration((g) => g + 1);
+          }
+        } else {
+          push(option);
+          if (state === "inactive") {
+            pop();
+            setState("active");
+          }
         }
       },
       pause: () => {
@@ -122,7 +165,7 @@ function useSnackbarState({ pauseOnInteraction = true }: UseSnackbarStateProps) 
         }
       },
     }),
-    [state, push, pop, invokeOnClose, pauseOnInteraction],
+    [state, strategy, push, pop, invokeOnClose, pauseOnInteraction],
   );
 
   return useMemo(

--- a/packages/react-headless/snackbar/src/useSnackbar.ts
+++ b/packages/react-headless/snackbar/src/useSnackbar.ts
@@ -58,7 +58,6 @@ function useSnackbarState({
   const [state, setState] = useState<SnackbarState>("inactive");
   const [queue, setQueue] = useState<CreateSnackbarOptions[]>([]);
   const [currentSnackbar, setCurrentSnackbar] = useState<CreateSnackbarOptions | null>(null);
-  const [generation, setGeneration] = useState(0);
 
   const visibleDuration = currentSnackbar?.timeout ?? 4000;
   const removeDelay = currentSnackbar?.removeDelay ?? 200;
@@ -110,16 +109,7 @@ function useSnackbarState({
       }, removeDelay);
       return () => clearTimeout(timeout);
     }
-  }, [
-    state,
-    queue,
-    generation,
-    visibleDuration,
-    removeDelay,
-    pop,
-    invokeOnClose,
-    removeCurrentSnackbar,
-  ]);
+  }, [state, queue, visibleDuration, removeDelay, pop, invokeOnClose, removeCurrentSnackbar]);
 
   // events
   const events = useMemo(
@@ -131,12 +121,11 @@ function useSnackbarState({
           if (state === "inactive") {
             setCurrentSnackbar(option);
             setState("active");
+          } else if (state === "dismissing") {
+            setQueue([option]);
           } else {
-            invokeOnClose();
-            setQueue([]);
-            setCurrentSnackbar(option);
-            setState("active");
-            setGeneration((g) => g + 1);
+            setQueue([option]);
+            setState("dismissing");
           }
         } else {
           push(option);

--- a/packages/react-headless/snackbar/src/useSnackbar.ts
+++ b/packages/react-headless/snackbar/src/useSnackbar.ts
@@ -1,6 +1,6 @@
 import { ariaAttr, buttonProps, dataAttr, elementProps } from "@seed-design/dom-utils";
 import { useSupports } from "@seed-design/react-supports";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useReducer } from "react";
 import { useSafeOffset } from "./useSafeOffset";
 
 type SnackbarState = "inactive" | "active" | "persist" | "dismissing";
@@ -51,120 +51,101 @@ export interface CreateSnackbarOptions {
   strategy?: "immediate" | "queued";
 }
 
+interface ReducerState {
+  state: SnackbarState;
+  queue: CreateSnackbarOptions[];
+  currentSnackbar: CreateSnackbarOptions | null;
+}
+
+type ReducerAction =
+  | { type: "PUSH"; option: CreateSnackbarOptions; strategy: "immediate" | "queued" }
+  | { type: "ACTIVATE_NEXT" }
+  | { type: "PAUSE"; pauseOnInteraction: boolean }
+  | { type: "RESUME" }
+  | { type: "DISMISS" }
+  | { type: "REMOVE" };
+
+const initialState: ReducerState = {
+  state: "inactive",
+  queue: [],
+  currentSnackbar: null,
+};
+
+function reducer(s: ReducerState, action: ReducerAction): ReducerState {
+  switch (action.type) {
+    case "PUSH": {
+      const { option, strategy } = action;
+      if (strategy === "immediate") {
+        switch (s.state) {
+          case "inactive":
+            return { state: "active", currentSnackbar: option, queue: [] };
+          case "dismissing":
+            return { ...s, queue: [option] };
+          default:
+            return { ...s, state: "dismissing", queue: [option] };
+        }
+      }
+      if (s.state === "inactive") {
+        return { state: "active", currentSnackbar: option, queue: [] };
+      }
+      return { ...s, queue: [...s.queue, option] };
+    }
+    case "ACTIVATE_NEXT": {
+      if (s.state !== "inactive" || s.queue.length === 0) return s;
+      const [first, ...rest] = s.queue;
+      return { state: "active", currentSnackbar: first, queue: rest };
+    }
+    case "PAUSE":
+      return action.pauseOnInteraction && s.state === "active" ? { ...s, state: "persist" } : s;
+    case "RESUME":
+      return s.state === "persist" ? { ...s, state: "active" } : s;
+    case "DISMISS":
+      return s.state === "active" || s.state === "persist" ? { ...s, state: "dismissing" } : s;
+    case "REMOVE":
+      return { ...s, state: "inactive", currentSnackbar: null };
+  }
+}
+
 function useSnackbarState({
   pauseOnInteraction = true,
   strategy = "immediate",
 }: UseSnackbarStateProps) {
-  const [state, setState] = useState<SnackbarState>("inactive");
-  const [queue, setQueue] = useState<CreateSnackbarOptions[]>([]);
-  const [currentSnackbar, setCurrentSnackbar] = useState<CreateSnackbarOptions | null>(null);
+  const [{ state, queue, currentSnackbar }, dispatch] = useReducer(reducer, initialState);
 
   const visibleDuration = currentSnackbar?.timeout ?? 4000;
   const removeDelay = currentSnackbar?.removeDelay ?? 200;
   const visible = state === "active" || state === "persist";
 
-  // actions
-  const push = useCallback((option: CreateSnackbarOptions) => {
-    setQueue((prev) => [...prev, option]);
-  }, []);
-
-  const pop = useCallback(() => {
-    setQueue(([snackbar, ...rest]) => {
-      setCurrentSnackbar(snackbar ?? null);
-      return rest;
-    });
-  }, []);
-
-  const removeCurrentSnackbar = useCallback(() => {
-    setCurrentSnackbar(null);
-  }, []);
-
-  const invokeOnClose = useCallback(() => {
-    if (currentSnackbar?.onClose) {
-      currentSnackbar.onClose();
-    }
-  }, [currentSnackbar]);
-
-  // entry events
   useEffect(() => {
     switch (state) {
       case "inactive": {
-        if (queue.length >= 1) {
-          pop();
-          setState("active");
-        }
+        if (queue.length >= 1) dispatch({ type: "ACTIVATE_NEXT" });
         break;
       }
       case "active": {
-        const timeout = setTimeout(() => {
-          setState("dismissing");
-        }, visibleDuration);
+        const timeout = setTimeout(() => dispatch({ type: "DISMISS" }), visibleDuration);
         return () => clearTimeout(timeout);
       }
       case "dismissing": {
         const timeout = setTimeout(() => {
-          setState("inactive");
-          invokeOnClose();
-          removeCurrentSnackbar();
+          currentSnackbar?.onClose?.();
+          dispatch({ type: "REMOVE" });
         }, removeDelay);
         return () => clearTimeout(timeout);
       }
     }
-  }, [state, queue, visibleDuration, removeDelay, pop, invokeOnClose, removeCurrentSnackbar]);
+  }, [state, queue.length, currentSnackbar, visibleDuration, removeDelay]);
 
-  // events
   const events = useMemo(
     () => ({
       push: (option: CreateSnackbarOptions) => {
-        const effectiveStrategy = option.strategy ?? strategy;
-
-        if (effectiveStrategy === "immediate") {
-          setState((prev) => {
-            switch (prev) {
-              case "inactive":
-                setCurrentSnackbar(option);
-                return "active";
-              case "dismissing":
-                setQueue([option]);
-                return prev;
-              default:
-                setQueue([option]);
-                return "dismissing";
-            }
-          });
-        } else {
-          push(option);
-          setState((prev) => {
-            switch (prev) {
-              case "inactive":
-                pop();
-                return "active";
-              default:
-                return prev;
-            }
-          });
-        }
+        dispatch({ type: "PUSH", option, strategy: option.strategy ?? strategy });
       },
-      pause: () => {
-        if (state === "active") {
-          if (pauseOnInteraction) {
-            setState("persist");
-          }
-        }
-      },
-      resume: () => {
-        if (state === "persist") {
-          setState("active");
-        }
-      },
-      dismiss: () => {
-        if (state === "active" || state === "persist") {
-          setState("dismissing");
-          invokeOnClose();
-        }
-      },
+      pause: () => dispatch({ type: "PAUSE", pauseOnInteraction }),
+      resume: () => dispatch({ type: "RESUME" }),
+      dismiss: () => dispatch({ type: "DISMISS" }),
     }),
-    [state, strategy, push, pop, invokeOnClose, pauseOnInteraction],
+    [strategy, pauseOnInteraction],
   );
 
   return useMemo(

--- a/packages/react-headless/snackbar/src/useSnackbar.ts
+++ b/packages/react-headless/snackbar/src/useSnackbar.ts
@@ -118,21 +118,30 @@ function useSnackbarState({
         const effectiveStrategy = option.strategy ?? strategy;
 
         if (effectiveStrategy === "immediate") {
-          if (state === "inactive") {
-            setCurrentSnackbar(option);
-            setState("active");
-          } else if (state === "dismissing") {
-            setQueue([option]);
-          } else {
-            setQueue([option]);
-            setState("dismissing");
-          }
+          setState((prev) => {
+            switch (prev) {
+              case "inactive":
+                setCurrentSnackbar(option);
+                return "active";
+              case "dismissing":
+                setQueue([option]);
+                return prev;
+              default:
+                setQueue([option]);
+                return "dismissing";
+            }
+          });
         } else {
           push(option);
-          if (state === "inactive") {
-            pop();
-            setState("active");
-          }
+          setState((prev) => {
+            switch (prev) {
+              case "inactive":
+                pop();
+                return "active";
+              default:
+                return prev;
+            }
+          });
         }
       },
       pause: () => {

--- a/packages/react-headless/snackbar/src/useSnackbar.ts
+++ b/packages/react-headless/snackbar/src/useSnackbar.ts
@@ -87,27 +87,28 @@ function useSnackbarState({
 
   // entry events
   useEffect(() => {
-    if (state === "inactive") {
-      if (queue.length >= 1) {
-        pop();
-        setState("active");
+    switch (state) {
+      case "inactive": {
+        if (queue.length >= 1) {
+          pop();
+          setState("active");
+        }
+        break;
       }
-    }
-
-    if (state === "active") {
-      const timeout = setTimeout(() => {
-        setState("dismissing");
-      }, visibleDuration);
-      return () => clearTimeout(timeout);
-    }
-
-    if (state === "dismissing") {
-      const timeout = setTimeout(() => {
-        setState("inactive");
-        invokeOnClose();
-        removeCurrentSnackbar();
-      }, removeDelay);
-      return () => clearTimeout(timeout);
+      case "active": {
+        const timeout = setTimeout(() => {
+          setState("dismissing");
+        }, visibleDuration);
+        return () => clearTimeout(timeout);
+      }
+      case "dismissing": {
+        const timeout = setTimeout(() => {
+          setState("inactive");
+          invokeOnClose();
+          removeCurrentSnackbar();
+        }, removeDelay);
+        return () => clearTimeout(timeout);
+      }
     }
   }, [state, queue, visibleDuration, removeDelay, pop, invokeOnClose, removeCurrentSnackbar]);
 

--- a/packages/react/src/components/Snackbar/useSnackbarAdapter.ts
+++ b/packages/react/src/components/Snackbar/useSnackbarAdapter.ts
@@ -17,6 +17,7 @@ export function useSnackbarAdapter() {
           removeDelay: options.removeDelay ?? 200,
           onClose: options.onClose,
           render: options.render,
+          strategy: options.strategy,
         });
       },
       dismiss: api.dismiss,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 스낵바 표시 전략 추가: 기존 스낵바를 즉시 교체하거나 순차 대기열로 처리하는 옵션 제공
  * 런타임에서 개별 스낵바에 전략을 지정할 수 있음

* **문서**
  * 전략 사용법과 예제 문서 추가(프로바이더 기본 설정 및 개별 오버라이드 설명)

* **테스트**
  * 스낵바 생명주기 및 전략 동작을 검증하는 통합 테스트 추가

* **데모**
  * 앱 데모에 전략 선택 및 대기열 동작 확인용 항목 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->