### PR TITLE
perf(stackflow): replace CSS variable cascade with direct DOM manipulation during swipe

### DIFF
--- a/packages/stackflow/src/primitive/GlobalInteraction/swipe-animation.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/swipe-animation.ts
@@ -1,0 +1,128 @@
+/**
+ * Swipe-back inline style helpers.
+ *
+ * During swiping (touchmove), we apply transform/opacity directly to each
+ * animated element via inline style instead of CSS variables on the stack root.
+ * This avoids cascading style recalculation across the entire subtree.
+ *
+ * On touchend, we remove inline styles and set CSS variables once so the
+ * existing CSS recipe transition (completing/canceling) takes over seamlessly.
+ */
+
+// Constants matching qvism-preset/stackflow/animation.ts
+const BEHIND_OFFSET = -30; // %
+const BEHIND_PARALLAX = 0.3;
+const OPACITY_FADE_MUL = 3;
+const TITLE_TRANSLATE = 0.15;
+
+// Selectors for finding app-bar elements
+const SEL_APP_BAR_MAIN_ROOT = '[class*="seed-app-bar-main__root"]';
+const SEL_APP_BAR_ROOT = '[class*="seed-app-bar__root"]';
+const SEL_APP_BAR_ICON = '[class*="seed-app-bar__icon"]';
+const SEL_APP_BAR_CUSTOM = '[class*="seed-app-bar__custom"]';
+
+export interface SwipeTargets {
+  topLayer: HTMLElement | null;
+  topDim: HTMLElement | null;
+  behindLayer: HTMLElement | null;
+  topTitle: HTMLElement | null;
+  behindTitle: HTMLElement | null;
+  topIcons: HTMLElement[];
+  behindIcons: HTMLElement[];
+  topAppBarRoot: HTMLElement | null;
+}
+
+/** Query DOM once at swipe start, cache results for the gesture duration. */
+export function findSwipeTargets(stackEl: HTMLElement): SwipeTargets {
+  const topActivity = stackEl.querySelector<HTMLElement>("[data-activity-is-top]");
+
+  let behindActivity: HTMLElement | null = null;
+  if (topActivity) {
+    const all = stackEl.querySelectorAll<HTMLElement>("[data-part='activity']");
+    const topId = topActivity.dataset["activityId"];
+    let found = false;
+    for (let i = all.length - 1; i >= 0; i--) {
+      const id = all[i].dataset["activityId"];
+      if (id === topId) {
+        found = true;
+        continue;
+      }
+      if (found && id) {
+        behindActivity = all[i];
+        break;
+      }
+    }
+  }
+
+  return {
+    topLayer: topActivity?.querySelector<HTMLElement>("[data-part='layer']") ?? null,
+    topDim: topActivity?.querySelector<HTMLElement>("[data-part='dim']") ?? null,
+    behindLayer: behindActivity?.querySelector<HTMLElement>("[data-part='layer']") ?? null,
+    topTitle: topActivity?.querySelector<HTMLElement>(SEL_APP_BAR_MAIN_ROOT) ?? null,
+    behindTitle: behindActivity?.querySelector<HTMLElement>(SEL_APP_BAR_MAIN_ROOT) ?? null,
+    topIcons: Array.from(
+      topActivity?.querySelectorAll<HTMLElement>(`${SEL_APP_BAR_ICON}, ${SEL_APP_BAR_CUSTOM}`) ??
+        [],
+    ),
+    behindIcons: Array.from(
+      behindActivity?.querySelectorAll<HTMLElement>(`${SEL_APP_BAR_ICON}, ${SEL_APP_BAR_CUSTOM}`) ??
+        [],
+    ),
+    topAppBarRoot: topActivity?.querySelector<HTMLElement>(SEL_APP_BAR_ROOT) ?? null,
+  };
+}
+
+/** Apply inline styles during swiping. Overrides CSS recipe values. */
+export function applySwipeStyles(t: SwipeTargets, displacement: number, ratio: number): void {
+  // Top layer
+  if (t.topLayer) {
+    t.topLayer.style.transform = `translate3d(${displacement}px, 0, 0)`;
+  }
+  // Behind layer (parallax)
+  if (t.behindLayer) {
+    t.behindLayer.style.transform = `translate3d(calc(${BEHIND_OFFSET}% + ${displacement * BEHIND_PARALLAX}px), 0, 0)`;
+  }
+  // Dim
+  if (t.topDim) {
+    t.topDim.style.opacity = `${1 - ratio}`;
+  }
+  // Title
+  if (t.topTitle) {
+    t.topTitle.style.opacity = `${Math.max(0, 1 - ratio * OPACITY_FADE_MUL)}`;
+    t.topTitle.style.transform = `translate3d(${displacement * TITLE_TRANSLATE}px, 0, 0)`;
+  }
+  if (t.behindTitle) {
+    t.behindTitle.style.opacity = `${ratio}`;
+    t.behindTitle.style.transform = `translate3d(calc(-25% + ${displacement * TITLE_TRANSLATE}px), 0, 0)`;
+  }
+  // Icons
+  for (const icon of t.topIcons) {
+    icon.style.opacity = `${Math.max(0, 1 - ratio * OPACITY_FADE_MUL)}`;
+    icon.style.transform = `translate3d(${displacement * TITLE_TRANSLATE}px, 0, 0)`;
+  }
+  for (const icon of t.behindIcons) {
+    icon.style.opacity = `${ratio}`;
+  }
+  // AppBar background ::before — can't inline on pseudo, use scoped CSS var
+  if (t.topAppBarRoot) {
+    t.topAppBarRoot.style.setProperty("--swipe-back-displacement", `${displacement}px`);
+  }
+}
+
+/** Remove all inline styles so CSS recipe regains control. */
+export function clearInlineStyles(t: SwipeTargets): void {
+  const els = [t.topLayer, t.topDim, t.behindLayer, t.topTitle, t.behindTitle];
+  for (const el of els) {
+    if (!el) continue;
+    el.style.transform = "";
+    el.style.opacity = "";
+  }
+  for (const icon of [...t.topIcons, ...t.behindIcons]) {
+    icon.style.transform = "";
+    icon.style.opacity = "";
+  }
+  // Clear scoped CSS var from appBar root (stack root will set the global one)
+  if (t.topAppBarRoot) {
+    t.topAppBarRoot.style.removeProperty("--swipe-back-displacement");
+  }
+}

