### PR TITLE
refactor(top-navigation): separate button rootage declarations

### DIFF
--- a/docs/public/rootage/components/top-navigation-icon-button.json
+++ b/docs/public/rootage/components/top-navigation-icon-button.json
@@ -1,0 +1,139 @@
+{
+  "kind": "ComponentSpec",
+  "metadata": {
+    "id": "top-navigation-icon-button",
+    "name": "Top Navigation Icon Button"
+  },
+  "data": {
+    "id": "top-navigation-icon-button",
+    "name": "Top Navigation Icon Button",
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "size": {
+              "type": "dimension"
+            }
+          }
+        },
+        "icon": {
+          "properties": {
+            "size": {
+              "type": "dimension"
+            },
+            "color": {
+              "type": "color"
+            }
+          }
+        }
+      },
+      "variants": {
+        "tone": {
+          "values": {
+            "layer": {},
+            "transparent": {}
+          },
+          "defaultValue": "layer"
+        }
+      }
+    },
+    "definitions": [
+      {
+        "variants": {},
+        "definitions": [
+          {
+            "states": [
+              "enabled"
+            ],
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension",
+                  "value": {
+                    "value": 44,
+                    "unit": "px"
+                  }
+                }
+              },
+              "icon": {
+                "size": {
+                  "type": "dimension",
+                  "value": {
+                    "value": 24,
+                    "unit": "px"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "variants": {
+          "tone": "layer"
+        },
+        "definitions": [
+          {
+            "states": [
+              "enabled"
+            ],
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color",
+                  "value": "$color.fg.neutral"
+                }
+              }
+            }
+          },
+          {
+            "states": [
+              "disabled"
+            ],
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color",
+                  "value": "$color.fg.disabled"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "variants": {
+          "tone": "transparent"
+        },
+        "definitions": [
+          {
+            "states": [
+              "enabled"
+            ],
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color",
+                  "value": "$color.palette.static-white"
+                }
+              }
+            }
+          },
+          {
+            "states": [
+              "disabled"
+            ],
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color",
+                  "value": "$color.fg.disabled"
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/public/rootage/components/top-navigation-text-button.json
+++ b/docs/public/rootage/components/top-navigation-text-button.json
@@ -1,0 +1,185 @@
+{
+  "kind": "ComponentSpec",
+  "metadata": {
+    "id": "top-navigation-text-button",
+    "name": "Top Navigation Text Button"
+  },
+  "data": {
+    "id": "top-navigation-text-button",
+    "name": "Top Navigation Text Button",
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "height": {
+              "type": "dimension"
+            },
+            "paddingX": {
+              "type": "dimension"
+            }
+          }
+        },
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color"
+            },
+            "fontSize": {
+              "type": "dimension"
+            },
+            "lineHeight": {
+              "type": "dimension"
+            },
+            "fontWeight": {
+              "type": "number"
+            },
+            "maxFontSizeScale": {
+              "type": "number"
+            },
+            "minFontSizeScale": {
+              "type": "number"
+            },
+            "maxLineHeightScale": {
+              "type": "number"
+            },
+            "minLineHeightScale": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "variants": {
+        "tone": {
+          "values": {
+            "layer": {},
+            "transparent": {}
+          },
+          "defaultValue": "layer"
+        }
+      }
+    },
+    "definitions": [
+      {
+        "variants": {},
+        "definitions": [
+          {
+            "states": [
+              "enabled"
+            ],
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension",
+                  "value": {
+                    "value": 44,
+                    "unit": "px"
+                  }
+                },
+                "paddingX": {
+                  "type": "dimension",
+                  "value": "$dimension.x2_5"
+                }
+              },
+              "label": {
+                "fontSize": {
+                  "type": "dimension",
+                  "value": "$font-size.t5"
+                },
+                "lineHeight": {
+                  "type": "dimension",
+                  "value": "$line-height.t5"
+                },
+                "fontWeight": {
+                  "type": "number",
+                  "value": "$font-weight.medium"
+                },
+                "maxFontSizeScale": {
+                  "type": "number",
+                  "value": 1.2
+                },
+                "minFontSizeScale": {
+                  "type": "number",
+                  "value": 1
+                },
+                "maxLineHeightScale": {
+                  "type": "number",
+                  "value": 1.2
+                },
+                "minLineHeightScale": {
+                  "type": "number",
+                  "value": 1
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "variants": {
+          "tone": "layer"
+        },
+        "definitions": [
+          {
+            "states": [
+              "enabled"
+            ],
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color",
+                  "value": "$color.fg.neutral"
+                }
+              }
+            }
+          },
+          {
+            "states": [
+              "disabled"
+            ],
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color",
+                  "value": "$color.fg.disabled"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "variants": {
+          "tone": "transparent"
+        },
+        "definitions": [
+          {
+            "states": [
+              "enabled"
+            ],
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color",
+                  "value": "$color.palette.static-white"
+                }
+              }
+            }
+          },
+          {
+            "states": [
+              "disabled"
+            ],
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color",
+                  "value": "$color.fg.disabled"
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/public/rootage/components/top-navigation.json
+++ b/docs/public/rootage/components/top-navigation.json
@@ -28,6 +28,22 @@
             }
           }
         },
