### PR TITLE
chore(cli): Add PostHog docs env wiring and CLI outcome telemetry

### DIFF
--- a/.changeset/brisk-rivers-glow.md
+++ b/.changeset/brisk-rivers-glow.md
@@ -1,0 +1,9 @@
+---
+"@seed-design/cli": patch
+---
+
+CLI 텔레메트리 수집을 개선합니다.
+
+- `add`, `add-all`, `compat`, `docs`, `init` 명령어의 실행 결과를 `completed`, `cancelled`, `failed`로 구분해 수집합니다.
+- `compat` 명령어는 `compatible`, `incompatible`, `empty` 결과를 추가로 구분해 수집합니다.
+- 텔레메트리 실패 테스트를 보강하고, 실패 시에는 상세 메시지 대신 안전한 에러 타입만 전송하도록 정리합니다.

--- a/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
@@ -64,7 +64,10 @@ jobs:
       - name: Build Docs
         working-directory: ./docs
         env:
+          # docs uses Next static export, so NEXT_PUBLIC_* values must be present at build time.
           FIGMA_CACHE_DISABLED: ${{ inputs.skip-figma-cache && '1' || '0' }}
+          NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
+          NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
         run: |
           bun run build
 

--- a/.github/workflows/deploy-seed-design-docs-prod-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-prod-pages.yml
@@ -66,7 +66,10 @@ jobs:
       - name: Build Docs
         working-directory: ./docs
         env:
+          # docs uses Next static export, so NEXT_PUBLIC_* values must be present at build time.
           FIGMA_CACHE_DISABLED: ${{ inputs.skip-figma-cache && '1' || '0' }}
+          NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
+          NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
         run: |
           bun run build
 

--- a/packages/cli/src/commands/add-all.ts
+++ b/packages/cli/src/commands/add-all.ts
@@ -241,7 +241,7 @@ export const addAllCommand = (cli: CAC) => {
           });
         } catch (telemetryError) {
           if (verbose) {
-            console.error("[Telemetry] add-all tracking failed:", telemetryError);
+            console.error("[Telemetry] add-all 이벤트 전송에 실패했어요:", telemetryError);
           }
         }
       } catch (error) {
@@ -256,7 +256,7 @@ export const addAllCommand = (cli: CAC) => {
             });
           } catch (telemetryError) {
             if (verbose) {
-              console.error("[Telemetry] add-all tracking failed:", telemetryError);
+              console.error("[Telemetry] add-all 이벤트 전송에 실패했어요:", telemetryError);
             }
           }
           p.outro(highlight(error.message));
@@ -273,7 +273,7 @@ export const addAllCommand = (cli: CAC) => {
           });
         } catch (telemetryError) {
           if (verbose) {
-            console.error("[Telemetry] add-all tracking failed:", telemetryError);
+            console.error("[Telemetry] add-all 이벤트 전송에 실패했어요:", telemetryError);
           }
         }
 

