### PR TITLE
feat(mcp): support OAuth Bearer token in createFigmaRestClient

### DIFF
--- a/.changeset/brave-tokens-flow.md
+++ b/.changeset/brave-tokens-flow.md
@@ -1,0 +1,17 @@
+---
+"@seed-design/mcp": minor
+---
+
+`createFigmaRestClient`에서 OAuth Bearer 토큰 인증을 지원합니다.
+
+- 기존 PAT(Personal Access Token) 방식 외에 OAuth 토큰으로도 Figma REST API를 호출할 수 있습니다.
+- `{ personalAccessToken: string }` 또는 `{ oAuthToken: string }` 중 하나를 전달하면 됩니다.
+- `FigmaRestClientOptions` 타입이 새롭게 export됩니다.
+
+```ts
+// PAT 방식 (기존)
+createFigmaRestClient({ personalAccessToken: "figd_..." })
+
+// OAuth Bearer 방식 (신규)
+createFigmaRestClient({ oAuthToken: "eyJ..." })
+```

--- a/packages/mcp/src/bin/index.ts
+++ b/packages/mcp/src/bin/index.ts
@@ -77,7 +77,7 @@ function createRestClient(mode: ToolMode): FigmaRestClient | null {
 
   logger.info("Initializing REST API client with PAT from environment");
 
-  return createFigmaRestClient(pat);
+  return createFigmaRestClient({ personalAccessToken: pat });
 }
 
 async function loadMcpConfig(configPath?: string): Promise<McpConfig | null> {

--- a/packages/mcp/src/figma-rest-client.ts
+++ b/packages/mcp/src/figma-rest-client.ts
@@ -5,8 +5,12 @@ export interface FigmaRestClient {
   getFileNodes(fileKey: string, nodeIds: string[]): Promise<GetFileNodesResponse>;
 }
 
-export function createFigmaRestClient(personalAccessToken: string): FigmaRestClient {
-  const api = new FigmaApi({ personalAccessToken });
+export type FigmaRestClientOptions =
+  | { personalAccessToken: string }
+  | { oAuthToken: string };
+
+export function createFigmaRestClient(options: FigmaRestClientOptions): FigmaRestClient {
+  const api = new FigmaApi(options);
 
   return {
     async getFileNodes(fileKey: string, nodeIds: string[]): Promise<GetFileNodesResponse> {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,4 +1,4 @@
 export { registerTools } from "./tools";
 export { createFigmaRestClient, parseFigmaUrl } from "./figma-rest-client";
-export type { FigmaRestClient } from "./figma-rest-client";
+export type { FigmaRestClient, FigmaRestClientOptions } from "./figma-rest-client";
 export type { ToolMode } from "./tools-helpers";

--- a/packages/mcp/src/tools-helpers.ts
+++ b/packages/mcp/src/tools-helpers.ts
@@ -36,7 +36,7 @@ function resolveRestClient(
   }
 
   if (personalAccessToken) {
-    return createFigmaRestClient(personalAccessToken);
+    return createFigmaRestClient({ personalAccessToken });
   }
 
   return context.restClient;


### PR DESCRIPTION
## Summary

Adds OAuth Bearer token support to `createFigmaRestClient`, in addition to the existing Personal Access Token (PAT) method.

The `figma-api` package (`didoo/figma-api@2.1.2-beta`) already supports `oAuthToken` option which sets `Authorization: Bearer <token>` header. This PR exposes that capability through `@seed-design/mcp`'s public API.

## Changes

- **`figma-rest-client.ts`**: Added `FigmaRestClientOptions` union type; changed `createFigmaRestClient` parameter from `string` to `FigmaRestClientOptions`
- **`index.ts`**: Export `FigmaRestClientOptions` type
- **`tools-helpers.ts`**, **`bin/index.ts`**: Updated internal call sites to use object form `{ personalAccessToken }`

## Usage

```ts
// PAT (existing)
createFigmaRestClient({ personalAccessToken: "figd_..." })

// OAuth Bearer (new)
createFigmaRestClient({ oAuthToken: "eyJ..." })
```

## Motivation

This enables AI agents (like Karby) that already have users' Figma OAuth tokens to call the SEED React codegen pipeline directly, without requiring each user to separately set up a PAT.

The Figma REST API officially supports both `X-Figma-Token` (PAT) and `Authorization: Bearer` (OAuth2) — see [openapi spec](https://github.com/figma/rest-api-spec/blob/main/openapi/openapi.yaml#L2620).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * OAuth 토큰 인증을 지원합니다. 기존 개인 액세스 토큰(PAT) 외에도 OAuth 토큰으로 Figma REST API에 인증할 수 있습니다.
  * 새로운 `FigmaRestClientOptions` 타입을 내보냅니다. 개인 액세스 토큰 또는 OAuth 토큰을 통해 인증 옵션을 지정할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->