+        "left": {
+          "properties": {},
+          "description": "왼쪽 영역입니다. 일반적으로 뒤로가기/닫기 Top Navigation Icon Button이 위치합니다."
+        },
+        "main": {
+          "properties": {
+            "paddingLeft": {
+              "type": "dimension"
+            }
+          },
+          "description": "title과 subtitle을 포함하는 영역입니다."
+        },
+        "right": {
+          "properties": {},
+          "description": "오른쪽 영역입니다. 일반적으로 Top Navigation Icon Button 또는 Top Navigation Text Button이 위치합니다."
+        },
         "title": {
           "properties": {
             "color": {
@@ -81,19 +97,6 @@
             },
             "minLineHeightScale": {
               "type": "number"
-            }
-          }
-        },
-        "icon": {
-          "properties": {
-            "size": {
-              "type": "dimension"
-            },
-            "targetSize": {
-              "type": "dimension"
-            },
-            "color": {
-              "type": "color"
             }
           }
         }
@@ -151,22 +154,6 @@
                   "type": "dimension",
                   "value": "$dimension.x4"
                 }
-              },
-              "icon": {
-                "size": {
-                  "type": "dimension",
-                  "value": {
-                    "value": 24,
-                    "unit": "px"
-                  }
-                },
-                "targetSize": {
-                  "type": "dimension",
-                  "value": {
-                    "value": 44,
-                    "unit": "px"
-                  }
-                }
               }
             }
           }
@@ -195,18 +182,11 @@
                   "value": "$dimension.x4"
                 }
               },
-              "icon": {
-                "size": {
+              "main": {
+                "paddingLeft": {
                   "type": "dimension",
                   "value": {
-                    "value": 24,
-                    "unit": "px"
-                  }
-                },
-                "targetSize": {
-                  "type": "dimension",
-                  "value": {
-                    "value": 44,
+                    "value": 16,
                     "unit": "px"
                   }
                 }
@@ -242,12 +222,6 @@
                   "type": "color",
                   "value": "$color.fg.neutral-muted"
                 }
-              },
-              "icon": {
-                "color": {
-                  "type": "color",
-                  "value": "$color.fg.neutral"
-                }
               }
             }
           }
