### PR TITLE
fix(docs): resolve nested dependency changes in changelog.txt

### DIFF
--- a/docs/app/llms/react/updates/changelog.txt/route.ts
+++ b/docs/app/llms/react/updates/changelog.txt/route.ts
@@ -1,24 +1,41 @@
 import { baseUrl } from "@/app/metadata";
+import {
+  buildLookupFromSources,
+  groupEntriesByVersion,
+  renderVersionMarkdown,
+} from "@/lib/changelog-llms";
 import type { ChangelogSource } from "@/lib/parse-changelog";
-import { loadChangelogSources } from "@/lib/parse-changelog";
+import { loadChangelogSources, splitVersionSections } from "@/lib/parse-changelog";
 
 export const revalidate = false;
 
 const CHANGELOG_SOURCE_URL = "https://github.com/daangn/seed-design/tree/dev/packages";
 
-function buildBody(sources: ChangelogSource[]): string {
-  return sources
-    .sort((a, b) => a.packageName.localeCompare(b.packageName))
+async function buildBody(sources: ChangelogSource[]): Promise<string> {
+  const { entries, lookup } = await buildLookupFromSources(sources);
+  const sorted = [...sources].sort((a, b) => a.packageName.localeCompare(b.packageName));
+
+  return sorted
     .map(({ packageName, raw }) => {
-      const normalized = raw.replace(/^# .+\n/, "").trimStart();
-      return `## ${packageName}\n\n${normalized}`;
+      const versions = splitVersionSections(raw);
+      const versionGroups = groupEntriesByVersion(entries, packageName);
+
+      const versionBlocks = versions
+        .map(({ version }) => {
+          const group = versionGroups.get(version);
+          if (!group) return `## ${version}\n\n(no entries)`;
+          return renderVersionMarkdown(packageName, version, group, lookup);
+        })
+        .join("\n\n");
+
+      return `## ${packageName}\n\n${versionBlocks}`;
     })
     .join("\n\n---\n\n");
 }
 
 export async function GET() {
   const sources = await loadChangelogSources(process.cwd());
-  const body = buildBody(sources);
+  const body = await buildBody(sources);
 
   const pageUrl = new URL("/react/updates/changelog", baseUrl).toString();
 


### PR DESCRIPTION
The aggregated changelog.txt endpoint was dumping raw CHANGELOG.md content, so dependency updates only showed package names without their actual change details. Now uses the same renderVersionMarkdown
+ EntryLookup resolution as per-version files to inline nested dependency changelogs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **리팩토링**
  * 변경 로그 생성 로직을 비동기 처리로 개선했습니다.
  * 버전별 항목 그룹화 및 마크다운 렌더링 방식이 개선되어 더욱 체계적인 변경 로그 구성을 제공합니다.
  * 항목이 없는 버전에 대해 명확한 표시를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->