### PR TITLE
feat(rootage): add menu-sheet handle spacing, deprecate close button

### DIFF
--- a/.changeset/menu-sheet-handle-rootage.md
+++ b/.changeset/menu-sheet-handle-rootage.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/rootage-artifacts": patch
+---
+
+menu-sheet 스펙에 핸들 여백을 위한 header.paddingTop 추가, menu-sheet-close-button deprecated 처리

--- a/docs/public/rootage/components/action-sheet-close-button.json
+++ b/docs/public/rootage/components/action-sheet-close-button.json
@@ -3,7 +3,7 @@
   "metadata": {
     "id": "action-sheet-close-button",
     "name": "Action Sheet Close Button",
-    "deprecated": "Use menu-sheet-close-button instead."
+    "deprecated": "No longer used."
   },
   "data": {
     "id": "action-sheet-close-button",

--- a/docs/public/rootage/components/extended-action-sheet-close-button.json
+++ b/docs/public/rootage/components/extended-action-sheet-close-button.json
@@ -3,7 +3,7 @@
   "metadata": {
     "id": "extended-action-sheet-close-button",
     "name": "Extended Action Sheet Close Button",
-    "deprecated": "Use menu-sheet-close-button instead."
+    "deprecated": "No longer used."
   },
   "data": {
     "id": "extended-action-sheet-close-button",

--- a/docs/public/rootage/components/menu-sheet-close-button.json
+++ b/docs/public/rootage/components/menu-sheet-close-button.json
@@ -2,7 +2,8 @@
   "kind": "ComponentSpec",
   "metadata": {
     "id": "menu-sheet-close-button",
-    "name": "Menu Sheet Close Button"
+    "name": "Menu Sheet Close Button",
+    "deprecated": "No longer used. Menu Sheet now uses a handle instead of a close button."
   },
   "data": {
     "id": "menu-sheet-close-button",

--- a/docs/public/rootage/components/menu-sheet.json
+++ b/docs/public/rootage/components/menu-sheet.json
@@ -70,6 +70,9 @@
             "gap": {
               "type": "dimension"
             },
+            "paddingTop": {
+              "type": "dimension"
+            },
             "paddingBottom": {
               "type": "dimension"
             }
@@ -225,6 +228,10 @@
                 "gap": {
                   "type": "dimension",
                   "value": "$dimension.x1"
+                },
+                "paddingTop": {
+                  "type": "dimension",
+                  "value": "$dimension.x2"
                 },
                 "paddingBottom": {
                   "type": "dimension",

--- a/packages/css/vars/component/menu-sheet.d.ts
+++ b/packages/css/vars/component/menu-sheet.d.ts
@@ -23,6 +23,7 @@ export declare const vars: {
       },
       "header": {
         "gap": "var(--seed-dimension-x1)",
+        "paddingTop": "var(--seed-dimension-x2)",
         "paddingBottom": "var(--seed-dimension-x4)"
       },
       "title": {

--- a/packages/css/vars/component/menu-sheet.mjs
+++ b/packages/css/vars/component/menu-sheet.mjs
@@ -23,6 +23,7 @@ export const vars = {
       },
       "header": {
         "gap": "var(--seed-dimension-x1)",
+        "paddingTop": "var(--seed-dimension-x2)",
         "paddingBottom": "var(--seed-dimension-x4)"
       },
       "title": {

--- a/packages/qvism-preset/src/vars/component/menu-sheet.d.ts
+++ b/packages/qvism-preset/src/vars/component/menu-sheet.d.ts
@@ -23,6 +23,7 @@ export declare const vars: {
       },
       "header": {
         "gap": "var(--seed-dimension-x1)",
+        "paddingTop": "var(--seed-dimension-x2)",
         "paddingBottom": "var(--seed-dimension-x4)"
       },
       "title": {

--- a/packages/qvism-preset/src/vars/component/menu-sheet.mjs
+++ b/packages/qvism-preset/src/vars/component/menu-sheet.mjs
@@ -23,6 +23,7 @@ export const vars = {
       },
       "header": {
         "gap": "var(--seed-dimension-x1)",
+        "paddingTop": "var(--seed-dimension-x2)",
         "paddingBottom": "var(--seed-dimension-x4)"
       },
       "title": {

--- a/packages/rootage/components/action-sheet-close-button.yaml
+++ b/packages/rootage/components/action-sheet-close-button.yaml
@@ -3,7 +3,7 @@ kind: ComponentSpec
 metadata:
   id: action-sheet-close-button
   name: Action Sheet Close Button
-  deprecated: Use menu-sheet-close-button instead.
+  deprecated: No longer used.
 data:
   schema:
     slots:

--- a/packages/rootage/components/extended-action-sheet-close-button.yaml
+++ b/packages/rootage/components/extended-action-sheet-close-button.yaml
@@ -3,7 +3,7 @@ kind: ComponentSpec
 metadata:
   id: extended-action-sheet-close-button
   name: Extended Action Sheet Close Button
-  deprecated: Use menu-sheet-close-button instead.
+  deprecated: No longer used.
 data:
   schema:
     slots:

--- a/packages/rootage/components/menu-sheet-close-button.yaml
+++ b/packages/rootage/components/menu-sheet-close-button.yaml
@@ -3,6 +3,7 @@ kind: ComponentSpec
 metadata:
   id: menu-sheet-close-button
   name: Menu Sheet Close Button
+  deprecated: No longer used. Menu Sheet now uses a handle instead of a close button.
 data:
   schema:
     slots:

--- a/packages/rootage/components/menu-sheet.yaml
+++ b/packages/rootage/components/menu-sheet.yaml
@@ -46,6 +46,8 @@ data:
         properties:
           gap:
             type: dimension
+          paddingTop:
+            type: dimension
           paddingBottom:
             type: dimension
       title:
@@ -110,6 +112,7 @@ data:
           exitTimingFunction: $timing-function.exit
         header:
           gap: $dimension.x1
+          paddingTop: $dimension.x2
           paddingBottom: $dimension.x4
         title:
           fontSize: $font-size.t6


### PR DESCRIPTION
## Summary
- Add `header.paddingTop: $dimension.x2` to menu-sheet rootage spec for handle spacing
- Deprecate `menu-sheet-close-button` (no longer used, replaced by handle)
- Update deprecated messages in `action-sheet-close-button` and `extended-action-sheet-close-button`

## Context
Part of menu-sheet handle migration (`claude/busy-noether` branch). Rootage changes shipped separately to dev first.

## Test plan
- [ ] `bun generate:all` completes without errors after merge
- [ ] Generated vars include new `paddingTop` property for menu-sheet header
- [ ] Deprecated metadata propagated to JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Menu Sheet의 헤더에 상단 여백(paddingTop) 설정 기능 추가

* **Chores**
  * 여러 컴포넌트의 상태 정보를 “더 이상 사용되지 않음”으로 업데이트(메뉴 시트가 핸들을 사용함을 안내)
  * 배포용 변경 사항을 기록한 변경셋 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->