--- a/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.ts
@@ -1,6 +1,12 @@
 import { useCallbackRef } from "@radix-ui/react-use-callback-ref";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useTopActivity } from "../private/useTopActivity";
+import {
+  type SwipeTargets,
+  applySwipeStyles,
+  clearInlineStyles,
+  findSwipeTargets,
+} from "./swipe-animation";
 
 export type SwipeBackState = "idle" | "swiping" | "canceling" | "completing";
 
@@ -57,103 +63,117 @@ export function useGlobalInteraction() {
   });
   const stackRef = useRef<HTMLDivElement>(null);
 
-  const setSwipeBackContext = useCallback((ctx: SwipeBackContext) => {
-    swipeBackContextRef.current = ctx;
-    stackRef.current?.style.setProperty(
-      "--swipe-back-displacement",
-      `${ctx.displacement.toString()}px`,
-    );
-    stackRef.current?.style.setProperty(
-      "--swipe-back-displacement-ratio",
-      ctx.displacementRatio.toString(),
-    );
-  }, []);
+  // Cached swipe targets — populated once on startSwipeBack, reused during gesture
+  const cachedTargetsRef = useRef<SwipeTargets | null>(null);
 
-  const getSwipeBackEvents = useCallback(
-    (props: SwipeBackProps) => {
-      const {
-        swipeBackDisplacementRatioThreshold: displacementRatioThreshold = 0.4,
-        swipeBackVelocityThreshold: velocityThreshold = 1,
-      } = props;
-      const onSwipeStart = useCallbackRef(props.onSwipeBackStart);
-      const onSwipeMove = useCallbackRef(props.onSwipeBackMove);
-      const onSwipeEnd = useCallbackRef(props.onSwipeBackEnd);
+  const getSwipeBackEvents = useCallback((props: SwipeBackProps) => {
+    const {
+      swipeBackDisplacementRatioThreshold: displacementRatioThreshold = 0.4,
+      swipeBackVelocityThreshold: velocityThreshold = 1,
+    } = props;
+    const onSwipeStart = useCallbackRef(props.onSwipeBackStart);
+    const onSwipeMove = useCallbackRef(props.onSwipeBackMove);
+    const onSwipeEnd = useCallbackRef(props.onSwipeBackEnd);
 
-      const startSwipeBack = useCallback(
-        ({ x0, t0 }: StartSwipeBackProps) => {
-          setSwipeBackContext({
-            x0,
-            t0,
-            displacement: 0,
-            displacementRatio: 0,
-            velocity: 0,
-          });
-          setSwipeBackState((prev) => (prev === "swiping" ? prev : "swiping"));
-          onSwipeStart?.();
-        },
-        [onSwipeStart],
-      );
-
-      const moveSwipeBack = useCallback(
-        ({ x, t }: MoveSwipeBackProps) => {
-          const displacement = Math.max(0, x - swipeBackContextRef.current.x0);
-          const displacementRatio = displacement / window.innerWidth;
-          const velocity = displacement / (t - swipeBackContextRef.current.t0);
-          setSwipeBackContext({
-            ...swipeBackContextRef.current,
-            displacement,
-            displacementRatio,
-            velocity,
-          });
-          setSwipeBackState((prev) => (prev === "swiping" ? prev : "swiping"));
-          onSwipeMove?.({ displacement, displacementRatio });
-        },
-        [onSwipeMove],
-      );
-
-      const endSwipeBack = useCallback(
-        (_: EndSwipeBackProps) => {
-          const swiped =
-            swipeBackContextRef.current.displacementRatio > displacementRatioThreshold ||
-            swipeBackContextRef.current.velocity > velocityThreshold;
-
-          if (swiped) {
-            stackRef.current?.style.setProperty("--swipe-back-target", "100%");
-            setSwipeBackState("completing");
-          } else {
-            stackRef.current?.style.setProperty("--swipe-back-target", "0");
-            setSwipeBackState("canceling");
-          }
-
-          onSwipeEnd?.({ swiped });
-        },
-        [onSwipeEnd, displacementRatioThreshold, velocityThreshold],
-      );
-
-      const reset = useCallback(() => {
-        setSwipeBackContext({
-          x0: 0,
-          t0: 0,
+    const startSwipeBack = useCallback(
+      ({ x0, t0 }: StartSwipeBackProps) => {
+        swipeBackContextRef.current = {
+          x0,
+          t0,
           displacement: 0,
           displacementRatio: 0,
           velocity: 0,
-        });
-        stackRef.current?.style.setProperty("--swipe-back-target", "0");
-        setSwipeBackState("idle");
-      }, []);
+        };
 
-      return useMemo(
-        () => ({
-          startSwipeBack,
-          moveSwipeBack,
-          endSwipeBack,
-          reset,
-        }),
-        [startSwipeBack, moveSwipeBack, endSwipeBack, reset],
-      );
-    },
-    [setSwipeBackContext],
-  );
+        // Cache target elements once per gesture
+        if (stackRef.current) {
+          cachedTargetsRef.current = findSwipeTargets(stackRef.current);
+        }
+
+        setSwipeBackState((prev) => (prev === "swiping" ? prev : "swiping"));
+        onSwipeStart?.();
+      },
+      [onSwipeStart],
+    );
+
+    const moveSwipeBack = useCallback(
+      ({ x, t }: MoveSwipeBackProps) => {
+        const displacement = Math.max(0, x - swipeBackContextRef.current.x0);
+        const displacementRatio = displacement / window.innerWidth;
+        const velocity = displacement / (t - swipeBackContextRef.current.t0);
+
+        swipeBackContextRef.current = {
+          ...swipeBackContextRef.current,
+          displacement,
+          displacementRatio,
+          velocity,
+        };
+
+        // Direct inline style on each element instead of CSS variables on stack root.
+        // Inline style only triggers repaint on that element, not cascading recalc.
+        const targets = cachedTargetsRef.current;
+        if (targets) {
+          applySwipeStyles(targets, displacement, displacementRatio);
+        }
+
+        onSwipeMove?.({ displacement, displacementRatio });
+      },
+      [onSwipeMove],
+    );
+
+    const endSwipeBack = useCallback(
+      (_: EndSwipeBackProps) => {
+        const ctx = swipeBackContextRef.current;
+        const swiped =
+          ctx.displacementRatio > displacementRatioThreshold || ctx.velocity > velocityThreshold;
+
+        // 1. Remove inline styles so CSS recipe regains control
+        if (cachedTargetsRef.current) {
+          clearInlineStyles(cachedTargetsRef.current);
+          cachedTargetsRef.current = null;
+        }
+
+        // 2. Set CSS variables ONCE to current displacement.
+        //    This ensures the CSS recipe transition starts from the correct position.
+        stackRef.current?.style.setProperty("--swipe-back-displacement", `${ctx.displacement}px`);
+        stackRef.current?.style.setProperty(
+          "--swipe-back-displacement-ratio",
+          ctx.displacementRatio.toString(),
+        );
+
+        // 3. Set target and state — CSS recipe transition takes over
+        if (swiped) {
+          stackRef.current?.style.setProperty("--swipe-back-target", "100%");
+          setSwipeBackState("completing");
+        } else {
+          stackRef.current?.style.setProperty("--swipe-back-target", "0");
+          setSwipeBackState("canceling");
+        }
+
+        onSwipeEnd?.({ swiped });
+      },
+      [onSwipeEnd, displacementRatioThreshold, velocityThreshold],
+    );
+
+    const reset = useCallback(() => {
+      // Clear CSS variables
+      stackRef.current?.style.setProperty("--swipe-back-displacement", "0px");
+      stackRef.current?.style.setProperty("--swipe-back-displacement-ratio", "0");
+      stackRef.current?.style.setProperty("--swipe-back-target", "0");
+      setSwipeBackState("idle");
+      cachedTargetsRef.current = null;
+    }, []);
+
+    return useMemo(
+      () => ({
+        startSwipeBack,
+        moveSwipeBack,
+        endSwipeBack,
+        reset,
+      }),
+      [startSwipeBack, moveSwipeBack, endSwipeBack, reset],
+    );
+  }, []);
 
   const topActivity = useTopActivity();
 
