### PR TITLE
fix(docs): disable llms heading anchors

### DIFF
--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -17,7 +17,9 @@ export const docs = defineDocs({
       coverImageFigmaId: z.string().optional(),
     }),
     postprocess: {
-      includeProcessedMarkdown: true,
+      includeProcessedMarkdown: {
+        headingIds: false,
+      },
     },
   },
 });
@@ -30,7 +32,9 @@ export const reactDocs = defineDocs({
       deprecated: z.boolean().optional(),
     }),
     postprocess: {
-      includeProcessedMarkdown: true,
+      includeProcessedMarkdown: {
+        headingIds: false,
+      },
     },
   },
 });
@@ -43,7 +47,9 @@ export const breezeDocs = defineDocs({
       deprecated: z.boolean().optional(),
     }),
     postprocess: {
-      includeProcessedMarkdown: true,
+      includeProcessedMarkdown: {
+        headingIds: false,
+      },
     },
   },
 });
@@ -56,7 +62,9 @@ export const lynxDocs = defineDocs({
       deprecated: z.boolean().optional(),
     }),
     postprocess: {
-      includeProcessedMarkdown: true,
+      includeProcessedMarkdown: {
+        headingIds: false,
+      },
     },
   },
 });
@@ -69,7 +77,9 @@ export const aiIntegrationDocs = defineDocs({
       deprecated: z.boolean().optional(),
     }),
     postprocess: {
-      includeProcessedMarkdown: true,
+      includeProcessedMarkdown: {
+        headingIds: false,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

- Disable Fumadocs processed markdown heading id suffixes for all docs collections.
- Prevent headings such as `Props` from entering the llms pipeline as `Props [#props]`, which later gets escaped as `Props \[#props]` during markdown normalization.

## Validation

- `bun generate:all`
- `bun test:all`
- `bun docs:build`
- Searched build output for `\[#props]` and `[#props]` after the docs build.