### PR TITLE
feat(docs): add React component name column to icon llms.txt

### DIFF
--- a/docs/app/_llms/rules/icon-library-rule.test.ts
+++ b/docs/app/_llms/rules/icon-library-rule.test.ts
@@ -10,6 +10,6 @@ describe("iconLibraryRule", () => {
 
     expect(actual).toContain("## Monochrome Icons");
     expect(actual).toContain("## Multicolor Icons");
-    expect(actual).toContain("| Icon Name | Figma Name | Keywords | Services | Tags |");
+    expect(actual).toContain("| Icon Name | React Component | Figma Name | Keywords | Services | Tags |");
   });
 });

--- a/docs/app/_llms/rules/icon-library-rule.ts
+++ b/docs/app/_llms/rules/icon-library-rule.ts
@@ -16,6 +16,7 @@ interface RawIconData {
 
 interface IconRow {
   name: string;
+  componentName: string;
   figmaName: string;
   keywords: string[];
   services: string[];
@@ -67,11 +68,19 @@ function splitMetadatas(metadatas: string[]): {
   };
 }
 
+function toComponentName(iconName: string): string {
+  return iconName
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join("");
+}
+
 function toRow(icon: RawIconData): IconRow {
   const { keywords, services, tags } = splitMetadatas(icon.metadatas ?? []);
 
   return {
     name: icon.name,
+    componentName: toComponentName(icon.name),
     figmaName: icon.figma?.name ?? "",
     keywords,
     services,
@@ -92,11 +101,12 @@ function formatList(values: string[]): string {
 }
 
 function buildTable(rows: IconRow[]): string {
-  const headers = ["Icon Name", "Figma Name", "Keywords", "Services", "Tags"];
+  const headers = ["Icon Name", "React Component", "Figma Name", "Keywords", "Services", "Tags"];
   const separator = headers.map(() => "---");
   const bodyRows = rows.map((row) =>
     markdownRow([
       escapeCell(row.name),
+      escapeCell(row.componentName),
       escapeCell(row.figmaName),
       escapeCell(formatList(row.keywords)),
       escapeCell(formatList(row.services)),


### PR DESCRIPTION
Adds a "React Component" column (PascalCase) alongside the existing snake_case icon name in the icon library llms.txt output, so LLMs can reference the correct React import name directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 아이콘 라이브러리 테이블에 React 컴포넌트 정보 열 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->