@@ -276,12 +250,6 @@
                 }
               },
               "subtitle": {
-                "color": {
-                  "type": "color",
-                  "value": "$color.palette.static-white"
-                }
-              },
-              "icon": {
                 "color": {
                   "type": "color",
                   "value": "$color.palette.static-white"

--- a/docs/public/rootage/index.json
+++ b/docs/public/rootage/index.json
@@ -234,6 +234,12 @@
       "path": "/components/toggle-button.json"
     },
     {
+      "path": "/components/top-navigation-icon-button.json"
+    },
+    {
+      "path": "/components/top-navigation-text-button.json"
+    },
+    {
       "path": "/components/top-navigation.json"
     },
     {

--- a/packages/css/vars/component/index.d.ts
+++ b/packages/css/vars/component/index.d.ts
@@ -73,5 +73,7 @@ export { vars as tagGroup } from "./tag-group";
 export { vars as textButton } from "./text-button";
 export { vars as textInput } from "./text-input";
 export { vars as toggleButton } from "./toggle-button";
+export { vars as topNavigationIconButton } from "./top-navigation-icon-button";
+export { vars as topNavigationTextButton } from "./top-navigation-text-button";
 export { vars as topNavigation } from "./top-navigation";
 export { vars as typography } from "./typography";

--- a/packages/css/vars/component/index.mjs
+++ b/packages/css/vars/component/index.mjs
@@ -73,5 +73,7 @@ export { vars as tagGroup } from "./tag-group.mjs";
 export { vars as textButton } from "./text-button.mjs";
 export { vars as textInput } from "./text-input.mjs";
 export { vars as toggleButton } from "./toggle-button.mjs";
+export { vars as topNavigationIconButton } from "./top-navigation-icon-button.mjs";
+export { vars as topNavigationTextButton } from "./top-navigation-text-button.mjs";
 export { vars as topNavigation } from "./top-navigation.mjs";
 export { vars as typography } from "./typography.mjs";

--- a/packages/css/vars/component/top-navigation-icon-button.d.ts
+++ b/packages/css/vars/component/top-navigation-icon-button.d.ts
@@ -1,0 +1,36 @@
+export declare const vars: {
+  "base": {
+    "enabled": {
+      "root": {
+        "size": "44px"
+      },
+      "icon": {
+        "size": "24px"
+      }
+    }
+  },
+  "toneLayer": {
+    "enabled": {
+      "icon": {
+        "color": "var(--seed-color-fg-neutral)"
+      }
+    },
+    "disabled": {
+      "icon": {
+        "color": "var(--seed-color-fg-disabled)"
+      }
+    }
+  },
+  "toneTransparent": {
+    "enabled": {
+      "icon": {
+        "color": "var(--seed-color-palette-static-white)"
+      }
+    },
+    "disabled": {
+      "icon": {
+        "color": "var(--seed-color-fg-disabled)"
+      }
+    }
+  }
+}

--- a/packages/css/vars/component/top-navigation-icon-button.mjs
+++ b/packages/css/vars/component/top-navigation-icon-button.mjs
@@ -1,0 +1,36 @@
+export const vars = {
+  "base": {
+    "enabled": {
+      "root": {
+        "size": "44px"
+      },
+      "icon": {
+        "size": "24px"
+      }
+    }
+  },
+  "toneLayer": {
+    "enabled": {
+      "icon": {
+        "color": "var(--seed-color-fg-neutral)"
+      }
+    },
+    "disabled": {
+      "icon": {
+        "color": "var(--seed-color-fg-disabled)"
+      }
+    }
+  },
+  "toneTransparent": {
+    "enabled": {
+      "icon": {
+        "color": "var(--seed-color-palette-static-white)"
+      }
+    },
+    "disabled": {
+      "icon": {
+        "color": "var(--seed-color-fg-disabled)"
+      }
+    }
+  }
+}

--- a/packages/css/vars/component/top-navigation-text-button.d.ts
+++ b/packages/css/vars/component/top-navigation-text-button.d.ts
@@ -1,0 +1,43 @@
+export declare const vars: {
+  "base": {
+    "enabled": {
+      "root": {
+        "height": "44px",
+        "paddingX": "var(--seed-dimension-x2_5)"
+      },
+      "label": {
+        "fontSize": "var(--seed-font-size-t5)",
+        "lineHeight": "var(--seed-line-height-t5)",
+        "fontWeight": "var(--seed-font-weight-medium)",
+        "maxFontSizeScale": "1.2",
+        "minFontSizeScale": "1",
+        "maxLineHeightScale": "1.2",
+        "minLineHeightScale": "1"
+      }
+    }
+  },
+  "toneLayer": {
+    "enabled": {
+      "label": {
+        "color": "var(--seed-color-fg-neutral)"
+      }
+    },
+    "disabled": {
+      "label": {
+        "color": "var(--seed-color-fg-disabled)"
+      }
+    }
+  },
+  "toneTransparent": {
+    "enabled": {
+      "label": {
+        "color": "var(--seed-color-palette-static-white)"
+      }
+    },
+    "disabled": {
+      "label": {
+        "color": "var(--seed-color-fg-disabled)"
+      }
+    }
+  }
+}

--- a/packages/css/vars/component/top-navigation-text-button.mjs
+++ b/packages/css/vars/component/top-navigation-text-button.mjs
@@ -1,0 +1,43 @@
+export const vars = {
+  "base": {
+    "enabled": {
+      "root": {
+        "height": "44px",
+        "paddingX": "var(--seed-dimension-x2_5)"
+      },
+      "label": {
+        "fontSize": "var(--seed-font-size-t5)",
+        "lineHeight": "var(--seed-line-height-t5)",
+        "fontWeight": "var(--seed-font-weight-medium)",
+        "maxFontSizeScale": "1.2",
+        "minFontSizeScale": "1",
+        "maxLineHeightScale": "1.2",
+        "minLineHeightScale": "1"
+      }
+    }
+  },
+  "toneLayer": {
+    "enabled": {
+      "label": {
+        "color": "var(--seed-color-fg-neutral)"
+      }
+    },
+    "disabled": {
+      "label": {
+        "color": "var(--seed-color-fg-disabled)"
+      }
+    }
+  },
+  "toneTransparent": {
+    "enabled": {
+      "label": {
+        "color": "var(--seed-color-palette-static-white)"
+      }
+    },
+    "disabled": {
+      "label": {
+        "color": "var(--seed-color-fg-disabled)"
+      }
+    }
+  }
+}

--- a/packages/css/vars/component/top-navigation.d.ts
+++ b/packages/css/vars/component/top-navigation.d.ts
@@ -4,10 +4,6 @@ export declare const vars: {
       "root": {
         "height": "44px",
         "paddingX": "var(--seed-dimension-x4)"
-      },
-      "icon": {
-        "size": "24px",
-        "targetSize": "44px"
       }
     }
   },
@@ -17,9 +13,9 @@ export declare const vars: {
         "height": "56px",
         "paddingX": "var(--seed-dimension-x4)"
       },
-      "icon": {
-        "size": "24px",
-        "targetSize": "44px"
+      /** title과 subtitle을 포함하는 영역입니다. */
+      "main": {
+        "paddingLeft": "16px"
       }
     }
   },
