### PR TITLE
fix(ci): allow renovate bot in claude-code-action dependency review

### DIFF
--- a/.github/workflows/renovate-dependency-review.yml
+++ b/.github/workflows/renovate-dependency-review.yml
@@ -154,6 +154,7 @@ jobs:
         uses: anthropics/claude-code-action@88c168b39e7e64da0286d812b6e9fbebb6708185 # v1
         with:
           anthropic_api_key: ${{ secrets.ORG_ANTHROPIC_API_KEY }}
+          allowed_bots: "renovate[bot]"
           track_progress: true
           use_sticky_comment: true
           prompt: |


### PR DESCRIPTION
## Summary
- `claude-code-action`이 기본적으로 봇 트리거 워크플로우를 차단하여 Renovate PR에서 의존성 분석이 실패하던 문제 수정
- `allowed_bots: "renovate[bot]"` 파라미터 추가로 Renovate 봇만 명시적 허용

## Test plan
- [ ] Renovate가 새 PR을 올리거나 기존 PR을 synchronize할 때 워크플로우 정상 실행 확인
- [ ] 또는 기존 Renovate PR에서 `/renovate-review` 코멘트로 수동 트리거

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI/CD 워크플로우 구성이 업데이트되었습니다.

**참고:** 이 변경사항은 최종 사용자에게 영향을 미치지 않는 내부 인프라 업데이트입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->