### PR TITLE
polish(stackflow): tune AppScreen transition easing and duration

### DIFF
--- a/.changeset/tune-waapi-transitions.md
+++ b/.changeset/tune-waapi-transitions.md
@@ -1,0 +1,9 @@
+---
+"@seed-design/stackflow": patch
+---
+
+AppScreen transition의 easing과 duration 값을 리팩합니다. 모션은 더 응답성 있게, ease-in 사용을 제거합니다.
+
+- iOS: easing을 `cubic-bezier(0.32, 0.72, 0, 1)`(Ionic drawer curve)로 변경, pop duration을 `280ms`로 분리해 진입/퇴장을 비대칭화합니다.
+- Android: exit easing을 `linear`에서 `cubic-bezier(0.4, 0, 1, 1)`(Material Accelerate)로 교체합니다.
+- FadeIn: ease-in을 제거하고 enter/exit 모두 `cubic-bezier(0.23, 1, 0.32, 1)`(strong ease-out)으로 통일합니다. enter duration은 opacity-only 모션에 맞춰 `220ms`로 축소합니다.

--- a/packages/stackflow/src/primitive/GlobalInteraction/animation.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/animation.ts
@@ -17,17 +17,28 @@ import {
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
-const IOS_EASING = "cubic-bezier(0.2, 0.1, 0.21, 0.99)";
-const IOS_DURATION = 350;
+// iOS drawer curve (Ionic Framework). Stronger than the native iOS UIKit
+// ease-in-out, giving slides a more intentional feel per Emil Kowalski's
+// design-engineering guidance.
+const IOS_EASING = "cubic-bezier(0.32, 0.72, 0, 1)";
+// Push duration matches the iOS native navigation baseline; pop runs slightly
+// shorter so the system feels responsive when the user steps back.
+const IOS_PUSH_DURATION = 350;
+const IOS_POP_DURATION = 280;
 
+// Material Decelerate (entering) and Accelerate (exiting). Replaces the
+// previous `linear` exit, which felt unfinished — exits want a curve that
+// gathers speed toward offscreen.
 const ANDROID_ENTER_EASING = "cubic-bezier(0.23, 0.1, 0.32, 1)";
 const ANDROID_ENTER_DURATION = 300;
-const ANDROID_EXIT_EASING = "linear";
+const ANDROID_EXIT_EASING = "cubic-bezier(0.4, 0, 1, 1)";
 const ANDROID_EXIT_DURATION = 150;
 
-const FADE_IN_ENTER_EASING = "ease-out";
-const FADE_IN_ENTER_DURATION = 300;
-const FADE_IN_EXIT_EASING = "ease-in";
+// Strong ease-out for both enter and exit. The standard `ease-in` is banned
+// for UI transitions — it delays the first movement where the user is looking
+// hardest. Opacity-only transitions can also be shorter than a full slide.
+const FADE_IN_EASING = "cubic-bezier(0.23, 1, 0.32, 1)";
+const FADE_IN_ENTER_DURATION = 220;
 const FADE_IN_EXIT_DURATION = 150;
 
 const MIN_SWIPE_DURATION = 150;
@@ -144,7 +155,7 @@ function calculateSwipeDuration(remainingDistance: number, velocity: number): nu
     return Math.max(MIN_SWIPE_DURATION, Math.min(MAX_SWIPE_DURATION, remainingDistance / velocity));
   }
   const ratio = remainingDistance / window.innerWidth;
-  return Math.max(MIN_SWIPE_DURATION, Math.min(MAX_SWIPE_DURATION, IOS_DURATION * ratio));
+  return Math.max(MIN_SWIPE_DURATION, Math.min(MAX_SWIPE_DURATION, IOS_PUSH_DURATION * ratio));
 }
 
 // ─── iOS Slide ──────────────────────────────────────────────────────────────
@@ -182,9 +193,14 @@ const IOS_OFFSCREEN: IosPositions = {
   appBarBackground: "translate3d(100%, 0, 0)",
 };
 
-function iosAnimate(t: TransitionTargets, from: IosPositions, to: IosPositions): AnimationResult {
+function iosAnimate(
+  t: TransitionTargets,
+  from: IosPositions,
+  to: IosPositions,
+  duration: number,
+): AnimationResult {
   const opts: KeyframeAnimationOptions = {
-    duration: IOS_DURATION,
+    duration,
     easing: IOS_EASING,
     fill: "forwards",
   };
@@ -232,7 +248,7 @@ function iosAnimate(t: TransitionTargets, from: IosPositions, to: IosPositions):
     ),
   );
 
