### PR TITLE
feat(lynx-react): add createSlotRecipeContext util

### DIFF
--- a/.changeset/lynx-slot-util.md
+++ b/.changeset/lynx-slot-util.md
@@ -1,0 +1,11 @@
+---
+"@seed-design/lynx-react": minor
+---
+
+`createSlotRecipeContext` 유틸 추가 — Lynx compound 컴포넌트용
+
+- 웹 `@seed-design/react`의 `createSlotRecipeContext`를 Lynx 런타임에 맞게 포팅
+- 외부 React 함수 컴포넌트 래핑: `withContext(Component, "slot")`
+- 네이티브 `<view>` 슬롯: `withViewContext("slot")` — 리터럴 JSX emit으로 Lynx 컴파일러의 `BackgroundSnapshot` 정적 분석을 통과
+- 네이티브 `<text>` 슬롯: `withTextContext("slot")`
+- 앞으로 Lynx compound 컴포넌트 (`BottomSheet`, `Dialog` 등)가 공통 기반으로 사용

--- a/packages/lynx-react/AGENTS.md
+++ b/packages/lynx-react/AGENTS.md
@@ -123,6 +123,37 @@ export interface ComponentProps
 - 네이티브 `<view>` 요소 직접 사용 (`Primitive.view` 사용 금지 — BackgroundSnapshot 에러)
 - `displayName` 필수
 
+## Variant Props 처리 패턴
+
+variant props는 반드시 아래 패턴 중 하나로 처리한다. 세 패턴 모두 내부적으로 `splitVariantProps`를 사용하여 variant props와 네이티브 속성을 타입 안전하게 분리한다.
+
+| 유형 | 도구 | 대표 예시 |
+|------|------|----------|
+| 직접 splitVariantProps | `recipe.splitVariantProps(props)` | ActionButton, ProgressCircle |
+| 단일 슬롯 | `createRecipeContext` → `withContext` | (추후 포팅 예정 — 별도 PR) |
+| 복합 슬롯 | `createSlotRecipeContext` → `withContext` / `withViewContext` / `withTextContext` | compound 컴포넌트 전반 |
+| 다중 Recipe | `splitMultipleVariantsProps` | (추후 포팅 예정 — 별도 PR) |
+
+### 절대 금지: variant props 수동 destructuring
+
+`({ variant, size, ...rest })` 형태로 variant를 함수 인자에서 직접 꺼내거나, `recipe({ variant, size })` 형태로 직접 전달하면 안 된다. variant가 추가/변경될 때 누락 위험이 있고, 타입 안전성이 보장되지 않는다.
+
+### SlotRecipe 사용 패턴
+
+복합 컴포넌트(슬롯이 여러 개인 경우)는 `createSlotRecipeContext`를 사용한다.
+
+- **import 경로**: `../../utils/create-slot-recipe-context`
+- `createSlotRecipeContext(slotRecipe)` 호출 결과에서 `ClassNamesProvider`, `withContext`, `withViewContext`, `withTextContext`, `useClassNames` 등을 꺼내 사용한다.
+- **외부 컴포넌트 슬롯** (lynx-ui 등 React 함수 컴포넌트): `withContext(Component, "slotName")` 한 줄로 연결한다.
+- **네이티브 `<view>` 슬롯**: `withViewContext("slotName")`. 반드시 리터럴 JSX로 `<view>`를 emit해 Lynx 컴파일러의 `BackgroundSnapshot` 정적 분석을 통과해야 한다.
+- **네이티브 `<text>` 슬롯**: `withTextContext("slotName")`.
+- **`withContext`의 intrinsic 문자열 인자 금지**: `withContext("view", ...)`는 `React.createElement("view", ...)`로 컴파일되어 위 정적 분석을 우회하고 `BackgroundSnapshot not found` 런타임 에러를 유발한다. 네이티브 슬롯은 반드시 `withViewContext`/`withTextContext`를 쓴다.
+- Root에 추가 context(예: Trigger용 imperative ref)가 필요하면 `ClassNamesProvider`를 수동으로 중첩하고 Root 자체는 `forwardRef`로 직접 구현한다.
+
+### 절대 금지: React 레이어에 style prop 직접 작성
+
+스타일은 반드시 recipe를 통해 className으로 적용한다. `style` prop 직접 작성은 `dynamicStyle()` 유틸을 경유할 때만 허용된다 (CSS custom property 동적 주입 케이스).
+
 ## 파일 작성 컨벤션
 
 - 컴포넌트: `src/components/<ComponentName>/<ComponentName>.tsx` + `index.ts`