@@ -33,9 +29,6 @@ export declare const vars: {
       },
       "subtitle": {
         "color": "var(--seed-color-fg-neutral-muted)"
-      },
-      "icon": {
-        "color": "var(--seed-color-fg-neutral)"
       }
     }
   },
@@ -48,9 +41,6 @@ export declare const vars: {
         "color": "var(--seed-color-palette-static-white)"
       },
       "subtitle": {
-        "color": "var(--seed-color-palette-static-white)"
-      },
-      "icon": {
         "color": "var(--seed-color-palette-static-white)"
       }
     }

--- a/packages/css/vars/component/top-navigation.mjs
+++ b/packages/css/vars/component/top-navigation.mjs
@@ -4,10 +4,6 @@ export const vars = {
       "root": {
         "height": "44px",
         "paddingX": "var(--seed-dimension-x4)"
-      },
-      "icon": {
-        "size": "24px",
-        "targetSize": "44px"
       }
     }
   },
@@ -17,9 +13,8 @@ export const vars = {
         "height": "56px",
         "paddingX": "var(--seed-dimension-x4)"
       },
-      "icon": {
-        "size": "24px",
-        "targetSize": "44px"
+      "main": {
+        "paddingLeft": "16px"
       }
     }
   },
@@ -33,9 +28,6 @@ export const vars = {
       },
       "subtitle": {
         "color": "var(--seed-color-fg-neutral-muted)"
-      },
-      "icon": {
-        "color": "var(--seed-color-fg-neutral)"
       }
     }
   },
@@ -48,9 +40,6 @@ export const vars = {
         "color": "var(--seed-color-palette-static-white)"
       },
       "subtitle": {
-        "color": "var(--seed-color-palette-static-white)"
-      },
-      "icon": {
         "color": "var(--seed-color-palette-static-white)"
       }
     }

--- a/packages/qvism-preset/src/stackflow/app-bar.ts
+++ b/packages/qvism-preset/src/stackflow/app-bar.ts
@@ -6,6 +6,7 @@ import {
 } from "../utils/focus-ring";
 import { pseudo, focusVisible } from "../utils/pseudo";
 import { topNavigation as vars } from "../vars/component";
