### PR TITLE
feat(lynx-react): add createRecipeContext and createSlotRecipeContext

### DIFF
--- a/.changeset/lynx-recipe-contexts.md
+++ b/.changeset/lynx-recipe-contexts.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/lynx-react": minor
+---
+
+variant props context 유틸 `createRecipeContext`(단일 슬롯)와 `createSlotRecipeContext`(복합 슬롯)를 추가했어요. 두 유틸은 Lynx 런타임 제약(children 분리, ref null 가드)을 반영해 포팅되었고, ActionButton 내부가 `createSlotRecipeContext` 기반으로 리팩토링되었습니다. 공개 API는 동일해요.

--- a/packages/lynx-react/AGENTS.md
+++ b/packages/lynx-react/AGENTS.md
@@ -123,6 +123,44 @@ export interface ComponentProps
 - 네이티브 `<view>` 요소 직접 사용 (`Primitive.view` 사용 금지 — BackgroundSnapshot 에러)
 - `displayName` 필수
 
+## Variant Props 처리 패턴
+
+variant props는 반드시 `splitVariantProps`를 통해 native 속성과 타입 안전하게 분리한다. 아래 유틸들은 내부에서 자동으로 `splitVariantProps`를 호출하고 Lynx 런타임 제약(children 분리, ref null 가드)을 이미 반영하므로, 사용하는 컴포넌트는 동일 처리를 중복할 필요가 없다.
+
+| 유형 | 도구 | Lynx 예시 |
+| --- | --- | --- |
+| 단일 슬롯 | `createRecipeContext` → `withContext` | (도입 예정) |
+| 복합 슬롯 | `createSlotRecipeContext` → `withProvider`/`withContext` | ActionButton |
+
+### createRecipeContext (단일 슬롯)
+
+Recipe 반환값이 `string`인 단일 슬롯 recipe용. `withContext(Component)`로 감싸면 내부에서 자동으로 `splitVariantProps`를 호출하고 `className`을 `clsx`로 병합해 Component에 적용한다.
+
+```tsx
+import { createRecipeContext } from "@seed-design/lynx-react";
+import { someRecipe, type SomeRecipeVariantProps } from "@seed-design/lynx-css/recipes/some";
+
+const { withContext } = createRecipeContext(someRecipe);
+
+export const MyComponent = withContext<unknown, SomeRecipeVariantProps & { className?: string }>(
+  "view",
+);
+```
+
+### createSlotRecipeContext (복합 슬롯)
+
+Recipe 반환값이 `Record<slot, string>`인 복합 슬롯 recipe용.
+
+- `withProvider(Component, slot, options?)`: Root 요소를 감싸 자체 slot className을 적용하고 `ClassNamesProvider`로 하위에 슬롯 className을 주입한다.
+- `withContext(Component, slot?)`: `ClassNamesProvider`에서 해당 slot className을 읽어 Component에 적용한다. slot이 없으면 className만 병합한다.
+- `withRootProvider(Component, options?)`: Root 자체에 className을 적용하지 않고 context 주입만 필요한 경우.
+
+현재 `ActionButton`이 `root`/`text` 두 슬롯을 합성하는 예시다. 외부에는 `<ActionButton>...</ActionButton>` 단일 API를 유지하되 내부는 `withProvider("view", "root")` + `withContext("text", "text")` 조합이다.
+
+### 절대 금지: variant props 수동 destructuring
+
+`({ variant, size, ...rest })` 형태로 variant를 함수 인자에서 직접 꺼내거나 `recipe({ variant, size })`로 직접 전달하지 않는다. variant가 추가/변경될 때 누락 위험이 있고 타입 안전성이 보장되지 않는다.
+
 ## 파일 작성 컨벤션
 
 - 컴포넌트: `src/components/<ComponentName>/<ComponentName>.tsx` + `index.ts`

--- a/packages/lynx-react/src/components/ActionButton/ActionButton.tsx
+++ b/packages/lynx-react/src/components/ActionButton/ActionButton.tsx
@@ -1,9 +1,33 @@
 import { actionButton } from "@seed-design/lynx-css/recipes/action-button";
 import type { ActionButtonVariantProps } from "@seed-design/lynx-css/recipes/action-button";
