### PR TITLE
feat(lynx-react): add recipe/slot-recipe context utilities

### DIFF
--- a/.changeset/lynx-react-utils.md
+++ b/.changeset/lynx-react-utils.md
@@ -1,0 +1,11 @@
+---
+"@seed-design/lynx-react": minor
+---
+
+Add recipe/slot-recipe context utilities and refactor ActionButton to use them.
+
+- `createRecipeContext`: single-slot recipe context with `withContext` HOC.
+- `createSlotRecipeContext`: multi-slot recipe context with `withRootProvider` / `withProvider` / `withContext` for wrapping React function components, plus `withViewContext` / `withTextContext` factories that emit literal `<view>` / `<text>` JSX for native intrinsic slots (required to pass the Lynx compiler's BackgroundSnapshot static analysis).
+- Export `NativeSlotProps` type for compound components extending native slot props.
+- Internal `splitMultipleVariantsProps` utility for compound components that host multiple recipes (first consumer: TagGroup in a follow-up PR).
+- `ActionButton` refactored internally to compose via `withProvider("view", "root")` + `withContext("text", "text")`. Public API unchanged.

--- a/packages/lynx-react/AGENTS.md
+++ b/packages/lynx-react/AGENTS.md
@@ -123,6 +123,37 @@ export interface ComponentProps
 - 네이티브 `<view>` 요소 직접 사용 (`Primitive.view` 사용 금지 — BackgroundSnapshot 에러)
 - `displayName` 필수
 
+## Variant Props 처리 패턴
+
+variant props는 반드시 아래 패턴 중 하나로 처리한다. 세 패턴 모두 내부적으로 `splitVariantProps`를 사용하여 variant props와 네이티브 속성을 타입 안전하게 분리한다.
+
+| 유형 | 도구 | 대표 예시 |
+|------|------|----------|
+| 직접 splitVariantProps | `recipe.splitVariantProps(props)` | ActionButton, ProgressCircle |
+| 단일 슬롯 | `createRecipeContext` → `withContext` | (유틸 제공, 소비자 컴포넌트는 후속 PR에서 도입) |
+| 복합 슬롯 | `createSlotRecipeContext` → `withContext` / `withViewContext` / `withTextContext` | compound 컴포넌트 전반 |
+| 다중 Recipe | `splitMultipleVariantsProps` | (유틸 제공, 소비자 컴포넌트는 후속 PR에서 도입) |
+
+### 절대 금지: variant props 수동 destructuring
+
+`({ variant, size, ...rest })` 형태로 variant를 함수 인자에서 직접 꺼내거나, `recipe({ variant, size })` 형태로 직접 전달하면 안 된다. variant가 추가/변경될 때 누락 위험이 있고, 타입 안전성이 보장되지 않는다.
+
+### SlotRecipe 사용 패턴
+
+복합 컴포넌트(슬롯이 여러 개인 경우)는 `createSlotRecipeContext`를 사용한다.
+
+- **import 경로**: `../../utils/create-slot-recipe-context`
+- `createSlotRecipeContext(slotRecipe)` 호출 결과에서 `ClassNamesProvider`, `withContext`, `withViewContext`, `withTextContext`, `useClassNames` 등을 꺼내 사용한다.
+- **외부 컴포넌트 슬롯** (lynx-ui 등 React 함수 컴포넌트): `withContext(Component, "slotName")` 한 줄로 연결한다.
+- **네이티브 `<view>` 슬롯**: `withViewContext("slotName")`. 반드시 리터럴 JSX로 `<view>`를 emit해 Lynx 컴파일러의 `BackgroundSnapshot` 정적 분석을 통과해야 한다.
+- **네이티브 `<text>` 슬롯**: `withTextContext("slotName")`.
+- **`withContext`의 intrinsic 문자열 인자 금지**: `withContext("view", ...)`는 `React.createElement("view", ...)`로 컴파일되어 위 정적 분석을 우회하고 `BackgroundSnapshot not found` 런타임 에러를 유발한다. 네이티브 슬롯은 반드시 `withViewContext`/`withTextContext`를 쓴다.
+- Root에 추가 context(예: Trigger용 imperative ref)가 필요하면 `ClassNamesProvider`를 수동으로 중첩하고 Root 자체는 `forwardRef`로 직접 구현한다.
+
+### 절대 금지: React 레이어에 style prop 직접 작성
+
+스타일은 반드시 recipe를 통해 className으로 적용한다. `style` prop 직접 작성은 `dynamicStyle()` 유틸을 경유할 때만 허용된다 (CSS custom property 동적 주입 케이스).
+
 ## 파일 작성 컨벤션
 
 - 컴포넌트: `src/components/<ComponentName>/<ComponentName>.tsx` + `index.ts`

--- a/packages/lynx-react/src/components/ActionButton/ActionButton.tsx
+++ b/packages/lynx-react/src/components/ActionButton/ActionButton.tsx
@@ -1,9 +1,33 @@
 import { actionButton } from "@seed-design/lynx-css/recipes/action-button";
 import type { ActionButtonVariantProps } from "@seed-design/lynx-css/recipes/action-button";
-import clsx from "clsx";
 import * as React from "react";
 
-import { usePressTap } from "../../utils/use-press-tap";
+import { createSlotRecipeContext } from "../../utils/create-slot-recipe-context";
+import { usePressTap, type UsePressTapReturn } from "../../utils/use-press-tap";
+
+const { withProvider, withContext } = createSlotRecipeContext(actionButton);
+
+type ActionButtonRootOwnProps = {
+  className?: string;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+  bindtouchstart?: UsePressTapReturn["bindtouchstart"];
+  bindtouchend?: UsePressTapReturn["bindtouchend"];
+  bindtouchcancel?: UsePressTapReturn["bindtouchcancel"];
+  bindtap?: UsePressTapReturn["bindtap"];
+  "main-thread:bindtap"?: UsePressTapReturn["main-thread:bindtap"];
+};
+
+const ActionButtonRoot = withProvider<unknown, ActionButtonVariantProps & ActionButtonRootOwnProps>(
+  "view",
+  "root",
+  { defaultProps: { layout: "withText" } },
+);
+
+const ActionButtonTextSlot = withContext<
+  unknown,
+  { children?: React.ReactNode; className?: string }
+>("text", "text");
 
 /**
  * @platform Lynx
@@ -25,23 +49,14 @@ export interface ActionButtonProps extends Omit<ActionButtonVariantProps, "layou
 }
 
 export const ActionButton = React.forwardRef<unknown, ActionButtonProps>((props, ref) => {
-  const [variantProps, restProps] = actionButton.splitVariantProps(props);
   const {
     children,
-    className,
     flexGrow,
     bindtap,
     "main-thread:bindtap": mainThreadBindtap,
-    ...nativeProps
-  } = restProps;
-
-  const { disabled = false, loading = false } = variantProps;
-  const classes = actionButton({
-    ...variantProps,
-    layout: "withText",
-    loading: loading ? true : undefined,
-    disabled: disabled ? true : undefined,
-  });
+    ...variantAndRest
+  } = props;
+  const { disabled = false, loading = false } = variantAndRest;
   const isInteractive = !disabled && !loading;
 
   const { pressed: _pressed, ...pressTapHandlers } = usePressTap({
@@ -51,15 +66,14 @@ export const ActionButton = React.forwardRef<unknown, ActionButtonProps>((props,
   });
 
   return (
-    <view
-      {...(ref ? { ref: ref as React.Ref<SVGViewElement> } : {})}
-      className={clsx(classes.root, className)}
+    <ActionButtonRoot
+      {...variantAndRest}
+      ref={ref}
       style={flexGrow != null ? { flexGrow } : undefined}
       {...pressTapHandlers}
-      {...nativeProps}
     >
-      {loading ? children : <text className={classes.text}>{children}</text>}
-    </view>
+      {loading ? children : <ActionButtonTextSlot>{children}</ActionButtonTextSlot>}
+    </ActionButtonRoot>
   );
 });
 ActionButton.displayName = "ActionButton";

--- a/packages/lynx-react/src/index.ts
+++ b/packages/lynx-react/src/index.ts
@@ -1,5 +1,10 @@
 export { ActionButton, type ActionButtonProps } from "./components/ActionButton";
 export { ProgressCircle, type ProgressCircleProps } from "./components/ProgressCircle";
+export { createRecipeContext } from "./utils/create-recipe-context";
+export {
+  createSlotRecipeContext,
+  type NativeSlotProps,
+} from "./utils/create-slot-recipe-context";
 export { dynamicStyle } from "./utils/dynamic-style";
 export { getSeedClassName } from "./get-seed-class-name";
 export {

--- a/packages/lynx-react/src/utils/__tests__/create-recipe-context.test.tsx
+++ b/packages/lynx-react/src/utils/__tests__/create-recipe-context.test.tsx
@@ -1,0 +1,156 @@
+import { forwardRef } from "@lynx-js/react";
+import { render, renderHook } from "@lynx-js/react/testing-library";
+import { describe, expect, it } from "vitest";
+
+import { createRecipeContext } from "../create-recipe-context";
+
+type MockVariantProps = {
+  variant?: "a" | "b";
+  size?: "sm" | "md";
+};
+
+const mockRecipe = Object.assign(
+  (props?: MockVariantProps) => `mock-${props?.variant ?? "a"}-${props?.size ?? "sm"}`,
+  {
+    splitVariantProps: <T extends MockVariantProps>(props: T) => {
+      const { variant, size, ...rest } = props;
+      return [{ variant, size }, rest] as [MockVariantProps, Omit<T, keyof MockVariantProps>];
+    },
+  },
+);
+
+type MockReceived = { props?: Record<string, unknown>; refValue?: unknown };
+
+function createMock() {
+  const received: MockReceived = {};
+  const Mock = forwardRef<{ tag: "mock" }, Record<string, unknown>>((props, ref) => {
+    received.props = props;
+    received.refValue = ref;
+    return null;
+  });
+  Mock.displayName = "Mock";
+  return { Mock, received };
+}
+
+describe("createRecipeContext", () => {
+  it("applies variant className to the wrapped component", () => {
+    const { Mock, received } = createMock();
+    const { withContext } = createRecipeContext(mockRecipe);
+    const Styled = withContext<{ tag: "mock" }, MockVariantProps>(Mock);
+
+    render(<Styled variant="b" size="md" />);
+
+    expect(received.props?.className).toBe("mock-b-md");
+  });
+
+  it("falls back to defaults when no variant props are provided", () => {
+    const { Mock, received } = createMock();
+    const { withContext } = createRecipeContext(mockRecipe);
+    const Styled = withContext<{ tag: "mock" }, MockVariantProps>(Mock);
+
+    render(<Styled />);
+
+    expect(received.props?.className).toBe("mock-a-sm");
+  });
+
+  it("passes PropsProvider value into the wrapped recipe", () => {
+    const { Mock, received } = createMock();
+    const { withContext, PropsProvider } = createRecipeContext(mockRecipe);
+    const Styled = withContext<{ tag: "mock" }, MockVariantProps>(Mock);
+
+    render(
+      <PropsProvider value={{ variant: "b", size: "md" }}>
+        <Styled />
+      </PropsProvider>,
+    );
+
+    expect(received.props?.className).toBe("mock-b-md");
+  });
+
+  it("prefers innerProps over PropsProvider value", () => {
+    const { Mock, received } = createMock();
+    const { withContext, PropsProvider } = createRecipeContext(mockRecipe);
+    const Styled = withContext<{ tag: "mock" }, MockVariantProps>(Mock);
+
+    render(
+      <PropsProvider value={{ variant: "b", size: "md" }}>
+        <Styled variant="a" />
+      </PropsProvider>,
+    );
+
+    expect(received.props?.className).toBe("mock-a-md");
+  });
+
+  it("merges defaultProps below PropsProvider and innerProps", () => {
+    const { Mock, received } = createMock();
+    const { withContext, PropsProvider } = createRecipeContext(mockRecipe);
+    const Styled = withContext<{ tag: "mock" }, MockVariantProps>(Mock, {
+      defaultProps: { variant: "a", size: "md" },
+    });
+
+    render(
+      <PropsProvider value={{ size: "sm" }}>
+        <Styled />
+      </PropsProvider>,
+    );
+
+    expect(received.props?.className).toBe("mock-a-sm");
+  });
+
+  it("combines recipe className with user-provided className via clsx", () => {
+    const { Mock, received } = createMock();
+    const { withContext } = createRecipeContext(mockRecipe);
+    type StyledProps = MockVariantProps & { className?: string };
+    const Styled = withContext<{ tag: "mock" }, StyledProps>(Mock);
+
+    render(<Styled variant="a" size="sm" className="extra" />);
+
+    expect(received.props?.className).toBe("mock-a-sm extra");
+  });
+
+  it("forwards the ref to the wrapped component", () => {
+    const { Mock, received } = createMock();
+    const { withContext } = createRecipeContext(mockRecipe);
+    const Styled = withContext<{ tag: "mock" }, MockVariantProps>(Mock);
+    const refFn = (node: { tag: "mock" } | null) => {
+      received.refValue = node;
+    };
+
+    render(<Styled ref={refFn} variant="a" />);
+
+    expect(received.refValue).toBe(refFn);
+  });
+
+  it("splits variant props away from native props before rendering", () => {
+    const { Mock, received } = createMock();
+    const { withContext } = createRecipeContext(mockRecipe);
+    type StyledProps = MockVariantProps & { "data-testid"?: string };
+    const Styled = withContext<{ tag: "mock" }, StyledProps>(Mock);
+
+    render(<Styled variant="b" size="md" data-testid="hello" />);
+
+    expect(received.props?.["data-testid"]).toBe("hello");
+    expect(received.props).not.toHaveProperty("variant");
+    expect(received.props).not.toHaveProperty("size");
+  });
+
+  describe("useProps", () => {
+    it("returns null outside of PropsProvider", () => {
+      const { useProps } = createRecipeContext(mockRecipe);
+      const { result } = renderHook(() => useProps());
+
+      expect(result.current).toBeNull();
+    });
+
+    it("returns the provided value inside PropsProvider", () => {
+      const { useProps, PropsProvider } = createRecipeContext(mockRecipe);
+      const { result } = renderHook(() => useProps(), {
+        wrapper: ({ children }) => (
+          <PropsProvider value={{ variant: "b", size: "md" }}>{children}</PropsProvider>
+        ),
+      });
+
+      expect(result.current).toEqual({ variant: "b", size: "md" });
+    });
+  });
+});

--- a/packages/lynx-react/src/utils/__tests__/create-slot-recipe-context.test.tsx
+++ b/packages/lynx-react/src/utils/__tests__/create-slot-recipe-context.test.tsx
@@ -1,0 +1,228 @@
+import { forwardRef } from "@lynx-js/react";
+import { render, renderHook } from "@lynx-js/react/testing-library";
+import { describe, expect, it } from "vitest";
+
+import { createSlotRecipeContext } from "../create-slot-recipe-context";
+
+type MockVariantProps = {
+  variant?: "a" | "b";
+};
+
+type MockClassnames = {
+  root: string;
+  label: string;
+};
+
+const mockSlotRecipe = Object.assign(
+  (props?: MockVariantProps): MockClassnames => ({
+    root: `root-${props?.variant ?? "a"}`,
+    label: `label-${props?.variant ?? "a"}`,
+  }),
+  {
+    splitVariantProps: <T extends MockVariantProps>(props: T) => {
+      const { variant, ...rest } = props;
+      return [{ variant }, rest] as [MockVariantProps, Omit<T, keyof MockVariantProps>];
+    },
+  },
+);
+
+type MockReceived = { props?: Record<string, unknown>; refValue?: unknown };
+
+function createMock(name: string) {
+  const received: MockReceived = {};
+  const Mock = forwardRef<{ tag: "mock" }, Record<string, unknown>>((props, ref) => {
+    received.props = props;
+    received.refValue = ref;
+    const { children } = props as { children?: unknown };
+    return <>{children as never}</>;
+  });
+  Mock.displayName = name;
+  return { Mock, received };
+}
+
+describe("createSlotRecipeContext", () => {
+  describe("useClassNames", () => {
+    it("throws when used outside a ClassNamesProvider", () => {
+      const { useClassNames } = createSlotRecipeContext(mockSlotRecipe);
+
+      expect(() => renderHook(() => useClassNames())).toThrow(
+        /useClassNames must be used within a ClassNamesProvider/,
+      );
+    });
+
+    it("returns the provided classnames inside ClassNamesProvider", () => {
+      const { useClassNames, ClassNamesProvider } = createSlotRecipeContext(mockSlotRecipe);
+      const value: MockClassnames = { root: "custom-root", label: "custom-label" };
+
+      const { result } = renderHook(() => useClassNames(), {
+        wrapper: ({ children }) => (
+          <ClassNamesProvider value={value}>{children}</ClassNamesProvider>
+        ),
+      });
+
+      expect(result.current).toEqual(value);
+    });
+  });
+
+  describe("useProps", () => {
+    it("returns null outside of PropsProvider", () => {
+      const { useProps } = createSlotRecipeContext(mockSlotRecipe);
+      const { result } = renderHook(() => useProps());
+
+      expect(result.current).toBeNull();
+    });
+
+    it("returns the provided value inside PropsProvider", () => {
+      const { useProps, PropsProvider } = createSlotRecipeContext(mockSlotRecipe);
+      const { result } = renderHook(() => useProps(), {
+        wrapper: ({ children }) => (
+          <PropsProvider value={{ variant: "b" }}>{children}</PropsProvider>
+        ),
+      });
+
+      expect(result.current).toEqual({ variant: "b" });
+    });
+  });
+
+  describe("withRootProvider", () => {
+    it("injects classnames into context without applying className on the root element", () => {
+      const { Mock: Root, received: rootReceived } = createMock("Root");
+      const { Mock: Child, received: childReceived } = createMock("Child");
+      const { withRootProvider, withContext } = createSlotRecipeContext(mockSlotRecipe);
+
+      const StyledRoot = withRootProvider<MockVariantProps>(Root);
+      const StyledLabel = withContext<{ tag: "mock" }, Record<string, unknown>>(Child, "label");
+
+      render(
+        <StyledRoot variant="b">
+          <StyledLabel />
+        </StyledRoot>,
+      );
+
+      expect(rootReceived.props).not.toHaveProperty("className");
+      expect(childReceived.props?.className).toBe("label-b");
+    });
+  });
+
+  describe("withProvider", () => {
+    it("applies slot className to the provider element and injects context", () => {
+      const { Mock: Root, received: rootReceived } = createMock("Root");
+      const { Mock: Child, received: childReceived } = createMock("Child");
+      const { withProvider, withContext } = createSlotRecipeContext(mockSlotRecipe);
+
+      const StyledRoot = withProvider<{ tag: "mock" }, MockVariantProps>(Root, "root");
+      const StyledLabel = withContext<{ tag: "mock" }, Record<string, unknown>>(Child, "label");
+
+      render(
+        <StyledRoot variant="a">
+          <StyledLabel />
+        </StyledRoot>,
+      );
+
+      expect(rootReceived.props?.className).toBe("root-a");
+      expect(childReceived.props?.className).toBe("label-a");
+    });
+
+    it("merges user-provided className with the slot className", () => {
+      const { Mock: Root, received: rootReceived } = createMock("Root");
+      const { withProvider } = createSlotRecipeContext(mockSlotRecipe);
+      type StyledProps = MockVariantProps & { className?: string };
+      const StyledRoot = withProvider<{ tag: "mock" }, StyledProps>(Root, "root");
+
+      render(<StyledRoot variant="a" className="extra" />);
+
+      expect(rootReceived.props?.className).toBe("root-a extra");
+    });
+
+    it("forwards the ref to the provider element", () => {
+      const { Mock: Root, received } = createMock("Root");
+      const { withProvider } = createSlotRecipeContext(mockSlotRecipe);
+      const StyledRoot = withProvider<{ tag: "mock" }, MockVariantProps>(Root, "root");
+      const refFn = (node: { tag: "mock" } | null) => {
+        received.refValue = node;
+      };
+
+      render(<StyledRoot ref={refFn} variant="a" />);
+
+      expect(received.refValue).toBe(refFn);
+    });
+
+    it("prefers innerProps over PropsProvider and defaultProps", () => {
+      const { Mock: Root, received } = createMock("Root");
+      const { withProvider, PropsProvider } = createSlotRecipeContext(mockSlotRecipe);
+      const StyledRoot = withProvider<{ tag: "mock" }, MockVariantProps>(Root, "root", {
+        defaultProps: { variant: "a" },
+      });
+
+      render(
+        <PropsProvider value={{ variant: "a" }}>
+          <StyledRoot variant="b" />
+        </PropsProvider>,
+      );
+
+      expect(received.props?.className).toBe("root-b");
+    });
+  });
+
+  describe("withContext", () => {
+    it("reads slot className from ClassNamesProvider", () => {
+      const { Mock: Label, received } = createMock("Label");
+      const { ClassNamesProvider, withContext } = createSlotRecipeContext(mockSlotRecipe);
+      const StyledLabel = withContext<{ tag: "mock" }, Record<string, unknown>>(Label, "label");
+      const classNames: MockClassnames = { root: "r", label: "custom-label" };
+
+      render(
+        <ClassNamesProvider value={classNames}>
+          <StyledLabel />
+        </ClassNamesProvider>,
+      );
+
+      expect(received.props?.className).toBe("custom-label");
+    });
+
+    it("merges user-provided className with slot className", () => {
+      const { Mock: Label, received } = createMock("Label");
+      const { ClassNamesProvider, withContext } = createSlotRecipeContext(mockSlotRecipe);
+      type StyledProps = { className?: string };
+      const StyledLabel = withContext<{ tag: "mock" }, StyledProps>(Label, "label");
+
+      render(
+        <ClassNamesProvider value={{ root: "r", label: "l" }}>
+          <StyledLabel className="extra" />
+        </ClassNamesProvider>,
+      );
+
+      expect(received.props?.className).toBe("l extra");
+    });
+
+    it("passes through native props like data attributes", () => {
+      const { Mock: Label, received } = createMock("Label");
+      const { ClassNamesProvider, withContext } = createSlotRecipeContext(mockSlotRecipe);
+      type StyledProps = { "data-testid"?: string };
+      const StyledLabel = withContext<{ tag: "mock" }, StyledProps>(Label, "label");
+
+      render(
+        <ClassNamesProvider value={{ root: "r", label: "l" }}>
+          <StyledLabel data-testid="hello" />
+        </ClassNamesProvider>,
+      );
+
+      expect(received.props?.["data-testid"]).toBe("hello");
+    });
+
+    it("renders without a slot className when slot argument is omitted", () => {
+      const { Mock: Label, received } = createMock("Label");
+      const { ClassNamesProvider, withContext } = createSlotRecipeContext(mockSlotRecipe);
+      const StyledLabel = withContext<{ tag: "mock" }, Record<string, unknown>>(Label);
+
+      render(
+        <ClassNamesProvider value={{ root: "r", label: "l" }}>
+          <StyledLabel />
+        </ClassNamesProvider>,
+      );
+
+      // clsx(undefined, undefined) → ""
+      expect(received.props?.className).toBe("");
+    });
+  });
+});

--- a/packages/lynx-react/src/utils/create-recipe-context.tsx
+++ b/packages/lynx-react/src/utils/create-recipe-context.tsx
@@ -1,0 +1,77 @@
+import clsx from "clsx";
+import { createContext, forwardRef, useContext } from "@lynx-js/react";
+import type * as React from "react";
+
+type Recipe<Props extends Record<string, string | boolean | undefined>> = ((
+  props?: Props,
+) => string) & {
+  splitVariantProps: <T extends Props>(props: T) => [Props, Omit<T, keyof Props>];
+};
+
+/**
+ * 단일 슬롯 recipe용 context 유틸.
+ *
+ * 웹 `@seed-design/react`의 `createRecipeContext`를 Lynx 런타임 제약에 맞춰 포팅했다:
+ * - `{...otherProps}` spread 시 `children`이 포함되면 Lynx `commitPatchUpdate`가
+ *   circular reference 에러를 발생시키므로 `children`을 분리해 JSX children으로 전달.
+ * - `forwardRef`에 null ref가 넘어오면 Lynx `applyRef`가 에러를 던지므로
+ *   `ref`가 truthy일 때만 Component로 전달.
+ */
+export function createRecipeContext<Props extends Record<string, string | boolean | undefined>>(
+  recipe: Recipe<Props>,
+) {
+  const PropsContext = createContext<Props | null>(null);
+
+  const PropsProvider = ({ children, value }: { children: React.ReactNode; value: Props }) => {
+    return <PropsContext.Provider value={value}>{children}</PropsContext.Provider>;
+  };
+
+  function useProps() {
+    return useContext(PropsContext);
+  }
+
+  const withContext = <T, P extends object>(
+    Component: React.ElementType,
+    options?: {
+      defaultProps?: Partial<P>;
+    },
+  ): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>> => {
+    const { defaultProps } = options ?? {};
+
+    const StyledComponent = forwardRef<unknown, Record<string, unknown>>((innerProps, ref) => {
+      const mergedProps = {
+        ...(defaultProps ?? {}),
+        ...(useProps() ?? {}),
+        ...innerProps,
+      } as Props & { className?: string; children?: React.ReactNode };
+      const [variantProps, otherProps] = recipe.splitVariantProps(mergedProps);
+      const className = recipe(variantProps);
+      const { children, ...nativeProps } = otherProps as {
+        children?: React.ReactNode;
+      } & Record<string, unknown>;
+
+      return (
+        <Component
+          {...(ref ? { ref } : {})}
+          {...nativeProps}
+          className={clsx(className, mergedProps.className)}
+        >
+          {children}
+        </Component>
+      );
+    });
+
+    const componentMeta = Component as { displayName?: string; name?: string };
+    StyledComponent.displayName = componentMeta.displayName ?? componentMeta.name ?? "";
+
+    return StyledComponent as React.ForwardRefExoticComponent<
+      React.PropsWithoutRef<P> & React.RefAttributes<T>
+    >;
+  };
+
+  return {
+    PropsProvider,
+    useProps,
+    withContext,
+  };
+}

--- a/packages/lynx-react/src/utils/create-slot-recipe-context.tsx
+++ b/packages/lynx-react/src/utils/create-slot-recipe-context.tsx
@@ -1,0 +1,231 @@
+import { createContext, forwardRef, useContext, type ReactNode, type Ref } from "@lynx-js/react";
+import type { CSSProperties } from "react";
+import clsx from "clsx";
+
+type SlotRecipe<
+  Props extends Record<string, string | boolean | undefined>,
+  Classnames extends Record<string, string>,
+> = ((props?: Props) => Classnames) & {
+  splitVariantProps: <T extends Props>(props: T) => [Props, Omit<T, keyof Props>];
+};
+
+/**
+ * Lynx compound 컴포넌트에서 slot recipe의 classNames를 Root→children 트리로 배포하기 위한
+ * 공용 유틸. `@seed-design/react`의 `createSlotRecipeContext`를 Lynx 런타임에 맞게 포팅했다.
+ *
+ * 기본 사용법 (lynx-ui 등 React 함수 컴포넌트 래핑):
+ * ```tsx
+ * const { ClassNamesProvider, withContext } = createSlotRecipeContext(bottomSheet);
+ * export const BottomSheetBackdrop = withContext(SheetBackdrop, "backdrop");
+ * ```
+ *
+ * 네이티브 `<view>`/`<text>` intrinsic 슬롯은 `withContext`를 **쓰면 안 된다**.
+ * `withContext("view", ...)`는 `React.createElement(Component, ...)`로 컴파일되어
+ * Lynx 컴파일러의 리터럴 `<view>` 정적 분석을 우회하고 `BackgroundSnapshot not found`
+ * 런타임 에러를 유발한다. 대신 `withViewContext` / `withTextContext`를 사용한다:
+ * ```tsx
+ * export const BottomSheetHeader = withViewContext("header");
+ * export const BottomSheetTitle = withTextContext("title");
+ * ```
+ * 이 팩토리들은 리터럴 JSX로 `<view>` / `<text>`를 emit하므로 컴파일러 정적 분석을 통과한다.
+ */
+export function createSlotRecipeContext<
+  Props extends Record<string, string | boolean | undefined>,
+  Classnames extends Record<string, string>,
+>(recipe: SlotRecipe<Props, Classnames>) {
+  const ClassNamesContext = createContext<Classnames | null>(null);
+  const PropsContext = createContext<Props | null>(null);
+
+  const ClassNamesProvider = ({
+    children,
+    value,
+  }: {
+    children: React.ReactNode;
+    value: Classnames;
+  }) => {
+    return <ClassNamesContext.Provider value={value}>{children}</ClassNamesContext.Provider>;
+  };
+
+  const PropsProvider = ({ children, value }: { children: React.ReactNode; value: Props }) => {
+    return <PropsContext.Provider value={value}>{children}</PropsContext.Provider>;
+  };
+
+  function useClassNames() {
+    const context = useContext(ClassNamesContext);
+    if (context === null) {
+      throw new Error(
+        "useClassNames must be used within a ClassNamesProvider. Did you forget to wrap your component in a ClassNamesProvider?",
+      );
+    }
+
+    return context;
+  }
+
+  function useProps() {
+    return useContext(PropsContext);
+  }
+
+  const withRootProvider = <P,>(
+    Component: React.ElementType<any>,
+    options?: {
+      defaultProps?: Partial<P>;
+    },
+  ): React.ForwardRefExoticComponent<React.PropsWithoutRef<P>> => {
+    const { defaultProps } = options ?? {};
+
+    const StyledComponent = (innerProps: any) => {
+      const props = { ...(defaultProps ?? {}), ...useProps(), ...innerProps } as Props &
+        Record<string, unknown>;
+      const [variantProps, otherProps] = recipe.splitVariantProps(props);
+      const classNames = recipe(variantProps);
+
+      return (
+        <ClassNamesProvider value={classNames}>
+          <Component {...otherProps} />
+        </ClassNamesProvider>
+      );
+    };
+
+    // @ts-expect-error — assigning displayName to a plain function component
+    StyledComponent.displayName = Component.displayName || Component.name;
+
+    return StyledComponent as any;
+  };
+
+  const withProvider = <T, P>(
+    Component: React.ElementType<any>,
+    slot: keyof Classnames,
+    options?: {
+      defaultProps?: Partial<P>;
+    },
+  ): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>> => {
+    const { defaultProps } = options ?? {};
+
+    const StyledComponent = forwardRef<any, any>((innerProps, ref) => {
+      const props: any = { ...(defaultProps ?? {}), ...useProps(), ...innerProps };
+      const [variantProps, otherProps] = recipe.splitVariantProps(props as Props);
+      const classNames = recipe(variantProps);
+      const slotClassName: string | undefined = classNames[slot];
+      const userClassName: string | undefined = props["className"];
+
+      return (
+        <ClassNamesProvider value={classNames}>
+          <Component
+            {...(ref ? { ref } : {})}
+            {...otherProps}
+            className={clsx(slotClassName, userClassName)}
+          />
+        </ClassNamesProvider>
+      );
+    });
+
+    StyledComponent.displayName = (Component as any).displayName || (Component as any).name;
+
+    return StyledComponent as any;
+  };
+
+  /**
+   * React 함수 컴포넌트 래핑용. lynx-ui 등 외부 컴포넌트를 감싸 slot className만 자동 주입한다.
+   *
+   * 네이티브 `<view>`/`<text>` intrinsic에는 사용하지 않는다 — `withViewContext` /
+   * `withTextContext`를 쓸 것.
+   */
+  const withContext = <T, P>(
+    Component: React.ElementType<any>,
+    slot?: keyof Classnames,
+    options?: {
+      defaultProps?: Partial<P>;
+    },
+  ): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>> => {
+    const { defaultProps } = options ?? {};
+
+    const StyledComponent = forwardRef<any, any>((innerProps, ref) => {
+      const props: any = { ...(defaultProps ?? {}), ...innerProps };
+      const classNames = useClassNames();
+      const slotClassName: string | undefined = slot ? classNames[slot] : undefined;
+      const userClassName: string | undefined = props["className"];
+
+      return (
+        <Component
+          {...(ref ? { ref } : {})}
+          {...props}
+          className={clsx(slotClassName, userClassName)}
+        />
+      );
+    });
+
+    StyledComponent.displayName = (Component as any).displayName || (Component as any).name;
+    return StyledComponent as any;
+  };
+
+  /**
+   * 네이티브 `<view>` 슬롯 전용. 리터럴 JSX로 `<view>`를 emit해 Lynx 컴파일러의
+   * `BackgroundSnapshot` 정적 분석을 통과한다.
+   *
+   * `withContext("view", ...)`는 `React.createElement(Component, ...)`로 컴파일되어
+   * 이 분석을 우회하므로 런타임 에러가 발생한다.
+   */
+  const withViewContext = (slot: keyof Classnames) => {
+    const StyledComponent = forwardRef<unknown, NativeSlotProps>((props, ref) => {
+      const { children, className, style } = props;
+      const classNames = useClassNames();
+
+      return (
+        <view
+          {...(ref ? { ref: ref as Ref<SVGViewElement> } : {})}
+          className={clsx(classNames[slot], className)}
+          style={style}
+        >
+          {children}
+        </view>
+      );
+    });
+    StyledComponent.displayName = `Slot(view:${String(slot)})`;
+    return StyledComponent;
+  };
+
+  /**
+   * 네이티브 `<text>` 슬롯 전용. 리터럴 JSX로 `<text>`를 emit해 Lynx 컴파일러의
+   * `BackgroundSnapshot` 정적 분석을 통과한다.
+   */
+  const withTextContext = (slot: keyof Classnames) => {
+    const StyledComponent = forwardRef<unknown, NativeSlotProps>((props, ref) => {
+      const { children, className, style } = props;
+      const classNames = useClassNames();
+
+      return (
+        <text
+          {...(ref ? { ref: ref as Ref<SVGTextElement> } : {})}
+          className={clsx(classNames[slot], className)}
+          style={style}
+        >
+          {children}
+        </text>
+      );
+    });
+    StyledComponent.displayName = `Slot(text:${String(slot)})`;
+    return StyledComponent;
+  };
+
+  return {
+    ClassNamesProvider,
+    PropsProvider,
+    useClassNames,
+    useProps,
+    withRootProvider,
+    withProvider,
+    withContext,
+    withViewContext,
+    withTextContext,
+  };
+}
+
+/**
+ * `withViewContext` / `withTextContext`로 생성된 네이티브 slot 컴포넌트의 공통 props 타입.
+ * 다른 compound 컴포넌트들이 slot props를 extend할 때 재사용할 수 있다.
+ */
+export interface NativeSlotProps {
+  children?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}

--- a/packages/lynx-react/src/utils/split-multiple-variants-props.ts
+++ b/packages/lynx-react/src/utils/split-multiple-variants-props.ts
@@ -1,0 +1,44 @@
+type Recipe = { splitVariantProps: (...args: never[]) => [unknown, unknown] };
+
+type ExtractVariantProps<T> = T extends {
+  splitVariantProps: (...args: never[]) => [infer V, unknown];
+}
+  ? V
+  : never;
+
+type ExtractAllVariantKeys<R> = {
+  [K in keyof R]: ExtractVariantProps<R[K]> extends infer V
+    ? V extends Record<string, unknown>
+      ? keyof V
+      : never
+    : never;
+}[keyof R];
+
+/**
+ * Split props into multiple recipe variant buckets at once.
+ *
+ * Each recipe in `recipesMap` picks the variant keys it knows about via its
+ * `splitVariantProps`. Keys that appear in more than one recipe (e.g. a shared
+ * `size` variant) land in every matching bucket. The second element is the
+ * props that no recipe claimed.
+ */
+export function splitMultipleVariantsProps<R extends Record<string, Recipe>, P>(
+  props: P,
+  recipesMap: R,
+): [{ [K in keyof R]: ExtractVariantProps<R[K]> }, Omit<P, ExtractAllVariantKeys<R>>] {
+  const multipleVariantsProps = {} as { [K in keyof R]: ExtractVariantProps<R[K]> };
+  const extractedKeys = new Set<string>();
+
+  for (const recipeKey in recipesMap) {
+    const [variantProps] = recipesMap[recipeKey].splitVariantProps(props as never);
+    multipleVariantsProps[recipeKey] = variantProps as ExtractVariantProps<R[typeof recipeKey]>;
+    for (const k in variantProps as Record<string, unknown>) extractedKeys.add(k);
+  }
+
+  const remainingProps = {} as Record<string, unknown>;
+  for (const k in props as Record<string, unknown>) {
+    if (!extractedKeys.has(k)) remainingProps[k] = (props as Record<string, unknown>)[k];
+  }
+
+  return [multipleVariantsProps, remainingProps as Omit<P, ExtractAllVariantKeys<R>>];
+}


### PR DESCRIPTION
## Summary

Combines #1488 and #1492 into a single PR so `packages/lynx-react/src/utils/create-slot-recipe-context.tsx` is edited exactly once on the `lynx` branch.

- **`createRecipeContext`** (from #1488): single-slot recipe context with `withContext` HOC. Strips `children` from nativeProps and null-guards `ref` to avoid Lynx `commitPatchUpdate` / `applyRef` runtime errors.
- **`createSlotRecipeContext`** (from #1488 + #1492): multi-slot recipe context providing
  - `withRootProvider` / `withProvider` / `withContext` — for wrapping React function components (e.g. lynx-ui library components).
  - `withViewContext` / `withTextContext` — for native `<view>` / `<text>` intrinsic slots. Emits literal JSX so the Lynx compiler's `BackgroundSnapshot` static analysis passes (`withContext("view", ...)` would route through `React.createElement(string, …)` and crash at runtime).
- Exports `NativeSlotProps` type for compound components extending native slot props.
- Internal `splitMultipleVariantsProps` utility for compound components hosting multiple recipes. First consumer: TagGroup (follow-up PR rebase).
- `ActionButton` refactored internally to `withProvider("view", "root")` + `withContext("text", "text")`. Public API unchanged.
- `packages/lynx-react/AGENTS.md` gains three sections (Variant Props patterns, Compound Context policy including HOC usage, native slot JSX literal rule).

Supersedes #1488 and #1492 — both will be closed after this lands.

## Test plan

- [x] `bun --filter @seed-design/lynx-react build` passes (tsc declaration emit clean)
- [x] 23 new tests pass (create-recipe-context + create-slot-recipe-context). Two pre-existing tests (`use-controllable-state`, `use-press-tap`) fail locally due to a preact resolution issue in the fresh node_modules — unrelated to this PR. CI to confirm.
- [x] \`bun qvism:generate\` clean; \`git diff origin/lynx -- packages/css/ packages/lynx-css/\` has no changes (utilities are runtime-only).
- [ ] lynx-spa ActionButton smoke check post-merge.

Refs: #1488, #1492