### PR TITLE
docs(qvism-preset): add state selector convention to AGENTS.md

### DIFF
--- a/packages/qvism-preset/AGENTS.md
+++ b/packages/qvism-preset/AGENTS.md
@@ -15,6 +15,14 @@
 - Pseudo 선택자: `active` (hover 대신, 모바일 우선), `disabled`, `focus`, `checked` 등
 - 토큰 참조: `vars.{variant}.{state}.{slot}.{property}`
 
+## 상태 기반 선택자 작성 규칙
+
+같은 headless 훅을 사용하는 recipe 간에는 CSS 선택자 전략을 통일한다.
+
+- 새로운 상태 기반 선택자를 추가할 때, 동일 훅을 사용하는 다른 recipe의 선택자 패턴을 먼저 확인한다.
+- HTML 속성(`hidden`, `disabled`)보다 `data-*` 상태 속성(`data-loading-state` 등)을 우선 사용한다. HTML 속성은 프레임워크 레이어에서 override될 수 있어 불안정하다.
+- 예시: `useImage` 훅을 사용하는 Avatar와 ImageFrame은 모두 `data-loading-state` 기반 선택자를 사용한다.
+
 ## defineRecipe vs defineSlotRecipe
 
 | 기준 | `defineRecipe` | `defineSlotRecipe` |


### PR DESCRIPTION
## Summary
- qvism-preset AGENTS.md에 상태 기반 선택자 작성 규칙 추가
- 같은 headless 훅을 쓰는 recipe 간 CSS 선택자 전략 통일 원칙 문서화
- HTML 속성(`hidden`)보다 `data-*` 상태 속성 우선 사용 가이드

## Context
`fix/image-frame-hidden-content` PR 리뷰에서 ImageFrame이 `&[hidden]` 대신 Avatar와 동일한 `data-loading-state` 선택자를 사용해야 한다는 피드백이 있었습니다. 같은 실수를 반복하지 않도록 AGENTS.md에 컨벤션으로 기록합니다.

## Test plan
- [x] AGENTS.md 문서 변경만 포함, 코드 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 상태 기반 CSS 선택자 작성 규칙 문서가 추가되었습니다. 동일한 훅을 사용하는 컴포넌트 간 선택자 전략의 일관성을 보장하기 위한 가이드라인이 강화되었으며, HTML 속성보다 `data-*` 상태 속성의 우선 사용을 명시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->