### PR TITLE
feat(top-navigation-text-button): add maxWidth to preserve main slot space

### DIFF
--- a/docs/public/rootage/components/top-navigation-text-button.json
+++ b/docs/public/rootage/components/top-navigation-text-button.json
@@ -11,6 +11,10 @@
       "slots": {
         "root": {
           "properties": {
+            "maxWidth": {
+              "type": "dimension",
+              "description": "버튼 레이블이 길어졌을 때 ellipsis 말줄임을 시작할 최대 너비입니다. Top Navigation main slot이 충분한 공간을 차지할 수 있도록 하기 위해 폰트 스케일링의 영향을 받지 않는 px 값을 사용합니다."
+            },
             "height": {
               "type": "dimension"
             },
@@ -68,6 +72,13 @@
             ],
             "slots": {
               "root": {
+                "maxWidth": {
+                  "type": "dimension",
+                  "value": {
+                    "value": 96,
+                    "unit": "px"
+                  }
+                },
                 "height": {
                   "type": "dimension",
                   "value": {

--- a/packages/css/vars/component/top-navigation-text-button.d.ts
+++ b/packages/css/vars/component/top-navigation-text-button.d.ts
@@ -2,6 +2,8 @@ export declare const vars: {
   "base": {
     "enabled": {
       "root": {
+        /** 버튼 레이블이 길어졌을 때 ellipsis 말줄임을 시작할 최대 너비입니다. Top Navigation main slot이 충분한 공간을 차지할 수 있도록 하기 위해 폰트 스케일링의 영향을 받지 않는 px 값을 사용합니다. */
+        "maxWidth": "96px",
         "height": "44px",
         "paddingX": "var(--seed-dimension-x2_5)"
       },

--- a/packages/css/vars/component/top-navigation-text-button.mjs
+++ b/packages/css/vars/component/top-navigation-text-button.mjs
@@ -2,6 +2,7 @@ export const vars = {
   "base": {
     "enabled": {
       "root": {
+        "maxWidth": "96px",
         "height": "44px",
         "paddingX": "var(--seed-dimension-x2_5)"
       },

--- a/packages/qvism-preset/src/vars/component/top-navigation-text-button.d.ts
+++ b/packages/qvism-preset/src/vars/component/top-navigation-text-button.d.ts
@@ -2,6 +2,8 @@ export declare const vars: {
   "base": {
     "enabled": {
       "root": {
+        /** 버튼 레이블이 길어졌을 때 ellipsis 말줄임을 시작할 최대 너비입니다. Top Navigation main slot이 충분한 공간을 차지할 수 있도록 하기 위해 폰트 스케일링의 영향을 받지 않는 px 값을 사용합니다. */
+        "maxWidth": "96px",
         "height": "44px",
         "paddingX": "var(--seed-dimension-x2_5)"
       },

--- a/packages/qvism-preset/src/vars/component/top-navigation-text-button.mjs
+++ b/packages/qvism-preset/src/vars/component/top-navigation-text-button.mjs
@@ -2,6 +2,7 @@ export const vars = {
   "base": {
     "enabled": {
       "root": {
+        "maxWidth": "96px",
         "height": "44px",
         "paddingX": "var(--seed-dimension-x2_5)"
       },

--- a/packages/rootage/components/top-navigation-text-button.yaml
+++ b/packages/rootage/components/top-navigation-text-button.yaml
@@ -8,6 +8,9 @@ data:
     slots:
       root:
         properties:
+          maxWidth:
+            type: dimension
+            description: 버튼 레이블이 길어졌을 때 ellipsis 말줄임을 시작할 최대 너비입니다. Top Navigation main slot이 충분한 공간을 차지할 수 있도록 하기 위해 폰트 스케일링의 영향을 받지 않는 px 값을 사용합니다.
           height:
             type: dimension
           paddingX:
@@ -34,6 +37,7 @@ data:
     base:
       enabled:
         root:
+          maxWidth: 96px
           height: 44px
           paddingX: $dimension.x2_5
         label:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 상단 네비게이션 텍스트 버튼 컴포넌트에 최대 너비 속성을 추가하여, 긴 레이블의 자동 줄임말(말줄임표) 처리를 일관된 너비에서 수행하도록 개선했습니다. 이제 폰트 크기와 무관하게 안정적인 표시 동작이 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->