### PR TITLE
docs(lynx): disable enableCSSStrictMode due to CSS property compatibility issues

### DIFF
--- a/docs/content/lynx/getting-started/feature-flags.mdx
+++ b/docs/content/lynx/getting-started/feature-flags.mdx
@@ -68,6 +68,11 @@ CSS 값 파싱을 웹 표준과 동일하게 엄격하게 적용합니다.
 | **켜면**             | 유효하지 않은 `<length>` 값을 드롭합니다. `width: 100`처럼 단위가 빠진 값은 무시됩니다      |
 | **SEED Design 이점** | SEED Design의 CSS가 웹과 Lynx에서 동일하게 파싱됩니다. 플랫폼 간 스타일 불일치를 방지합니다 |
 
+<Callout type="warn">
+  `enableCSSStrictMode`를 활성화하면 일부 CSS 속성이 Lynx에서 올바르게 파싱되지 않는 호환성 문제가 있습니다.
+  현재는 **비활성화(`false`)를 권장**합니다.
+</Callout>
+
 #### `enableCSSInheritance`
 
 CSS 속성 상속을 활성화합니다.
@@ -278,7 +283,7 @@ export default defineConfig({
       // CSS
       enableCSSInheritance: true,
       enableCSSInlineVariables: true,
-      enableCSSStrictMode: true,
+      // enableCSSStrictMode: false (CSS 속성 호환성 이슈로 비활성화 권장)
 
       // 텍스트 & 레이아웃
       enableTextRefactor: true,

--- a/docs/content/lynx/getting-started/installation.mdx
+++ b/docs/content/lynx/getting-started/installation.mdx
@@ -136,7 +136,7 @@ export default defineConfig({
       enableCSSInvalidation: true,
       enableCSSInheritance: true,
       enableCSSInlineVariables: true,
-      enableCSSStrictMode: true,
+      enableCSSStrictMode: false,
       enableTextRefactor: true,
       fontScaleEffectiveOnlyOnSp: true,
       enableFixedNew: true,

--- a/examples/lynx-spa/lynx.config.ts
+++ b/examples/lynx-spa/lynx.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
       // CSS
       enableCSSInheritance: true,
       enableCSSInlineVariables: true,
-      enableCSSStrictMode: true,
+      enableCSSStrictMode: false,
 
       // 텍스트 & 레이아웃
       enableTextRefactor: true,


### PR DESCRIPTION
## Summary
- `enableCSSStrictMode`를 활성화하면 Lynx에서 다수의 CSS 속성이 깨지는 호환성 문제가 있어, 권장값을 `false`로 변경
- `feature-flags.mdx`: 비활성화 권장 Callout 추가 + 코드 예시 변경
- `installation.mdx`: 코드 예시에서 `true` → `false`
- `examples/lynx-spa/lynx.config.ts`: `true` → `false`

## Test plan
- [ ] 문서 사이트 빌드 정상 확인
- [ ] feature-flags, installation 페이지에서 변경된 내용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)