### PR TITLE
docs(list): update Align Property description

### DIFF
--- a/docs/content/docs/components/(layout)/list.mdx
+++ b/docs/content/docs/components/(layout)/list.mdx
@@ -17,15 +17,15 @@ List Item은 Suffix, Prefix, Title, Detail로 구성됩니다.
 
 ## Properties
 
-### Single, Multi Line Variants
+### Single, Multi Line Variants → Align Property
 
 <FigmaImage id="2:137495" alt="List Item의 Single Line과 Multi Line Variants" />
 
-Single Line은 한 줄로만 제목, 설명이 표시됩니다. Multi Line은 제목, 설명이 두 줄 이상으로 표시될 수 있습니다. 필요한 경우 사용처에서 최대 표시 줄 수를 정의해주세요.
+Align의 기본값은 Center입니다. Prefix와 Suffix가 콘텐츠 영역의 수직 중앙에 정렬됩니다. Title과 Detail이 한 줄로 짧게 표시되는 경우에 적합합니다.
 
 <FigmaImage id="2:137502" alt="List Item을 상단으로 정렬한 예시" />
 
-Multi Line으로 활용하는 경우 Suffix, Prefix가 상단 정렬로 고정됩니다.
+Align을 Top으로 설정하면 Prefix와 Suffix가 콘텐츠 영역의 상단에 고정됩니다. Title이 길어져 두 줄 이상으로 넘어가거나, Detail 텍스트가 많아질 때 사용합니다.
 
 ### Highlighted Property
 


### PR DESCRIPTION
List 컴포넌트 문서의 Single, Multi Line Variants > Align Property 섹션 아래 두 단락을 업데이트했습니다.

**변경 내용**
- 첫 번째 단락: Align의 기본값(Center)에 대한 설명 개선
- 두 번째 단락: Align을 Top으로 설정할 때에 대한 설명 개선

**변경 파일**
- `docs/content/docs/components/(layout)/list.mdx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

* **List 컴포넌트 가이드 업데이트**
  * Single/Multi Line 설명이 변형 중심에서 Align 속성 중심으로 재구성되었습니다. Align의 기본값(Center)과 Prefix/Suffix 및 Title/Detail의 정렬 동작을 명확히 안내하며, Align을 Top으로 설정했을 때 Prefix/Suffix가 상단에 고정되는 동작과 긴 텍스트 처리 사례를 추가 설명합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->