### PR TITLE
refactor(docs): replace manual frontmatter parsing with gray-matter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -117,6 +117,7 @@
         "concurrently": "^9.2.1",
         "figma-api": "^2.1.2-beta",
         "flat-cache": "^6.1.19",
+        "gray-matter": "^4.0.3",
         "mdast-util-mdx-jsx": "^3.2.0",
         "postcss": "^8.5.3",
         "storybook": "^10.1.10",
@@ -3656,6 +3657,8 @@
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
+    "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
+
     "extendable-error": ["extendable-error@0.1.7", "", {}, "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
@@ -3832,6 +3835,8 @@
 
     "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
 
+    "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
+
     "groq": ["groq@4.22.0", "", {}, "sha512-98P1gLlIHbdB0wP2dPsKsn6c31iaUoPi+ES+iwNpe7L8sQp7zYWm/yZDdX/KEdCloCPthTlWIYEXVKHqiTc0eA=="],
 
     "groq-js": ["groq-js@1.24.1", "", { "dependencies": { "debug": "^4.3.4" } }, "sha512-xSTHTxN+lZt6gK5hm4S7CQm5Z8SUkZOd7sa1FlwqK/hbKgSnfc0zkmlWBF4rkkcqWCugHMDjPNRVIreeO3Vq8Q=="],
@@ -4001,6 +4006,8 @@
     "is-deflate": ["is-deflate@1.0.0", "", {}, "sha512-YDoFpuZWu1VRXlsnlYMzKyVRITXj7Ej/V9gXQ2/pAe7X1J7M/RNOqaIYi6qUn+B7nGyB9pDXrv02dsB58d2ZAQ=="],
 
     "is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
+
+    "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -5004,6 +5011,8 @@
 
     "scrollmirror": ["scrollmirror@1.2.4", "", {}, "sha512-UkEHHOV6j5cE3IsObQRK6vO4twSuhE4vtLD4UmX+doHgrtg2jRwXkz4O6cz0jcoxK5NGU7rFjyvLcWHzw7eQ5A=="],
 
+    "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
+
     "select-hose": ["select-hose@2.0.0", "", {}, "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg=="],
 
     "selfsigned": ["selfsigned@2.4.1", "", { "dependencies": { "@types/node-forge": "^1.3.0", "node-forge": "^1" } }, "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q=="],
@@ -5149,6 +5158,8 @@
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
+
+    "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
 
     "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
 
@@ -6266,6 +6277,8 @@
 
     "globby/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
+    "gray-matter/js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
+
     "gunzip-maybe/browserify-zlib": ["browserify-zlib@0.1.4", "", { "dependencies": { "pako": "~0.2.0" } }, "sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ=="],
 
     "gunzip-maybe/through2": ["through2@2.0.5", "", { "dependencies": { "readable-stream": "~2.3.6", "xtend": "~4.0.1" } }, "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ=="],
@@ -7351,6 +7364,8 @@
     "get-uri/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "global-prefix/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "gunzip-maybe/browserify-zlib/pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
 

--- a/docs/migrations/import-components-to-sanity.ts
+++ b/docs/migrations/import-components-to-sanity.ts
@@ -1,11 +1,12 @@
 import chalk from "chalk";
 import { createClient } from "@sanity/client";
 import { promises as fs } from "fs";
+import matter from "gray-matter";
 import path from "node:path";
 import { apiVersion, dataset, projectId } from "../sanity-studio/env.js";
 
 interface ComponentFrontmatter {
-  title: string;
+  title?: string;
   description?: string;
 }
 
@@ -13,25 +14,6 @@ interface ComponentToImport {
   id: string;
   name: string;
   filePath: string;
-}
-
-// Parse MDX frontmatter
-function parseFrontmatter(content: string): ComponentFrontmatter | null {
-  const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---/;
-  const match = content.match(frontmatterRegex);
-
-  if (!match) return null;
-
-  const frontmatterContent = match[1];
-  const titleMatch = frontmatterContent.match(/title:\s*(.+)/);
-  const descriptionMatch = frontmatterContent.match(/description:\s*"?([^"\n]+)"?/);
-
-  if (!titleMatch) return null;
-
-  return {
-    title: titleMatch[1].trim(),
-    description: descriptionMatch ? descriptionMatch[1].trim() : undefined,
-  };
 }
 
 // Scan components directory