+import { topNavigationIconButton as iconButtonVars } from "../vars/component";
 import { fadeInAnimations, fadeFromBottomAndroidAnimations, iOSAnimations } from "./animation";
 import {
   idle,
@@ -218,25 +219,26 @@ export const appBar = defineSlotRecipe({
           paddingTop: "var(--seed-safe-area-top)",
         },
         iconButton: {
-          width: vars.themeCupertino.enabled.icon.targetSize,
-          height: vars.themeCupertino.enabled.icon.targetSize,
+          width: iconButtonVars.base.enabled.root.size,
+          height: iconButtonVars.base.enabled.root.size,
 
           // cursor: "pointer"; // we might need this later
 
           "&:first-child": {
-            marginLeft: `calc(-1 * (${vars.themeCupertino.enabled.icon.targetSize} - ${vars.themeCupertino.enabled.icon.size}) / 2)`,
+            marginLeft: `calc(-1 * (${iconButtonVars.base.enabled.root.size} - ${iconButtonVars.base.enabled.icon.size}) / 2)`,
           },
           "&:last-child": {
-            marginRight: `calc(-1 * (${vars.themeCupertino.enabled.icon.targetSize} - ${vars.themeCupertino.enabled.icon.size}) / 2)`,
+            marginRight: `calc(-1 * (${iconButtonVars.base.enabled.root.size} - ${iconButtonVars.base.enabled.icon.size}) / 2)`,
           },
         },
         // Instead of making another `icon` slot, defining the icon style using ...onlyIcon({}) inside the `iconButton` slot sounds better
         // if we decide to do so, we should require users to wrap the icon with the <Icon /> component. (currently it's optional)
         icon: {
-          width: `var(--seed-icon-size, ${vars.themeCupertino.enabled.icon.size})`,
-          height: `var(--seed-icon-size, ${vars.themeCupertino.enabled.icon.size})`,
+          width: `var(--seed-icon-size, ${iconButtonVars.base.enabled.icon.size})`,
+          height: `var(--seed-icon-size, ${iconButtonVars.base.enabled.icon.size})`,
         },
       },
+      // TODO: most of these can be shared with cupertino, we can just override the necessary styles
       android: {
         root: {
           height: `calc(${vars.themeAndroid.enabled.root.height} + var(--seed-safe-area-top))`,
@@ -245,22 +247,22 @@ export const appBar = defineSlotRecipe({
           paddingTop: "var(--seed-safe-area-top)",
         },
         iconButton: {
-          width: vars.themeAndroid.enabled.icon.targetSize,
-          height: vars.themeAndroid.enabled.icon.targetSize,
+          width: iconButtonVars.base.enabled.root.size,
+          height: iconButtonVars.base.enabled.root.size,
 
           "&:first-child": {
-            marginLeft: `calc(-1 * (${vars.themeAndroid.enabled.icon.targetSize} - ${vars.themeAndroid.enabled.icon.size}) / 2)`,
+            marginLeft: `calc(-1 * (${iconButtonVars.base.enabled.root.size} - ${iconButtonVars.base.enabled.icon.size}) / 2)`,
           },
           "&:last-child": {
-            marginRight: `calc(-1 * (${vars.themeAndroid.enabled.icon.targetSize} - ${vars.themeAndroid.enabled.icon.size}) / 2)`,
+            marginRight: `calc(-1 * (${iconButtonVars.base.enabled.root.size} - ${iconButtonVars.base.enabled.icon.size}) / 2)`,
           },
         },
         icon: {
-          width: `var(--seed-icon-size, ${vars.themeAndroid.enabled.icon.size})`,
-          height: `var(--seed-icon-size, ${vars.themeAndroid.enabled.icon.size})`,
+          width: `var(--seed-icon-size, ${iconButtonVars.base.enabled.icon.size})`,
+          height: `var(--seed-icon-size, ${iconButtonVars.base.enabled.icon.size})`,
         },
         left: {
-          paddingRight: "16px",
+          paddingRight: vars.themeAndroid.enabled.main.paddingLeft,
         },
       },
     },
@@ -330,7 +332,7 @@ export const appBar = defineSlotRecipe({
           },
         },
         icon: {
-          color: `var(--seed-icon-color, ${vars.toneLayer.enabled.icon.color})`,
+          color: `var(--seed-icon-color, ${iconButtonVars.toneLayer.enabled.icon.color})`,
         },
       },
       transparent: {
@@ -338,7 +340,7 @@ export const appBar = defineSlotRecipe({
           backgroundColor: vars.toneTransparent.enabled.root.color,
         },
         icon: {
-          color: `var(--seed-icon-color, ${vars.toneTransparent.enabled.icon.color})`,
+          color: `var(--seed-icon-color, ${iconButtonVars.toneTransparent.enabled.icon.color})`,
         },
       },
     },

--- a/packages/qvism-preset/src/vars/component/index.d.ts
+++ b/packages/qvism-preset/src/vars/component/index.d.ts
@@ -73,5 +73,7 @@ export { vars as tagGroup } from "./tag-group";
 export { vars as textButton } from "./text-button";
 export { vars as textInput } from "./text-input";
 export { vars as toggleButton } from "./toggle-button";
+export { vars as topNavigationIconButton } from "./top-navigation-icon-button";
+export { vars as topNavigationTextButton } from "./top-navigation-text-button";
 export { vars as topNavigation } from "./top-navigation";
 export { vars as typography } from "./typography";

--- a/packages/qvism-preset/src/vars/component/index.mjs
+++ b/packages/qvism-preset/src/vars/component/index.mjs
@@ -73,5 +73,7 @@ export { vars as tagGroup } from "./tag-group.mjs";
 export { vars as textButton } from "./text-button.mjs";
 export { vars as textInput } from "./text-input.mjs";
 export { vars as toggleButton } from "./toggle-button.mjs";
+export { vars as topNavigationIconButton } from "./top-navigation-icon-button.mjs";
+export { vars as topNavigationTextButton } from "./top-navigation-text-button.mjs";
 export { vars as topNavigation } from "./top-navigation.mjs";
 export { vars as typography } from "./typography.mjs";

--- a/packages/qvism-preset/src/vars/component/top-navigation-icon-button.d.ts
+++ b/packages/qvism-preset/src/vars/component/top-navigation-icon-button.d.ts
@@ -1,0 +1,36 @@
+export declare const vars: {
+  "base": {
+    "enabled": {
+      "root": {
+        "size": "44px"
+      },
+      "icon": {
+        "size": "24px"
+      }
+    }
+  },
+  "toneLayer": {
+    "enabled": {
+      "icon": {
+        "color": "var(--seed-color-fg-neutral)"
+      }
+    },
+    "disabled": {
+      "icon": {
+        "color": "var(--seed-color-fg-disabled)"
+      }
+    }
+  },
+  "toneTransparent": {
+    "enabled": {
+      "icon": {
+        "color": "var(--seed-color-palette-static-white)"
+      }
+    },
+    "disabled": {
+      "icon": {
+        "color": "var(--seed-color-fg-disabled)"
+      }
+    }
+  }
+}

--- a/packages/qvism-preset/src/vars/component/top-navigation-icon-button.mjs
+++ b/packages/qvism-preset/src/vars/component/top-navigation-icon-button.mjs
@@ -1,0 +1,36 @@
+export const vars = {
+  "base": {
+    "enabled": {
+      "root": {
+        "size": "44px"
+      },
+      "icon": {
+        "size": "24px"
+      }
+    }
+  },
+  "toneLayer": {
+    "enabled": {
+      "icon": {
+        "color": "var(--seed-color-fg-neutral)"
+      }
+    },
+    "disabled": {
+      "icon": {
+        "color": "var(--seed-color-fg-disabled)"
+      }
+    }
+  },
+  "toneTransparent": {
+    "enabled": {
+      "icon": {
+        "color": "var(--seed-color-palette-static-white)"
+      }
+    },
+    "disabled": {
+      "icon": {
+        "color": "var(--seed-color-fg-disabled)"
+      }
+    }
+  }
+}

--- a/packages/qvism-preset/src/vars/component/top-navigation-text-button.d.ts
+++ b/packages/qvism-preset/src/vars/component/top-navigation-text-button.d.ts
@@ -1,0 +1,43 @@
+export declare const vars: {
+  "base": {
+    "enabled": {
+      "root": {
+        "height": "44px",
+        "paddingX": "var(--seed-dimension-x2_5)"
+      },
+      "label": {
+        "fontSize": "var(--seed-font-size-t5)",
+        "lineHeight": "var(--seed-line-height-t5)",
+        "fontWeight": "var(--seed-font-weight-medium)",
+        "maxFontSizeScale": "1.2",
+        "minFontSizeScale": "1",
+        "maxLineHeightScale": "1.2",
+        "minLineHeightScale": "1"
+      }
+    }
+  },
+  "toneLayer": {
+    "enabled": {
+      "label": {
+        "color": "var(--seed-color-fg-neutral)"
+      }
+    },
+    "disabled": {
+      "label": {
+        "color": "var(--seed-color-fg-disabled)"
+      }
+    }
+  },
+  "toneTransparent": {
+    "enabled": {
+      "label": {
+        "color": "var(--seed-color-palette-static-white)"
+      }
+    },
+    "disabled": {
+      "label": {
+        "color": "var(--seed-color-fg-disabled)"
+      }
+    }
+  }
+}

--- a/packages/qvism-preset/src/vars/component/top-navigation-text-button.mjs
+++ b/packages/qvism-preset/src/vars/component/top-navigation-text-button.mjs
@@ -1,0 +1,43 @@
+export const vars = {
+  "base": {
+    "enabled": {
+      "root": {
+        "height": "44px",
+        "paddingX": "var(--seed-dimension-x2_5)"
+      },
+      "label": {
+        "fontSize": "var(--seed-font-size-t5)",
+        "lineHeight": "var(--seed-line-height-t5)",
+        "fontWeight": "var(--seed-font-weight-medium)",
+        "maxFontSizeScale": "1.2",
+        "minFontSizeScale": "1",
+        "maxLineHeightScale": "1.2",
+        "minLineHeightScale": "1"
+      }
+    }
+  },
+  "toneLayer": {
+    "enabled": {
+      "label": {
+        "color": "var(--seed-color-fg-neutral)"
+      }
+    },
+    "disabled": {
+      "label": {
+        "color": "var(--seed-color-fg-disabled)"
+      }
+    }
+  },
+  "toneTransparent": {
+    "enabled": {
+      "label": {
+        "color": "var(--seed-color-palette-static-white)"
+      }
+    },
+    "disabled": {
+      "label": {
+        "color": "var(--seed-color-fg-disabled)"
+      }
+    }
+  }
+}

--- a/packages/qvism-preset/src/vars/component/top-navigation.d.ts
+++ b/packages/qvism-preset/src/vars/component/top-navigation.d.ts
@@ -4,10 +4,6 @@ export declare const vars: {
       "root": {
         "height": "44px",
         "paddingX": "var(--seed-dimension-x4)"
-      },
-      "icon": {
-        "size": "24px",
-        "targetSize": "44px"
       }
     }
   },
