### PR TITLE
docs(stackflow): document modal-on-modal stacking for Bottom Sheet

### DIFF
--- a/docs/content/react/stackflow/bottom-sheet.mdx
+++ b/docs/content/react/stackflow/bottom-sheet.mdx
@@ -107,6 +107,49 @@ return (
 1. `modal={isActive}`로 Bottom Sheet Activity가 비활성 상태일 때 `modal`을 `false`로 설정합니다. 이렇게 하지 않으면, 위에 push된 Activity에서 스크롤 등의 상호작용이 동작하지 않습니다.
 1. `onOpenChange` 핸들러에서 `isActive`인 경우에만 `pop()`을 실행하여, 비활성 상태에서의 의도치 않은 Activity 종료를 방지합니다.
 
+#### Stacking Another Modal Overlay on Top
+
+Bottom Sheet Activity 위에 자체 backdrop을 갖는 또 다른 modal Activity(예: Alert Dialog Activity)를 push해 얹는 경우에는, `modal={isActive}` 대신 `modal`을 항상 `true`로 두는 것을 권장합니다.
+
+`modal={isActive}` 패턴은 위에 push되는 Activity가 일반 AppScreen일 때 스크롤 등의 상호작용을 보장하기 위한 것이지만, 위로 push되는 Activity가 자체 backdrop을 갖는 modal overlay라면 비활성 시점에 Bottom Sheet의 backdrop이 사라지면서 dim layering이 끊겨 보일 수 있습니다.
+
+<StackflowExample path="/nested-bottom-sheet">
+  ```json doc-gen:file
+  {
+    "file": "../examples/stackflow-spa/src/activities/ActivityNestedBottomSheet.tsx",
+    "codeblock": {
+      "meta": "title='ActivityNestedBottomSheet.tsx'"
+    }
+  }
+  ```
+</StackflowExample>
+
+```tsx
+const { isActive, transitionState } = useActivity();
+
+return (
+  <BottomSheetRoot
+    open={
+      transitionState === "enter-active" || transitionState === "enter-done"
+    }
+    // [!code highlight]
+    modal
+    onOpenChange={(open) => !open && isActive && pop()}
+  >
+    {/* ... */}
+  </BottomSheetRoot>
+);
+```
+
+1. `modal`을 항상 `true`로 두어 위에 또 다른 modal Activity가 push되어도 Bottom Sheet의 backdrop layering이 끊기지 않도록 합니다.
+1. `onOpenChange`의 `isActive` 가드 덕분에 비활성 상태에서의 outside 상호작용으로 의도치 않게 `pop()`이 발생하지 않습니다.
+
+<Callout title="언제 `modal={isActive}`를 유지해야 하나요?">
+
+위에 push되는 Activity가 Bottom Sheet 영역까지 덮는 backdrop을 갖지 않는 일반 AppScreen이라면, 위 Activity의 스크롤 등 상호작용을 위해 `modal={isActive}` 가이드가 적합합니다. modal overlay 두 개가 stack되는 경우에 한해 `modal`을 항상 `true`로 두는 변형을 사용하세요.
+
+</Callout>
+
 ## Syncing BottomSheet State with a Step
 
 Bottom Sheet를 Activity로 만들 수 없는 경우, Bottom Sheet가 표시된 상태를 [Step](https://stackflow.so/docs/get-started/navigating-step)으로 만들 수 있습니다.

--- a/examples/stackflow-spa/src/activities/ActivityBottomSheetWithAlertDialogStep.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityBottomSheetWithAlertDialogStep.tsx
@@ -1,0 +1,120 @@
+import { Box, Portal, VStack } from "@seed-design/react";
+import { useActivityZIndexBase } from "@seed-design/stackflow";
+import { type StaticActivityComponentType } from "@stackflow/react/future";
+import { ActionButton } from "seed-design/ui/action-button";
+import {
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogRoot,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "seed-design/ui/alert-dialog";
+import { AppBar, AppBarBackButton, AppBarLeft, AppBarMain } from "seed-design/ui/app-bar";
+import { AppScreen, AppScreenContent } from "seed-design/ui/app-screen";
+import {
+  BottomSheetBody,
+  BottomSheetContent,
+  BottomSheetFooter,
+  BottomSheetRoot,
+  BottomSheetTrigger,
+} from "seed-design/ui/bottom-sheet";
+import { Callout } from "seed-design/ui/callout";
+import { useStepOverlay } from "seed-design/stackflow/use-step-overlay";
+
+declare module "@stackflow/config" {
+  interface Register {
+    ActivityBottomSheetWithAlertDialogStep: {
+      "bottom-sheet"?: "open";
+      "alert-dialog"?: "open";
+    };
+  }
+}
+
+const ActivityBottomSheetWithAlertDialogStep: StaticActivityComponentType<
+  "ActivityBottomSheetWithAlertDialogStep"
+> = () => {
+  const bottomSheet = useStepOverlay({ key: "bottom-sheet" });
+  const alertDialog = useStepOverlay({ key: "alert-dialog" });
+
+  return (
+    <AppScreen>
+      <AppBar>
+        <AppBarLeft>
+          <AppBarBackButton />
+        </AppBarLeft>
+        <AppBarMain title="BottomSheet × AlertDialog (Step)" />
+      </AppBar>
+      <AppScreenContent>
+        <VStack p="x5" gap="x4">
+          <Box px="spacingX.globalGutter">
+            <Callout
+              tone="neutral"
+              title="Step 패턴"
+              description="useStepOverlay로 BottomSheet step과 AlertDialog step을 한 Activity 안에서 동시에 사용합니다. BottomSheet 위에 AlertDialog를 얹은 상태에서 AlertDialog의 Backdrop이나 Content 빈 영역을 클릭해 동작을 관찰해보세요."
+            />
+          </Box>
+          <BottomSheetRoot {...bottomSheet.overlayProps}>
+            <BottomSheetTrigger asChild>
+              <ActionButton variant="neutralSolid" flexGrow>
+                Open BottomSheet
+              </ActionButton>
+            </BottomSheetTrigger>
+            <Portal>
+              <BottomSheetContent
+                showHandle
+                title="BottomSheet (step)"
+                description="이 BottomSheet 위에 AlertDialog를 얹어볼 수 있어요."
+                layerIndex={useActivityZIndexBase({ activityOffset: 1 })}
+                onPointerDownOutside={(e) => {
+                  // AlertDialog가 떠있는 동안 BottomSheet의 outside 발화는 무시한다.
+                  // AlertDialog는 closeOnInteractOutside=true이므로 자체적으로 닫히고,
+                  // BottomSheet만 닫히지 않도록 preventDefault.
+                  if (alertDialog.open) {
+                    e.preventDefault();
+                  }
+                }}
+              >
+                <BottomSheetBody>
+                  <AlertDialogRoot {...alertDialog.overlayProps} closeOnInteractOutside>
+                    <AlertDialogTrigger asChild>
+                      <ActionButton variant="neutralSolid" flexGrow>
+                        Open AlertDialog
+                      </ActionButton>
+                    </AlertDialogTrigger>
+                    <Portal>
+                      <AlertDialogContent layerIndex={useActivityZIndexBase({ activityOffset: 2 })}>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>제목</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            AlertDialog Backdrop 또는 Content 빈 영역을 클릭해 동작을 관찰해보세요.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <ActionButton
+                            variant="neutralSolid"
+                            onClick={() => alertDialog.setOpen(false)}
+                          >
+                            닫기
+                          </ActionButton>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </Portal>
+                  </AlertDialogRoot>
+                </BottomSheetBody>
+                <BottomSheetFooter>
+                  <ActionButton variant="neutralWeak" onClick={() => bottomSheet.setOpen(false)}>
+                    닫기
+                  </ActionButton>
+                </BottomSheetFooter>
+              </BottomSheetContent>
+            </Portal>
+          </BottomSheetRoot>
+        </VStack>
+      </AppScreenContent>
+    </AppScreen>
+  );
+};
+
+export default ActivityBottomSheetWithAlertDialogStep;

--- a/examples/stackflow-spa/src/activities/ActivityHome.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityHome.tsx
@@ -158,6 +158,14 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
           onClick: () => push("ActivityBottomSheetModalTest", {}),
         },
         {
+          title: "BottomSheet × AlertDialog (Step)",
+          onClick: () => push("ActivityBottomSheetWithAlertDialogStep", {}),
+        },
+        {
+          title: "BottomSheet × AlertDialog (Activity)",
+          onClick: () => push("ActivityNestedBottomSheet", {}),
+        },
+        {
           title: "MenuSheet",
           component: (
             <DialogPushTrigger

--- a/examples/stackflow-spa/src/activities/ActivityNestedBottomSheet.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityNestedBottomSheet.tsx
@@ -1,0 +1,62 @@
+import { VStack } from "@seed-design/react";
+import { useActivityZIndexBase } from "@seed-design/stackflow";
+import { useActivity, useFlow, type StaticActivityComponentType } from "@stackflow/react/future";
+import { ActionButton } from "seed-design/ui/action-button";
+import {
+  BottomSheetBody,
+  BottomSheetContent,
+  BottomSheetFooter,
+  BottomSheetRoot,
+} from "seed-design/ui/bottom-sheet";
+import { Callout } from "seed-design/ui/callout";
+
+declare module "@stackflow/config" {
+  interface Register {
+    ActivityNestedBottomSheet: {};
+  }
+}
+
+const ActivityNestedBottomSheet: StaticActivityComponentType<"ActivityNestedBottomSheet"> = () => {
+  const { pop, push } = useFlow();
+  const { isActive, transitionState } = useActivity();
+
+  const open = transitionState === "enter-active" || transitionState === "enter-done";
+  const onOpenChange = (next: boolean) => !next && isActive && pop();
+
+  return (
+    // 위에 AlertDialog Activity가 push되어 BottomSheet가 비활성(isActive=false)이 되더라도
+    // BottomSheet 자체의 modal 동작과 backdrop을 유지해 dim layering이 끊기지 않도록 modal을 항상 true로 둔다.
+    // outside close는 onOpenChange에서 isActive 가드로 막혀 비활성 상태에서는 pop이 발생하지 않는다.
+    <BottomSheetRoot open={open} onOpenChange={onOpenChange} modal>
+      <BottomSheetContent
+        showHandle
+        title="BottomSheet × AlertDialog (Activity)"
+        description="아래 버튼으로 AlertDialog Activity를 push해 위에 얹어보세요."
+        layerIndex={useActivityZIndexBase()}
+      >
+        <BottomSheetBody>
+          <Callout
+            tone="neutral"
+            description="Activity 패턴: BottomSheet가 자체 Activity로 떠 있고, 그 위에 AlertDialog Activity가 push되어 얹힙니다. 위에 떠 있는 AlertDialog의 Backdrop이나 Content 빈 영역을 클릭해 동작을 관찰해보세요."
+          />
+        </BottomSheetBody>
+        <BottomSheetFooter>
+          <VStack gap="x2">
+            <ActionButton
+              variant="neutralSolid"
+              flexGrow
+              onClick={() => push("ActivityAlertDialog", {})}
+            >
+              Open AlertDialog
+            </ActionButton>
+            <ActionButton variant="neutralWeak" onClick={pop}>
+              닫기
+            </ActionButton>
+          </VStack>
+        </BottomSheetFooter>
+      </BottomSheetContent>
+    </BottomSheetRoot>
+  );
+};
+
+export default ActivityNestedBottomSheet;

--- a/examples/stackflow-spa/src/stackflow/Stack.tsx
+++ b/examples/stackflow-spa/src/stackflow/Stack.tsx
@@ -49,6 +49,10 @@ export const { Stack, actions, stepActions } = stackflow({
     ActivityBottomSheetActivity: lazy(() => import("../activities/ActivityBottomSheetActivity")),
     ActivityBottomSheetModalTest: lazy(() => import("../activities/ActivityBottomSheetModalTest")),
     ActivityBottomSheetStep: lazy(() => import("../activities/ActivityBottomSheetStep")),
+    ActivityBottomSheetWithAlertDialogStep: lazy(
+      () => import("../activities/ActivityBottomSheetWithAlertDialogStep"),
+    ),
+    ActivityNestedBottomSheet: lazy(() => import("../activities/ActivityNestedBottomSheet")),
     ActivityCheckbox: lazy(() => import("../activities/ActivityCheckbox")),
     ActivityChipButton: lazy(() => import("../activities/ActivityChipButton")),
     ActivityChipToggle: lazy(() => import("../activities/ActivityChipToggle")),

--- a/examples/stackflow-spa/src/stackflow/stackflow.config.ts
+++ b/examples/stackflow-spa/src/stackflow/stackflow.config.ts
@@ -19,6 +19,11 @@ export const config = defineConfig({
     { route: "/bottom-sheet-step", name: "ActivityBottomSheetStep" },
     { route: "/bottom-sheet", name: "ActivityBottomSheet" },
     { route: "/bottom-sheet-modal-test", name: "ActivityBottomSheetModalTest" },
+    {
+      route: "/bottom-sheet-with-alert-dialog-step",
+      name: "ActivityBottomSheetWithAlertDialogStep",
+    },
+    { route: "/nested-bottom-sheet", name: "ActivityNestedBottomSheet" },
     { route: "/checkbox", name: "ActivityCheckbox" },
     { route: "/chip-button", name: "ActivityChipButton" },
     { route: "/chip-toggle", name: "ActivityChipToggle" },


### PR DESCRIPTION
## 요약

- Bottom Sheet Stackflow 가이드의 *Keeping Bottom Sheet Mounted* 섹션 아래에 **Stacking Another Modal Overlay on Top** 섹션을 추가했습니다. Bottom Sheet Activity 위에 자체 backdrop을 가진 또 다른 modal Activity가 push되는 경우, `modal={isActive}` 대신 `modal`을 항상 `true`로 두어 backdrop layering이 끊기지 않도록 안내합니다. 일반 AppScreen이 push되는 케이스를 위한 트레이드오프 콜아웃도 함께 제공합니다.
- 새 `ActivityNestedBottomSheet` (Activity 패턴: Bottom Sheet Activity → Alert Dialog Activity push)를 추가하고, 위 docs 섹션에 `<StackflowExample path="/nested-bottom-sheet">` 로 라이브 예시를 임베드했습니다.
- `ActivityBottomSheetWithAlertDialogStep` 은 Step 패턴 워크어라운드용 내부 reference로 추가했습니다. (docs에는 임베드하지 않음 — 사유는 아래 *왜* 섹션 참고.)

## 왜

외부 사용자 문의에서 두 가지가 함께 보고되었습니다.

1. **dim layering 이슈** (Activity 패턴): Bottom Sheet Activity 위에 Alert Dialog Activity를 push하면 dim이 의도와 다르게 보였습니다. 원인은 keep-mounted 권장 패턴인 `modal={isActive}` 가 Bottom Sheet 비활성 시점에 자체 backdrop을 떨어뜨리는 데 있었습니다. `modal` 을 항상 `true` 로 두면 backdrop layering이 유지되며, 기존 `onOpenChange` 의 `isActive` 가드가 비활성 상태에서의 의도치 않은 `pop()` 을 그대로 막아줍니다. 이번 PR에서 docs에 보강합니다.

2. **Step 패턴 outside-click chain reaction**: 같은 Activity 안에서 Bottom Sheet step 안에 Alert Dialog step을 nested로 띄울 때, DismissableLayer의 layer stack이 React Context로 전파되는데 Stackflow `pushStep` 은 두 step을 React tree 형제로 붙이기 때문에 Context가 단절되어 부모 Bottom Sheet가 자식 Alert Dialog 클릭을 outside로 잡습니다. 사용자 측 워크어라운드는 `if (childOverlay.open) e.preventDefault()` 한 줄이면 충분합니다. **이 케이스는 의도적으로 docs에 추가하지 않았습니다.** 이유는 Step-안의-Step 패턴 자체를 정식 추천하는 신호로 받아들여질 수 있고, docs는 이미 “Activity로 만들 수 없을 때만” Step 패턴을 권장하고 있기 때문입니다. 대신 examples에 시연 화면만 두고 1:1 회신 시 reference로만 활용합니다.

## 테스트 플랜

- [x] `bun docs:test` 통과 (post-edit hook 검증)
- [x] `bun --filter @seed-design/stackflow-spa build` 통과
- [ ] 시각 검증: `bun --filter @seed-design/docs dev` → `/react/stackflow/bottom-sheet` 페이지에서 새 섹션과 `[!code highlight]` 의 `modal` 라인 강조, 그리고 임베드된 `/nested-bottom-sheet` 예시가 정상 동작
- [ ] 시각 검증: `bun --filter @seed-design/stackflow-spa dev` → Home → "BottomSheet × AlertDialog (Activity)" 진입 → Alert Dialog Activity push 후 Bottom Sheet 영역까지 dim이 단단히 깔리는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)