### PR TITLE
feat(docs): transform ProgressBoardTable in llms.txt output

### DIFF
--- a/docs/app/_llms/__fixtures__/progress-board/basic.input.mdx
+++ b/docs/app/_llms/__fixtures__/progress-board/basic.input.mdx
@@ -1,0 +1,3 @@
+## 플랫폼별 구현 상태
+
+<ProgressBoardTable />

--- a/docs/app/_llms/__fixtures__/progress-board/basic.output.mdx
+++ b/docs/app/_llms/__fixtures__/progress-board/basic.output.mdx
@@ -1,0 +1,18 @@
+## 플랫폼별 구현 상태
+
+### 플랫폼별 진행률
+
+| Platform | Progress | Ready/Total |
+| --- | --- | --- |
+| Figma | 67% | 2/3 |
+| React | 67% | 2/3 |
+| iOS | 50% | 1/2 |
+| Android | 100% | 1/1 |
+
+### 컴포넌트별 상태
+
+| Component | Figma | React | iOS | Android |
+| --- | --- | --- | --- | --- |
+| Button | Done | Done | Done | Done |
+| Card | [Done](https://figma.com/card) | In Progress | Not Ready | Not Planned |
+| Tab | Deprecated (Use NewTab) | [Done](https://example.com/tab) (see migration) | Not Planned | Not Planned |

--- a/docs/app/_llms/__fixtures__/progress-board/edge-cases.input.mdx
+++ b/docs/app/_llms/__fixtures__/progress-board/edge-cases.input.mdx
@@ -1,0 +1,1 @@
+<ProgressBoardTable />

--- a/docs/app/_llms/__fixtures__/progress-board/edge-cases.output.mdx
+++ b/docs/app/_llms/__fixtures__/progress-board/edge-cases.output.mdx
@@ -1,0 +1,14 @@
+### 플랫폼별 진행률
+
+| Platform | Progress | Ready/Total |
+| --- | --- | --- |
+| Figma | 0% | 0/0 |
+| React | 0% | 0/0 |
+| iOS | 0% | 0/0 |
+| Android | 0% | 0/0 |
+
+### 컴포넌트별 상태
+
+| Component | Figma | React | iOS | Android |
+| --- | --- | --- | --- | --- |
+| AllNotPlanned | Not Planned | Not Planned | Not Planned | Not Planned |

--- a/docs/app/_llms/rules/index.ts
+++ b/docs/app/_llms/rules/index.ts
@@ -2,6 +2,7 @@ import { changelogPageRule } from "./changelog-page-rule";
 import { codeBlockTabsRule } from "./codeblock-tabs-rule";
 import { componentExampleRule } from "./component-example-rule";
 import { platformStatusRule } from "./platform-status-rule";
+import { progressBoardRule } from "./progress-board-rule";
 import { typeTableRule } from "./type-table-rule";
 import { tokenReferenceRule } from "./token-reference-rule";
 import { componentSpecBlockRule } from "./component-spec-block-rule";
@@ -14,6 +15,7 @@ export const activeRules: Rule[] = [
   typeTableRule,
   tokenReferenceRule,
   platformStatusRule,
+  progressBoardRule,
   iconLibraryRule,
   componentSpecBlockRule,
   changelogPageRule,
@@ -27,5 +29,6 @@ export {
   tokenReferenceRule,
   componentSpecBlockRule,
   platformStatusRule,
+  progressBoardRule,
   iconLibraryRule,
 };

--- a/docs/app/_llms/rules/progress-board-rule.test.ts
+++ b/docs/app/_llms/rules/progress-board-rule.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeLLMBodyWithRules } from "../normalize-llm-body";
+import { progressBoardRule } from "./progress-board-rule";
+
+describe("progressBoardRule", () => {
+  it("keeps the original node when component cache is empty", () => {
+    const input = "<ProgressBoardTable />";
+
+    const actual = normalizeLLMBodyWithRules(input, [progressBoardRule]);
+
+    expect(actual).toContain("ProgressBoardTable");
+  });
+});

--- a/docs/app/_llms/rules/progress-board-rule.test.ts
+++ b/docs/app/_llms/rules/progress-board-rule.test.ts
@@ -1,13 +1,81 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+import type { ComponentData } from "../../../sanity-studio/lib/types";
 import { normalizeLLMBodyWithRules } from "../normalize-llm-body";
-import { progressBoardRule } from "./progress-board-rule";
+import { normalizeForAssert, readFixture } from "../test-utils";
+import { __setComponentsCacheForTests, progressBoardRule } from "./progress-board-rule";
+
+const mockComponents: ComponentData[] = [
+  {
+    id: "button",
+    name: "Button",
+    figmaStatus: "ready",
+    reactStatus: "ready",
+    iosStatus: "ready",
+    androidStatus: "ready",
+  },
+  {
+    id: "card",
+    name: "Card",
+    figmaStatus: "ready",
+    figmaUrl: "https://figma.com/card",
+    reactStatus: "in-progress",
+    iosStatus: "not-ready",
+    androidStatus: "not-planned",
+  },
+  {
+    id: "tab",
+    name: "Tab",
+    figmaStatus: "deprecated",
+    figmaNote: "Use NewTab",
+    reactStatus: "ready",
+    reactUrl: "https://example.com/tab",
+    reactNote: "see migration",
+    iosStatus: "not-planned",
+    androidStatus: "not-planned",
+  },
+];
+
+const edgeCaseComponents: ComponentData[] = [
+  {
+    id: "all-not-planned",
+    name: "AllNotPlanned",
+    figmaStatus: "not-planned",
+    reactStatus: "not-planned",
+    iosStatus: "not-planned",
+    androidStatus: "not-planned",
+  },
+];
+
+afterEach(() => {
+  __setComponentsCacheForTests(null);
+});
 
 describe("progressBoardRule", () => {
-  it("keeps the original node when component cache is empty", () => {
+  it("keeps the original node when cache is empty", () => {
     const input = "<ProgressBoardTable />";
 
     const actual = normalizeLLMBodyWithRules(input, [progressBoardRule]);
 
     expect(actual).toContain("ProgressBoardTable");
+  });
+
+  it("renders summary and component tables for typical data", () => {
+    __setComponentsCacheForTests(mockComponents);
+    const input = readFixture("progress-board", "basic.input.mdx");
+    const expected = readFixture("progress-board", "basic.output.mdx");
+
+    const actual = normalizeLLMBodyWithRules(input, [progressBoardRule]);
+
+    expect(normalizeForAssert(actual)).toBe(normalizeForAssert(expected));
+  });
+
+  it("renders 0/0 progress when every component is not-planned", () => {
+    __setComponentsCacheForTests(edgeCaseComponents);
+    const input = readFixture("progress-board", "edge-cases.input.mdx");
+    const expected = readFixture("progress-board", "edge-cases.output.mdx");
+
+    const actual = normalizeLLMBodyWithRules(input, [progressBoardRule]);
+
+    expect(normalizeForAssert(actual)).toBe(normalizeForAssert(expected));
   });
 });

--- a/docs/app/_llms/rules/progress-board-rule.ts
+++ b/docs/app/_llms/rules/progress-board-rule.ts
@@ -1,0 +1,99 @@
+import type { MdxJsxFlowElement } from "mdast-util-mdx-jsx";
+import { createClient } from "@sanity/client";
+import { apiVersion, dataset, projectId } from "../../../sanity-studio/env";
+import { ALL_COMPONENTS_QUERY } from "../../../sanity-studio/lib/queries";
+import type { ComponentData, PlatformStatus } from "../../../sanity-studio/lib/types";
+import type { Rule } from "./types";
+import { escapeCell, markdownRow } from "./markdown-utils";
+
+const sanityClient = createClient({ projectId, dataset, apiVersion, useCdn: false });
+
+const platformConfig = [
+  { key: "figma" as const, label: "Figma" },
+  { key: "react" as const, label: "React" },
+  { key: "ios" as const, label: "iOS" },
+  { key: "android" as const, label: "Android" },
+] as const;
+
+const statusLabel: Record<PlatformStatus, string> = {
+  ready: "Done",
+  "in-progress": "In Progress",
+  "not-ready": "Not Ready",
+  deprecated: "Deprecated",
+  "not-planned": "Not Planned",
+};
+
+function formatStatusCell(component: ComponentData, key: (typeof platformConfig)[number]["key"]) {
+  const status = component[`${key}Status`] as PlatformStatus;
+  const url = component[`${key}Url`] as string | undefined;
+  const note = component[`${key}Note`] as string | undefined;
+
+  const label = statusLabel[status] ?? "Not Ready";
+  const base = url ? `[${label}](${escapeCell(url)})` : label;
+
+  return note ? `${base} (${escapeCell(note)})` : base;
+}
+
+function buildSummaryTable(components: ComponentData[]): string {
+  const headers = ["Platform", "Progress", "Ready/Total"];
+  const rows = platformConfig.map(({ key, label }) => {
+    const statusKey = `${key}Status` as keyof ComponentData;
+    const planned = components.filter((c) => c[statusKey] !== "not-planned");
+    const ready = planned.filter((c) => c[statusKey] === "ready").length;
+    const total = planned.length;
+    const percentage = total === 0 ? 0 : Math.round((ready / total) * 100);
+
+    return markdownRow([label, `${percentage}%`, `${ready}/${total}`]);
+  });
+
+  return [markdownRow(headers), markdownRow(headers.map(() => "---")), ...rows].join("\n");
+}
+
+function buildComponentTable(components: ComponentData[]): string {
+  const headers = ["Component", ...platformConfig.map(({ label }) => label)];
+  const rows = components.map((component) =>
+    markdownRow([
+      escapeCell(component.name),
+      ...platformConfig.map(({ key }) => formatStatusCell(component, key)),
+    ]),
+  );
+
+  return [markdownRow(headers), markdownRow(headers.map(() => "---")), ...rows].join("\n");
+}
+
+let componentsCache: ComponentData[] | null = null;
+let initPromise: Promise<void> | null = null;
+
+async function fetchAndCacheComponents(): Promise<void> {
+  try {
+    componentsCache = await sanityClient.fetch<ComponentData[]>(ALL_COMPONENTS_QUERY);
+  } catch {
+    componentsCache = [];
+  }
+}
+
+async function init(): Promise<void> {
+  if (!initPromise) {
+    initPromise = fetchAndCacheComponents();
+  }
+  await initPromise;
+}
+
+export const progressBoardRule: Rule = {
+  name: "ProgressBoardTable",
+  init,
+  match: (node): node is MdxJsxFlowElement =>
+    node.type === "mdxJsxFlowElement" && node.name === "ProgressBoardTable",
+  transform: (node) => {
+    if (!componentsCache || componentsCache.length === 0) return [node];
+
+    const sections = [
+      "### 플랫폼별 진행률",
+      buildSummaryTable(componentsCache),
+      "### 컴포넌트별 상태",
+      buildComponentTable(componentsCache),
+    ];
+
+    return [{ type: "html", value: sections.join("\n\n") }];
+  },
+};

--- a/docs/app/_llms/rules/progress-board-rule.ts
+++ b/docs/app/_llms/rules/progress-board-rule.ts
@@ -24,13 +24,14 @@ const statusLabel: Record<PlatformStatus, string> = {
 };
 
 function formatStatusCell(component: ComponentData, key: (typeof platformConfig)[number]["key"]) {
-  const status = component[`${key}Status`] as PlatformStatus;
+  const status = component[`${key}Status`] as PlatformStatus | undefined;
   const url = component[`${key}Url`] as string | undefined;
   const note = component[`${key}Note`] as string | undefined;
 
-  const label = statusLabel[status] ?? "Not Ready";
-  const base = url ? `[${label}](${escapeCell(url)})` : label;
+  const label = status ? statusLabel[status] : undefined;
+  if (!label) return "";
 
+  const base = url ? `[${label}](${escapeCell(url)})` : label;
   return note ? `${base} (${escapeCell(note)})` : base;
 }
 
@@ -61,6 +62,15 @@ function buildComponentTable(components: ComponentData[]): string {
   return [markdownRow(headers), markdownRow(headers.map(() => "---")), ...rows].join("\n");
 }
 
+function buildProgressBoardContent(components: ComponentData[]): string {
+  return [
+    "### 플랫폼별 진행률",
+    buildSummaryTable(components),
+    "### 컴포넌트별 상태",
+    buildComponentTable(components),
+  ].join("\n\n");
+}
+
 let componentsCache: ComponentData[] | null = null;
 let initPromise: Promise<void> | null = null;
 
@@ -79,6 +89,10 @@ async function init(): Promise<void> {
   await initPromise;
 }
 
+export function __setComponentsCacheForTests(cache: ComponentData[] | null): void {
+  componentsCache = cache;
+}
+
 export const progressBoardRule: Rule = {
   name: "ProgressBoardTable",
   init,
@@ -86,14 +100,6 @@ export const progressBoardRule: Rule = {
     node.type === "mdxJsxFlowElement" && node.name === "ProgressBoardTable",
   transform: (node) => {
     if (!componentsCache || componentsCache.length === 0) return [node];
-
-    const sections = [
-      "### 플랫폼별 진행률",
-      buildSummaryTable(componentsCache),
-      "### 컴포넌트별 상태",
-      buildComponentTable(componentsCache),
-    ];
-
-    return [{ type: "html", value: sections.join("\n\n") }];
+    return [{ type: "html", value: buildProgressBoardContent(componentsCache) }];
   },
 };


### PR DESCRIPTION
Adds a normalize rule that replaces <ProgressBoardTable /> with markdown summary and per-component status tables sourced from Sanity, mirroring the existing platformStatusRule pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 진행 상황 보드 테이블 추가 — 플랫폼별 구현 완료 비율과 컴포넌트별 상태를 마크다운 표 형식으로 페이지에 표시합니다.
  * 모든 플랫폼이 미계획인 경우에도 0% 및 Ready/Total을 0/0으로 정확히 렌더링합니다.
  * 출력 일관성 검증이 강화되어 동작이 예측 가능해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->