@@ -17,9 +13,9 @@ export declare const vars: {
         "height": "56px",
         "paddingX": "var(--seed-dimension-x4)"
       },
-      "icon": {
-        "size": "24px",
-        "targetSize": "44px"
+      /** title과 subtitle을 포함하는 영역입니다. */
+      "main": {
+        "paddingLeft": "16px"
       }
     }
   },
@@ -33,9 +29,6 @@ export declare const vars: {
       },
       "subtitle": {
         "color": "var(--seed-color-fg-neutral-muted)"
-      },
-      "icon": {
-        "color": "var(--seed-color-fg-neutral)"
       }
     }
   },
@@ -48,9 +41,6 @@ export declare const vars: {
         "color": "var(--seed-color-palette-static-white)"
       },
       "subtitle": {
-        "color": "var(--seed-color-palette-static-white)"
-      },
-      "icon": {
         "color": "var(--seed-color-palette-static-white)"
       }
     }

--- a/packages/qvism-preset/src/vars/component/top-navigation.mjs
+++ b/packages/qvism-preset/src/vars/component/top-navigation.mjs
@@ -4,10 +4,6 @@ export const vars = {
       "root": {
         "height": "44px",
         "paddingX": "var(--seed-dimension-x4)"
-      },
-      "icon": {
-        "size": "24px",
-        "targetSize": "44px"
       }
     }
   },
