### PR TITLE
docs(lynx): fix registry index and MDX example gaps

### DIFF
--- a/docs/content/lynx/components/switch.mdx
+++ b/docs/content/lynx/components/switch.mdx
@@ -41,7 +41,9 @@ Label 없이 본체만 쓰고 싶다면 `Switchmark`를 사용합니다.
 ```tsx
 import { Switchmark } from "@/components/ui/switch";
 
-<Switchmark size="24" tone="brand" defaultChecked />
+export function App() {
+  return <Switchmark size="24" tone="brand" defaultChecked />;
+}
 ```
 
 ### Compound 사용 (고급)

--- a/docs/content/lynx/components/tag-group.mdx
+++ b/docs/content/lynx/components/tag-group.mdx
@@ -92,7 +92,3 @@ Lynx TagGroup은 Lynx view 엔진(Yoga 기반 flex)의 제약으로 React 웹 �
 
 - 이벤트: Lynx는 `onClick`이 없고 `bindtap` / `main-thread:bindtap`을 사용합니다. TagGroup은 기본적으로 정적 표시라 인터랙션 prop이 노출되지는 않지만, `TagGroupItem`을 눌러야 한다면 호출부에서 직접 view 속성으로 처리하세요.
 - ref: `React.forwardRef`로 ref가 전달됩니다 (`SVGViewElement` 타입으로 캐스트됨).
-
-## Examples
-
-간단한 사용 패턴은 위 Usage 섹션을 참고하세요. 실제 렌더 예시는 `lynx-spa`의 TagGroup 페이지에서 확인할 수 있습니다.

--- a/docs/public/__registry__/lynx/ui/index.json
+++ b/docs/public/__registry__/lynx/ui/index.json
@@ -69,6 +69,18 @@
       "dependencies": [
         "@seed-design/lynx-react"
       ]
+    },
+    {
+      "snippets": [
+        {
+          "path": "tag-group.tsx",
+          "dependencies": {
+            "@seed-design/lynx-react": "~0.1.0-alpha.0",
+            "@seed-design/lynx-css": "~0.1.0-alpha.0"
+          }
+        }
+      ],
+      "id": "tag-group"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Audit of the three newly-landed Lynx component docs (`TagGroup`, `Switch`, `BottomSheet`) against an 11-item checklist surfaced one P0 defect plus two P1 MDX quality issues. All fixes are scoped to `docs/` and re-verified via `bun --filter @seed-design/docs build`.

### P0 — `fix(docs): regenerate lynx registry index to include tag-group`

`docs/public/__registry__/lynx/ui/index.json` had the wrong set of items on `origin/lynx`: `tag-group.json` existed as a standalone file and `registry-ui.ts` already listed it, but the generated index only contained `action-button`, `bottom-sheet`, `progress-circle`, `switch`. That broke the `LynxManualInstallation` lookup on `/lynx/components/tag-group` and would have caused CLI `add-all` flows to silently skip the component.

Running `bun --filter @seed-design/docs generate:registry` regenerates the index cleanly and re-emits the missing entry.

### P1 — `docs(lynx/switch): make Switchmark example runnable`

The last snippet on `/lynx/components/switch` (the `Switchmark`-only example) rendered a bare JSX expression at module scope instead of returning it from `export function App()`. All other blocks on the page use the `App()` pattern and TS flags unused-expression warnings on the old form. Wrapped it for consistency.

### P1 — `docs(lynx/tag-group): drop stub Examples section`

The `## Examples` section on `/lynx/components/tag-group` only pointed readers at the `lynx-spa` playground with no additional snippet. None of the other Lynx component pages (`action-button`, `progress-circle`, `switch`, `bottom-sheet`) have an Examples section, so the stub was Lynx-docs-convention drift. Removed.

### Out of scope (reviewed, not changed)

- a11y sections — intentionally absent across Lynx docs; keyboard / focus absence is already covered in the "Lynx 미지원 기능" tables.
- Storybook — no Lynx Storybook infra exists; `lynx-spa` is the agreed-upon preview surface.
- Web-side parity (Anatomy/Properties/Guidelines/Specification) — web MDX is designer-facing, Lynx MDX is implementation-facing. Intentional split.

## Test plan

- [x] `bun --filter @seed-design/docs generate:registry` — emits `tag-group` in `lynx/ui/index.json`
- [x] `bun --filter @seed-design/docs build` — exit 0, all 14 `/lynx/**` routes prerender including `/lynx/components/tag-group`
- [ ] Spot-check `/lynx/components/{tag-group, switch, bottom-sheet}` in the deploy preview to confirm LynxManualInstallation loads the snippet and no MDX compiler warnings remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)