-  return collectAnimations(anims, IOS_DURATION);
+  return collectAnimations(anims, duration);
 }
 
 /**
@@ -268,14 +284,14 @@ function pinIosInlineStyles(t: TransitionTargets, pos: IosPositions) {
 
 function iosAnimatePush(t: TransitionTargets): AnimationResult {
   pinIosInlineStyles(t, IOS_OFFSCREEN);
-  return iosAnimate(t, IOS_OFFSCREEN, IOS_ONSCREEN);
+  return iosAnimate(t, IOS_OFFSCREEN, IOS_ONSCREEN, IOS_PUSH_DURATION);
 }
 
 function iosAnimatePop(t: TransitionTargets): AnimationResult {
   // No inline pinning here — top is already onscreen (no flash risk) and
   // pinning `-30%` on the behind layer caused it to stick there when
   // cleanup got skipped for any reason.
-  return iosAnimate(t, IOS_ONSCREEN, IOS_OFFSCREEN);
+  return iosAnimate(t, IOS_ONSCREEN, IOS_OFFSCREEN, IOS_POP_DURATION);
 }
 
 // ─── Android / FadeIn ───────────────────────────────────────────────────────
@@ -336,7 +352,7 @@ function fadeInAnimate(t: TransitionTargets, direction: "push" | "pop"): Animati
   const duration = isPush ? FADE_IN_ENTER_DURATION : FADE_IN_EXIT_DURATION;
   const opts: KeyframeAnimationOptions = {
     duration,
-    easing: isPush ? FADE_IN_ENTER_EASING : FADE_IN_EXIT_EASING,
+    easing: FADE_IN_EASING,
     fill: "forwards",
   };
 


### PR DESCRIPTION
## Summary

Follow-up polish on top of `feature/des-1079-waapi`. Apply design-engineering guidance (Emil Kowalski's principles) to the WAAPI transition values — crisper, more intentional motion without touching any structural behaviour.

### Changes

| Constant | Before | After | Why |
| --- | --- | --- | --- |
| `IOS_EASING` | `cubic-bezier(0.2, 0.1, 0.21, 0.99)` | `cubic-bezier(0.32, 0.72, 0, 1)` | Ionic's iOS drawer curve — iOS-feel without the flat tail |
| `IOS_PUSH_DURATION` | — | `350` | Unchanged (matches iOS navigation) |
| `IOS_POP_DURATION` | (shared 350) | `280` | Asymmetric: deliberate on entry, snappy on exit |
| `ANDROID_EXIT_EASING` | `linear` | `cubic-bezier(0.4, 0, 1, 1)` | Material Accelerate; linear reserved for constant motion |
| `FADE_IN_EXIT_EASING` | `ease-in` ⚠️ | `cubic-bezier(0.23, 1, 0.32, 1)` | Ban `ease-in` on UI — starting slow reads as lag |
| `FADE_IN_ENTER_EASING` | `ease-out` | `cubic-bezier(0.23, 1, 0.32, 1)` | Strong ease-out, cohesive with exit |
| `FADE_IN_ENTER_DURATION` | `300` | `220` | Opacity-only transitions drag past 300ms |

Also:
- `iosAnimate` now takes an explicit `duration` so push/pop can pass the right value without branching internally.
- `calculateSwipeDuration` references `IOS_PUSH_DURATION` (swipe-back scales off the push baseline).

### Base

This PR targets `feature/des-1079-waapi` (#1444) — the structural WAAPI migration. These value tweaks are intentionally separated so visual QA can land independently and the WAAPI PR stays focused on behaviour (jank, Chrome 77 fallback, `::before` → real DOM).

### Test plan

- [x] `bun test:all` (596/596 pass)
- [x] `bun --filter @seed-design/stackflow build`
- [ ] examples/stackflow-spa iOS push/pop feel
- [ ] examples/stackflow-spa Android push/pop (fadeFromBottomAndroid + fadeIn)
- [ ] swipe back cancel/complete still natural at various velocities

🤖 Generated with [Claude Code](https://claude.com/claude-code)