--- a/packages/lynx-react/src/index.ts
+++ b/packages/lynx-react/src/index.ts
@@ -1,5 +1,9 @@
 export { ActionButton, type ActionButtonProps } from "./components/ActionButton";
 export { ProgressCircle, type ProgressCircleProps } from "./components/ProgressCircle";
+export {
+  createSlotRecipeContext,
+  type NativeSlotProps,
+} from "./utils/create-slot-recipe-context";
 export { dynamicStyle } from "./utils/dynamic-style";
 export { getSeedClassName } from "./get-seed-class-name";
 export {

--- a/packages/lynx-react/src/utils/create-slot-recipe-context.tsx
+++ b/packages/lynx-react/src/utils/create-slot-recipe-context.tsx
@@ -1,0 +1,231 @@
+import { createContext, forwardRef, useContext, type ReactNode, type Ref } from "@lynx-js/react";
+import type { CSSProperties } from "react";
+import clsx from "clsx";
+
+type SlotRecipe<
+  Props extends Record<string, string | boolean | undefined>,
+  Classnames extends Record<string, string>,
+> = ((props?: Props) => Classnames) & {
+  splitVariantProps: <T extends Props>(props: T) => [Props, Omit<T, keyof Props>];
+};
+
+/**
+ * Lynx compound 컴포넌트에서 slot recipe의 classNames를 Root→children 트리로 배포하기 위한
+ * 공용 유틸. `@seed-design/react`의 `createSlotRecipeContext`를 Lynx 런타임에 맞게 포팅했다.
+ *
+ * 기본 사용법 (lynx-ui 등 React 함수 컴포넌트 래핑):
+ * ```tsx
+ * const { ClassNamesProvider, withContext } = createSlotRecipeContext(bottomSheet);
+ * export const BottomSheetBackdrop = withContext(SheetBackdrop, "backdrop");
+ * ```
+ *
+ * 네이티브 `<view>`/`<text>` intrinsic 슬롯은 `withContext`를 **쓰면 안 된다**.
+ * `withContext("view", ...)`는 `React.createElement(Component, ...)`로 컴파일되어
+ * Lynx 컴파일러의 리터럴 `<view>` 정적 분석을 우회하고 `BackgroundSnapshot not found`
+ * 런타임 에러를 유발한다. 대신 `withViewContext` / `withTextContext`를 사용한다:
+ * ```tsx
+ * export const BottomSheetHeader = withViewContext("header");
+ * export const BottomSheetTitle = withTextContext("title");
+ * ```
+ * 이 팩토리들은 리터럴 JSX로 `<view>` / `<text>`를 emit하므로 컴파일러 정적 분석을 통과한다.
+ */
+export function createSlotRecipeContext<
+  Props extends Record<string, string | boolean | undefined>,
+  Classnames extends Record<string, string>,
+>(recipe: SlotRecipe<Props, Classnames>) {
+  const ClassNamesContext = createContext<Classnames | null>(null);
+  const PropsContext = createContext<Props | null>(null);
+
+  const ClassNamesProvider = ({
+    children,
+    value,
+  }: {
+    children: React.ReactNode;
+    value: Classnames;
+  }) => {
+    return <ClassNamesContext.Provider value={value}>{children}</ClassNamesContext.Provider>;
+  };
+
+  const PropsProvider = ({ children, value }: { children: React.ReactNode; value: Props }) => {
+    return <PropsContext.Provider value={value}>{children}</PropsContext.Provider>;
+  };
+
+  function useClassNames() {
+    const context = useContext(ClassNamesContext);
+    if (context === null) {
+      throw new Error(
+        "useClassNames must be used within a ClassNamesProvider. Did you forget to wrap your component in a ClassNamesProvider?",
+      );
+    }
+
+    return context;
+  }
+
+  function useProps() {
+    return useContext(PropsContext);
+  }
+
+  const withRootProvider = <P,>(
+    Component: React.ElementType<any>,
+    options?: {
+      defaultProps?: Partial<P>;
+    },
+  ): React.ForwardRefExoticComponent<React.PropsWithoutRef<P>> => {
+    const { defaultProps } = options ?? {};
+
+    const StyledComponent = (innerProps: any) => {
+      const props = { ...(defaultProps ?? {}), ...useProps(), ...innerProps } as Props &
+        Record<string, unknown>;
+      const [variantProps, otherProps] = recipe.splitVariantProps(props);
+      const classNames = recipe(variantProps);
+
+      return (
+        <ClassNamesProvider value={classNames}>
+          <Component {...otherProps} />
+        </ClassNamesProvider>
+      );
+    };
+
+    // @ts-expect-error — assigning displayName to a plain function component
+    StyledComponent.displayName = Component.displayName || Component.name;
+
+    return StyledComponent as any;
+  };
+
+  const withProvider = <T, P>(
+    Component: React.ElementType<any>,
+    slot: keyof Classnames,
+    options?: {
+      defaultProps?: Partial<P>;
+    },
+  ): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>> => {
+    const { defaultProps } = options ?? {};
+
+    const StyledComponent = forwardRef<any, any>((innerProps, ref) => {
+      const props: any = { ...(defaultProps ?? {}), ...useProps(), ...innerProps };
+      const [variantProps, otherProps] = recipe.splitVariantProps(props as Props);
+      const classNames = recipe(variantProps);
+      const slotClassName: string | undefined = classNames[slot];
+      const userClassName: string | undefined = props["className"];
+
+      return (
+        <ClassNamesProvider value={classNames}>
+          <Component
+            {...(ref ? { ref } : {})}
+            {...otherProps}
+            className={clsx(slotClassName, userClassName)}
+          />
+        </ClassNamesProvider>
+      );
+    });
+
+    StyledComponent.displayName = (Component as any).displayName || (Component as any).name;
+
+    return StyledComponent as any;
+  };
+
+  /**
+   * React 함수 컴포넌트 래핑용. lynx-ui 등 외부 컴포넌트를 감싸 slot className만 자동 주입한다.
+   *
+   * 네이티브 `<view>`/`<text>` intrinsic에는 사용하지 않는다 — `withViewContext` /
+   * `withTextContext`를 쓸 것.
+   */
+  const withContext = <T, P>(
+    Component: React.ElementType<any>,
+    slot?: keyof Classnames,
+    options?: {
+      defaultProps?: Partial<P>;
+    },
+  ): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>> => {
+    const { defaultProps } = options ?? {};
+
+    const StyledComponent = forwardRef<any, any>((innerProps, ref) => {
+      const props: any = { ...(defaultProps ?? {}), ...innerProps };
+      const classNames = useClassNames();
+      const slotClassName: string | undefined = slot ? classNames[slot] : undefined;
+      const userClassName: string | undefined = props["className"];
+
+      return (
+        <Component
+          {...(ref ? { ref } : {})}
+          {...props}
+          className={clsx(slotClassName, userClassName)}
+        />
+      );
+    });
+
+    StyledComponent.displayName = (Component as any).displayName || (Component as any).name;
+    return StyledComponent as any;
+  };
+
+  /**
+   * 네이티브 `<view>` 슬롯 전용. 리터럴 JSX로 `<view>`를 emit해 Lynx 컴파일러의
+   * `BackgroundSnapshot` 정적 분석을 통과한다.
+   *
+   * `withContext("view", ...)`는 `React.createElement(Component, ...)`로 컴파일되어
+   * 이 분석을 우회하므로 런타임 에러가 발생한다.
+   */
+  const withViewContext = (slot: keyof Classnames) => {
+    const StyledComponent = forwardRef<unknown, NativeSlotProps>((props, ref) => {
+      const { children, className, style } = props;
+      const classNames = useClassNames();
+
+      return (
+        <view
+          {...(ref ? { ref: ref as Ref<SVGViewElement> } : {})}
+          className={clsx(classNames[slot], className)}
+          style={style}
+        >
+          {children}
+        </view>
+      );
+    });
+    StyledComponent.displayName = `Slot(view:${String(slot)})`;
+    return StyledComponent;
+  };
+
+  /**
+   * 네이티브 `<text>` 슬롯 전용. 리터럴 JSX로 `<text>`를 emit해 Lynx 컴파일러의
+   * `BackgroundSnapshot` 정적 분석을 통과한다.
+   */
+  const withTextContext = (slot: keyof Classnames) => {
+    const StyledComponent = forwardRef<unknown, NativeSlotProps>((props, ref) => {
+      const { children, className, style } = props;
+      const classNames = useClassNames();
+
+      return (
+        <text
+          {...(ref ? { ref: ref as Ref<SVGTextElement> } : {})}
+          className={clsx(classNames[slot], className)}
+          style={style}
+        >
+          {children}
+        </text>
+      );
+    });
+    StyledComponent.displayName = `Slot(text:${String(slot)})`;
+    return StyledComponent;
+  };
+
+  return {
+    ClassNamesProvider,
+    PropsProvider,
+    useClassNames,
+    useProps,
+    withRootProvider,
+    withProvider,
+    withContext,
+    withViewContext,
+    withTextContext,
+  };
+}
+
+/**
+ * `withViewContext` / `withTextContext`로 생성된 네이티브 slot 컴포넌트의 공통 props 타입.
+ * 다른 compound 컴포넌트들이 slot props를 extend할 때 재사용할 수 있다.
+ */
+export interface NativeSlotProps {
+  children?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}


### PR DESCRIPTION
## Summary

Port `@seed-design/react`'s `createSlotRecipeContext` to `@seed-design/lynx-react` so Lynx compound components (`BottomSheet`, `Dialog`, etc.) can share slot className distribution. Adds Lynx-specific `withViewContext(slot)` / `withTextContext(slot)` factories that emit literal `<view>` / `<text>` JSX — required so Lynx's compile-time `BackgroundSnapshot` analysis registers the slots and avoids the `BackgroundSnapshot not found` runtime error that occurs when `withContext("view", slot)` compiles to `React.createElement(Component, …)` with a runtime string variable.

Document the pattern in `packages/lynx-react/AGENTS.md` as the canonical approach for any future compound component. This PR is a prerequisite for #1489 (BottomSheet) which will rebase to drop its local `createViewSlot` / `createTextSlot` factories and use this util instead.

## Test plan

- [ ] `bun --filter @seed-design/lynx-react build` — declarations emit without TS2742 / TS4023
- [ ] `bun --filter @seed-design/lynx-react test` — existing 21 hook tests still pass
- [ ] `bun changeset status` reports `@seed-design/lynx-react` minor bump
- [ ] Verify `withContext` works for a lynx-ui React function component wrapper (#1489 BottomSheetBackdrop/Content/Positioner)
- [ ] Verify `withViewContext` / `withTextContext` work for native `<view>` / `<text>` slots without `BackgroundSnapshot not found` runtime error (#1489 BottomSheet Header/Body/Footer/Title/Description)

🤖 Generated with [Claude Code](https://claude.com/claude-code)