### PR TITLE
fix(lynx): recipe 타입 경계 정리

### DIFF
--- a/packages/qvism-preset/src/recipes/lynx/action-button.ts
+++ b/packages/qvism-preset/src/recipes/lynx/action-button.ts
@@ -3,29 +3,11 @@ import { actionButton as vars } from "../../vars/component";
 import { defineLynxSlotRecipe } from "../../utils/define-lynx";
 
 /**
- * ActionButton recipe (Lynx fork).
+ * Lynx-전용 ActionButton recipe.
  *
- * Derived from the web `action-button` recipe with these changes for Lynx:
- * - **Slot-recipe shape** (`root`/`text`/`prefixIcon`/`suffixIcon`).
- * - **`prefixIcon`/`suffixIcon` 슬롯에 `color: var(--seed-color-...)` 만 지정한다.**
- *   Lynx 3.7 의 `<image>` 는 `tint-color` CSS property 도 `tint-color` attribute
- *   에서 `var()` 스트링도 해석하지 않는다. concrete color(hex/rgb) 만 받는다.
- *   대신 `<image>` 의 CSS `color` 값은 main-thread API `getComputedStyleProperty("color")`
- *   로 resolved hex 를 읽어올 수 있다 (POC D 에서 검증).
- *   따라서 recipe 는 slot 에 `color` 만 박고, React 쪽
- *   `ActionButton.PrefixIcon`/`SuffixIcon` 에서 `useIconColor` 훅이 main-thread 로
- *   가 `color` 를 읽어 `tint-color` attribute 로 mirror 하는 방식으로 처리한다.
- * - 슬롯에 width/height/flexShrink 만 남겨 아이콘 크기는 CSS 로 결정한다.
- * - `pressed` / `disabled` / `loading` boolean variants replace the web's
- *   pseudo selectors (`:active`, `:disabled`, etc.). Lynx 는 native form pseudo
- *   가 없으므로 컴포넌트 런타임에서 boolean prop 으로 직접 상태를 전달한다.
- * - No focus-ring / `:focusVisible` — Lynx has no keyboard focus UX.
- * - No `iconOnly` / `loading` icon styles yet. `layout: "iconOnly"` and
- *   `loading` spinner remain Tier B (pending dedicated icon slots).
- * - `ghost` variant drops the `--seed-box-color` indirection since Lynx does
- *   not cascade CSS variables down to descendants the same way.
- * - `progressCircle` track/range custom properties preserved so the `loading`
- *   spinner component can opt in once implemented.
+ * `pressed`, `disabled`, `loading` 상태는 boolean variant로 받아 slot별 className
+ * 조합으로 반영한다. 아이콘 slot은 `useIconColor`가 resolved color를 native tint로
+ * mirror할 수 있도록 color만 가진다.
  */
 const actionButton = defineLynxSlotRecipe({
   name: "action-button",

--- a/packages/qvism-preset/src/recipes/lynx/bottom-sheet-handle.ts
+++ b/packages/qvism-preset/src/recipes/lynx/bottom-sheet-handle.ts
@@ -2,11 +2,9 @@ import { defineLynxSlotRecipe } from "../../utils/define-lynx";
 import { bottomSheetHandle as handleVars } from "../../vars/component";
 
 /**
- * BottomSheet handle recipe (Lynx fork).
+ * Lynx-전용 BottomSheet handle recipe.
  *
- * Identical in spirit to the web recipe but stripped of CSS features Lynx
- * does not support (CSS `transition`, pseudo-class hover, etc.). Pressed-state
- * feedback is driven by lynx-ui-sheet's touch handlers, not CSS `:active`.
+ * handle과 touch area의 정적 geometry만 제공한다.
  */
 const bottomSheetHandle = defineLynxSlotRecipe({
   name: "bottom-sheet-handle",

--- a/packages/qvism-preset/src/recipes/lynx/bottom-sheet.ts
+++ b/packages/qvism-preset/src/recipes/lynx/bottom-sheet.ts
@@ -2,19 +2,10 @@ import { defineLynxSlotRecipe } from "../../utils/define-lynx";
 import { bottomSheet as vars } from "../../vars/component";
 
 /**
- * BottomSheet recipe (Lynx fork).
+ * Lynx-전용 BottomSheet recipe.
  *
- * Derived from the web `bottom-sheet` recipe but pruned for Lynx runtime:
- * - No `[data-snap-points]` / `[data-open]` attribute selectors (Lynx only
- *   supports class-based selectors). Backdrop opacity and content transform
- *   are driven entirely by `@lynx-js/lynx-ui-sheet` via main-thread worklets.
- * - No `::after` pseudo-element (unsupported in Lynx) — the web rule extends
- *   content background below the viewport to hide bounce-back. Not needed on
- *   Lynx because there is no native rubber-band scroll beneath the sheet.
- * - No `animation-name` / `animation-duration`. Open/close/snap animations are
- *   tweened by lynx-ui-sheet's motion engine, not CSS keyframes.
- * - No `focus` / `focusVisible` outline — Lynx has no keyboard focus UX.
- *   `closeButton` slot is retained for future Tier B SVG support.
+ * 정적 layout/surface/typography 스타일만 className으로 제공하고, backdrop/content
+ * motion은 `@lynx-js/lynx-ui-sheet`의 main-thread worklet이 직접 구동한다.
  */
 const bottomSheet = defineLynxSlotRecipe({
   name: "bottom-sheet",

--- a/packages/qvism-preset/src/recipes/lynx/checkmark.ts
+++ b/packages/qvism-preset/src/recipes/lynx/checkmark.ts
@@ -4,14 +4,9 @@ import { defineLynxSlotRecipe } from "../../utils/define-lynx";
 /**
  * Lynx-전용 checkmark recipe.
  *
- * 웹 recipe (`../checkmark.ts`) 가 `pseudo(checked)` / `pseudo(disabled)` 등 CSS
- * pseudo selector 기반으로 상태를 표현하는 반면, Lynx 는 native form 이 없어 pseudo
- * 를 직접 사용할 수 없다. 대신 boolean variants (`checked`, `disabled`,
- * `indeterminate`) 로 상태를 일급 노출한다. 컴포넌트 런타임에서 prop 값을 그대로
- * 넘기면 `StringToBoolean` 을 통해 타입 캐스팅 없이 compile 된다.
- *
- * variant=square: 박스 + 체크 아이콘. unchecked 시 아이콘 숨김.
- * variant=ghost: 박스 없음, 항상 아이콘 표시. selected 시 tone 색상으로 강조.
+ * `checked`, `disabled`, `indeterminate`, `pressed` 상태를 boolean variant로 받아
+ * className 조합으로 반영한다. square는 박스와 아이콘을 함께 그리고, ghost는
+ * 아이콘 색상만 상태에 맞게 바꾼다.
  */
 const checkmarkRecipe = defineLynxSlotRecipe({
   name: "checkmark",

--- a/packages/qvism-preset/src/recipes/lynx/radiomark.ts
+++ b/packages/qvism-preset/src/recipes/lynx/radiomark.ts
@@ -4,10 +4,8 @@ import { defineLynxSlotRecipe } from "../../utils/define-lynx";
 /**
  * Lynx-전용 radiomark recipe.
  *
- * 웹 recipe (`../radiomark.ts`) 가 `pseudo(checked)` / `pseudo(disabled)` 기반인 것과
- * 달리, Lynx 는 `checked` / `disabled` 를 boolean variants 로 일급 노출한다.
- * 런타임에서 prop 값을 그대로 넘기면 `StringToBoolean` 을 통해 타입 캐스팅 없이
- * compile 된다.
+ * `checked`, `disabled`, `pressed` 상태를 boolean variant로 받아 className 조합으로
+ * 반영한다.
  */
 const radiomarkRecipe = defineLynxSlotRecipe({
   name: "radiomark",

--- a/packages/qvism-preset/src/utils/define-lynx.ts
+++ b/packages/qvism-preset/src/utils/define-lynx.ts
@@ -1,29 +1,29 @@
 import type { CSSProperties as LynxCss } from "@lynx-js/types";
 import type {
-  AnySelector,
-  CssVarProperties,
   RecipeDefinition,
   RecipeVariantRecord,
-  Selectors,
   SlotRecipeDefinition,
   SlotRecipeVariantRecord,
 } from "@seed-design/qvism-core";
 
-type LynxStyleProperties = LynxCss & CssVarProperties;
+type CssVarRef = `var(--${string})`;
+type CssVarKey = `--${string}`;
 
-type LynxNested<P> = P & {
-  [K in Selectors]?: LynxNested<P>;
+type LynxStyleProperties = {
+  [K in keyof LynxCss]: LynxCss[K] | CssVarRef;
 } & {
-  [K in AnySelector]?: LynxNested<P>;
+  [K in CssVarKey]?: string;
 };
 
 /**
  * Style object constrained to properties/values that the Lynx view engine
  * actually supports. Derived from `@lynx-js/types` `CSSProperties`, so keys
  * like `inline-*` display values or `verticalAlign` are unavailable at
- * compile time — unlike the web `StyleObject` which accepts them.
+ * compile time. Unlike the web style object, selector nesting is intentionally
+ * omitted so state styles are modeled as recipe variants and emitted as
+ * className combinations.
  */
-export type LynxStyleObject = LynxNested<LynxStyleProperties>;
+export type LynxStyleObject = LynxStyleProperties;
 
 type LynxSlotRecord<S extends string> = Partial<Record<S, LynxStyleObject>>;
 


### PR DESCRIPTION
## 요약

- Lynx recipe style 타입에서 CSS variable reference(`var(--*)`)를 허용해 fontWeight 토큰 타입 오류를 수정했습니다.
- Lynx recipe style object에서 selector nesting을 제거해 pseudo/data selector 대신 variant className 조합을 사용하도록 타입 경계를 좁혔습니다.
- checkbox recipe 기준에 맞춰 다른 Lynx recipe의 과한 pseudo/data selector 설명 주석을 정리했습니다.

## 검증

- `bun generate:all`
- `bun --filter @seed-design/qvism-preset typecheck`
- `bun --filter @seed-design/qvism-preset build`
- `bun --filter @seed-design/lynx-react test`
- `bun --filter @seed-design/lynx-react build`
- Lynx generated recipe 전수 확인: variant별 className 생성 정상, generated CSS의 pseudo/data selector 0건

## 참고

- `bun test:all`은 711개 테스트 통과 후 `examples/lynx-spa/src/__tests__/index.test.tsx`에서 `react/jsx-dev-runtime` 모듈을 찾지 못해 1건 실패했습니다. 이번 변경 파일과는 별개의 예제 패키지 의존성 해석 문제로 보입니다.
