### PR TITLE
fix(docs): fix icon page 404 and add React component names to llms.txt

### DIFF
--- a/docs/app/_llms/rules/icon-library-rule.test.ts
+++ b/docs/app/_llms/rules/icon-library-rule.test.ts
@@ -10,6 +10,8 @@ describe("iconLibraryRule", () => {
 
     expect(actual).toContain("## Monochrome Icons");
     expect(actual).toContain("## Multicolor Icons");
-    expect(actual).toContain("| Icon Name | Figma Name | Keywords | Services | Tags |");
+    expect(actual).toContain(
+      "| Icon Name | React Component Name | Figma Name | Keywords | Services | Tags |",
+    );
   });
 });

--- a/docs/app/_llms/rules/icon-library-rule.ts
+++ b/docs/app/_llms/rules/icon-library-rule.ts
@@ -16,10 +16,18 @@ interface RawIconData {
 
 interface IconRow {
   name: string;
+  reactComponentName: string;
   figmaName: string;
   keywords: string[];
   services: string[];
   tags: string[];
+}
+
+function toComponentName(iconName: string): string {
+  return iconName
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join("");
 }
 
 const SERVICE_PREFIX = "service:";
@@ -72,6 +80,7 @@ function toRow(icon: RawIconData): IconRow {
 
   return {
     name: icon.name,
+    reactComponentName: toComponentName(icon.name),
     figmaName: icon.figma?.name ?? "",
     keywords,
     services,
@@ -92,11 +101,19 @@ function formatList(values: string[]): string {
 }
 
 function buildTable(rows: IconRow[]): string {
-  const headers = ["Icon Name", "Figma Name", "Keywords", "Services", "Tags"];
+  const headers = [
+    "Icon Name",
+    "React Component Name",
+    "Figma Name",
+    "Keywords",
+    "Services",
+    "Tags",
+  ];
   const separator = headers.map(() => "---");
   const bodyRows = rows.map((row) =>
     markdownRow([
       escapeCell(row.name),
+      escapeCell(row.reactComponentName),
       escapeCell(row.figmaName),
       escapeCell(formatList(row.keywords)),
       escapeCell(formatList(row.services)),

--- a/docs/content/react/components/(foundation)/iconography/library.mdx
+++ b/docs/content/react/components/(foundation)/iconography/library.mdx
@@ -18,7 +18,3 @@ description: 리액트 아이콘 패키지는 아이콘을 사용할 때 필요�
 npm install @karrotmarket/react-monochrome-icon @karrotmarket/react-multicolor-icon
 ```
 
-## Package
-
-- [@karrotmarket/react-monochrome-icon](https://github.com/daangn/seed-icon-v3/pkgs/npm/react-monochrome-icon)
-- [@karrotmarket/react-multicolor-icon](https://github.com/daangn/seed-icon-v3/pkgs/npm/react-multicolor-icon)

--- a/skills/seed-design/references/foundation.md
+++ b/skills/seed-design/references/foundation.md
@@ -32,6 +32,16 @@ https://seed-design.io/docs/llms.txt
 
 핵심 원칙: 스케일은 t1(가장 작음)부터 t10(가장 큼). CSS 변수 `--seed-font-size-t{n}`, `--seed-line-height-t{n}`, `--seed-font-weight-*`로 사용합니다.
 
+### 아이코노그래피
+
+| 토픽 | URL |
+|------|-----|
+| 아이코노그래피 개요 | https://seed-design.io/llms/docs/foundation/iconography/overview.txt |
+| 아이콘 사용법 | https://seed-design.io/llms/docs/foundation/iconography/usage.txt |
+| 아이콘 라이브러리 | https://seed-design.io/llms/docs/foundation/iconography/library.txt |
+
+핵심 원칙: React 아이콘 컴포넌트는 `@karrotmarket/react-monochrome-icon`(단색)과 `@karrotmarket/react-multicolor-icon`(멀티컬러)에서 import합니다. 아이콘명은 PascalCase로 변환하여 사용합니다 (예: `icon_heart_fill` → `IconHeartFill`).
+
 ### 스페이싱, 테마, 기타
 
 | 토픽 | URL |

--- a/skills/seed-design/references/foundation.md
+++ b/skills/seed-design/references/foundation.md
@@ -32,15 +32,13 @@ https://seed-design.io/docs/llms.txt
 
 핵심 원칙: 스케일은 t1(가장 작음)부터 t10(가장 큼). CSS 변수 `--seed-font-size-t{n}`, `--seed-line-height-t{n}`, `--seed-font-weight-*`로 사용합니다.
 
-### 아이코노그래피
+### Iconography
 
 | 토픽 | URL |
 |------|-----|
-| 아이코노그래피 개요 | https://seed-design.io/llms/docs/foundation/iconography/overview.txt |
-| 아이콘 사용법 | https://seed-design.io/llms/docs/foundation/iconography/usage.txt |
-| 아이콘 라이브러리 | https://seed-design.io/llms/docs/foundation/iconography/library.txt |
-
-핵심 원칙: React 아이콘 컴포넌트는 `@karrotmarket/react-monochrome-icon`(단색)과 `@karrotmarket/react-multicolor-icon`(멀티컬러)에서 import합니다. 아이콘명은 PascalCase로 변환하여 사용합니다 (예: `icon_heart_fill` → `IconHeartFill`).
+| Overview | https://seed-design.io/llms/docs/foundation/iconography/overview.txt |
+| Usage | https://seed-design.io/llms/docs/foundation/iconography/usage.txt |
+| Library | https://seed-design.io/llms/docs/foundation/iconography/library.txt |
 
 ### 스페이싱, 테마, 기타
 


### PR DESCRIPTION
## Summary
- Remove broken Package links from `/react/components/iconography/library` (packages moved to internal org)
- Add "React Component Name" column to icon library llms.txt table (`icon_arrow_left_line` → `IconArrowLeftLine`)
- Add iconography section to seed-design skill `foundation.md` reference with llms.txt URLs and React package usage guide

Closes DES-1582

## Test plan
- [ ] `bun test -- icon-library-rule` passes
- [ ] Verify llms.txt output at `/llms/docs/foundation/iconography/library.txt` includes React Component Name column
- [ ] Verify `/react/components/iconography/library` page no longer shows broken Package links
- [ ] Verify seed-design skill shows iconography references when asked about icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 아이콘 라이브러리 문서에 "React Component Name" 열 추가 및 설치 명령 간소화
  * 아이콘그래피 섹션에 관련 참조(개요·사용법·라이브러리) 추가 및 구현 규칙(PascalCase 명명 기준) 명시

* **Tests**
  * 아이콘 라이브러리 테스트 기대값을 React 컴포넌트명 열을 포함하도록 갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->