@@ -47,10 +29,10 @@ async function scanComponents(): Promise<ComponentToImport[]> {
 
     const filePath = path.join(componentsDir, file);
     const content = await fs.readFile(filePath, "utf-8");
-    const frontmatter = parseFrontmatter(content);
+    const frontmatter = matter(content).data as ComponentFrontmatter;
 
-    if (!frontmatter) {
-      console.log(chalk.yellow(`⚠️  Skipping ${file} - no frontmatter found`));
+    if (!frontmatter.title) {
+      console.log(chalk.yellow(`⚠️  Skipping ${file} - no frontmatter title found`));
       continue;
     }
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -94,6 +94,7 @@
     "concurrently": "^9.2.1",
     "figma-api": "^2.1.2-beta",
     "flat-cache": "^6.1.19",
+    "gray-matter": "^4.0.3",
     "mdast-util-mdx-jsx": "^3.2.0",
     "postcss": "^8.5.3",
     "storybook": "^10.1.10",

--- a/docs/scripts/generate-docs-index.ts
+++ b/docs/scripts/generate-docs-index.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import { existsSync, readFileSync, readdirSync, statSync } from "fs";
 import { promises as fs } from "fs";
+import matter from "gray-matter";
 import path from "node:path";
 
 type DocsSnippet = {
@@ -63,32 +64,11 @@ const SECTION_LABELS: Record<string, string> = {
   patterns: "패턴",
 };
 
-/**
- * Parse YAML frontmatter from an MDX file.
- * Returns null if no frontmatter is found.
- */
-function parseFrontmatter(content: string): Record<string, string> | null {
-  const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
-  if (!match) return null;
-
-  const result: Record<string, string> = {};
-  for (const line of match[1].split("\n")) {
-    const colonIdx = line.indexOf(":");
-    if (colonIdx === -1) continue;
-    const key = line.slice(0, colonIdx).trim();
-    let value = line.slice(colonIdx + 1).trim();
-    // Strip matching surrounding quotes so YAML values like
-    // description: "@seed-design/cli..." parse cleanly.
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
-    result[key] = value;
-  }
-  return result;
-}
+type Frontmatter = {
+  title?: string;
+  description?: string;
+  deprecated?: boolean;
+};
 
 /**
  * Convert a file path relative to its content dir into URL slugs.
@@ -205,8 +185,8 @@ async function main() {
 
       const fullPath = path.join(sourceDir, relPath);
       const content = readFileSync(fullPath, "utf-8");
-      const frontmatter = parseFrontmatter(content);
-      if (!frontmatter?.title) continue;
+      const frontmatter = matter(content).data as Frontmatter;
+      if (!frontmatter.title) continue;
 
       // Section ID is the first slug for multi-level categories,
       // or "components" as default for flat categories (breeze, lynx, ai-integration)
@@ -222,7 +202,7 @@ async function main() {
         title: frontmatter.title,
         ...(frontmatter.description && { description: frontmatter.description }),
         docUrl,
-        ...(frontmatter.deprecated === "true" && { deprecated: true }),
+        ...(frontmatter.deprecated && { deprecated: true }),
         ...(registryEntry && {
           snippetKey: `${registryEntry.registryId}:${itemId}`,
           snippets: registryEntry.snippets,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 문서 및 컴포넌트 스캔 프로세스의 메타데이터 추출 메커니즘을 개선했습니다.
  * 컴포넌트 제목이 없는 경우의 처리 로직을 조정했습니다.
  * 더 이상 사용되지 않는 컴포넌트 감지 방식을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->