### PR TITLE
docs(lynx): replace hook installation with imports

### DIFF
--- a/docs/content/lynx/hooks/use-controllable-state.mdx
+++ b/docs/content/lynx/hooks/use-controllable-state.mdx
@@ -3,10 +3,10 @@ title: useControllableState
 description: Controlled/uncontrolled 상태 패턴을 지원하는 훅입니다.
 ---
 
-## Installation
+## Import
 
-```package-install
-npx @seed-design/cli@alpha add ui:action-button --baseUrl https://lynx.seed-design.pages.dev
+```ts
+import { useControllableState } from "@seed-design/lynx-react";
 ```
 
 `useControllableState`는 `@seed-design/lynx-react` 패키지에 포함되어 있습니다.

--- a/docs/content/lynx/hooks/use-press-tap.mdx
+++ b/docs/content/lynx/hooks/use-press-tap.mdx
@@ -3,10 +3,10 @@ title: usePressTap
 description: Lynx 요소의 press/tap 인터랙션 상태를 관리하는 훅입니다.
 ---
 
-## Installation
+## Import
 
-```package-install
-npx @seed-design/cli@alpha add ui:action-button --baseUrl https://lynx.seed-design.pages.dev
+```ts
+import { usePressTap } from "@seed-design/lynx-react";
 ```
 
 `usePressTap`은 `@seed-design/lynx-react` 패키지에 포함되어 있습니다.


### PR DESCRIPTION
## What changed
- replaced the `Installation` section in the Lynx hook docs with a simple `Import` section
- removed the misleading `package-install` snippet from `usePressTap` and `useControllableState`
- kept the docs focused on how these hooks are consumed from `@seed-design/lynx-react`

## Why
The Lynx hook docs were showing a component installation command for `action-button`, which does not match how hooks are used. For hooks, the most helpful entry point is the import itself rather than a CLI snippet.

## Impact
- Lynx hook docs now better reflect the actual usage model
- readers are less likely to assume hooks require a component snippet install step

## Validation
- ran `bun generate:all`
- ran `bun test:all`
  - this failed due to pre-existing unrelated environment/test issues:
  - `docs/app/_llms` tests hit socket/network errors (`ECONNREFUSED` / `FailedToOpenSocket`)
  - `examples/lynx-spa` test failed with missing `react/jsx-dev-runtime`
