### PR TITLE
feat(top-navigation): rename theme to ios/android and add gradient/layer support

### DIFF
--- a/docs/public/rootage/components/top-navigation-text-button.json
+++ b/docs/public/rootage/components/top-navigation-text-button.json
@@ -59,6 +59,13 @@
             "transparent": {}
           },
           "defaultValue": "layer"
+        },
+        "theme": {
+          "values": {
+            "ios": {},
+            "android": {}
+          },
+          "defaultValue": "ios"
         }
       }
     },
@@ -72,13 +79,6 @@
             ],
             "slots": {
               "root": {
-                "maxWidth": {
-                  "type": "dimension",
-                  "value": {
-                    "value": 96,
-                    "unit": "px"
-                  }
-                },
                 "height": {
                   "type": "dimension",
                   "value": {
@@ -190,6 +190,35 @@
             }
           }
         ]
+      },
+      {
+        "variants": {
+          "theme": "ios"
+        },
+        "definitions": [
+          {
+            "states": [
+              "enabled"
+            ],
+            "slots": {
+              "root": {
+                "maxWidth": {
+                  "type": "dimension",
+                  "value": {
+                    "value": 96,
+                    "unit": "px"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "variants": {
+          "theme": "android"
+        },
+        "definitions": []
       }
     ]
   }

--- a/docs/public/rootage/components/top-navigation.json
+++ b/docs/public/rootage/components/top-navigation.json
@@ -25,6 +25,13 @@
             },
             "strokeWidth": {
               "type": "dimension"
+            },
+            "gradient": {
+              "type": "gradient"
+            },
+            "bleedBottom": {
+              "type": "dimension",
+              "description": "gradient가 표시될 때 하단 아래로 gradient가 확장되는 길이입니다."
             }
           }
         },
@@ -104,17 +111,29 @@
       "variants": {
         "theme": {
           "values": {
-            "cupertino": {},
+            "ios": {},
             "android": {}
           },
-          "defaultValue": "cupertino"
+          "defaultValue": "ios"
         },
         "tone": {
           "values": {
-            "layer": {},
+            "layer": {
+              "description": "color를 $color.bg.layer-basement 등으로 변경하여 사용할 수 있습니다."
+            },
             "transparent": {}
           },
           "defaultValue": "layer"
+        },
+        "gradient": {
+          "values": {
+            "false": {
+              "description": "false로 사용하는 것을 권장하지 않습니다. gradient 없이 사용하면 Top Navigation의 콘텐츠 가독성을 직접 확보해야 합니다. 스크린 배경 색상이 Top Navigation에 보이기를 원하는 경우 tone=layer를 사용하세요."
+            },
+            "true": {}
+          },
+          "defaultValue": "false",
+          "description": "tone=transparent일 때만 동작합니다."
         },
         "divider": {
           "values": {
@@ -134,7 +153,7 @@
     "definitions": [
       {
         "variants": {
-          "theme": "cupertino"
+          "theme": "ios"
         },
         "definitions": [
           {
@@ -237,12 +256,6 @@
               "enabled"
             ],
             "slots": {
-              "root": {
-                "color": {
-                  "type": "color",
-                  "value": "#00000000"
-                }
-              },
               "title": {
                 "color": {
                   "type": "color",
@@ -253,6 +266,61 @@
                 "color": {
                   "type": "color",
                   "value": "$color.palette.static-white"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "variants": {
+          "tone": "transparent",
+          "gradient": "false"
+        },
+        "definitions": [
+          {
+            "states": [
+              "enabled"
+            ],
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color",
+                  "value": "#00000000"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "variants": {
+          "tone": "transparent",
+          "gradient": "true"
+        },
+        "definitions": [
+          {
+            "states": [
+              "enabled"
+            ],
+            "slots": {
+              "root": {
+                "gradient": {
+                  "type": "gradient",
+                  "value": [
+                    {
+                      "color": "#00000059",
+                      "position": 0
+                    },
+                    {
+                      "color": "#00000000",
+                      "position": 1
+                    }
+                  ]
+                },
+                "bleedBottom": {
+                  "type": "dimension",
+                  "value": "$dimension.x5"
                 }
               }
             }

--- a/packages/css/vars/component/top-navigation-text-button.d.ts
+++ b/packages/css/vars/component/top-navigation-text-button.d.ts
@@ -2,8 +2,6 @@ export declare const vars: {
   "base": {
     "enabled": {
       "root": {
-        /** 버튼 레이블이 길어졌을 때 ellipsis 말줄임을 시작할 최대 너비입니다. Top Navigation main slot이 충분한 공간을 차지할 수 있도록 하기 위해 폰트 스케일링의 영향을 받지 않는 px 값을 사용합니다. */
-        "maxWidth": "96px",
         "height": "44px",
         "paddingX": "var(--seed-dimension-x2_5)"
       },
@@ -41,5 +39,14 @@ export declare const vars: {
         "color": "var(--seed-color-fg-disabled)"
       }
     }
-  }
+  },
+  "themeIos": {
+    "enabled": {
+      "root": {
+        /** 버튼 레이블이 길어졌을 때 ellipsis 말줄임을 시작할 최대 너비입니다. Top Navigation main slot이 충분한 공간을 차지할 수 있도록 하기 위해 폰트 스케일링의 영향을 받지 않는 px 값을 사용합니다. */
+        "maxWidth": "96px"
+      }
+    }
+  },
+  "themeAndroid": {}
 }

--- a/packages/css/vars/component/top-navigation-text-button.mjs
+++ b/packages/css/vars/component/top-navigation-text-button.mjs
@@ -2,7 +2,6 @@ export const vars = {
   "base": {
     "enabled": {
       "root": {
-        "maxWidth": "96px",
         "height": "44px",
         "paddingX": "var(--seed-dimension-x2_5)"
       },
@@ -40,5 +39,13 @@ export const vars = {
         "color": "var(--seed-color-fg-disabled)"
       }
     }
-  }
+  },
+  "themeIos": {
+    "enabled": {
+      "root": {
+        "maxWidth": "96px"
+      }
+    }
+  },
+  "themeAndroid": {}
 }

--- a/packages/css/vars/component/top-navigation.d.ts
+++ b/packages/css/vars/component/top-navigation.d.ts
@@ -1,5 +1,5 @@
 export declare const vars: {
-  "themeCupertino": {
+  "themeIos": {
     "enabled": {
       "root": {
         "height": "44px",
@@ -19,6 +19,9 @@ export declare const vars: {
       }
     }
   },
+  /**
+   * color를 $color.bg.layer-basement 등으로 변경하여 사용할 수 있습니다.
+   */
   "toneLayer": {
     "enabled": {
       "root": {
@@ -34,14 +37,30 @@ export declare const vars: {
   },
   "toneTransparent": {
     "enabled": {
-      "root": {
-        "color": "#00000000"
-      },
       "title": {
         "color": "var(--seed-color-palette-static-white)"
       },
       "subtitle": {
         "color": "var(--seed-color-palette-static-white)"
+      }
+    }
+  },
+  /**
+   * - `gradient=false`: false로 사용하는 것을 권장하지 않습니다. gradient 없이 사용하면 Top Navigation의 콘텐츠 가독성을 직접 확보해야 합니다. 스크린 배경 색상이 Top Navigation에 보이기를 원하는 경우 tone=layer를 사용하세요.
+   */
+  "toneTransparentGradientFalse": {
+    "enabled": {
+      "root": {
+        "color": "#00000000"
+      }
+    }
+  },
+  "toneTransparentGradientTrue": {
+    "enabled": {
+      "root": {
+        "gradient": "#00000059 0%, #00000000 100%",
+        /** gradient가 표시될 때 하단 아래로 gradient가 확장되는 길이입니다. */
+        "bleedBottom": "var(--seed-dimension-x5)"
       }
     }
   },

--- a/packages/css/vars/component/top-navigation.mjs
+++ b/packages/css/vars/component/top-navigation.mjs
@@ -1,5 +1,5 @@
 export const vars = {
-  "themeCupertino": {
+  "themeIos": {
     "enabled": {
       "root": {
         "height": "44px",
@@ -33,14 +33,26 @@ export const vars = {
   },
   "toneTransparent": {
     "enabled": {
-      "root": {
-        "color": "#00000000"
-      },
       "title": {
         "color": "var(--seed-color-palette-static-white)"
       },
       "subtitle": {
         "color": "var(--seed-color-palette-static-white)"
+      }
+    }
+  },
+  "toneTransparentGradientFalse": {
+    "enabled": {
+      "root": {
+        "color": "#00000000"
+      }
+    }
+  },
+  "toneTransparentGradientTrue": {
+    "enabled": {
+      "root": {
+        "gradient": "#00000059 0%, #00000000 100%",
+        "bleedBottom": "var(--seed-dimension-x5)"
       }
     }
   },

--- a/packages/qvism-preset/src/stackflow/app-bar.ts
+++ b/packages/qvism-preset/src/stackflow/app-bar.ts
@@ -213,9 +213,9 @@ export const appBar = defineSlotRecipe({
     theme: {
       cupertino: {
         root: {
-          height: `calc(${vars.themeCupertino.enabled.root.height} + var(--seed-safe-area-top))`,
-          paddingLeft: vars.themeCupertino.enabled.root.paddingX,
-          paddingRight: vars.themeCupertino.enabled.root.paddingX,
+          height: `calc(${vars.themeIos.enabled.root.height} + var(--seed-safe-area-top))`,
+          paddingLeft: vars.themeIos.enabled.root.paddingX,
+          paddingRight: vars.themeIos.enabled.root.paddingX,
           paddingTop: "var(--seed-safe-area-top)",
         },
         iconButton: {
@@ -337,7 +337,8 @@ export const appBar = defineSlotRecipe({
       },
       transparent: {
         root: {
-          backgroundColor: vars.toneTransparent.enabled.root.color,
+          // gradient is handled in app-screen.ts
+          backgroundColor: vars.toneTransparentGradientFalse.enabled.root.color,
         },
         icon: {
           color: `var(--seed-icon-color, ${iconButtonVars.toneTransparent.enabled.icon.color})`,

--- a/packages/qvism-preset/src/stackflow/app-screen.ts
+++ b/packages/qvism-preset/src/stackflow/app-screen.ts
@@ -70,7 +70,7 @@ export const appScreen = defineSlotRecipe({
     theme: {
       cupertino: {
         root: {
-          "--app-bar-height": navVars.themeCupertino.enabled.root.height,
+          "--app-bar-height": navVars.themeIos.enabled.root.height,
         },
       },
       android: {
@@ -210,6 +210,7 @@ export const appScreen = defineSlotRecipe({
             // since we're using sticky, when iOS overscroll happens the before pseudoelement will stick to the top of `layer` and won't show the gradient in the overscroll area.
             // so we extend the height of the gradient and use transform to move it up to the possible gradient area.
             // rgba(0, 0, 0, 0.2) is for a natural look; if we use rgba(0, 0, 0, 0.35) on 0% the gradient looks off
+            // TODO: consume rootage variables
             background: `linear-gradient(180deg, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.35) ${OVERSCROLL_GRADIENT_OFFSET}, rgba(0, 0, 0, 0.00) 100%)`,
             pointerEvents: "none",
             zIndex: 1,

--- a/packages/qvism-preset/src/vars/component/top-navigation-text-button.d.ts
+++ b/packages/qvism-preset/src/vars/component/top-navigation-text-button.d.ts
@@ -2,8 +2,6 @@ export declare const vars: {
   "base": {
     "enabled": {
       "root": {
-        /** 버튼 레이블이 길어졌을 때 ellipsis 말줄임을 시작할 최대 너비입니다. Top Navigation main slot이 충분한 공간을 차지할 수 있도록 하기 위해 폰트 스케일링의 영향을 받지 않는 px 값을 사용합니다. */
-        "maxWidth": "96px",
         "height": "44px",
         "paddingX": "var(--seed-dimension-x2_5)"
       },
@@ -41,5 +39,14 @@ export declare const vars: {
         "color": "var(--seed-color-fg-disabled)"
       }
     }
-  }
+  },
+  "themeIos": {
+    "enabled": {
+      "root": {
+        /** 버튼 레이블이 길어졌을 때 ellipsis 말줄임을 시작할 최대 너비입니다. Top Navigation main slot이 충분한 공간을 차지할 수 있도록 하기 위해 폰트 스케일링의 영향을 받지 않는 px 값을 사용합니다. */
+        "maxWidth": "96px"
+      }
+    }
+  },
+  "themeAndroid": {}
 }

--- a/packages/qvism-preset/src/vars/component/top-navigation-text-button.mjs
+++ b/packages/qvism-preset/src/vars/component/top-navigation-text-button.mjs
@@ -2,7 +2,6 @@ export const vars = {
   "base": {
     "enabled": {
       "root": {
-        "maxWidth": "96px",
         "height": "44px",
         "paddingX": "var(--seed-dimension-x2_5)"
       },
@@ -40,5 +39,13 @@ export const vars = {
         "color": "var(--seed-color-fg-disabled)"
       }
     }
-  }
+  },
+  "themeIos": {
+    "enabled": {
+      "root": {
+        "maxWidth": "96px"
+      }
+    }
+  },
+  "themeAndroid": {}
 }

--- a/packages/qvism-preset/src/vars/component/top-navigation.d.ts
+++ b/packages/qvism-preset/src/vars/component/top-navigation.d.ts
@@ -1,5 +1,5 @@
 export declare const vars: {
-  "themeCupertino": {
+  "themeIos": {
     "enabled": {
       "root": {
         "height": "44px",
@@ -19,6 +19,9 @@ export declare const vars: {
       }
     }
   },
+  /**
+   * color를 $color.bg.layer-basement 등으로 변경하여 사용할 수 있습니다.
+   */
   "toneLayer": {
     "enabled": {
       "root": {
@@ -34,14 +37,30 @@ export declare const vars: {
   },
   "toneTransparent": {
     "enabled": {
-      "root": {
-        "color": "#00000000"
-      },
       "title": {
         "color": "var(--seed-color-palette-static-white)"
       },
       "subtitle": {
         "color": "var(--seed-color-palette-static-white)"
+      }
+    }
+  },
+  /**
+   * - `gradient=false`: false로 사용하는 것을 권장하지 않습니다. gradient 없이 사용하면 Top Navigation의 콘텐츠 가독성을 직접 확보해야 합니다. 스크린 배경 색상이 Top Navigation에 보이기를 원하는 경우 tone=layer를 사용하세요.
+   */
+  "toneTransparentGradientFalse": {
+    "enabled": {
+      "root": {
+        "color": "#00000000"
+      }
+    }
+  },
+  "toneTransparentGradientTrue": {
+    "enabled": {
+      "root": {
+        "gradient": "#00000059 0%, #00000000 100%",
+        /** gradient가 표시될 때 하단 아래로 gradient가 확장되는 길이입니다. */
+        "bleedBottom": "var(--seed-dimension-x5)"
       }
     }
   },

--- a/packages/qvism-preset/src/vars/component/top-navigation.mjs
+++ b/packages/qvism-preset/src/vars/component/top-navigation.mjs
@@ -1,5 +1,5 @@
 export const vars = {
-  "themeCupertino": {
+  "themeIos": {
     "enabled": {
       "root": {
         "height": "44px",
@@ -33,14 +33,26 @@ export const vars = {
   },
   "toneTransparent": {
     "enabled": {
-      "root": {
-        "color": "#00000000"
-      },
       "title": {
         "color": "var(--seed-color-palette-static-white)"
       },
       "subtitle": {
         "color": "var(--seed-color-palette-static-white)"
+      }
+    }
+  },
+  "toneTransparentGradientFalse": {
+    "enabled": {
+      "root": {
+        "color": "#00000000"
+      }
+    }
+  },
+  "toneTransparentGradientTrue": {
+    "enabled": {
+      "root": {
+        "gradient": "#00000059 0%, #00000000 100%",
+        "bleedBottom": "var(--seed-dimension-x5)"
       }
     }
   },

--- a/packages/rootage/components/top-navigation-text-button.yaml
+++ b/packages/rootage/components/top-navigation-text-button.yaml
@@ -10,7 +10,8 @@ data:
         properties:
           maxWidth:
             type: dimension
-            description: 버튼 레이블이 길어졌을 때 ellipsis 말줄임을 시작할 최대 너비입니다. Top Navigation main slot이 충분한 공간을 차지할 수 있도록 하기 위해 폰트 스케일링의 영향을 받지 않는 px 값을 사용합니다.
+            description: 버튼 레이블이 길어졌을 때 ellipsis 말줄임을 시작할 최대 너비입니다. Top Navigation main
+              slot이 충분한 공간을 차지할 수 있도록 하기 위해 폰트 스케일링의 영향을 받지 않는 px 값을 사용합니다.
           height:
             type: dimension
           paddingX:
@@ -37,7 +38,6 @@ data:
     base:
       enabled:
         root:
-          maxWidth: 96px
           height: 44px
           paddingX: $dimension.x2_5
         label:
@@ -62,3 +62,8 @@ data:
       disabled:
         label:
           color: $color.fg.disabled
+    theme=ios:
+      enabled:
+        root:
+          maxWidth: 96px
+    theme=android: {}

--- a/packages/rootage/components/top-navigation.yaml
+++ b/packages/rootage/components/top-navigation.yaml
@@ -18,6 +18,11 @@ data:
             type: color
           strokeWidth:
             type: dimension
+          gradient:
+            type: gradient
+          bleedBottom:
+            type: dimension
+            description: gradient가 표시될 때 하단 아래로 gradient가 확장되는 길이입니다.
       left:
         properties: {}
         description: 왼쪽 영역입니다. 일반적으로 뒤로가기/닫기 Top Navigation Icon Button이 위치합니다.
@@ -66,8 +71,20 @@ data:
             type: number
           minLineHeightScale:
             type: number
+    variants:
+      tone:
+        values:
+          layer:
+            description: color를 $color.bg.layer-basement 등으로 변경하여 사용할 수 있습니다.
+      gradient:
+        description: tone=transparent일 때만 동작합니다.
+        values:
+          "false":
+            description: false로 사용하는 것을 권장하지 않습니다. gradient 없이 사용하면 Top Navigation의 콘텐츠 가독성을
+              직접 확보해야 합니다. 스크린 배경 색상이 Top Navigation에 보이기를 원하는 경우 tone=layer를
+              사용하세요.
   definitions:
-    theme=cupertino:
+    theme=ios:
       enabled:
         root:
           height: 44px
@@ -91,12 +108,25 @@ data:
           color: $color.fg.neutral-muted
     tone=transparent:
       enabled:
-        root:
-          color: "#00000000"
         title:
           color: $color.palette.static-white
         subtitle:
           color: $color.palette.static-white
+    tone=transparent,gradient=false:
+      enabled:
+        root:
+          color: "#00000000"
+    tone=transparent,gradient=true:
+      enabled:
+        root:
+          gradient:
+            type: gradient
+            value:
+              - color: "#00000059" # 35%
+                position: 0
+              - color: "#00000000"
+                position: 1
+          bleedBottom: $dimension.x5
     divider=true:
       enabled:
         root:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 상단 네비게이션 컴포넌트의 테마 일관성을 개선했습니다.
  * 투명 톤의 상단 네비게이션에 새로운 그래디언트 스타일 옵션을 추가했습니다.
  * 앱 바와 상단 네비게이션의 높이 및 패딩 계산을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->