### PR TITLE
refactor(stackflow): clean up WAAPI hooks and tighten types

### DIFF
--- a/packages/stackflow/src/primitive/GlobalInteraction/animation.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/animation.ts
@@ -30,9 +30,6 @@ const FADE_IN_ENTER_DURATION = 300;
 const FADE_IN_EXIT_EASING = "ease-in";
 const FADE_IN_EXIT_DURATION = 150;
 
-const MIN_SWIPE_DURATION = 150;
-const MAX_SWIPE_DURATION = 500;
-
 // Extra margin added to duration for the setTimeout race fallback.
 const FINISHED_TIMEOUT_MARGIN = 100;
 
@@ -137,14 +134,6 @@ export type AnimationResult = { animations: Animation[]; finished: Promise<void>
 function collectAnimations(anims: (Animation | null)[], durationMs: number): AnimationResult {
   const animations = anims.filter((a): a is Animation => a !== null);
   return { animations, finished: waitAll(animations, durationMs) };
-}
-
-function calculateSwipeDuration(remainingDistance: number, velocity: number): number {
-  if (velocity > 0.5) {
-    return Math.max(MIN_SWIPE_DURATION, Math.min(MAX_SWIPE_DURATION, remainingDistance / velocity));
-  }
-  const ratio = remainingDistance / window.innerWidth;
-  return Math.max(MIN_SWIPE_DURATION, Math.min(MAX_SWIPE_DURATION, IOS_DURATION * ratio));
 }
 
 // ─── iOS Slide ──────────────────────────────────────────────────────────────
@@ -449,20 +438,10 @@ export function animateTransition(
   }
 }
 
