### PR TITLE
fix(ci): remove restore-keys from build cache

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -44,8 +44,6 @@ runs:
           ecosystem/**/build
           ecosystem/**/lib
         key: ${{ runner.os }}-build-rootage-${{ inputs.build-rootage }}-${{ hashFiles('packages/**', 'ecosystem/**', 'bun.lock', 'bun.lockb') }}
-        restore-keys: |
-          ${{ runner.os }}-build-rootage-${{ inputs.build-rootage }}-
 
     - name: Relink workspace after cache restore
       if: ${{ inputs.build-packages == 'true' && steps.cache-build.outputs.cache-hit == 'true' }}


### PR DESCRIPTION
Prevent partial cache matches that can restore stale build artifacts, ensuring builds always use exact-match caches or rebuild from scratch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기타 (Chores)**
  * GitHub Actions 캐시 설정이 정확한 키 값 기반 일치로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->