--- a/packages/cli/src/commands/add-all.ts
+++ b/packages/cli/src/commands/add-all.ts
@@ -56,6 +56,7 @@ export const addAllCommand = (cli: CAC) => {
     .action(async (registryIds, opts) => {
       const startTime = Date.now();
       const verbose = isVerboseMode(opts);
+      const trackCwd = typeof opts?.cwd === "string" ? opts.cwd : process.cwd();
       p.intro("seed-design add-all");
 
       try {
@@ -227,8 +228,9 @@ export const addAllCommand = (cli: CAC) => {
         // add-all 성공 이벤트 추적
         const duration = Date.now() - startTime;
         try {
-          await analytics.track(options.cwd, {
-            event: "add-all",
+          await analytics.trackCommandOutcome(options.cwd, {
+            command: "add-all",
+            status: "completed",
             properties: {
               registries: selectedRegistryIds,
               items_count: itemKeys.length,
@@ -244,8 +246,35 @@ export const addAllCommand = (cli: CAC) => {
         }
       } catch (error) {
         if (isCliCancelError(error)) {
+          try {
+            await analytics.trackCommandOutcome(trackCwd, {
+              command: "add-all",
+              status: "cancelled",
+              properties: {
+                duration_ms: Date.now() - startTime,
+              },
+            });
+          } catch (telemetryError) {
+            if (verbose) {
+              console.error("[Telemetry] add-all tracking failed:", telemetryError);
+            }
+          }
           p.outro(highlight(error.message));
           process.exit(0);
+        }
+
+        try {
+          await analytics.trackCommandFailure(trackCwd, {
+            command: "add-all",
+            error,
+            properties: {
+              duration_ms: Date.now() - startTime,
+            },
+          });
+        } catch (telemetryError) {
+          if (verbose) {
+            console.error("[Telemetry] add-all tracking failed:", telemetryError);
+          }
         }
 
         handleCliError(error, {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -262,7 +262,7 @@ export const addCommand = (cli: CAC) => {
           });
         } catch (telemetryError) {
           if (verbose) {
-            console.error("[Telemetry] add tracking failed:", telemetryError);
+            console.error("[Telemetry] add 이벤트 전송에 실패했어요:", telemetryError);
           }
         }
       } catch (error) {
@@ -277,7 +277,7 @@ export const addCommand = (cli: CAC) => {
             });
           } catch (telemetryError) {
             if (verbose) {
-              console.error("[Telemetry] add tracking failed:", telemetryError);
+              console.error("[Telemetry] add 이벤트 전송에 실패했어요:", telemetryError);
             }
           }
           p.outro(highlight(error.message));
@@ -294,7 +294,7 @@ export const addCommand = (cli: CAC) => {
           });
         } catch (telemetryError) {
           if (verbose) {
-            console.error("[Telemetry] add tracking failed:", telemetryError);
+            console.error("[Telemetry] add 이벤트 전송에 실패했어요:", telemetryError);
           }
         }
 

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -55,6 +55,7 @@ export const addCommand = (cli: CAC) => {
     .action(async (itemIds, opts) => {
       const startTime = Date.now();
       const verbose = isVerboseMode(opts);
+      const trackCwd = typeof opts?.cwd === "string" ? opts.cwd : process.cwd();
       p.intro("seed-design add");
 
       try {
@@ -248,8 +249,9 @@ export const addCommand = (cli: CAC) => {
         });
 
         try {
-          await analytics.track(options.cwd, {
-            event: "add",
+          await analytics.trackCommandOutcome(options.cwd, {
+            command: "add",
+            status: "completed",
             properties: {
               items_count: filteredItemKeys.length,
               registries: Array.from(uniqueRegistries),
@@ -265,8 +267,35 @@ export const addCommand = (cli: CAC) => {
         }
       } catch (error) {
         if (isCliCancelError(error)) {
+          try {
+            await analytics.trackCommandOutcome(trackCwd, {
+              command: "add",
+              status: "cancelled",
+              properties: {
+                duration_ms: Date.now() - startTime,
+              },
+            });
+          } catch (telemetryError) {
+            if (verbose) {
+              console.error("[Telemetry] add tracking failed:", telemetryError);
+            }
+          }
           p.outro(highlight(error.message));
           process.exit(0);
+        }
+
+        try {
+          await analytics.trackCommandFailure(trackCwd, {
+            command: "add",
+            error,
+            properties: {
+              duration_ms: Date.now() - startTime,
+            },
+          });
+        } catch (telemetryError) {
+          if (verbose) {
+            console.error("[Telemetry] add tracking failed:", telemetryError);
+          }
         }
 
         handleCliError(error, {

--- a/packages/cli/src/commands/compat.ts
+++ b/packages/cli/src/commands/compat.ts
@@ -214,7 +214,7 @@ export const compatCommand = (cli: CAC) => {
             });
           } catch (telemetryError) {
             if (verbose) {
-              console.error("[Telemetry] compat tracking failed:", telemetryError);
+              console.error("[Telemetry] compat 이벤트 전송에 실패했어요:", telemetryError);
             }
           }
           p.outro("검사할 스니펫이 없어요.");
@@ -246,7 +246,7 @@ export const compatCommand = (cli: CAC) => {
             });
           } catch (telemetryError) {
             if (verbose) {
-              console.error("[Telemetry] compat tracking failed:", telemetryError);
+              console.error("[Telemetry] compat 이벤트 전송에 실패했어요:", telemetryError);
             }
           }
 
@@ -278,7 +278,7 @@ export const compatCommand = (cli: CAC) => {
           });
         } catch (telemetryError) {
           if (verbose) {
-            console.error("[Telemetry] compat tracking failed:", telemetryError);
+            console.error("[Telemetry] compat 이벤트 전송에 실패했어요:", telemetryError);
           }
         }
 
@@ -295,7 +295,7 @@ export const compatCommand = (cli: CAC) => {
             });
           } catch (telemetryError) {
             if (verbose) {
-              console.error("[Telemetry] compat tracking failed:", telemetryError);
+              console.error("[Telemetry] compat 이벤트 전송에 실패했어요:", telemetryError);
             }
           }
           p.outro(highlight(error.message));
@@ -312,7 +312,7 @@ export const compatCommand = (cli: CAC) => {
           });
         } catch (telemetryError) {
           if (verbose) {
-            console.error("[Telemetry] compat tracking failed:", telemetryError);
+            console.error("[Telemetry] compat 이벤트 전송에 실패했어요:", telemetryError);
           }
         }
 

--- a/packages/cli/src/commands/compat.ts
+++ b/packages/cli/src/commands/compat.ts
@@ -123,6 +123,7 @@ export const compatCommand = (cli: CAC) => {
     .action(async (itemIds, opts) => {
       const startTime = Date.now();
       const verbose = isVerboseMode(opts);
+      const trackCwd = typeof opts?.cwd === "string" ? opts.cwd : process.cwd();
       p.intro("seed-design compat");
 
       try {
@@ -202,6 +203,20 @@ export const compatCommand = (cli: CAC) => {
             })();
 
         if (!resolvedTargetItemKeys.length) {
+          try {
+            await analytics.trackCommandOutcome(options.cwd, {
+              command: "compat",
+              status: "completed",
+              result: "empty",
+              properties: {
+                duration_ms: Date.now() - startTime,
+              },
+            });
+          } catch (telemetryError) {
+            if (verbose) {
+              console.error("[Telemetry] compat tracking failed:", telemetryError);
+            }
+          }
           p.outro("검사할 스니펫이 없어요.");
           process.exit(0);
         }
@@ -219,8 +234,10 @@ export const compatCommand = (cli: CAC) => {
           p.outro("모든 스니펫이 현재 @seed-design/react, @seed-design/css와 호환돼요.");
 
           try {
-            await analytics.track(options.cwd, {
-              event: "compat",
+            await analytics.trackCommandOutcome(options.cwd, {
+              command: "compat",
+              status: "completed",
+              result: "compatible",
               properties: {
                 checked_items_count: compatibilityReport.checkedItemKeys.length,
                 incompatible_items_count: 0,
@@ -246,8 +263,10 @@ export const compatCommand = (cli: CAC) => {
         p.outro("호환성 이슈가 있어요.");
 
         try {
-          await analytics.track(options.cwd, {
-            event: "compat",
+          await analytics.trackCommandOutcome(options.cwd, {
+            command: "compat",
+            status: "completed",
+            result: "incompatible",
             properties: {
               checked_items_count: compatibilityReport.checkedItemKeys.length,
               incompatible_items_count: new Set(
@@ -266,8 +285,35 @@ export const compatCommand = (cli: CAC) => {
         process.exit(1);
       } catch (error) {
         if (isCliCancelError(error)) {
+          try {
+            await analytics.trackCommandOutcome(trackCwd, {
+              command: "compat",
+              status: "cancelled",
+              properties: {
+                duration_ms: Date.now() - startTime,
+              },
+            });
+          } catch (telemetryError) {
+            if (verbose) {
+              console.error("[Telemetry] compat tracking failed:", telemetryError);
+            }
+          }
           p.outro(highlight(error.message));
           process.exit(0);
+        }
+
+        try {
+          await analytics.trackCommandFailure(trackCwd, {
+            command: "compat",
+            error,
+            properties: {
+              duration_ms: Date.now() - startTime,
+            },
+          });
+        } catch (telemetryError) {
+          if (verbose) {
+            console.error("[Telemetry] compat tracking failed:", telemetryError);
+          }
         }
 
         handleCliError(error, {

--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -479,7 +479,7 @@ export const docsCommand = (cli: CAC) => {
           });
         } catch (telemetryError) {
           if (verbose) {
-            console.error("[Telemetry] docs tracking failed:", telemetryError);
+            console.error("[Telemetry] docs 이벤트 전송에 실패했어요:", telemetryError);
           }
         }
       } catch (error) {
@@ -495,7 +495,7 @@ export const docsCommand = (cli: CAC) => {
             });
           } catch (telemetryError) {
             if (verbose) {
-              console.error("[Telemetry] docs tracking failed:", telemetryError);
+              console.error("[Telemetry] docs 이벤트 전송에 실패했어요:", telemetryError);
             }
           }
           if (!raw) p.outro(highlight(error.message));
@@ -513,7 +513,7 @@ export const docsCommand = (cli: CAC) => {
           });
         } catch (telemetryError) {
           if (verbose) {
-            console.error("[Telemetry] docs tracking failed:", telemetryError);
+            console.error("[Telemetry] docs 이벤트 전송에 실패했어요:", telemetryError);
           }
         }
 

--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -246,6 +246,7 @@ export const docsCommand = (cli: CAC) => {
       const startTime = Date.now();
       const verbose = isVerboseMode(opts);
       const raw = opts.raw ?? false;
+      const trackCwd = process.cwd();
 
       if (!raw) p.intro("seed-design docs");
 
@@ -465,12 +466,14 @@ export const docsCommand = (cli: CAC) => {
 
         const duration = Date.now() - startTime;
         try {
-          await analytics.track(process.cwd(), {
-            event: "docs",
+          await analytics.trackCommandOutcome(trackCwd, {
+            command: "docs",
+            status: "completed",
             properties: {
               query: options.query ?? null,
               item_id: selectedItem?.id ?? options.query ?? null,
               has_snippet: !!(selectedItem?.snippets && selectedItem.snippets.length > 0),
+              raw_mode: raw,
               duration_ms: duration,
             },
           });
@@ -481,8 +484,37 @@ export const docsCommand = (cli: CAC) => {
         }
       } catch (error) {
         if (isCliCancelError(error)) {
+          try {
+            await analytics.trackCommandOutcome(trackCwd, {
+              command: "docs",
+              status: "cancelled",
+              properties: {
+                raw_mode: raw,
+                duration_ms: Date.now() - startTime,
+              },
+            });
+          } catch (telemetryError) {
+            if (verbose) {
+              console.error("[Telemetry] docs tracking failed:", telemetryError);
+            }
+          }
           if (!raw) p.outro(highlight(error.message));
           process.exit(0);
+        }
+
+        try {
+          await analytics.trackCommandFailure(trackCwd, {
+            command: "docs",
+            error,
+            properties: {
+              raw_mode: raw,
+              duration_ms: Date.now() - startTime,
+            },
+          });
+        } catch (telemetryError) {
+          if (verbose) {
+            console.error("[Telemetry] docs tracking failed:", telemetryError);
+          }
         }
 
         if (raw) {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -92,7 +92,7 @@ export const initCommand = (cli: CAC) => {
           });
         } catch (telemetryError) {
           if (verbose) {
-            console.error("[Telemetry] init tracking failed:", telemetryError);
+            console.error("[Telemetry] init 이벤트 전송에 실패했어요:", telemetryError);
           }
         }
       } catch (error) {
@@ -107,7 +107,7 @@ export const initCommand = (cli: CAC) => {
             });
           } catch (telemetryError) {
             if (verbose) {
-              console.error("[Telemetry] init tracking failed:", telemetryError);
+              console.error("[Telemetry] init 이벤트 전송에 실패했어요:", telemetryError);
             }
           }
           p.outro(highlight(error.message));
@@ -124,7 +124,7 @@ export const initCommand = (cli: CAC) => {
           });
         } catch (telemetryError) {
           if (verbose) {
-            console.error("[Telemetry] init tracking failed:", telemetryError);
+            console.error("[Telemetry] init 이벤트 전송에 실패했어요:", telemetryError);
           }
         }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -27,6 +27,7 @@ export const initCommand = (cli: CAC) => {
     .action(async (opts) => {
       const startTime = Date.now();
       const verbose = isVerboseMode(opts);
+      const trackCwd = typeof opts?.cwd === "string" ? opts.cwd : process.cwd();
       p.intro("seed-design.json 파일 생성");
 
       try {
@@ -78,8 +79,9 @@ export const initCommand = (cli: CAC) => {
         // init 성공 이벤트 추적
         const duration = Date.now() - startTime;
         try {
-          await analytics.track(options.cwd, {
-            event: "init",
+          await analytics.trackCommandOutcome(options.cwd, {
+            command: "init",
+            status: "completed",
             properties: {
               tsx: config.tsx,
               rsc: config.rsc,
@@ -95,8 +97,35 @@ export const initCommand = (cli: CAC) => {
         }
       } catch (error) {
         if (isCliCancelError(error)) {
+          try {
+            await analytics.trackCommandOutcome(trackCwd, {
+              command: "init",
+              status: "cancelled",
+              properties: {
+                duration_ms: Date.now() - startTime,
+              },
+            });
+          } catch (telemetryError) {
+            if (verbose) {
+              console.error("[Telemetry] init tracking failed:", telemetryError);
+            }
+          }
           p.outro(highlight(error.message));
           process.exit(0);
+        }
+
+        try {
+          await analytics.trackCommandFailure(trackCwd, {
+            command: "init",
+            error,
+            properties: {
+              duration_ms: Date.now() - startTime,
+            },
+          });
+        } catch (telemetryError) {
+          if (verbose) {
+            console.error("[Telemetry] init tracking failed:", telemetryError);
+          }
         }
 
         handleCliError(error, {

--- a/packages/cli/src/tests/analytics.test.ts
+++ b/packages/cli/src/tests/analytics.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import * as prompts from "@clack/prompts";
+import { analytics } from "../utils/analytics";
+
+describe("analytics command outcome tracking", () => {
+  const originalEnv = { ...process.env };
+  const tempDirs: string[] = [];
+
+  beforeEach(() => {
+    process.env.NODE_ENV = "prod";
+    process.env.POSTHOG_API_KEY = "test-api-key";
+    process.env.POSTHOG_HOST = "https://us.i.posthog.com";
+    delete process.env.DISABLE_TELEMETRY;
+    delete process.env.SEED_DISABLE_TELEMETRY;
+  });
+
+  afterEach(async () => {
+    process.env = { ...originalEnv };
+    mock.restore();
+
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) {
+        await fs.remove(dir);
+      }
+    }
+  });
+
+  async function createTempCwd() {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "seed-cli-analytics-"));
+    tempDirs.push(cwd);
+    return cwd;
+  }
+
+  it("command outcome payload에 status를 포함해야 한다", async () => {
+    const cwd = await createTempCwd();
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+      async () => new Response(null, { status: 200 }),
+    );
+    const infoSpy = spyOn(prompts.log, "info").mockImplementation(() => {});
+
+    await analytics.trackCommandOutcome(cwd, {
+      command: "add",
+      status: "completed",
+      properties: {
+        items_count: 2,
+      },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalled();
+
+    const [, request] = fetchSpy.mock.calls[0] ?? [];
+    const payload = JSON.parse(String(request?.body));
+
+    expect(payload.event).toBe("seed_cli.add");
+    expect(payload.properties).toMatchObject({
+      status: "completed",
+      items_count: 2,
+      $process_person_profile: false,
+    });
+  });
+
+  it("failed outcome payload에는 error_type만 포함하고 message는 포함하지 않아야 한다", async () => {
+    const cwd = await createTempCwd();
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+      async () => new Response(null, { status: 200 }),
+    );
+    spyOn(prompts.log, "info").mockImplementation(() => {});
+
+    await analytics.trackCommandFailure(cwd, {
+      command: "docs",
+      error: new Error("sensitive details"),
+      properties: {
+        raw_mode: true,
+      },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const [, request] = fetchSpy.mock.calls[0] ?? [];
+    const payload = JSON.parse(String(request?.body));
+
+    expect(payload.event).toBe("seed_cli.docs");
+    expect(payload.properties).toMatchObject({
+      status: "failed",
+      error_type: "Error",
+      raw_mode: true,
+    });
+    expect(payload.properties.error_message).toBeUndefined();
+  });
+});

--- a/packages/cli/src/tests/command-telemetry.test.ts
+++ b/packages/cli/src/tests/command-telemetry.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import type { CAC } from "cac";
+import { cac } from "cac";
+import { CliCancelError } from "../utils/error";
+import { analytics } from "../utils/analytics";
+
+const introMock = mock(() => {});
+const outroMock = mock(() => {});
+const infoMock = mock(() => {});
+const messageMock = mock(() => {});
+const errorMock = mock(() => {});
+const noteMock = mock(() => {});
+const spinnerStartMock = mock(() => {});
+const spinnerStopMock = mock(() => {});
+const promptInitConfigMock = mock(async () => ({
+  tsx: true,
+  rsc: false,
+  path: "./seed-design",
+  telemetry: true,
+}));
+const writeInitConfigFileMock = mock(async () => ({
+  relativePath: "seed-design.json",
+}));
+
+mock.module("@clack/prompts", () => ({
+  intro: introMock,
+  outro: outroMock,
+  note: noteMock,
+  log: {
+    info: infoMock,
+    message: messageMock,
+    error: errorMock,
+  },
+  spinner: () => ({
+    start: spinnerStartMock,
+    stop: spinnerStopMock,
+  }),
+  isCancel: () => false,
+}));
+
+mock.module("../utils/init-config", () => ({
+  DEFAULT_INIT_CONFIG: {
+    tsx: true,
+    rsc: false,
+    path: "./seed-design",
+    telemetry: true,
+  },
+  promptInitConfig: promptInitConfigMock,
+  writeInitConfigFile: writeInitConfigFileMock,
+}));
+
+const { addCommand } = await import("../commands/add");
+const { initCommand } = await import("../commands/init");
+
+function getCommand(cli: CAC, name: string) {
+  const command = cli.commands.find((item) => item.name === name);
+
+  if (!command) {
+    throw new Error(`Command not found: ${name}`);
+  }
+
+  return command;
+}
+
+describe("command telemetry", () => {
+  beforeEach(() => {
+    introMock.mockClear();
+    outroMock.mockClear();
+    infoMock.mockClear();
+    messageMock.mockClear();
+    errorMock.mockClear();
+    noteMock.mockClear();
+    spinnerStartMock.mockClear();
+    spinnerStopMock.mockClear();
+    promptInitConfigMock.mockClear();
+    writeInitConfigFileMock.mockClear();
+  });
+
+  it("init 성공 시 completed outcome을 전송해야 한다", async () => {
+    const trackCommandOutcomeSpy = spyOn(analytics, "trackCommandOutcome").mockImplementation(
+      async () => {},
+    );
+    const trackCommandFailureSpy = spyOn(analytics, "trackCommandFailure").mockImplementation(
+      async () => {},
+    );
+    const cli = cac("seed-design");
+    initCommand(cli);
+
+    await getCommand(cli, "init").commandAction({
+      cwd: "/tmp/seed-design",
+      yes: true,
+      default: false,
+    });
+
+    expect(writeInitConfigFileMock).toHaveBeenCalledTimes(1);
+    expect(trackCommandOutcomeSpy).toHaveBeenCalledWith(
+      "/tmp/seed-design",
+      expect.objectContaining({
+        command: "init",
+        status: "completed",
+        properties: expect.objectContaining({
+          yes_option: true,
+          telemetry: true,
+        }),
+      }),
+    );
+    expect(trackCommandFailureSpy).not.toHaveBeenCalled();
+
+    trackCommandOutcomeSpy.mockRestore();
+    trackCommandFailureSpy.mockRestore();
+  });
+
+  it("init 취소 시 cancelled outcome을 전송해야 한다", async () => {
+    const trackCommandOutcomeSpy = spyOn(analytics, "trackCommandOutcome").mockImplementation(
+      async () => {},
+    );
+    const trackCommandFailureSpy = spyOn(analytics, "trackCommandFailure").mockImplementation(
+      async () => {},
+    );
+    promptInitConfigMock.mockImplementationOnce(async () => {
+      throw new CliCancelError("작업이 취소됐어요.");
+    });
+
+    const exitSpy = spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`EXIT:${code}`);
+    }) as never);
+
+    const cli = cac("seed-design");
+    initCommand(cli);
+
+    await expect(
+      getCommand(cli, "init").commandAction({
+        cwd: "/tmp/seed-design",
+        yes: false,
+        default: false,
+      }),
+    ).rejects.toThrow("EXIT:0");
+
+    expect(trackCommandOutcomeSpy).toHaveBeenCalledWith(
+      "/tmp/seed-design",
+      expect.objectContaining({
+        command: "init",
+        status: "cancelled",
+      }),
+    );
+    expect(trackCommandFailureSpy).not.toHaveBeenCalled();
+
+    exitSpy.mockRestore();
+    trackCommandOutcomeSpy.mockRestore();
+    trackCommandFailureSpy.mockRestore();
+  });
+
+  it("add 실패 시 failed outcome을 전송해야 한다", async () => {
+    const trackCommandFailureSpy = spyOn(analytics, "trackCommandFailure").mockImplementation(
+      async () => {},
+    );
+    const exitSpy = spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`EXIT:${code}`);
+    }) as never);
+
+    const cli = cac("seed-design");
+    addCommand(cli);
+
+    await expect(
+      getCommand(cli, "add").commandAction([], {
+        all: true,
+        cwd: "/tmp/seed-design",
+        baseUrl: "https://seed-design.io",
+      }),
+    ).rejects.toThrow("EXIT:1");
+
+    expect(trackCommandFailureSpy).toHaveBeenCalledWith(
+      "/tmp/seed-design",
+      expect.objectContaining({
+        command: "add",
+        error: expect.objectContaining({
+          name: "CliError",
+        }),
+      }),
+    );
+
+    exitSpy.mockRestore();
+    trackCommandFailureSpy.mockRestore();
+  });
+});

--- a/packages/cli/src/utils/analytics.ts
+++ b/packages/cli/src/utils/analytics.ts
@@ -3,9 +3,24 @@ import * as p from "@clack/prompts";
 import { getRawConfig } from "./get-config";
 
 const EVENT_PREFIX = "seed_cli";
+const COMMAND_STATUSES = ["completed", "cancelled", "failed"] as const;
 
 interface TrackOptions {
   event: string;
+  properties?: Record<string, unknown>;
+}
+
+interface TrackCommandOutcomeOptions {
+  command: string;
+  status: (typeof COMMAND_STATUSES)[number];
+  result?: string;
+  properties?: Record<string, unknown>;
+}
+
+interface TrackCommandFailureOptions {
+  command: string;
+  error: unknown;
+  result?: string;
   properties?: Record<string, unknown>;
 }
 
@@ -47,6 +62,24 @@ const sessionId = generateSessionId();
 
 // 세션당 한 번만 메시지 표시
 let hasShownMessage = false;
+
+function omitUndefined(properties: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(properties).filter(([, value]) => value !== undefined),
+  );
+}
+
+function getSafeErrorType(error: unknown): string {
+  if (error instanceof Error && error.name) {
+    return error.name;
+  }
+
+  if (typeof error === "object" && error !== null) {
+    return error.constructor?.name ?? "Object";
+  }
+
+  return typeof error;
+}
 
 /**
  * PostHog에 이벤트를 전송합니다.
@@ -113,6 +146,37 @@ async function track(cwd: string, { event, properties = {} }: TrackOptions): Pro
   }
 }
 
+async function trackCommandOutcome(
+  cwd: string,
+  { command, status, result, properties = {} }: TrackCommandOutcomeOptions,
+): Promise<void> {
+  await track(cwd, {
+    event: command,
+    properties: omitUndefined({
+      status,
+      result,
+      ...properties,
+    }),
+  });
+}
+
+async function trackCommandFailure(
+  cwd: string,
+  { command, error, result, properties = {} }: TrackCommandFailureOptions,
+): Promise<void> {
+  await trackCommandOutcome(cwd, {
+    command,
+    status: "failed",
+    result,
+    properties: omitUndefined({
+      error_type: getSafeErrorType(error),
+      ...properties,
+    }),
+  });
+}
+
 export const analytics = {
   track,
+  trackCommandFailure,
+  trackCommandOutcome,
 };

--- a/packages/cli/src/utils/analytics.ts
+++ b/packages/cli/src/utils/analytics.ts
@@ -109,7 +109,7 @@ async function track(cwd: string, { event, properties = {} }: TrackOptions): Pro
   // PostHog API 호출 (fire-and-forget)
   try {
     if (!process.env.POSTHOG_HOST || !process.env.POSTHOG_API_KEY) {
-      console.warn("[Analytics] Missing POSTHOG_HOST or POSTHOG_API_KEY");
+      console.error("[Telemetry] POSTHOG_HOST 또는 POSTHOG_API_KEY가 없어서 이벤트를 전송하지 않아요.");
       return;
     }
 


### PR DESCRIPTION
## Summary
- Wire `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST` into both docs deployment workflows so the static export can initialize PostHog at build time.
- Add CLI outcome tracking helpers and attach `completed`, `cancelled`, and `failed` telemetry to `add`, `add-all`, `compat`, `docs`, and `init`.
- Add unit tests for telemetry payloads and command outcome coverage.

## Testing
- `bun generate:all`
- `bun test packages/cli/src/tests`
- `bun test:all`
- Verified the docs build succeeds without PostHog env; the env-injected docs build was started and inspected via logs/artifacts, but the full completion log was not captured in this session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * CLI 명령어 텔레메트리 페이로드 검증 및 명령별 동작을 확인하는 테스트 추가

* **리팩토링**
  * 모든 CLI 명령어의 텔레메트리 추적을 구조화된 명령 결과(완료/취소/실패)로 정비
  * `compat` 명령에 대한 상세 결과(호환/비호환/비발견) 수집 표준화
  * 텔레메트리 실패 보고에서 노출 정보를 안전하게 제한

* **배포**
  * 배포 워크플로우에 분석 도구 환경 변수 주입 및 빌드 시 구성 보장 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->