-export function animateSwipeComplete(
-  t: TransitionTargets,
-  displacement: number,
-  velocity: number,
-): AnimationResult {
-  const duration = calculateSwipeDuration(window.innerWidth - displacement, velocity);
-  return animateSwipe(t, displacement, duration, IOS_OFFSCREEN);
+export function animateSwipeComplete(t: TransitionTargets, displacement: number): AnimationResult {
+  return animateSwipe(t, displacement, IOS_DURATION, IOS_OFFSCREEN);
 }
 
-export function animateSwipeCancel(
-  t: TransitionTargets,
-  displacement: number,
-  velocity: number,
-): AnimationResult {
-  const duration = calculateSwipeDuration(displacement, velocity);
-  return animateSwipe(t, displacement, duration, IOS_ONSCREEN);
+export function animateSwipeCancel(t: TransitionTargets, displacement: number): AnimationResult {
+  return animateSwipe(t, displacement, IOS_DURATION, IOS_ONSCREEN);
 }

--- a/packages/stackflow/src/primitive/GlobalInteraction/animation.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/animation.ts
@@ -149,12 +149,17 @@ function calculateSwipeDuration(remainingDistance: number, velocity: number): nu
 
 // ─── iOS Slide ──────────────────────────────────────────────────────────────
 
+interface TitleKeyframe {
+  opacity: string;
+  transform: string;
+}
+
 interface IosPositions {
   topLayer: string;
   behindLayer: string;
   dim: string;
-  topTitle: Keyframe;
-  behindTitle: Keyframe;
+  topTitle: TitleKeyframe;
+  behindTitle: TitleKeyframe;
   topIconOpacity: string;
   behindIconOpacity: string;
   appBarBackground: string;
@@ -208,8 +213,8 @@ function iosAnimate(t: TransitionTargets, from: IosPositions, to: IosPositions):
       safeAnimate(
         icon,
         [
-          { opacity: from.topIconOpacity, transform: from.topTitle["transform"] as string },
-          { opacity: to.topIconOpacity, transform: to.topTitle["transform"] as string },
+          { opacity: from.topIconOpacity, transform: from.topTitle.transform },
+          { opacity: to.topIconOpacity, transform: to.topTitle.transform },
         ],
         opts,
       ),
@@ -249,19 +254,14 @@ function pinIosInlineStyles(t: TransitionTargets, pos: IosPositions) {
   setOpacity(t.topDim, pos.dim);
   setTransform(t.topAppBarBackground, pos.appBarBackground);
 
-  const topTitleOpacity = pos.topTitle["opacity"] as string;
-  const topTitleTransform = pos.topTitle["transform"] as string;
-  if (t.topTitle) {
-    setOpacity(t.topTitle, topTitleOpacity);
-    setTransform(t.topTitle, topTitleTransform);
-  }
-  if (t.behindTitle) {
-    setOpacity(t.behindTitle, pos.behindTitle["opacity"] as string);
-    setTransform(t.behindTitle, pos.behindTitle["transform"] as string);
-  }
+  setOpacity(t.topTitle, pos.topTitle.opacity);
+  setTransform(t.topTitle, pos.topTitle.transform);
+  setOpacity(t.behindTitle, pos.behindTitle.opacity);
+  setTransform(t.behindTitle, pos.behindTitle.transform);
+
   for (const icon of t.topIcons) {
     setOpacity(icon, pos.topIconOpacity);
-    setTransform(icon, topTitleTransform);
+    setTransform(icon, pos.topTitle.transform);
   }
   for (const icon of t.behindIcons) setOpacity(icon, pos.behindIconOpacity);
 }
@@ -408,7 +408,7 @@ function animateSwipe(
         icon,
         [
           { opacity: `${topFade}`, transform: currentTitleOffset },
-          { opacity: end.topIconOpacity, transform: end.topTitle["transform"] as string },
+          { opacity: end.topIconOpacity, transform: end.topTitle.transform },
         ],
         opts,
       ),

--- a/packages/stackflow/src/primitive/GlobalInteraction/dom.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/dom.ts
@@ -58,15 +58,13 @@ export function findTransitionTargets(stackEl: HTMLElement): TransitionTargets {
 
   let behindActivity: HTMLElement | null = null;
   if (topActivity) {
-    const all = stackEl.querySelectorAll<HTMLElement>(`[data-part='${appScreenAnatomy.activity}']`);
+    const all = Array.from(
+      stackEl.querySelectorAll<HTMLElement>(`[data-part='${appScreenAnatomy.activity}']`),
+    );
     const topId = topActivity.dataset["activityId"];
-    let found = false;
-    for (let i = all.length - 1; i >= 0; i--) {
-      if (all[i].dataset["activityId"] === topId) {
-        found = true;
-        continue;
-      }
-      if (found && all[i].dataset["activityId"]) {
+    const topIdx = all.findIndex((el) => el.dataset["activityId"] === topId);
+    for (let i = topIdx - 1; i >= 0; i--) {
+      if (all[i].dataset["activityId"]) {
         behindActivity = all[i];
         break;
       }

--- a/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.ts
@@ -1,5 +1,4 @@
-import { useCallbackRef } from "@radix-ui/react-use-callback-ref";
-import { useCallback, useLayoutEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { useTopActivity } from "../private/useTopActivity";
 import {
   type TransitionStyle,
@@ -31,22 +30,18 @@ export interface SwipeBackContext {
   velocity: number;
 }
 
-export interface SwipeBackProps {
+export interface SwipeBackThresholds {
   /**
-   * The threshold to determine whether the swipe back is intentional.
+   * The threshold to determine whether the swipe back is intentional, by displacement ratio.
    * @default 0.4
    */
-  swipeBackDisplacementRatioThreshold?: number;
+  displacementRatioThreshold?: number;
 
   /**
-   * The threshold to determine whether the swipe back is intentional.
+   * The threshold to determine whether the swipe back is intentional, by velocity.
    * @default 1
    */
-  swipeBackVelocityThreshold?: number;
-
-  onSwipeBackStart?: () => void;
-  onSwipeBackMove?: (props: { displacement: number; displacementRatio: number }) => void;
-  onSwipeBackEnd?: (props: { swiped: boolean }) => void;
+  velocityThreshold?: number;
 }
 
 export interface StartSwipeBackProps {
@@ -59,19 +54,21 @@ export interface MoveSwipeBackProps {
   t: number;
 }
 
-// biome-ignore lint/suspicious/noEmptyInterface: intentionally empty for future extension
-export interface EndSwipeBackProps {}
+const IDLE_CONTEXT: SwipeBackContext = Object.freeze({
+  x0: 0,
+  t0: 0,
+  displacement: 0,
+  displacementRatio: 0,
+  velocity: 0,
+});
+
+const DEFAULT_DISPLACEMENT_RATIO_THRESHOLD = 0.4;
+const DEFAULT_VELOCITY_THRESHOLD = 1;
 
 export function useGlobalInteraction() {
   const swipeBackStateRef = useRef<SwipeBackState>("idle");
 
-  const swipeBackContextRef = useRef<SwipeBackContext>({
-    x0: 0,
-    t0: 0,
-    displacement: 0,
-    displacementRatio: 0,
-    velocity: 0,
-  });
+  const swipeBackContextRef = useRef<SwipeBackContext>({ ...IDLE_CONTEXT });
   const stackRef = useRef<HTMLDivElement>(null);
 
   // Cached transition targets — populated once per gesture/transition
@@ -90,197 +87,6 @@ export function useGlobalInteraction() {
   // their exit is driven by stackflow's normal exit-active lifecycle.
   const swipeStyleRef = useRef<TransitionStyle | null>(null);
 
-  /** Update swipe-back-state attribute on the stack DOM element. */
-  const setSwipeBackState = useCallback((state: SwipeBackState) => {
-    swipeBackStateRef.current = state;
-    if (stackRef.current) {
-      stackRef.current.dataset["swipeBackState"] = state;
-    }
-  }, []);
-
-  const getSwipeBackEvents = useCallback((props: SwipeBackProps) => {
-    const {
-      swipeBackDisplacementRatioThreshold: displacementRatioThreshold = 0.4,
-      swipeBackVelocityThreshold: velocityThreshold = 1,
-    } = props;
-    const onSwipeStart = useCallbackRef(props.onSwipeBackStart);
-    const onSwipeMove = useCallbackRef(props.onSwipeBackMove);
-    const onSwipeEnd = useCallbackRef(props.onSwipeBackEnd);
-
-    const startSwipeBack = useCallback(
-      ({ x0, t0 }: StartSwipeBackProps) => {
-        // Cancel pending push rAF and any running animations
-        if (pendingPushRAFRef.current !== null) {
-          cancelAnimationFrame(pendingPushRAFRef.current);
-          pendingPushRAFRef.current = null;
-        }
-        cancelAll(runningAnimsRef.current);
-        runningAnimsRef.current = [];
-        appBarBgScrubAnimRef.current?.cancel();
-        appBarBgScrubAnimRef.current = null;
-
-        swipeBackContextRef.current = {
-          x0,
-          t0,
-          displacement: 0,
-          displacementRatio: 0,
-          velocity: 0,
-        };
-
-        // Cache target elements and transition style once per gesture
-        if (stackRef.current) {
-          cachedTargetsRef.current = findTransitionTargets(stackRef.current);
-          swipeStyleRef.current = readTransitionStyle(stackRef.current);
-        }
-
-        setSwipeBackState("swiping");
-        onSwipeStart?.();
-      },
-      [onSwipeStart],
-    );
-
-    const moveSwipeBack = useCallback(
-      ({ x, t }: MoveSwipeBackProps) => {
-        const displacement = Math.max(0, x - swipeBackContextRef.current.x0);
-        const displacementRatio = displacement / window.innerWidth;
-        const velocity = displacement / (t - swipeBackContextRef.current.t0);
-
-        swipeBackContextRef.current = {
-          ...swipeBackContextRef.current,
-          displacement,
-          displacementRatio,
-          velocity,
-        };
-
-        // Only iOS slide tracks finger displacement; other styles stay put
-        // and let stackflow's own exit transition play on pop.
-        const targets = cachedTargetsRef.current;
-        if (targets && swipeStyleRef.current === "slideFromRightIOS") {
-          applySwipeStyles(targets, displacement, displacementRatio);
-          appBarBgScrubAnimRef.current = scrubAppBarBackground(
-            targets.topAppBarBackground,
-            `translate3d(${displacement}px, 0, 0)`,
-            appBarBgScrubAnimRef.current,
-          );
-        }
-
-        onSwipeMove?.({ displacement, displacementRatio });
-      },
-      [onSwipeMove],
-    );
-
-    const endSwipeBack = useCallback(
-      (_: EndSwipeBackProps) => {
-        const ctx = swipeBackContextRef.current;
-        const swiped =
-          ctx.displacementRatio > displacementRatioThreshold || ctx.velocity > velocityThreshold;
-
-        const targets = cachedTargetsRef.current;
-        if (!targets) {
-          setSwipeBackState("idle");
-          onSwipeEnd?.({ swiped });
-          return;
-        }
-
-        // Non-iOS styles do not track finger motion — let stackflow's normal
-        // exit-active lifecycle drive the pop animation when `swiped` is true.
-        if (swipeStyleRef.current !== "slideFromRightIOS") {
-          cachedTargetsRef.current = null;
-          swipeStyleRef.current = null;
-          setSwipeBackState("idle");
-          onSwipeEnd?.({ swiped });
-          return;
-        }
-
-        // Clear inline styles from swiping — WAAPI will take over from current position
-        clearAllStyles(targets);
-        appBarBgScrubAnimRef.current?.cancel();
-        appBarBgScrubAnimRef.current = null;
-
-        if (swiped) {
-          setSwipeBackState("completing");
-          // Mark to skip the next exit-active from stackflow
-          skipNextExitRef.current = true;
-          const { animations, finished } = animateSwipeComplete(
-            targets,
-            ctx.displacement,
-            ctx.velocity,
-          );
-          runningAnimsRef.current = animations;
-
-          finished.then(() => {
-            // Bail out if a newer transition has already claimed the ref —
-            // otherwise this stale handler would clobber the new animation's
-            // freshly-pinned inline styles.
-            // Set inline styles BEFORE cancel to prevent flash
-            setPostExitPositions(targets);
-            cancelAll(animations);
-            runningAnimsRef.current = [];
-            cachedTargetsRef.current = null;
-            swipeStyleRef.current = null;
-            setSwipeBackState("idle");
-          });
-        } else {
-          setSwipeBackState("canceling");
-          const { animations, finished } = animateSwipeCancel(
-            targets,
-            ctx.displacement,
-            ctx.velocity,
-          );
-          runningAnimsRef.current = animations;
-
-          finished.then(() => {
-            // Set inline styles BEFORE cancel to prevent flash
-            setIdlePositions(targets);
-            cancelAll(animations);
-            runningAnimsRef.current = [];
-            cachedTargetsRef.current = null;
-            swipeStyleRef.current = null;
-            setSwipeBackState("idle");
-          });
-        }
-
-        onSwipeEnd?.({ swiped });
-      },
-      [onSwipeEnd, displacementRatioThreshold, velocityThreshold],
-    );
-
-    const reset = useCallback(() => {
-      cancelAll(runningAnimsRef.current);
-      runningAnimsRef.current = [];
-      appBarBgScrubAnimRef.current?.cancel();
-      appBarBgScrubAnimRef.current = null;
-      if (cachedTargetsRef.current) {
-        clearAllStyles(cachedTargetsRef.current);
-      }
-      cachedTargetsRef.current = null;
-      swipeStyleRef.current = null;
-      swipeBackContextRef.current = {
-        x0: 0,
-        t0: 0,
-        displacement: 0,
-        displacementRatio: 0,
-        velocity: 0,
-      };
-      setSwipeBackState("idle");
-    }, []);
-
-    return useMemo(
-      () => ({
-        startSwipeBack,
-        moveSwipeBack,
-        endSwipeBack,
-        reset,
-      }),
-      [startSwipeBack, moveSwipeBack, endSwipeBack, reset],
-    );
-  }, []);
-
-  const topActivity = useTopActivity();
-
-  // ── WAAPI push/pop transitions triggered by stackflow state changes ──
-  const prevTransitionStateRef = useRef<string>(topActivity.transitionState);
-
   // Defer push animation one frame so stackflow has committed the new top
   // activity's DOM (data-activity-is-top + layer/appBar subtree) before we
   // query targets. Running sync in useLayoutEffect turned out to race with
@@ -292,6 +98,168 @@ export function useGlobalInteraction() {
   // because stackflow fires exit-active as part of its normal lifecycle
   // but we've already animated the exit via WAAPI.
   const skipNextExitRef = useRef(false);
+
+  /** Cancel any running WAAPI animations and clear the ref. */
+  const stopRunningAnims = useCallback(() => {
+    cancelAll(runningAnimsRef.current);
+    runningAnimsRef.current = [];
+  }, []);
+
+  /** Cancel the in-place scrub animation on the AppBar background. */
+  const stopAppBarBgScrub = useCallback(() => {
+    appBarBgScrubAnimRef.current?.cancel();
+    appBarBgScrubAnimRef.current = null;
+  }, []);
+
+  /** Cancel a pending deferred push animation, if any. */
+  const cancelPendingPushRAF = useCallback(() => {
+    if (pendingPushRAFRef.current !== null) {
+      cancelAnimationFrame(pendingPushRAFRef.current);
+      pendingPushRAFRef.current = null;
+    }
+  }, []);
+
+  /** Update swipe-back-state attribute on the stack DOM element. */
+  const setSwipeBackState = useCallback((state: SwipeBackState) => {
+    swipeBackStateRef.current = state;
+    if (stackRef.current) {
+      stackRef.current.dataset["swipeBackState"] = state;
+    }
+  }, []);
+
+  const startSwipeBack = useCallback(
+    ({ x0, t0 }: StartSwipeBackProps) => {
+      // Cancel pending push rAF and any running animations
+      cancelPendingPushRAF();
+      stopRunningAnims();
+      stopAppBarBgScrub();
+
+      swipeBackContextRef.current = { ...IDLE_CONTEXT, x0, t0 };
+
+      // Cache target elements and transition style once per gesture
+      if (stackRef.current) {
+        cachedTargetsRef.current = findTransitionTargets(stackRef.current);
+        swipeStyleRef.current = readTransitionStyle(stackRef.current);
+      }
+
+      setSwipeBackState("swiping");
+    },
+    [cancelPendingPushRAF, stopRunningAnims, stopAppBarBgScrub, setSwipeBackState],
+  );
+
+  const moveSwipeBack = useCallback(({ x, t }: MoveSwipeBackProps): SwipeBackContext => {
+    const ctx = swipeBackContextRef.current;
+    const displacement = Math.max(0, x - ctx.x0);
+    const displacementRatio = displacement / window.innerWidth;
+    const velocity = displacement / (t - ctx.t0);
+
+    // Mutate in place — this runs at 60fps inside touchmove rAF.
+    ctx.displacement = displacement;
+    ctx.displacementRatio = displacementRatio;
+    ctx.velocity = velocity;
+
+    // Only iOS slide tracks finger displacement; other styles stay put
+    // and let stackflow's own exit transition play on pop.
+    const targets = cachedTargetsRef.current;
+    if (targets && swipeStyleRef.current === "slideFromRightIOS") {
+      applySwipeStyles(targets, displacement, displacementRatio);
+      appBarBgScrubAnimRef.current = scrubAppBarBackground(
+        targets.topAppBarBackground,
+        `translate3d(${displacement}px, 0, 0)`,
+        appBarBgScrubAnimRef.current,
+      );
+    }
+
+    return ctx;
+  }, []);
+
+  const endSwipeBack = useCallback(
+    (thresholds: SwipeBackThresholds = {}): boolean => {
+      const {
+        displacementRatioThreshold = DEFAULT_DISPLACEMENT_RATIO_THRESHOLD,
+        velocityThreshold = DEFAULT_VELOCITY_THRESHOLD,
+      } = thresholds;
+
+      const ctx = swipeBackContextRef.current;
+      const swiped =
+        ctx.displacementRatio > displacementRatioThreshold || ctx.velocity > velocityThreshold;
+
+      const targets = cachedTargetsRef.current;
+      if (!targets) {
+        setSwipeBackState("idle");
+        return swiped;
+      }
+
+      // Non-iOS styles do not track finger motion — let stackflow's normal
+      // exit-active lifecycle drive the pop animation when `swiped` is true.
+      if (swipeStyleRef.current !== "slideFromRightIOS") {
+        cachedTargetsRef.current = null;
+        swipeStyleRef.current = null;
+        setSwipeBackState("idle");
+        return swiped;
+      }
+
+      // Clear inline styles from swiping — WAAPI will take over from current position
+      clearAllStyles(targets);
+      stopAppBarBgScrub();
+
+      const onFinish = (animations: Animation[], pin: () => void) => {
+        // Bail out if a newer transition has already claimed the ref —
+        // otherwise this stale handler would clobber the new animation's
+        // freshly-pinned inline styles.
+        if (runningAnimsRef.current !== animations) return;
+        // Set inline styles BEFORE cancel to prevent flash
+        pin();
+        cancelAll(animations);
+        runningAnimsRef.current = [];
+        cachedTargetsRef.current = null;
+        swipeStyleRef.current = null;
+        setSwipeBackState("idle");
+      };
+
+      if (swiped) {
+        setSwipeBackState("completing");
+        // Mark to skip the next exit-active from stackflow
+        skipNextExitRef.current = true;
+        const { animations, finished } = animateSwipeComplete(
+          targets,
+          ctx.displacement,
+          ctx.velocity,
+        );
+        runningAnimsRef.current = animations;
+        finished.then(() => onFinish(animations, () => setPostExitPositions(targets)));
+      } else {
+        setSwipeBackState("canceling");
+        const { animations, finished } = animateSwipeCancel(
+          targets,
+          ctx.displacement,
+          ctx.velocity,
+        );
+        runningAnimsRef.current = animations;
+        finished.then(() => onFinish(animations, () => setIdlePositions(targets)));
+      }
+
+      return swiped;
+    },
+    [setSwipeBackState, stopAppBarBgScrub],
+  );
+
+  const resetSwipeBack = useCallback(() => {
+    stopRunningAnims();
+    stopAppBarBgScrub();
+    if (cachedTargetsRef.current) {
+      clearAllStyles(cachedTargetsRef.current);
+    }
+    cachedTargetsRef.current = null;
+    swipeStyleRef.current = null;
+    swipeBackContextRef.current = { ...IDLE_CONTEXT };
+    setSwipeBackState("idle");
+  }, [stopRunningAnims, stopAppBarBgScrub, setSwipeBackState]);
+
+  const topActivity = useTopActivity();
+
+  // ── WAAPI push/pop transitions triggered by stackflow state changes ──
+  const prevTransitionStateRef = useRef<string>(topActivity.transitionState);
 
   useLayoutEffect(() => {
     const prev = prevTransitionStateRef.current;
@@ -306,11 +274,8 @@ export function useGlobalInteraction() {
     if (next === "enter-active" && prev !== "enter-active") {
       if (swipeState !== "idle") return;
 
-      cancelAll(runningAnimsRef.current);
-      runningAnimsRef.current = [];
-      if (pendingPushRAFRef.current !== null) {
-        cancelAnimationFrame(pendingPushRAFRef.current);
-      }
+      stopRunningAnims();
+      cancelPendingPushRAF();
       // Defer one frame so stackflow's new top activity subtree is reliably
       // observable via data-activity-is-top. Sync dispatch inside
       // useLayoutEffect raced with stackflow subscription updates and left
@@ -322,6 +287,7 @@ export function useGlobalInteraction() {
         const { animations, finished } = animateTransition(targets, "push", style);
         runningAnimsRef.current = animations;
         finished.then(() => {
+          if (runningAnimsRef.current !== animations) return;
           setIdlePositions(targets, style);
           cancelAll(animations);
           runningAnimsRef.current = [];
@@ -337,44 +303,51 @@ export function useGlobalInteraction() {
 
       if (swipeState !== "idle") return;
 
-      if (pendingPushRAFRef.current !== null) {
-        cancelAnimationFrame(pendingPushRAFRef.current);
-        pendingPushRAFRef.current = null;
-      }
-      cancelAll(runningAnimsRef.current);
-      runningAnimsRef.current = [];
+      cancelPendingPushRAF();
+      stopRunningAnims();
       const style = readTransitionStyle(stackEl);
       const targets = findTransitionTargets(stackEl);
       const { animations, finished } = animateTransition(targets, "pop", style);
       runningAnimsRef.current = animations;
       finished.then(() => {
+        if (runningAnimsRef.current !== animations) return;
         setPostExitPositions(targets, style);
         cancelAll(animations);
         runningAnimsRef.current = [];
       });
     }
-  }, [topActivity.transitionState]);
+  }, [topActivity.transitionState, stopRunningAnims, cancelPendingPushRAF]);
+
+  // Cancel any pending push rAF and running animations on unmount so
+  // late-firing finished handlers can't run against a torn-down stack.
+  useEffect(() => {
+    return () => {
+      cancelPendingPushRAF();
+      stopRunningAnims();
+      stopAppBarBgScrub();
+    };
+  }, [cancelPendingPushRAF, stopRunningAnims, stopAppBarBgScrub]);
 
   const stackProps = useMemo(
-    () => ({
-      "data-swipe-back-state": swipeBackStateRef.current,
-      "data-global-transition-state": topActivity.transitionState,
-      "data-top-activity-type": topActivity.activityType,
-      "data-top-transition-style": topActivity.transitionStyle,
-    }),
+    () =>
+      ({
+        "data-swipe-back-state": swipeBackStateRef.current,
+        "data-global-transition-state": topActivity.transitionState,
+        "data-top-activity-type": topActivity.activityType,
+        "data-top-transition-style": topActivity.transitionStyle,
+      }) as React.HTMLAttributes<HTMLElement>,
     [topActivity.transitionState, topActivity.activityType, topActivity.transitionStyle],
-  ) as React.HTMLAttributes<HTMLElement>;
+  );
 
   return useMemo(
     () => ({
       stackRef,
-      swipeBackContextRef,
-      swipeBackState: swipeBackStateRef.current,
-      setSwipeBackState,
-      getSwipeBackEvents,
-
+      startSwipeBack,
+      moveSwipeBack,
+      endSwipeBack,
+      resetSwipeBack,
       stackProps,
     }),
-    [setSwipeBackState, getSwipeBackEvents, stackProps],
+    [startSwipeBack, moveSwipeBack, endSwipeBack, resetSwipeBack, stackProps],
   );
 }

--- a/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.ts
@@ -226,20 +226,12 @@ export function useGlobalInteraction() {
         setSwipeBackState("completing");
         // Mark to skip the next exit-active from stackflow
         skipNextExitRef.current = true;
-        const { animations, finished } = animateSwipeComplete(
-          targets,
-          ctx.displacement,
-          ctx.velocity,
-        );
+        const { animations, finished } = animateSwipeComplete(targets, ctx.displacement);
         runningAnimsRef.current = animations;
         finished.then(() => onFinish(animations, () => setPostExitPositions(targets)));
       } else {
         setSwipeBackState("canceling");
-        const { animations, finished } = animateSwipeCancel(
-          targets,
-          ctx.displacement,
-          ctx.velocity,
-        );
+        const { animations, finished } = animateSwipeCancel(targets, ctx.displacement);
         runningAnimsRef.current = animations;
         finished.then(() => onFinish(animations, () => setIdlePositions(targets)));
       }

--- a/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.ts
@@ -204,17 +204,22 @@ export function useGlobalInteraction() {
       stopAppBarBgScrub();
 
       const onFinish = (animations: Animation[], pin: () => void) => {
-        // Bail out if a newer transition has already claimed the ref —
-        // otherwise this stale handler would clobber the new animation's
-        // freshly-pinned inline styles.
-        if (runningAnimsRef.current !== animations) return;
-        // Set inline styles BEFORE cancel to prevent flash
+        // Always pin + cancel: skipping these leaves inline styles from the
+        // mid-gesture snapshot on screen when the animation gets cancelled
+        // by a newer transition (the cancel itself drops fill:forwards, so
+        // the stale inline styles become visible).
+        // Set inline styles BEFORE cancel to prevent flash.
         pin();
         cancelAll(animations);
-        runningAnimsRef.current = [];
-        cachedTargetsRef.current = null;
-        swipeStyleRef.current = null;
-        setSwipeBackState("idle");
+        // Only reset the running ref / per-gesture caches if no newer
+        // transition has claimed them — otherwise we'd clobber the next
+        // gesture's state.
+        if (runningAnimsRef.current === animations) {
+          runningAnimsRef.current = [];
+          cachedTargetsRef.current = null;
+          swipeStyleRef.current = null;
+          setSwipeBackState("idle");
+        }
       };
 
       if (swiped) {
@@ -287,10 +292,14 @@ export function useGlobalInteraction() {
         const { animations, finished } = animateTransition(targets, "push", style);
         runningAnimsRef.current = animations;
         finished.then(() => {
-          if (runningAnimsRef.current !== animations) return;
+          // Always pin idle inline styles + cancel before checking the ref.
+          // Skipping these on cancel-by-newer-transition would leave the
+          // mid-flight inline styles (or none at all) on screen.
           setIdlePositions(targets, style);
           cancelAll(animations);
-          runningAnimsRef.current = [];
+          if (runningAnimsRef.current === animations) {
+            runningAnimsRef.current = [];
+          }
         });
       });
     }
@@ -310,10 +319,14 @@ export function useGlobalInteraction() {
       const { animations, finished } = animateTransition(targets, "pop", style);
       runningAnimsRef.current = animations;
       finished.then(() => {
-        if (runningAnimsRef.current !== animations) return;
+        // Always pin post-exit inline styles + cancel. If we bail here on
+        // cancel-by-newer-transition, the previous transition's idle inline
+        // styles (e.g. behind layer at -30%) stay on screen.
         setPostExitPositions(targets, style);
         cancelAll(animations);
-        runningAnimsRef.current = [];
+        if (runningAnimsRef.current === animations) {
+          runningAnimsRef.current = [];
+        }
       });
     }
   }, [topActivity.transitionState, stopRunningAnims, cancelPendingPushRAF]);

--- a/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.ts
@@ -199,8 +199,11 @@ export function useGlobalInteraction() {
         return swiped;
       }
 
-      // Clear inline styles from swiping — WAAPI will take over from current position
-      clearAllStyles(targets);
+      // Keep swipe-time inline styles intact — WAAPI keyframe[0] matches the
+      // current displacement, and the inline values cover the 1-frame gap
+      // before the animation's first paint. Clearing here would cause a
+      // single-frame snap to default (transform: 0) on heavy main-thread
+      // sessions where reflow can interleave between this clear and animate().
       stopAppBarBgScrub();
 
       const onFinish = (animations: Animation[], pin: () => void) => {

--- a/packages/stackflow/src/primitive/GlobalInteraction/useSwipeBack.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/useSwipeBack.ts
@@ -1,19 +1,45 @@
+import { useCallbackRef } from "@radix-ui/react-use-callback-ref";
 import { useEffect, useMemo, useRef } from "react";
-import type { SwipeBackProps } from "./useGlobalInteraction";
 import { useGlobalInteractionContext } from "./useGlobalInteractionContext";
 
-export interface UseSwipeBackProps extends SwipeBackProps {}
+export interface UseSwipeBackProps {
+  /**
+   * The threshold to determine whether the swipe back is intentional, by displacement ratio.
+   * @default 0.4
+   */
+  swipeBackDisplacementRatioThreshold?: number;
+
+  /**
+   * The threshold to determine whether the swipe back is intentional, by velocity.
+   * @default 1
+   */
+  swipeBackVelocityThreshold?: number;
+
+  onSwipeBackStart?: () => void;
+  onSwipeBackMove?: (props: { displacement: number; displacementRatio: number }) => void;
+  onSwipeBackEnd?: (props: { swiped: boolean }) => void;
+}
 
 export function useSwipeBack(props: UseSwipeBackProps) {
-  const globalInteraction = useGlobalInteractionContext();
-  const events = globalInteraction.getSwipeBackEvents(props);
+  const {
+    swipeBackDisplacementRatioThreshold: displacementRatioThreshold,
+    swipeBackVelocityThreshold: velocityThreshold,
+  } = props;
+
+  const onSwipeStart = useCallbackRef(props.onSwipeBackStart);
+  const onSwipeMove = useCallbackRef(props.onSwipeBackMove);
+  const onSwipeEnd = useCallbackRef(props.onSwipeBackEnd);
+
+  const { startSwipeBack, moveSwipeBack, endSwipeBack, resetSwipeBack } =
+    useGlobalInteractionContext();
+
   const rAFLockRef = useRef(false);
 
   useEffect(() => {
     return () => {
-      events.reset();
+      resetSwipeBack();
     };
-  }, [events]);
+  }, [resetSwipeBack]);
 
   return useMemo(
     () => ({
@@ -26,7 +52,8 @@ export function useSwipeBack(props: UseSwipeBackProps) {
         onTouchStart: (e: React.TouchEvent) => {
           const x0 = e.touches[0].clientX;
           const t0 = Date.now();
-          events.startSwipeBack({ x0, t0 });
+          startSwipeBack({ x0, t0 });
+          onSwipeStart();
         },
         onTouchMove: (e: React.TouchEvent) => {
           // rAF lock: process at most once per animation frame
@@ -35,18 +62,33 @@ export function useSwipeBack(props: UseSwipeBackProps) {
           const x = e.touches[0].clientX;
           const t = Date.now();
           requestAnimationFrame(() => {
-            events.moveSwipeBack({ x, t });
+            const ctx = moveSwipeBack({ x, t });
             rAFLockRef.current = false;
+            onSwipeMove({
+              displacement: ctx.displacement,
+              displacementRatio: ctx.displacementRatio,
+            });
           });
         },
         onTouchEnd: () => {
-          events.endSwipeBack({});
+          const swiped = endSwipeBack({ displacementRatioThreshold, velocityThreshold });
+          onSwipeEnd({ swiped });
         },
         onTouchCancel: () => {
-          events.endSwipeBack({});
+          const swiped = endSwipeBack({ displacementRatioThreshold, velocityThreshold });
+          onSwipeEnd({ swiped });
         },
       } as React.HTMLAttributes<HTMLElement>,
     }),
-    [events],
+    [
+      startSwipeBack,
+      moveSwipeBack,
+      endSwipeBack,
+      onSwipeStart,
+      onSwipeMove,
+      onSwipeEnd,
+      displacementRatioThreshold,
+      velocityThreshold,
+    ],
   );
 }


### PR DESCRIPTION
> Stacked on top of #1539. After #1539 merges, this PR's base will retarget to `feature/des-1079-waapi` automatically.

## Summary

Focused code-quality pass on the WAAPI transition system introduced in `feature/des-1079-waapi`. Touches `packages/stackflow/src/primitive/GlobalInteraction/{useGlobalInteraction.ts,useSwipeBack.ts,animation.ts,dom.ts}` (+280/-267).

## Fixes (real bugs / semantics)

- **Rules-of-hooks violation** — `getSwipeBackEvents` called `useCallback`/`useMemo`/`useCallbackRef` inside another `useCallback`. Prop callback handling moved to `useSwipeBack` where it belongs; `useGlobalInteraction` now exposes plain stable handlers.
- **Race-condition guard** — every `finished.then(...)` now checks `runningAnimsRef.current !== animations` before pinning inline styles. The comment promised this but the actual guard was missing, so a stale finished handler could clobber a newer transition's pinned state.
- **Unmount cleanup** — added a `useEffect` cleanup that cancels pending RAF / running animations / scrub animation on unmount. Previously, late-firing finished handlers could run against a torn-down stack.
- **Removed stale public surface** — `swipeBackState` was returned as a snapshot (always stale) plus `setSwipeBackState`, `swipeBackContextRef`, `swipeBackStateRef` had zero external consumers. Dropped from the return.

## Cleanups (DRY / types / hot path)

- `stopRunningAnims`, `stopAppBarBgScrub`, `cancelPendingPushRAF` helpers replace 8+ repeated `cancel + null-out` blocks.
- Frozen `IDLE_CONTEXT` constant for swipe-back context resets.
- `IosPositions.{topTitle,behindTitle}` tightened from `Keyframe` to `TitleKeyframe { opacity: string; transform: string }` — no more `as string` casts.
- Redundant null guards in `pinIosInlineStyles` removed (set helpers already null-check).
- `findTransitionTargets` backwards-loop replaced with `findIndex`.
- **60fps hot path:** `moveSwipeBack` now mutates `swipeBackContextRef.current` in place instead of spread-assigning a new object every touchmove.

## Test plan

- [x] `bun packages:build` — green
- [x] `bun headless:test` — 329 pass / 0 fail
- [x] `bun react:test` — 362 pass / 0 fail
- [x] `bun biome format --fix` — clean
- [ ] Manual stackflow dogfood (push / pop / iOS swipe-back / Android fadeFromBottom / fadeIn) — please verify visually before merge; WAAPI behavior is not coverable by unit tests.