### PR TITLE
docs(lynx): add LynxManualInstallation component and apply to component pages

### DIFF
--- a/docs/components/lynx-manual-installation.tsx
+++ b/docs/components/lynx-manual-installation.tsx
@@ -1,0 +1,85 @@
+import type { GeneratedRegistryItem } from "@/registry/schema";
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
+import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
+import { Heading } from "fumadocs-ui/components/heading";
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
+import ErrorBoundary from "./error-boundary";
+
+interface LynxManualInstallationProps {
+  name: string;
+}
+
+/**
+ * Lynx용 Manual Installation 컴포넌트
+ * @/public/__registry__/lynx/ui/{name}.json을 읽어 의존성 설치 명령과 snippet 본문을 렌더한다.
+ */
+export async function LynxManualInstallation(props: LynxManualInstallationProps) {
+  const { name } = props;
+
+  let json: GeneratedRegistryItem | null = null;
+
+  try {
+    json = (await import(`@/public/__registry__/lynx/ui/${name}.json`).then((module) => {
+      return module.default;
+    })) as GeneratedRegistryItem;
+  } catch (error) {
+    console.error(`Failed to load lynx registry for ${name}:`, error);
+    return (
+      <ErrorBoundary>
+        <div>Lynx 레지스트리를 불러올 수 없습니다. `bun generate:all`을 실행해주세요.</div>
+      </ErrorBoundary>
+    );
+  }
+
+  const packageManagers = ["npm", "yarn", "pnpm", "bun"];
+
+  return (
+    <ErrorBoundary>
+      <Accordions type="single">
+        <Accordion title="Manual Installation" id="manual-install">
+          <Steps>
+            {json?.dependencies && (
+              <Step>
+                <Heading as="h3">의존성 설치</Heading>
+                <Tabs items={packageManagers} groupId="package-manager" persist>
+                  <Tab value="npm">
+                    <DynamicCodeBlock
+                      lang="bash"
+                      code={`npm install ${json?.dependencies.join(" ")}`}
+                    />
+                  </Tab>
+                  <Tab value="yarn">
+                    <DynamicCodeBlock
+                      lang="bash"
+                      code={`yarn add ${json?.dependencies.join(" ")}`}
+                    />
+                  </Tab>
+                  <Tab value="pnpm">
+                    <DynamicCodeBlock
+                      lang="bash"
+                      code={`pnpm add ${json?.dependencies.join(" ")}`}
+                    />
+                  </Tab>
+                  <Tab value="bun">
+                    <DynamicCodeBlock
+                      lang="bash"
+                      code={`bun add ${json?.dependencies.join(" ")}`}
+                    />
+                  </Tab>
+                </Tabs>
+              </Step>
+            )}
+
+            <Step>
+              <Heading as="h3">아래 코드를 복사 후 붙여넣고 사용하세요</Heading>
+              {json?.snippets.map(({ path, content }) => {
+                return <DynamicCodeBlock key={path} lang="tsx" code={content} />;
+              })}
+            </Step>
+          </Steps>
+        </Accordion>
+      </Accordions>
+    </ErrorBoundary>
+  );
+}

--- a/docs/components/mdx-components.tsx
+++ b/docs/components/mdx-components.tsx
@@ -23,6 +23,7 @@ import defaultMdxComponents from "fumadocs-ui/mdx";
 import clsx from "clsx";
 import type { MDXComponents } from "mdx/types";
 import { BreezeManualInstallation } from "./breeze-manual-installation";
+import { LynxManualInstallation } from "./lynx-manual-installation";
 import { DoImage } from "./guideline/do-image";
 import { DontImage } from "./guideline/dont-image";
 import { Image } from "./guideline/image";
@@ -64,6 +65,7 @@ export const mdxComponents: MDXComponents = {
   TokenReference,
   ComponentSpecBlock,
   BreezeManualInstallation,
+  LynxManualInstallation,
   Tab,
   Tabs,
   Step,

--- a/docs/content/lynx/components/action-button.mdx
+++ b/docs/content/lynx/components/action-button.mdx
@@ -10,6 +10,8 @@ description: 명확한 액션을 쉽게 수행할 수 있도록 돕는 기본 �
 npx @seed-design/cli@alpha add ui:action-button --baseUrl https://lynx.seed-design.pages.dev
 ```
 
+<LynxManualInstallation name="action-button" />
+
 ## Usage
 
 ```tsx

--- a/docs/content/lynx/components/progress-circle.mdx
+++ b/docs/content/lynx/components/progress-circle.mdx
@@ -10,6 +10,8 @@ description: 작업이 진행 중임을 알리거나 작업 시간을 시각적�
 npx @seed-design/cli@alpha add ui:progress-circle --baseUrl https://lynx.seed-design.pages.dev
 ```
 
+<LynxManualInstallation name="progress-circle" />
+
 ## Usage
 
 ```tsx


### PR DESCRIPTION
## Summary

Mirror the React/Breeze pattern (`ManualInstallation`, `BreezeManualInstallation`) for Lynx component docs. The new `LynxManualInstallation` targets `/public/__registry__/lynx/ui/{name}.json` directly because the existing web component hardcodes the React registry path and webpack can't cleanly mix two dynamic-import prefixes behind a prop.

Applied to the two existing Lynx component pages. The Switch page will pick it up in its own PR (#1485).

## Changes

- `docs/components/lynx-manual-installation.tsx` — new component
- `docs/components/mdx-components.tsx` — register so MDX can use it
- `docs/content/lynx/components/action-button.mdx` — add `<LynxManualInstallation name="action-button" />` under the CLI block
- `docs/content/lynx/components/progress-circle.mdx` — same for `progress-circle`

## Test plan

- [x] `bun docs:test --dots` passes
- [ ] Preview `/lynx/components/action-button` → Manual Installation accordion shows package-manager tabs + snippet body
- [ ] Same for `/lynx/components/progress-circle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)