### PR TITLE
docs(lynx): reorder hooks after components

### DIFF
--- a/docs/content/lynx/meta.json
+++ b/docs/content/lynx/meta.json
@@ -7,9 +7,9 @@
     "...getting-started",
     "---Foundation---",
     "...foundation",
-    "---Hooks---",
-    "...hooks",
     "---Components---",
-    "...components"
+    "...components",
+    "---Hooks---",
+    "...hooks"
   ]
 }


### PR DESCRIPTION
## What changed
- moved the `Hooks` section below `Components` in `docs/content/lynx/meta.json`
- kept the Lynx docs navigation order aligned with the requested content grouping

## Why
- the Lynx content nav currently shows `Hooks` before `Components`
- this change updates the section order so components appear first, then hooks

## Impact
- Lynx docs readers will see `Components` before `Hooks` in the docs navigation
- no component API or runtime behavior changes

## Validation
- ran `bun test:all`
- the suite currently fails due to pre-existing unrelated issues:
  - `docs/app/_llms/rules/token-reference-rule.test.ts` timed out in `tokenReferenceRule > keeps the original node when regex matches nothing`
  - `examples/lynx-spa/src/__tests__/index.test.tsx` could not resolve `react/jsx-dev-runtime`