-import clsx from "clsx";
 import * as React from "react";
 
-import { usePressTap } from "../../utils/use-press-tap";
+import { createSlotRecipeContext } from "../../utils/create-slot-recipe-context";
+import { usePressTap, type UsePressTapReturn } from "../../utils/use-press-tap";
+
+const { withProvider, withContext } = createSlotRecipeContext(actionButton);
+
+type ActionButtonRootOwnProps = {
+  className?: string;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+  bindtouchstart?: UsePressTapReturn["bindtouchstart"];
+  bindtouchend?: UsePressTapReturn["bindtouchend"];
+  bindtouchcancel?: UsePressTapReturn["bindtouchcancel"];
+  bindtap?: UsePressTapReturn["bindtap"];
+  "main-thread:bindtap"?: UsePressTapReturn["main-thread:bindtap"];
+};
+
+const ActionButtonRoot = withProvider<unknown, ActionButtonVariantProps & ActionButtonRootOwnProps>(
+  "view",
+  "root",
+  { defaultProps: { layout: "withText" } },
+);
+
+const ActionButtonTextSlot = withContext<
+  unknown,
+  { children?: React.ReactNode; className?: string }
+>("text", "text");
 
 /**
  * @platform Lynx
@@ -25,23 +49,14 @@ export interface ActionButtonProps extends Omit<ActionButtonVariantProps, "layou
 }
 
 export const ActionButton = React.forwardRef<unknown, ActionButtonProps>((props, ref) => {
-  const [variantProps, restProps] = actionButton.splitVariantProps(props);
   const {
     children,
-    className,
     flexGrow,
     bindtap,
     "main-thread:bindtap": mainThreadBindtap,
-    ...nativeProps
-  } = restProps;
-
-  const { disabled = false, loading = false } = variantProps;
-  const classes = actionButton({
-    ...variantProps,
-    layout: "withText",
-    loading: loading ? true : undefined,
-    disabled: disabled ? true : undefined,
-  });
+    ...variantAndRest
+  } = props;
+  const { disabled = false, loading = false } = variantAndRest;
   const isInteractive = !disabled && !loading;
 
   const { pressed: _pressed, ...pressTapHandlers } = usePressTap({
@@ -51,15 +66,14 @@ export const ActionButton = React.forwardRef<unknown, ActionButtonProps>((props,
   });
 
   return (
-    <view
-      {...(ref ? { ref: ref as React.Ref<SVGViewElement> } : {})}
-      className={clsx(classes.root, className)}
+    <ActionButtonRoot
+      {...variantAndRest}
+      ref={ref}
       style={flexGrow != null ? { flexGrow } : undefined}
       {...pressTapHandlers}
-      {...nativeProps}
     >
-      {loading ? children : <text className={classes.text}>{children}</text>}
-    </view>
+      {loading ? children : <ActionButtonTextSlot>{children}</ActionButtonTextSlot>}
+    </ActionButtonRoot>
   );
 });
 ActionButton.displayName = "ActionButton";

--- a/packages/lynx-react/src/index.ts
+++ b/packages/lynx-react/src/index.ts
@@ -1,5 +1,7 @@
 export { ActionButton, type ActionButtonProps } from "./components/ActionButton";
 export { ProgressCircle, type ProgressCircleProps } from "./components/ProgressCircle";
+export { createRecipeContext } from "./utils/create-recipe-context";
+export { createSlotRecipeContext } from "./utils/create-slot-recipe-context";
 export { dynamicStyle } from "./utils/dynamic-style";
 export { getSeedClassName } from "./get-seed-class-name";
 export {

--- a/packages/lynx-react/src/utils/__tests__/create-recipe-context.test.tsx
+++ b/packages/lynx-react/src/utils/__tests__/create-recipe-context.test.tsx
@@ -1,0 +1,156 @@
+import { forwardRef } from "@lynx-js/react";
+import { render, renderHook } from "@lynx-js/react/testing-library";
+import { describe, expect, it } from "vitest";
+
+import { createRecipeContext } from "../create-recipe-context";
+
+type MockVariantProps = {
+  variant?: "a" | "b";
+  size?: "sm" | "md";
+};
+
+const mockRecipe = Object.assign(
+  (props?: MockVariantProps) => `mock-${props?.variant ?? "a"}-${props?.size ?? "sm"}`,
+  {
+    splitVariantProps: <T extends MockVariantProps>(props: T) => {
+      const { variant, size, ...rest } = props;
+      return [{ variant, size }, rest] as [MockVariantProps, Omit<T, keyof MockVariantProps>];
+    },
+  },
+);
+
+type MockReceived = { props?: Record<string, unknown>; refValue?: unknown };
+
+function createMock() {
+  const received: MockReceived = {};
+  const Mock = forwardRef<{ tag: "mock" }, Record<string, unknown>>((props, ref) => {
+    received.props = props;
+    received.refValue = ref;
+    return null;
+  });
+  Mock.displayName = "Mock";
+  return { Mock, received };
+}
+
+describe("createRecipeContext", () => {
+  it("applies variant className to the wrapped component", () => {
+    const { Mock, received } = createMock();
+    const { withContext } = createRecipeContext(mockRecipe);
+    const Styled = withContext<{ tag: "mock" }, MockVariantProps>(Mock);
+
+    render(<Styled variant="b" size="md" />);
+
+    expect(received.props?.className).toBe("mock-b-md");
+  });
+
+  it("falls back to defaults when no variant props are provided", () => {
+    const { Mock, received } = createMock();
+    const { withContext } = createRecipeContext(mockRecipe);
+    const Styled = withContext<{ tag: "mock" }, MockVariantProps>(Mock);
+
+    render(<Styled />);
+
+    expect(received.props?.className).toBe("mock-a-sm");
+  });
+
+  it("passes PropsProvider value into the wrapped recipe", () => {
+    const { Mock, received } = createMock();
+    const { withContext, PropsProvider } = createRecipeContext(mockRecipe);
+    const Styled = withContext<{ tag: "mock" }, MockVariantProps>(Mock);
+
+    render(
+      <PropsProvider value={{ variant: "b", size: "md" }}>
+        <Styled />
+      </PropsProvider>,
+    );
+
+    expect(received.props?.className).toBe("mock-b-md");
+  });
+
+  it("prefers innerProps over PropsProvider value", () => {
+    const { Mock, received } = createMock();
+    const { withContext, PropsProvider } = createRecipeContext(mockRecipe);
+    const Styled = withContext<{ tag: "mock" }, MockVariantProps>(Mock);
+
+    render(
+      <PropsProvider value={{ variant: "b", size: "md" }}>
+        <Styled variant="a" />
+      </PropsProvider>,
+    );
+
+    expect(received.props?.className).toBe("mock-a-md");
+  });
+
+  it("merges defaultProps below PropsProvider and innerProps", () => {
+    const { Mock, received } = createMock();
+    const { withContext, PropsProvider } = createRecipeContext(mockRecipe);
+    const Styled = withContext<{ tag: "mock" }, MockVariantProps>(Mock, {
+      defaultProps: { variant: "a", size: "md" },
+    });
+
+    render(
+      <PropsProvider value={{ size: "sm" }}>
+        <Styled />
+      </PropsProvider>,
+    );
+
+    expect(received.props?.className).toBe("mock-a-sm");
+  });
+
+  it("combines recipe className with user-provided className via clsx", () => {
+    const { Mock, received } = createMock();
+    const { withContext } = createRecipeContext(mockRecipe);
+    type StyledProps = MockVariantProps & { className?: string };
+    const Styled = withContext<{ tag: "mock" }, StyledProps>(Mock);
+
+    render(<Styled variant="a" size="sm" className="extra" />);
+
+    expect(received.props?.className).toBe("mock-a-sm extra");
+  });
+
+  it("forwards the ref to the wrapped component", () => {
+    const { Mock, received } = createMock();
+    const { withContext } = createRecipeContext(mockRecipe);
+    const Styled = withContext<{ tag: "mock" }, MockVariantProps>(Mock);
+    const refFn = (node: { tag: "mock" } | null) => {
+      received.refValue = node;
+    };
+
+    render(<Styled ref={refFn} variant="a" />);
+
+    expect(received.refValue).toBe(refFn);
+  });
+
+  it("splits variant props away from native props before rendering", () => {
+    const { Mock, received } = createMock();
+    const { withContext } = createRecipeContext(mockRecipe);
+    type StyledProps = MockVariantProps & { "data-testid"?: string };
+    const Styled = withContext<{ tag: "mock" }, StyledProps>(Mock);
+
+    render(<Styled variant="b" size="md" data-testid="hello" />);
+
+    expect(received.props?.["data-testid"]).toBe("hello");
+    expect(received.props).not.toHaveProperty("variant");
+    expect(received.props).not.toHaveProperty("size");
+  });
+
+  describe("useProps", () => {
+    it("returns null outside of PropsProvider", () => {
+      const { useProps } = createRecipeContext(mockRecipe);
+      const { result } = renderHook(() => useProps());
+
+      expect(result.current).toBeNull();
+    });
+
+    it("returns the provided value inside PropsProvider", () => {
+      const { useProps, PropsProvider } = createRecipeContext(mockRecipe);
+      const { result } = renderHook(() => useProps(), {
+        wrapper: ({ children }) => (
+          <PropsProvider value={{ variant: "b", size: "md" }}>{children}</PropsProvider>
+        ),
+      });
+
+      expect(result.current).toEqual({ variant: "b", size: "md" });
+    });
+  });
+});

--- a/packages/lynx-react/src/utils/__tests__/create-slot-recipe-context.test.tsx
+++ b/packages/lynx-react/src/utils/__tests__/create-slot-recipe-context.test.tsx
@@ -1,0 +1,228 @@
+import { forwardRef } from "@lynx-js/react";
+import { render, renderHook } from "@lynx-js/react/testing-library";
+import { describe, expect, it } from "vitest";
+
+import { createSlotRecipeContext } from "../create-slot-recipe-context";
+
+type MockVariantProps = {
+  variant?: "a" | "b";
+};
+
+type MockClassnames = {
+  root: string;
+  label: string;
+};
+
+const mockSlotRecipe = Object.assign(
+  (props?: MockVariantProps): MockClassnames => ({
+    root: `root-${props?.variant ?? "a"}`,
+    label: `label-${props?.variant ?? "a"}`,
+  }),
+  {
+    splitVariantProps: <T extends MockVariantProps>(props: T) => {
+      const { variant, ...rest } = props;
+      return [{ variant }, rest] as [MockVariantProps, Omit<T, keyof MockVariantProps>];
+    },
+  },
+);
+
+type MockReceived = { props?: Record<string, unknown>; refValue?: unknown };
+
+function createMock(name: string) {
+  const received: MockReceived = {};
+  const Mock = forwardRef<{ tag: "mock" }, Record<string, unknown>>((props, ref) => {
+    received.props = props;
+    received.refValue = ref;
+    const { children } = props as { children?: unknown };
+    return <>{children as never}</>;
+  });
+  Mock.displayName = name;
+  return { Mock, received };
+}
+
+describe("createSlotRecipeContext", () => {
+  describe("useClassNames", () => {
+    it("throws when used outside a ClassNamesProvider", () => {
+      const { useClassNames } = createSlotRecipeContext(mockSlotRecipe);
+
+      expect(() => renderHook(() => useClassNames())).toThrow(
+        /useClassNames must be used within a ClassNamesProvider/,
+      );
+    });
+
+    it("returns the provided classnames inside ClassNamesProvider", () => {
+      const { useClassNames, ClassNamesProvider } = createSlotRecipeContext(mockSlotRecipe);
+      const value: MockClassnames = { root: "custom-root", label: "custom-label" };
+
+      const { result } = renderHook(() => useClassNames(), {
+        wrapper: ({ children }) => (
+          <ClassNamesProvider value={value}>{children}</ClassNamesProvider>
+        ),
+      });
+
+      expect(result.current).toEqual(value);
+    });
+  });
+
+  describe("useProps", () => {
+    it("returns null outside of PropsProvider", () => {
+      const { useProps } = createSlotRecipeContext(mockSlotRecipe);
+      const { result } = renderHook(() => useProps());
+
+      expect(result.current).toBeNull();
+    });
+
+    it("returns the provided value inside PropsProvider", () => {
+      const { useProps, PropsProvider } = createSlotRecipeContext(mockSlotRecipe);
+      const { result } = renderHook(() => useProps(), {
+        wrapper: ({ children }) => (
+          <PropsProvider value={{ variant: "b" }}>{children}</PropsProvider>
+        ),
+      });
+
+      expect(result.current).toEqual({ variant: "b" });
+    });
+  });
+
+  describe("withRootProvider", () => {
+    it("injects classnames into context without applying className on the root element", () => {
+      const { Mock: Root, received: rootReceived } = createMock("Root");
+      const { Mock: Child, received: childReceived } = createMock("Child");
+      const { withRootProvider, withContext } = createSlotRecipeContext(mockSlotRecipe);
+
+      const StyledRoot = withRootProvider<MockVariantProps>(Root);
+      const StyledLabel = withContext<{ tag: "mock" }, Record<string, unknown>>(Child, "label");
+
+      render(
+        <StyledRoot variant="b">
+          <StyledLabel />
+        </StyledRoot>,
+      );
+
+      expect(rootReceived.props).not.toHaveProperty("className");
+      expect(childReceived.props?.className).toBe("label-b");
+    });
+  });
+
+  describe("withProvider", () => {
+    it("applies slot className to the provider element and injects context", () => {
+      const { Mock: Root, received: rootReceived } = createMock("Root");
+      const { Mock: Child, received: childReceived } = createMock("Child");
+      const { withProvider, withContext } = createSlotRecipeContext(mockSlotRecipe);
+
+      const StyledRoot = withProvider<{ tag: "mock" }, MockVariantProps>(Root, "root");
+      const StyledLabel = withContext<{ tag: "mock" }, Record<string, unknown>>(Child, "label");
+
+      render(
+        <StyledRoot variant="a">
+          <StyledLabel />
+        </StyledRoot>,
+      );
+
+      expect(rootReceived.props?.className).toBe("root-a");
+      expect(childReceived.props?.className).toBe("label-a");
+    });
+
+    it("merges user-provided className with the slot className", () => {
+      const { Mock: Root, received: rootReceived } = createMock("Root");
+      const { withProvider } = createSlotRecipeContext(mockSlotRecipe);
+      type StyledProps = MockVariantProps & { className?: string };
+      const StyledRoot = withProvider<{ tag: "mock" }, StyledProps>(Root, "root");
+
+      render(<StyledRoot variant="a" className="extra" />);
+
+      expect(rootReceived.props?.className).toBe("root-a extra");
+    });
+
+    it("forwards the ref to the provider element", () => {
+      const { Mock: Root, received } = createMock("Root");
+      const { withProvider } = createSlotRecipeContext(mockSlotRecipe);
+      const StyledRoot = withProvider<{ tag: "mock" }, MockVariantProps>(Root, "root");
+      const refFn = (node: { tag: "mock" } | null) => {
+        received.refValue = node;
+      };
+
+      render(<StyledRoot ref={refFn} variant="a" />);
+
+      expect(received.refValue).toBe(refFn);
+    });
+
+    it("prefers innerProps over PropsProvider and defaultProps", () => {
+      const { Mock: Root, received } = createMock("Root");
+      const { withProvider, PropsProvider } = createSlotRecipeContext(mockSlotRecipe);
+      const StyledRoot = withProvider<{ tag: "mock" }, MockVariantProps>(Root, "root", {
+        defaultProps: { variant: "a" },
+      });
+
+      render(
+        <PropsProvider value={{ variant: "a" }}>
+          <StyledRoot variant="b" />
+        </PropsProvider>,
+      );
+
+      expect(received.props?.className).toBe("root-b");
+    });
+  });
+
+  describe("withContext", () => {
+    it("reads slot className from ClassNamesProvider", () => {
+      const { Mock: Label, received } = createMock("Label");
+      const { ClassNamesProvider, withContext } = createSlotRecipeContext(mockSlotRecipe);
+      const StyledLabel = withContext<{ tag: "mock" }, Record<string, unknown>>(Label, "label");
+      const classNames: MockClassnames = { root: "r", label: "custom-label" };
+
+      render(
+        <ClassNamesProvider value={classNames}>
+          <StyledLabel />
+        </ClassNamesProvider>,
+      );
+
+      expect(received.props?.className).toBe("custom-label");
+    });
+
+    it("merges user-provided className with slot className", () => {
+      const { Mock: Label, received } = createMock("Label");
+      const { ClassNamesProvider, withContext } = createSlotRecipeContext(mockSlotRecipe);
+      type StyledProps = { className?: string };
+      const StyledLabel = withContext<{ tag: "mock" }, StyledProps>(Label, "label");
+
+      render(
+        <ClassNamesProvider value={{ root: "r", label: "l" }}>
+          <StyledLabel className="extra" />
+        </ClassNamesProvider>,
+      );
+
+      expect(received.props?.className).toBe("l extra");
+    });
+
+    it("passes through native props like data attributes", () => {
+      const { Mock: Label, received } = createMock("Label");
+      const { ClassNamesProvider, withContext } = createSlotRecipeContext(mockSlotRecipe);
+      type StyledProps = { "data-testid"?: string };
+      const StyledLabel = withContext<{ tag: "mock" }, StyledProps>(Label, "label");
+
+      render(
+        <ClassNamesProvider value={{ root: "r", label: "l" }}>
+          <StyledLabel data-testid="hello" />
+        </ClassNamesProvider>,
+      );
+
+      expect(received.props?.["data-testid"]).toBe("hello");
+    });
+
+    it("renders without a slot className when slot argument is omitted", () => {
+      const { Mock: Label, received } = createMock("Label");
+      const { ClassNamesProvider, withContext } = createSlotRecipeContext(mockSlotRecipe);
+      const StyledLabel = withContext<{ tag: "mock" }, Record<string, unknown>>(Label);
+
+      render(
+        <ClassNamesProvider value={{ root: "r", label: "l" }}>
+          <StyledLabel />
+        </ClassNamesProvider>,
+      );
+
+      // clsx(undefined, undefined) → ""
+      expect(received.props?.className).toBe("");
+    });
+  });
+});

--- a/packages/lynx-react/src/utils/create-recipe-context.tsx
+++ b/packages/lynx-react/src/utils/create-recipe-context.tsx
@@ -1,0 +1,77 @@
+import clsx from "clsx";
+import { createContext, forwardRef, useContext } from "@lynx-js/react";
+import type * as React from "react";
+
+type Recipe<Props extends Record<string, string | boolean | undefined>> = ((
+  props?: Props,
+) => string) & {
+  splitVariantProps: <T extends Props>(props: T) => [Props, Omit<T, keyof Props>];
+};
+
+/**
+ * 단일 슬롯 recipe용 context 유틸.
+ *
+ * 웹 `@seed-design/react`의 `createRecipeContext`를 Lynx 런타임 제약에 맞춰 포팅했다:
+ * - `{...otherProps}` spread 시 `children`이 포함되면 Lynx `commitPatchUpdate`가
+ *   circular reference 에러를 발생시키므로 `children`을 분리해 JSX children으로 전달.
+ * - `forwardRef`에 null ref가 넘어오면 Lynx `applyRef`가 에러를 던지므로
+ *   `ref`가 truthy일 때만 Component로 전달.
+ */
+export function createRecipeContext<Props extends Record<string, string | boolean | undefined>>(
+  recipe: Recipe<Props>,
+) {
+  const PropsContext = createContext<Props | null>(null);
+
+  const PropsProvider = ({ children, value }: { children: React.ReactNode; value: Props }) => {
+    return <PropsContext.Provider value={value}>{children}</PropsContext.Provider>;
+  };
+
+  function useProps() {
+    return useContext(PropsContext);
+  }
+
+  const withContext = <T, P extends object>(
+    Component: React.ElementType,
+    options?: {
+      defaultProps?: Partial<P>;
+    },
+  ): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>> => {
+    const { defaultProps } = options ?? {};
+
+    const StyledComponent = forwardRef<unknown, Record<string, unknown>>((innerProps, ref) => {
+      const mergedProps = {
+        ...(defaultProps ?? {}),
+        ...(useProps() ?? {}),
+        ...innerProps,
+      } as Props & { className?: string; children?: React.ReactNode };
+      const [variantProps, otherProps] = recipe.splitVariantProps(mergedProps);
+      const className = recipe(variantProps);
+      const { children, ...nativeProps } = otherProps as {
+        children?: React.ReactNode;
+      } & Record<string, unknown>;
+
+      return (
+        <Component
+          {...(ref ? { ref } : {})}
+          {...nativeProps}
+          className={clsx(className, mergedProps.className)}
+        >
+          {children}
+        </Component>
+      );
+    });
+
+    const componentMeta = Component as { displayName?: string; name?: string };
+    StyledComponent.displayName = componentMeta.displayName ?? componentMeta.name ?? "";
+
+    return StyledComponent as React.ForwardRefExoticComponent<
+      React.PropsWithoutRef<P> & React.RefAttributes<T>
+    >;
+  };
+
+  return {
+    PropsProvider,
+    useProps,
+    withContext,
+  };
+}

