### PR TITLE
feat(lynx-spa): 테마 예제 액티비티 확장

### DIFF
--- a/examples/lynx-spa/src/__tests__/index.test.tsx
+++ b/examples/lynx-spa/src/__tests__/index.test.tsx
@@ -1,13 +1,22 @@
-// Copyright 2024 The Lynx Authors. All rights reserved.
-// Licensed under the Apache License Version 2.0 that can be found in the
-// LICENSE file in the root directory of this source tree.
+/** @jsxImportSource @lynx-js/react */
 import '@testing-library/jest-dom';
+import { getQueriesForElement, render } from '@lynx-js/react/testing-library';
 import { expect, test, vi } from 'vitest';
-import { render, getQueriesForElement } from '@lynx-js/react/testing-library';
 
 import { App } from '../App.jsx';
+import { ThemingPage } from '../pages/ThemingPage.jsx';
 
-test('App', async () => {
+function getRenderedQueries() {
+  const root = elementTree.root;
+
+  if (!root) {
+    throw new Error('Expected Lynx render root to exist.');
+  }
+
+  return getQueriesForElement(root);
+}
+
+test('App renders the current Lynx catalog home', async () => {
   const cb = vi.fn();
 
   render(
@@ -17,6 +26,7 @@ test('App', async () => {
       }}
     />,
   );
+
   expect(cb).toBeCalledTimes(1);
   expect(cb.mock.calls).toMatchInlineSnapshot(`
     [
@@ -25,76 +35,22 @@ test('App', async () => {
       ],
     ]
   `);
-  expect(elementTree.root).toMatchInlineSnapshot(`
-    <page>
-      <view>
-        <view
-          class="Background"
-        />
-        <view
-          class="App"
-        >
-          <view
-            class="Banner"
-          >
-            <view
-              class="Logo"
-            >
-              <image
-                class="Logo--lynx"
-                src="/src/assets/lynx-logo.png"
-              />
-            </view>
-            <text
-              class="Title"
-            >
-              React
-            </text>
-            <text
-              class="Subtitle"
-            >
-              on Lynx
-            </text>
-          </view>
-          <view
-            class="Content"
-          >
-            <image
-              class="Arrow"
-              src="/src/assets/arrow.png"
-            />
-            <text
-              class="Description"
-            >
-              Tap the logo and have fun!
-            </text>
-            <text
-              class="Hint"
-            >
-              Edit
-              <text
-                style="font-style:italic;color:rgba(255, 255, 255, 0.85)"
-              >
-                 src/App.tsx 
-              </text>
-              to see updates!
-            </text>
-          </view>
-          <view
-            style="flex:1"
-          />
-        </view>
-      </view>
-    </page>
-  `);
-  const { findByText } = getQueriesForElement(elementTree.root!);
-  const element = await findByText('Tap the logo and have fun!');
-  expect(element).toBeInTheDocument();
-  expect(element).toMatchInlineSnapshot(`
-    <text
-      class="Description"
-    >
-      Tap the logo and have fun!
-    </text>
-  `);
+
+  const { findByText } = getRenderedQueries();
+
+  expect(await findByText('SEED Design Lynx Catalog')).toBeInTheDocument();
+  expect(await findByText('Getting Started')).toBeInTheDocument();
+  expect(await findByText('Theming')).toBeInTheDocument();
+});
+
+test('ThemingPage renders class-based theme examples', async () => {
+  render(<ThemingPage />);
+
+  const { findByText } = getRenderedQueries();
+
+  expect(await findByText('getSeedClassName()')).toBeInTheDocument();
+  expect(await findByText('Theme Overrides')).toBeInTheDocument();
+  expect(await findByText('Light only')).toBeInTheDocument();
+  expect(await findByText('Dark only')).toBeInTheDocument();
+  expect(await findByText('Tailwind Tokens')).toBeInTheDocument();
 });

--- a/examples/lynx-spa/src/pages/HomePage.tsx
+++ b/examples/lynx-spa/src/pages/HomePage.tsx
@@ -64,6 +64,9 @@ export function HomePage({ navigate }: { navigate: (page: Page) => void }) {
         SEED Design Lynx Catalog
       </text>
 
+      <SectionHeader>Getting Started</SectionHeader>
+      <ListItem title="Theming" onTap={() => navigate('theming')} />
+
       <SectionHeader>Foundation</SectionHeader>
       <ListItem title="Color" onTap={() => navigate('foundation-color')} />
       <ListItem
@@ -109,7 +112,6 @@ export function HomePage({ navigate }: { navigate: (page: Page) => void }) {
       />
 
       <SectionHeader>Test</SectionHeader>
-      <ListItem title="Theming" onTap={() => navigate('theming')} />
       <ListItem
         title="Nested Vars Test (Lynx 3.6+)"
         onTap={() => navigate('nested-vars-test')}

--- a/examples/lynx-spa/src/pages/ThemingPage.tsx
+++ b/examples/lynx-spa/src/pages/ThemingPage.tsx
@@ -1,71 +1,311 @@
-import { ActionButton, getSeedClassName } from "@seed-design/lynx-react";
-import { vars } from "@seed-design/lynx-css/vars";
+import { vars } from '@seed-design/lynx-css/vars';
+import { getSeedClassName } from '@seed-design/lynx-react';
+
+import { ActionButton } from '../seed-design/ui/action-button';
 
 const { $color } = vars;
 
+type ColorMode = 'system' | 'light-only' | 'dark-only';
+
+type LynxRuntime = typeof globalThis & {
+  lynx?: {
+    __globalProps?: Record<string, unknown> | null;
+  };
+  SystemInfo?: {
+    platform?: string;
+  };
+};
+
+const runtime = globalThis as LynxRuntime;
+
+function getGlobalProps() {
+  return runtime.lynx?.__globalProps ?? {};
+}
+
+function getRuntimePlatform() {
+  return runtime.SystemInfo?.platform ?? 'unknown';
+}
+
+function getFallbackSeedClassName(colorMode: ColorMode) {
+  const systemTheme = String(getGlobalProps().theme ?? '').toLowerCase();
+  const resolvedTheme =
+    colorMode === 'dark-only' ||
+    (colorMode === 'system' && systemTheme === 'dark')
+      ? 'dark'
+      : 'light';
+  const platformClass =
+    getRuntimePlatform() === 'iOS'
+      ? 'seed-platform-ios'
+      : 'seed-platform-android';
+
+  return `seed-user-color-scheme-${resolvedTheme} ${platformClass}`;
+}
+
+function getSafeSeedClassName(colorMode: ColorMode) {
+  try {
+    return getSeedClassName({ colorMode });
+  } catch {
+    return getFallbackSeedClassName(colorMode);
+  }
+}
+
+function SectionTitle({ children }: { children: string }) {
+  return (
+    <text
+      style={{
+        fontSize: '16px',
+        fontWeight: 'bold',
+        marginTop: '16px',
+        marginBottom: '8px',
+        color: $color.fg.neutral,
+      }}
+    >
+      {children}
+    </text>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '2px',
+      }}
+    >
+      <text style={{ fontSize: '12px', color: $color.fg.neutralSubtle }}>
+        {label}
+      </text>
+      <text style={{ fontSize: '13px', color: $color.fg.neutral }}>
+        {value}
+      </text>
+    </view>
+  );
+}
+
+function TokenLine({ name, value }: { name: string; value: string }) {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: '8px',
+      }}
+    >
+      <view
+        style={{
+          width: '20px',
+          height: '20px',
+          borderRadius: '4px',
+          borderWidth: '1px',
+          borderColor: $color.stroke.neutralMuted,
+          backgroundColor: value,
+        }}
+      />
+      <text style={{ fontSize: '12px', color: $color.fg.neutralMuted }}>
+        {name}
+      </text>
+    </view>
+  );
+}
+
+function ThemeSurface({
+  title,
+  description,
+  className,
+}: {
+  title: string;
+  description: string;
+  className?: string;
+}) {
+  return (
+    <view
+      className={className}
+      style={{
+        padding: '12px',
+        borderRadius: '8px',
+        borderWidth: '1px',
+        borderColor: $color.stroke.neutralMuted,
+        backgroundColor: $color.bg.layerDefault,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '10px',
+      }}
+    >
+      <view style={{ display: 'flex', flexDirection: 'column', gap: '3px' }}>
+        <text
+          style={{
+            fontSize: '14px',
+            fontWeight: 'bold',
+            color: $color.fg.neutral,
+          }}
+        >
+          {title}
+        </text>
+        <text style={{ fontSize: '12px', color: $color.fg.neutralSubtle }}>
+          {description}
+        </text>
+      </view>
+
+      <view
+        style={{
+          padding: '10px',
+          borderRadius: '6px',
+          backgroundColor: $color.bg.neutralWeak,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '6px',
+        }}
+      >
+        <text style={{ fontSize: '13px', color: $color.fg.neutral }}>
+          CSS variables inherit through this surface.
+        </text>
+        <TokenLine name="bg.neutralWeak" value={$color.bg.neutralWeak} />
+        <TokenLine name="fg.neutral" value={$color.fg.neutral} />
+        <TokenLine
+          name="stroke.neutralMuted"
+          value={$color.stroke.neutralMuted}
+        />
+      </view>
+
+      <view
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          flexWrap: 'wrap',
+          gap: '8px',
+        }}
+      >
+        <ActionButton size="small" variant="brandSolid">
+          Brand
+        </ActionButton>
+        <ActionButton size="small" variant="neutralWeak">
+          Neutral
+        </ActionButton>
+      </view>
+    </view>
+  );
+}
+
+function TailwindTokenPreview({ className }: { className?: string }) {
+  return (
+    <view
+      className={className}
+      style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}
+    >
+      <view className="bg-bg-layer-default border border-stroke-neutral-muted rounded-lg p-3">
+        <text className="t4-bold text-fg-neutral">Tailwind token surface</text>
+        <text className="t3-regular text-fg-neutral-subtle">
+          bg-bg-layer-default / text-fg-neutral / border-stroke-neutral-muted
+        </text>
+      </view>
+      <view className="bg-bg-brand-weak rounded-lg p-3">
+        <text className="t4-regular text-fg-brand">
+          Theme-aware Tailwind brand token
+        </text>
+      </view>
+    </view>
+  );
+}
+
 export function ThemingPage() {
-  const globalProps = lynx?.__globalProps as Record<string, unknown> | undefined;
-  const systemTheme = (globalProps?.theme as string) ?? "unknown";
-  const frontendTheme = (globalProps?.frontendTheme as string) ?? "unknown";
-  const seedClassName = getSeedClassName({ colorMode: "system" });
+  const globalProps = getGlobalProps();
+  const systemTheme = String(globalProps.theme ?? 'unknown');
+  const frontendTheme = String(globalProps.frontendTheme ?? 'unknown');
+  const platform = getRuntimePlatform();
 
   return (
     <scroll-view
       scroll-y
-      style={{ display: "flex", flexDirection: "column", gap: "12px", flex: 1 }}
+      style={{ display: 'flex', flexDirection: 'column', gap: '12px', flex: 1 }}
     >
-      <text style={{ fontSize: "20px", fontWeight: "bold" }}>Theming</text>
+      <text
+        style={{
+          fontSize: '20px',
+          fontWeight: 'bold',
+          color: $color.fg.neutral,
+        }}
+      >
+        Theming
+      </text>
+      <text style={{ fontSize: '13px', color: $color.fg.neutralSubtle }}>
+        Class-based SEED theme tokens for Lynx.
+      </text>
 
       <view
         style={{
-          padding: "12px",
+          padding: '12px',
           backgroundColor: $color.bg.neutralWeak,
-          borderRadius: "8px",
-          display: "flex",
-          flexDirection: "column",
-          gap: "6px",
+          borderRadius: '8px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '10px',
         }}
       >
-        <text style={{ fontSize: "14px", fontWeight: "bold", color: $color.fg.neutral }}>
-          Environment
+        <text
+          style={{
+            fontSize: '14px',
+            fontWeight: 'bold',
+            color: $color.fg.neutral,
+          }}
+        >
+          Runtime
         </text>
-        <text style={{ fontSize: "13px", color: $color.fg.neutralMuted }}>
-          systemTheme (device): "{systemTheme}"
-        </text>
-        <text style={{ fontSize: "13px", color: $color.fg.neutralMuted }}>
-          frontendTheme (app): "{frontendTheme}"
-        </text>
-        <text style={{ fontSize: "13px", color: $color.fg.neutralMuted }}>
-          Applied class: "{seedClassName}"
-        </text>
+        <InfoRow label="lynx.__globalProps.theme" value={systemTheme} />
+        <InfoRow
+          label="lynx.__globalProps.frontendTheme"
+          value={frontendTheme}
+        />
+        <InfoRow label="SystemInfo.platform" value={platform} />
       </view>
 
-      <text style={{ fontSize: "16px", fontWeight: "bold", marginTop: "8px" }}>Theme Preview</text>
+      <SectionTitle>getSeedClassName()</SectionTitle>
       <view
         style={{
-          display: "flex",
-          flexDirection: "row",
-          flexWrap: "wrap",
-          gap: "8px",
+          padding: '12px',
+          borderRadius: '8px',
+          borderWidth: '1px',
+          borderColor: $color.stroke.neutralMuted,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '8px',
         }}
       >
-        <ActionButton variant="brandSolid">Brand Solid</ActionButton>
-        <ActionButton variant="neutralSolid">Neutral Solid</ActionButton>
-        <ActionButton variant="neutralWeak">Neutral Weak</ActionButton>
-        <ActionButton variant="criticalSolid">Critical Solid</ActionButton>
+        <InfoRow
+          label='colorMode: "system"'
+          value={getSafeSeedClassName('system')}
+        />
+        <InfoRow
+          label='colorMode: "light-only"'
+          value={getSafeSeedClassName('light-only')}
+        />
+        <InfoRow
+          label='colorMode: "dark-only"'
+          value={getSafeSeedClassName('dark-only')}
+        />
       </view>
-      <view
-        style={{
-          display: "flex",
-          flexDirection: "row",
-          flexWrap: "wrap",
-          gap: "8px",
-        }}
-      >
-        <ActionButton variant="brandOutline">Brand Outline</ActionButton>
-        <ActionButton variant="neutralOutline">Neutral Outline</ActionButton>
-        <ActionButton variant="ghost">Ghost</ActionButton>
-      </view>
+
+      <SectionTitle>Theme Overrides</SectionTitle>
+      <ThemeSurface
+        title="Global theme"
+        description="No override class. Follows the page theme."
+      />
+      <ThemeSurface
+        title="Light only"
+        description="Uses seed-color-mode-light-only on this subtree."
+        className="seed-color-mode-light-only"
+      />
+      <ThemeSurface
+        title="Dark only"
+        description="Uses seed-color-mode-dark-only on this subtree."
+        className="seed-color-mode-dark-only"
+      />
+
+      <SectionTitle>Tailwind Tokens</SectionTitle>
+      <TailwindTokenPreview />
+      <TailwindTokenPreview className="seed-color-mode-dark-only" />
     </scroll-view>
   );
 }


### PR DESCRIPTION
## Summary

- `examples/lynx-spa`의 Theming activity를 Lynx theming 문서 흐름에 맞춰 재구성했습니다.
- `getSeedClassName()` 결과, 현재 Lynx theme/platform 런타임 정보, system/light-only/dark-only override 영역을 화면에서 확인할 수 있게 했습니다.
- Home의 `Theming` 항목을 `Getting Started` 섹션으로 이동하고, 현재 Home/Theming 기준 smoke test로 갱신했습니다.

## Notes

- `lynx-compat` 및 `packages/lynx-css` 변경은 포함하지 않았습니다.
- CSS variable이 안 먹던 현상은 Lynx Explorer 버전 차이로 확인되어, compat 패치 대신 Explorer 3.7 이상에서 확인하는 방향으로 정리했습니다.

## Test Plan

- [x] `git diff --check`
- [x] `bun generate:all`
- [x] `cd examples/lynx-spa && bun run build`
- [ ] `cd examples/lynx-spa && bun run test` - 기존 의존성 해석 문제로 collection 전에 실패합니다: `Cannot find package 'preact' imported from @lynx-js/internal-preact/jsx-runtime/dist/jsxRuntime.mjs`