@@ -178,11 +198,10 @@ export function useGlobalInteraction() {
       swipeBackContextRef,
       swipeBackState,
       setSwipeBackState,
-      setSwipeBackContext,
       getSwipeBackEvents,
 
       stackProps,
     }),
-    [swipeBackState, setSwipeBackContext, getSwipeBackEvents, stackProps],
+    [swipeBackState, getSwipeBackEvents, stackProps],
   );
 }

--- a/packages/stackflow/src/primitive/GlobalInteraction/useSwipeBack.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/useSwipeBack.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { SwipeBackProps } from "./useGlobalInteraction";
 import { useGlobalInteractionContext } from "./useGlobalInteractionContext";
 
@@ -7,11 +7,34 @@ export interface UseSwipeBackProps extends SwipeBackProps {}
 export function useSwipeBack(props: UseSwipeBackProps) {
   const globalInteraction = useGlobalInteractionContext();
   const events = globalInteraction.getSwipeBackEvents(props);
+  const edgeRef = useRef<HTMLElement>(null);
+  const rAFLockRef = useRef(false);
 
   useEffect(() => {
     return () => {
       events.reset();
     };
+  }, [events]);
+
+  // Passive native touchmove listener — avoids compositor blocking
+  useEffect(() => {
+    const edge = edgeRef.current;
+    if (!edge) return;
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (rAFLockRef.current) return;
+      rAFLockRef.current = true;
+      requestAnimationFrame(() => {
+        const touch = e.touches[0];
+        if (touch) {
+          events.moveSwipeBack({ x: touch.clientX, t: Date.now() });
+        }
+        rAFLockRef.current = false;
+      });
+    };
+
+    edge.addEventListener("touchmove", handleTouchMove, { passive: true });
+    return () => edge.removeEventListener("touchmove", handleTouchMove);
   }, [events]);
 
   return useMemo(
@@ -20,36 +43,33 @@ export function useSwipeBack(props: UseSwipeBackProps) {
         "data-swipe-back": "",
       } as React.HTMLAttributes<HTMLDivElement>,
       layerProps: {
-        onAnimationEnd: (e) => {
+        onAnimationEnd: (e: React.AnimationEvent) => {
           if (e.target === e.currentTarget) {
             events.reset();
           }
         },
-        onTransitionEnd: (e) => {
+        onTransitionEnd: (e: React.TransitionEvent) => {
           if (e.target === e.currentTarget) {
             events.reset();
           }
         },
       } as React.HTMLAttributes<HTMLDivElement>,
       edgeProps: {
+        ref: edgeRef,
         tabIndex: -1,
-        onTouchStart: (e) => {
+        onTouchStart: (e: React.TouchEvent) => {
           const x0 = e.touches[0].clientX;
           const t0 = Date.now();
           events.startSwipeBack({ x0, t0 });
         },
-        onTouchMove: (e) => {
-          const x = e.touches[0].clientX;
-          const t = Date.now();
-          events.moveSwipeBack({ x, t });
-        },
+        // onTouchMove handled by passive native listener above
         onTouchEnd: () => {
           events.endSwipeBack({});
         },
         onTouchCancel: () => {
           events.endSwipeBack({});
         },
-      } as React.HTMLAttributes<HTMLElement>,
+      } as React.HTMLAttributes<HTMLElement> & { ref: React.RefObject<HTMLElement | null> },
     }),
     [events],
   );