--- a/packages/lynx-react/src/utils/create-slot-recipe-context.tsx
+++ b/packages/lynx-react/src/utils/create-slot-recipe-context.tsx
@@ -1,0 +1,172 @@
+import clsx from "clsx";
+import { createContext, forwardRef, useContext } from "@lynx-js/react";
+import type * as React from "react";
+
+type SlotRecipe<
+  Props extends Record<string, string | boolean | undefined>,
+  Classnames extends Record<string, string>,
+> = ((props?: Props) => Classnames) & {
+  splitVariantProps: <T extends Props>(props: T) => [Props, Omit<T, keyof Props>];
+};
+
+/**
+ * 복합 슬롯 recipe용 context 유틸.
+ *
+ * 웹 `@seed-design/react`의 `createSlotRecipeContext`를 Lynx 런타임 제약에 맞춰 포팅했다:
+ * - `{...otherProps}` spread 시 `children`이 포함되면 Lynx `commitPatchUpdate`가
+ *   circular reference 에러를 발생시키므로 `children`을 분리해 JSX children으로 전달.
+ * - `forwardRef`에 null ref가 넘어오면 Lynx `applyRef`가 에러를 던지므로
+ *   `ref`가 truthy일 때만 Component로 전달. (`withProvider`, `withContext` 한정)
+ */
+export function createSlotRecipeContext<
+  Props extends Record<string, string | boolean | undefined>,
+  Classnames extends Record<string, string>,
+>(recipe: SlotRecipe<Props, Classnames>) {
+  const ClassNamesContext = createContext<Classnames | null>(null);
+  const PropsContext = createContext<Props | null>(null);
+
+  const ClassNamesProvider = ({
+    children,
+    value,
+  }: {
+    children: React.ReactNode;
+    value: Classnames;
+  }) => {
+    return <ClassNamesContext.Provider value={value}>{children}</ClassNamesContext.Provider>;
+  };
+
+  const PropsProvider = ({ children, value }: { children: React.ReactNode; value: Props }) => {
+    return <PropsContext.Provider value={value}>{children}</PropsContext.Provider>;
+  };
+
+  function useClassNames(): Classnames {
+    const context = useContext(ClassNamesContext);
+    if (context === null) {
+      throw new Error(
+        "useClassNames must be used within a ClassNamesProvider. Did you forget to wrap your component in a ClassNamesProvider?",
+      );
+    }
+    return context;
+  }
+
+  function useProps() {
+    return useContext(PropsContext);
+  }
+
+  const withRootProvider = <P extends object>(
+    Component: React.ElementType,
+    options?: {
+      defaultProps?: Partial<P>;
+    },
+  ): React.FunctionComponent<P> => {
+    const { defaultProps } = options ?? {};
+
+    const StyledComponent = (innerProps: Record<string, unknown>) => {
+      const mergedProps = {
+        ...(defaultProps ?? {}),
+        ...(useProps() ?? {}),
+        ...innerProps,
+      } as Props & { children?: React.ReactNode };
+      const [variantProps, otherProps] = recipe.splitVariantProps(mergedProps);
+      const classNames = recipe(variantProps);
+      const { children, ...nativeProps } = otherProps as {
+        children?: React.ReactNode;
+      } & Record<string, unknown>;
+
+      return (
+        <ClassNamesProvider value={classNames}>
+          <Component {...nativeProps}>{children}</Component>
+        </ClassNamesProvider>
+      );
+    };
+
+    const componentMeta = Component as { displayName?: string; name?: string };
+    StyledComponent.displayName = componentMeta.displayName ?? componentMeta.name ?? "";
+
+    return StyledComponent as React.FunctionComponent<P>;
+  };
+
+  const withProvider = <T, P extends object>(
+    Component: React.ElementType,
+    slot: keyof Classnames,
+    options?: {
+      defaultProps?: Partial<P>;
+    },
+  ): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>> => {
+    const { defaultProps } = options ?? {};
+
+    const StyledComponent = forwardRef<unknown, Record<string, unknown>>((innerProps, ref) => {
+      const mergedProps = {
+        ...(defaultProps ?? {}),
+        ...(useProps() ?? {}),
+        ...innerProps,
+      } as Props & { className?: string; children?: React.ReactNode };
+      const [variantProps, otherProps] = recipe.splitVariantProps(mergedProps);
+      const classNames = recipe(variantProps);
+      const className = classNames[slot];
+      const { children, ...nativeProps } = otherProps as {
+        children?: React.ReactNode;
+      } & Record<string, unknown>;
+
+      return (
+        <ClassNamesProvider value={classNames}>
+          <Component
+            {...(ref ? { ref } : {})}
+            {...nativeProps}
+            className={clsx(className, mergedProps.className)}
+          >
+            {children}
+          </Component>
+        </ClassNamesProvider>
+      );
+    });
+
+    const componentMeta = Component as { displayName?: string; name?: string };
+    StyledComponent.displayName = componentMeta.displayName ?? componentMeta.name ?? "";
+
+    return StyledComponent as React.ForwardRefExoticComponent<
+      React.PropsWithoutRef<P> & React.RefAttributes<T>
+    >;
+  };
+
+  const withContext = <T, P extends object>(
+    Component: React.ElementType,
+    slot?: keyof Classnames,
+  ): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>> => {
+    const StyledComponent = forwardRef<unknown, Record<string, unknown>>((innerProps, ref) => {
+      const classNames = useClassNames();
+      const slotClassName = slot !== undefined ? classNames[slot] : undefined;
+      const { children, className, ...nativeProps } = innerProps as {
+        children?: React.ReactNode;
+        className?: string;
+      } & Record<string, unknown>;
+
+      return (
+        <Component
+          {...(ref ? { ref } : {})}
+          {...nativeProps}
+          className={clsx(slotClassName, className)}
+        >
+          {children}
+        </Component>
+      );
+    });
+
+    const componentMeta = Component as { displayName?: string; name?: string };
+    StyledComponent.displayName = componentMeta.displayName ?? componentMeta.name ?? "";
+
+    return StyledComponent as React.ForwardRefExoticComponent<
+      React.PropsWithoutRef<P> & React.RefAttributes<T>
+    >;
+  };
+
+  return {
+    ClassNamesProvider,
+    PropsProvider,
+    useClassNames,
+    useProps,
+    withRootProvider,
+    withProvider,
+    withContext,
+  };
+}