@@ -17,9 +13,8 @@ export const vars = {
         "height": "56px",
         "paddingX": "var(--seed-dimension-x4)"
       },
-      "icon": {
-        "size": "24px",
-        "targetSize": "44px"
+      "main": {
+        "paddingLeft": "16px"
       }
     }
   },
@@ -33,9 +28,6 @@ export const vars = {
       },
       "subtitle": {
         "color": "var(--seed-color-fg-neutral-muted)"
-      },
-      "icon": {
-        "color": "var(--seed-color-fg-neutral)"
       }
     }
   },
@@ -48,9 +40,6 @@ export const vars = {
         "color": "var(--seed-color-palette-static-white)"
       },
       "subtitle": {
-        "color": "var(--seed-color-palette-static-white)"
-      },
-      "icon": {
         "color": "var(--seed-color-palette-static-white)"
       }
     }

--- a/packages/rootage/components/top-navigation-icon-button.yaml
+++ b/packages/rootage/components/top-navigation-icon-button.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=./schema.json
+kind: ComponentSpec
+metadata:
+  id: top-navigation-icon-button
+  name: Top Navigation Icon Button
+data:
+  schema:
+    slots:
+      root:
+        properties:
+          size:
+            type: dimension
+      icon:
+        properties:
+          size:
+            type: dimension
+          color:
+            type: color
+  definitions:
+    base:
+      enabled:
+        root:
+          size: 44px
+        icon:
+          size: 24px
+    tone=layer:
+      enabled:
+        icon:
+          color: $color.fg.neutral
+      disabled:
+        icon:
+          color: $color.fg.disabled
+    tone=transparent:
+      enabled:
+        icon:
+          color: $color.palette.static-white
+      disabled:
+        icon:
+          color: $color.fg.disabled