### PR DESCRIPTION
## Summary

- 스와이프 백 중 CSS 변수(`--swipe-back-displacement`)를 GlobalInteraction 루트에 설정하던 방식을 **각 애니메이션 대상 요소에 직접 inline style 설정**으로 교체
- CSS 변수는 inheritable이라 전체 자식 트리의 스타일 재계산을 유발하지만, inline style은 해당 요소만 리페인트
- touchend 시 inline style 제거 → CSS 변수를 현재 값으로 한번 설정 → 기존 CSS recipe transition이 그대로 인계
- **CSS recipe 시스템(pseudo.ts, animation.ts, app-screen.ts, app-bar.ts)은 일절 수정 없음**

### 변경 사항

| 파일 | 변경 |
|------|------|
| `swipe-animation.ts` (신규) | `findSwipeTargets`, `applySwipeStyles`, `clearInlineStyles` 유틸 |
| `useGlobalInteraction.ts` | swiping 중 inline style, touchend 시 CSS 핸드오프 |
| `useSwipeBack.ts` | passive native touchmove listener + rAF lock |

### 동작 흐름

```
touchstart → DOM query로 요소 캐시 (1회)
touchmove  → 각 요소에 inline style 직접 설정 (CSS 변수 없음, passive + rAF)
touchend   → inline style 제거 → CSS 변수 한번 설정 → CSS recipe transition 인계
```

## Test plan

- [ ] `bun test:all` 통과 확인
- [ ] examples/stackflow-spa에서 스와이프 백 기본 동작 확인
- [ ] 스와이프 완료/취소 시 매끄러운 전환 확인
- [ ] AppBar title/icon/background 스와이프 따라 움직임 확인
- [ ] behind layer 패럴랙스 효과 정상 확인
- [ ] 일반 push/pop 애니메이션 영향 없음 확인
- [ ] Chrome DevTools Performance에서 Recalculate Style 감소 확인

Closes DES-1079

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 스와이프 백 제스처 처리 최적화로 더욱 부드러운 애니메이션 성능 제공
  * 터치 입력 응답성 향상으로 더욱 빠른 인터랙션 경험 개선

* **개선 사항**
  * 스와이프 제스처 중 시각적 피드백 강화로 사용자 경험 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->