### PR DESCRIPTION
## Summary
- Port `createRecipeContext` (single slot) and `createSlotRecipeContext` (multi slot) from `@seed-design/react` to `@seed-design/lynx-react`, handling Lynx runtime constraints internally: strip `children` from nativeProps to avoid `commitPatchUpdate` circular refs, and null-guard `ref` spread so `applyRef` never sees `null`.
- Refactor `ActionButton` internals to compose via `withProvider("view", "root")` + `withContext("text", "text")`; its public API (props, layout=`withText` constraint, loading/disabled handling) stays identical.
- Add a `Variant Props 처리 패턴` section to `packages/lynx-react/AGENTS.md`, aligning structure with the web package's guide so the single-slot, multi-slot, and "no manual destructuring" rules are colocated.
- 23 new mock-recipe unit tests cover Provider/Context priority, className merging via `clsx`, ref forwarding, and error paths on the two utilities.
- Tested: `bun --filter @seed-design/lynx-react build`, `bun --filter @seed-design/lynx-react test` (44 passed), biome format/lint clean. Runtime verification on `examples/lynx-spa` pending reviewer sanity check.

## Test plan
- [x] `bun --filter @seed-design/lynx-react build`
- [x] `bun --filter @seed-design/lynx-react test` — 44 tests passed
- [x] `bun biome format/lint` — clean
- [ ] Verify ActionButton renders / tap / loading in `examples/lynx-spa`

🤖 Generated with [Claude Code](https://claude.com/claude-code)