--- a/packages/rootage/components/top-navigation-text-button.yaml
+++ b/packages/rootage/components/top-navigation-text-button.yaml
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=./schema.json
+kind: ComponentSpec
+metadata:
+  id: top-navigation-text-button
+  name: Top Navigation Text Button
+data:
+  schema:
+    slots:
+      root:
+        properties:
+          height:
+            type: dimension
+          paddingX:
+            type: dimension
+      label:
+        properties:
+          color:
+            type: color
+          fontSize:
+            type: dimension
+          lineHeight:
+            type: dimension
+          fontWeight:
+            type: number
+          maxFontSizeScale:
+            type: number
+          minFontSizeScale:
+            type: number
+          maxLineHeightScale:
+            type: number
+          minLineHeightScale:
+            type: number
+  definitions:
+    base:
+      enabled:
+        root:
+          height: 44px
+          paddingX: $dimension.x2_5
+        label:
+          fontSize: $font-size.t5
+          lineHeight: $line-height.t5
+          fontWeight: $font-weight.medium
+          maxFontSizeScale: 1.2
+          minFontSizeScale: 1
+          maxLineHeightScale: 1.2
+          minLineHeightScale: 1
+    tone=layer:
+      enabled:
+        label:
+          color: $color.fg.neutral
+      disabled:
+        label:
+          color: $color.fg.disabled
+    tone=transparent:
+      enabled:
+        label:
+          color: $color.palette.static-white
+      disabled:
+        label:
+          color: $color.fg.disabled

--- a/packages/rootage/components/top-navigation.yaml
+++ b/packages/rootage/components/top-navigation.yaml
@@ -18,6 +18,18 @@ data:
             type: color
           strokeWidth:
             type: dimension
+      left:
+        properties: {}
+        description: 왼쪽 영역입니다. 일반적으로 뒤로가기/닫기 Top Navigation Icon Button이 위치합니다.
+      main:
+        properties:
+          paddingLeft:
+            type: dimension
+        description: title과 subtitle을 포함하는 영역입니다.
+      right:
+        properties: {}
+        description: 오른쪽 영역입니다. 일반적으로 Top Navigation Icon Button 또는 Top Navigation Text
+          Button이 위치합니다.
       title:
         properties:
           color:
@@ -54,31 +66,21 @@ data:
             type: number
           minLineHeightScale:
             type: number
-      icon:
-        properties:
-          size:
-            type: dimension
-          targetSize:
-            type: dimension
-          color:
-            type: color
   definitions:
     theme=cupertino:
       enabled:
         root:
           height: 44px
           paddingX: $dimension.x4
-        icon:
-          size: 24px
-          targetSize: 44px
+        # main:
+        #   paddingLeft: $dimension.x1
     theme=android:
       enabled:
         root:
           height: 56px
           paddingX: $dimension.x4
-        icon:
-          size: 24px
-          targetSize: 44px
+        main:
+          paddingLeft: 16px # should be $dimension.x1_5 after we add pressed styles to top navigation icon buttons and do the layout based on the button size rather than the icon size
     tone=layer:
       enabled:
         root:
@@ -87,8 +89,6 @@ data:
           color: $color.fg.neutral
         subtitle:
           color: $color.fg.neutral-muted
-        icon:
-          color: $color.fg.neutral
     tone=transparent:
       enabled:
         root:
@@ -96,8 +96,6 @@ data:
         title:
           color: $color.palette.static-white
         subtitle:
-          color: $color.palette.static-white
-        icon:
           color: $color.palette.static-white
     divider=true:
       enabled:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 상단 네비게이션 아이콘 버튼 컴포넌트 추가 (기본 크기 44px)
* 상단 네비게이션 텍스트 버튼 컴포넌트 추가 (크기 및 타이포그래피 설정 가능)
* 상단 네비게이션 레이아웃 영역 개선 (좌/중앙/우 영역으로 재구성)

## 리팩토링
* 아이콘 사이징을 공유 토큰 세트 기반으로 통합
* 테마 전반에 일관된 색상 및 스타일 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->