### PR TITLE
feat(lynx-spa): unify component variant catalog

### DIFF
--- a/examples/lynx-spa/src/App.tsx
+++ b/examples/lynx-spa/src/App.tsx
@@ -64,10 +64,17 @@ function BackButton({ onBack }: { onBack: () => void }) {
   );
 }
 
-// VariantPlayground 를 쓰는 카탈로그 페이지들은 scroll-view 루트 대신 flex column
-// fullscreen shell 을 사용한다. preview 가 남은 공간을 flex:1 로 점유하고 controls 가
-// 하단 고정되려면 부모가 scroll-view 가 아니어야 함.
-const CATALOG_PAGES = new Set<Page>(['checkbox', 'radio-group']);
+// Variant catalog pages use a fullscreen flex shell so previews, tabs, and
+// controls can own their own scroll areas.
+const CATALOG_PAGES = new Set<Page>([
+  'action-button',
+  'bottom-sheet',
+  'checkbox',
+  'progress-circle',
+  'radio-group',
+  'switch',
+  'tag-group',
+]);
 
 export function App(props: { onRender?: () => void }) {
   const [currentPage, setCurrentPage] = useState<Page>('home');
@@ -87,8 +94,13 @@ export function App(props: { onRender?: () => void }) {
         <view style={{ paddingLeft: '16px', paddingRight: '16px' }}>
           <BackButton onBack={() => setCurrentPage('home')} />
         </view>
+        {currentPage === 'action-button' && <ActionButtonPage />}
+        {currentPage === 'bottom-sheet' && <BottomSheetPage />}
         {currentPage === 'checkbox' && <CheckboxPage />}
+        {currentPage === 'progress-circle' && <ProgressCirclePage />}
         {currentPage === 'radio-group' && <RadioGroupPage />}
+        {currentPage === 'switch' && <SwitchPage />}
+        {currentPage === 'tag-group' && <TagGroupPage />}
         <Suspense>
           <LynxConsole theme="light" />
         </Suspense>
@@ -113,11 +125,6 @@ export function App(props: { onRender?: () => void }) {
       )}
       {currentPage === 'home' && <HomePage navigate={setCurrentPage} />}
       {currentPage === 'theming' && <ThemingPage />}
-      {currentPage === 'action-button' && <ActionButtonPage />}
-      {currentPage === 'bottom-sheet' && <BottomSheetPage />}
-      {currentPage === 'progress-circle' && <ProgressCirclePage />}
-      {currentPage === 'switch' && <SwitchPage />}
-      {currentPage === 'tag-group' && <TagGroupPage />}
       {currentPage === 'nested-vars-test' && <NestedVarsTestPage />}
       {currentPage === 'foundation-color' && <FoundationColorPage />}
       {currentPage === 'foundation-monochrome-icon' && (

--- a/examples/lynx-spa/src/components/catalog-examples.tsx
+++ b/examples/lynx-spa/src/components/catalog-examples.tsx
@@ -1,0 +1,54 @@
+import { type ReactNode } from '@lynx-js/react';
+import { vars } from '@seed-design/lynx-css/vars';
+
+const { $color } = vars;
+
+export function CatalogExamples({
+  title,
+  gap,
+  children,
+}: {
+  title: string;
+  gap?: string;
+  children: ReactNode;
+}) {
+  return (
+    <scroll-view
+      scroll-y
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        padding: '16px',
+        ...(gap == null ? {} : { gap }),
+      }}
+    >
+      <text style={{ fontSize: '20px', fontWeight: 'bold' }}>{title}</text>
+      {children}
+    </scroll-view>
+  );
+}
+
+export function CatalogSectionTitle({ children }: { children: string }) {
+  return (
+    <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>
+      {children}
+    </text>
+  );
+}
+
+export function CatalogSectionHeader({ children }: { children: string }) {
+  return (
+    <text
+      style={{
+        fontSize: '14px',
+        fontWeight: 'bold',
+        marginTop: '16px',
+        marginBottom: '8px',
+        color: $color.fg.neutralSubtle,
+      }}
+    >
+      {children}
+    </text>
+  );
+}

--- a/examples/lynx-spa/src/components/variant-catalog.tsx
+++ b/examples/lynx-spa/src/components/variant-catalog.tsx
@@ -1,9 +1,8 @@
 import { type ReactNode, useState } from '@lynx-js/react';
 
 import {
-  VariantPlayground,
   type SetVariantValue,
-  type VariantAxis,
+  VariantPlayground,
   type VariantPlaygroundProps,
   type VariantValues,
 } from './variant-playground.jsx';

--- a/examples/lynx-spa/src/components/variant-catalog.tsx
+++ b/examples/lynx-spa/src/components/variant-catalog.tsx
@@ -2,26 +2,42 @@ import { type ReactNode, useState } from '@lynx-js/react';
 
 import {
   VariantPlayground,
+  type SetVariantValue,
+  type VariantAxis,
   type VariantPlaygroundProps,
+  type VariantValues,
 } from './variant-playground.jsx';
 import { VariantTable } from './variant-table.jsx';
 
-type PrimitiveValue = string | number | boolean;
-type Mode = 'playground' | 'table';
+export type {
+  PrimitiveValue,
+  SetVariantValue,
+  VariantAxis,
+  VariantValues,
+} from './variant-playground.jsx';
 
-export interface VariantCatalogProps extends VariantPlaygroundProps {}
+type Mode = 'playground' | 'table' | 'examples';
+
+export interface VariantCatalogProps extends VariantPlaygroundProps {
+  examples?: ReactNode;
+}
 
 /**
- * 컴포넌트 카탈로그 페이지의 두 가지 뷰를 탭으로 전환한다.
+ * 컴포넌트 카탈로그 페이지의 뷰를 탭으로 전환한다.
  *
  * - Playground: 변수 하나하나를 선택하며 단일 미리보기 (디테일 검사)
- * - Table: 모든 조합을 매트릭스로 나열 (전체 형태 비교)
+ * - Table: variant 축 하나씩 펼쳐 빠르게 비교 (나머지는 default 고정)
+ * - Examples: 사용 시나리오 중심 수동 예시
  *
  * 두 모드 모두 같은 `children` render function 을 공유한다.
  */
 export function VariantCatalog(props: VariantCatalogProps) {
-  const { children, ...rest } = props;
+  const { children, variants, examples } = props;
   const [mode, setMode] = useState<Mode>('playground');
+  const tabs: Mode[] =
+    examples == null
+      ? ['playground', 'table']
+      : ['playground', 'table', 'examples'];
 
   return (
     <view
@@ -44,23 +60,24 @@ export function VariantCatalog(props: VariantCatalogProps) {
           borderBottomColor: '#e5e5e5',
         }}
       >
-        <TabButton
-          active={mode === 'playground'}
-          onTap={() => setMode('playground')}
-          label="Playground"
-        />
-        <TabButton
-          active={mode === 'table'}
-          onTap={() => setMode('table')}
-          label="Table"
-        />
+        {tabs.map((tab) => (
+          <TabButton
+            key={tab}
+            active={mode === tab}
+            width={`${100 / tabs.length}%`}
+            onTap={() => setMode(tab)}
+            label={toTabLabel(tab)}
+          />
+        ))}
       </view>
       {mode === 'playground' ? (
-        <VariantPlayground {...rest}>{children}</VariantPlayground>
-      ) : (
-        <VariantTable variantMaps={props.variantMaps}>
-          {(combo) => renderForTable(children, combo)}
+        <VariantPlayground variants={variants}>{children}</VariantPlayground>
+      ) : mode === 'table' ? (
+        <VariantTable variants={variants}>
+          {(values) => renderForTable(children, values)}
         </VariantTable>
+      ) : (
+        <view style={{ flex: 1, minHeight: 0 }}>{examples}</view>
       )}
     </view>
   );
@@ -69,17 +86,25 @@ export function VariantCatalog(props: VariantCatalogProps) {
 const noopSetValue = () => {};
 function renderForTable(
   children: VariantPlaygroundProps['children'],
-  combo: Record<string, PrimitiveValue>,
+  values: VariantValues,
 ): ReactNode {
-  return children(combo, noopSetValue);
+  return children(values, noopSetValue as SetVariantValue);
+}
+
+function toTabLabel(mode: Mode) {
+  if (mode === 'playground') return 'Playground';
+  if (mode === 'table') return 'Table';
+  return 'Examples';
 }
 
 function TabButton({
   active,
+  width,
   onTap,
   label,
 }: {
   active: boolean;
+  width: string;
   onTap: () => void;
   label: string;
 }) {
@@ -87,7 +112,7 @@ function TabButton({
     <view
       bindtap={onTap}
       style={{
-        width: '50%',
+        width,
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',

--- a/examples/lynx-spa/src/components/variant-catalog.tsx
+++ b/examples/lynx-spa/src/components/variant-catalog.tsx
@@ -83,12 +83,12 @@ export function VariantCatalog(props: VariantCatalogProps) {
   );
 }
 
-const noopSetValue = () => {};
+const noopSetValue: SetVariantValue = () => {};
 function renderForTable(
   children: VariantPlaygroundProps['children'],
   values: VariantValues,
 ): ReactNode {
-  return children(values, noopSetValue as SetVariantValue);
+  return children(values, noopSetValue);
 }
 
 function toTabLabel(mode: Mode) {

--- a/examples/lynx-spa/src/components/variant-playground.tsx
+++ b/examples/lynx-spa/src/components/variant-playground.tsx
@@ -1,25 +1,27 @@
 import { type ReactNode, useMemo, useState } from '@lynx-js/react';
 
-type PrimitiveValue = string | number | boolean;
-type VariantMap = Record<string, readonly PrimitiveValue[]>;
+export type PrimitiveValue = string | number | boolean;
+export type VariantValues = Record<string, PrimitiveValue>;
+export type SetVariantValue = (key: string, value: PrimitiveValue) => void;
+
+export interface VariantAxis {
+  key: string;
+  label?: string;
+  options: readonly PrimitiveValue[];
+  defaultValue: PrimitiveValue;
+}
 
 export interface VariantPlaygroundProps {
   /**
-   * 여러 recipe 의 variantMap 을 병합해 받는다 (wrapper + mark 등). 같은 key 중복 시
-   * 뒤 항목이 이긴다. recipe 생성물에서 `{recipe}VariantMap` 을 import 해서 그대로 전달.
-   * boolean 옵션(`[true, false]`) 을 가진 variant 는 자동으로 toggle pill 로 렌더된다.
+   * Public하게 조작 가능한 variant 축만 넘긴다. recipe에는 있어도 컴포넌트 prop으로
+   * 고정할 수 없는 상태(예: pressed)는 포함하지 않는다.
    */
-  variantMaps: readonly VariantMap[];
-  /** 초기 값 매핑 (prop 이름 → 값). 지정되지 않은 variant 는 variantMap 의 첫 값이 적용된다. */
-  initialValues?: Record<string, PrimitiveValue>;
+  variants: readonly VariantAxis[];
   /**
    * preview 영역. 현재 값 스냅샷과 setter 를 받아 실제 컴포넌트를 렌더한다.
    * setter 는 controlled state (예: `checked`) 를 playground 로 되돌릴 때 사용.
    */
-  children: (
-    values: Record<string, PrimitiveValue>,
-    setValue: (key: string, value: PrimitiveValue) => void,
-  ) => ReactNode;
+  children: (values: VariantValues, setValue: SetVariantValue) => ReactNode;
 }
 
 function isBooleanOptions(
@@ -31,29 +33,17 @@ function isBooleanOptions(
 const toLabel = (value: PrimitiveValue) => String(value);
 
 export function VariantPlayground(props: VariantPlaygroundProps) {
-  const { variantMaps, initialValues = {}, children } = props;
+  const { variants, children } = props;
 
-  const mergedMap = useMemo<VariantMap>(() => {
-    const result: Record<string, readonly PrimitiveValue[]> = {};
-    for (const map of variantMaps) {
-      for (const [key, options] of Object.entries(map)) {
-        result[key] = options;
-      }
+  const defaultValues = useMemo<VariantValues>(() => {
+    const result: VariantValues = {};
+    for (const variant of variants) {
+      result[variant.key] = variant.defaultValue;
     }
     return result;
-  }, [variantMaps]);
+  }, [variants]);
 
-  const [values, setValues] = useState<Record<string, PrimitiveValue>>(() => {
-    const init: Record<string, PrimitiveValue> = { ...initialValues };
-    for (const [key, options] of Object.entries(mergedMap)) {
-      if (key in init || options.length === 0) continue;
-      // boolean variant 는 false 를 기본으로 (checked/disabled/indeterminate 등 — 명시적 활성화)
-      init[key] = isBooleanOptions(options)
-        ? false
-        : (options[0] as PrimitiveValue);
-    }
-    return init;
-  });
+  const [values, setValues] = useState<VariantValues>(() => defaultValues);
 
   const setValue = (key: string, value: PrimitiveValue) => {
     setValues((prev) =>
@@ -70,7 +60,7 @@ export function VariantPlayground(props: VariantPlaygroundProps) {
         minHeight: 0,
       }}
     >
-      {/* Preview — 남은 공간 + 중앙 정렬 */}
+      {/* Preview: fills the remaining space and centers the component. */}
       <view
         style={{
           flex: 1,
@@ -84,7 +74,7 @@ export function VariantPlayground(props: VariantPlaygroundProps) {
         {children(values, setValue)}
       </view>
 
-      {/* Controls — 하단 고정 */}
+      {/* Controls: fixed to the bottom with its own scroll area. */}
       <view
         style={{
           flexShrink: 0,
@@ -104,21 +94,21 @@ export function VariantPlayground(props: VariantPlaygroundProps) {
               padding: '12px 16px',
             }}
           >
-            {Object.entries(mergedMap).map(([key, options]) =>
-              isBooleanOptions(options) ? (
+            {variants.map((variant) =>
+              isBooleanOptions(variant.options) ? (
                 <BooleanRow
-                  key={key}
-                  name={key}
-                  current={!!values[key]}
-                  onChange={(next) => setValue(key, next)}
+                  key={variant.key}
+                  name={variant.label ?? variant.key}
+                  current={!!values[variant.key]}
+                  onChange={(next) => setValue(variant.key, next)}
                 />
               ) : (
                 <VariantRow
-                  key={key}
-                  name={key}
-                  options={options}
-                  current={values[key]}
-                  onChange={(next) => setValue(key, next)}
+                  key={variant.key}
+                  name={variant.label ?? variant.key}
+                  options={variant.options}
+                  current={values[variant.key]}
+                  onChange={(next) => setValue(variant.key, next)}
                 />
               ),
             )}

--- a/examples/lynx-spa/src/components/variant-playground.tsx
+++ b/examples/lynx-spa/src/components/variant-playground.tsx
@@ -32,16 +32,23 @@ function isBooleanOptions(
 
 const toLabel = (value: PrimitiveValue) => String(value);
 
+export function getVariantDefaultValues(
+  variants: readonly VariantAxis[],
+): VariantValues {
+  const result: VariantValues = {};
+  for (const variant of variants) {
+    result[variant.key] = variant.defaultValue;
+  }
+  return result;
+}
+
 export function VariantPlayground(props: VariantPlaygroundProps) {
   const { variants, children } = props;
 
-  const defaultValues = useMemo<VariantValues>(() => {
-    const result: VariantValues = {};
-    for (const variant of variants) {
-      result[variant.key] = variant.defaultValue;
-    }
-    return result;
-  }, [variants]);
+  const defaultValues = useMemo(
+    () => getVariantDefaultValues(variants),
+    [variants],
+  );
 
   const [values, setValues] = useState<VariantValues>(() => defaultValues);
 

--- a/examples/lynx-spa/src/components/variant-table.tsx
+++ b/examples/lynx-spa/src/components/variant-table.tsx
@@ -1,45 +1,52 @@
 import { type ReactNode, useMemo } from '@lynx-js/react';
 
-type PrimitiveValue = string | number | boolean;
-type VariantMap = Record<string, readonly PrimitiveValue[]>;
-type Combination = Record<string, PrimitiveValue>;
+import type {
+  PrimitiveValue,
+  VariantAxis,
+  VariantValues,
+} from './variant-playground.jsx';
 
 export interface VariantTableProps {
-  variantMaps: readonly VariantMap[];
-  children: (combination: Combination) => ReactNode;
+  variants: readonly VariantAxis[];
+  children: (values: VariantValues) => ReactNode;
 }
 
-function generateCombinations(mergedMap: VariantMap): Combination[] {
-  const keys = Object.keys(mergedMap);
-  let combos: Combination[] = [{}];
-  for (const key of keys) {
-    const values = mergedMap[key];
-    if (values == null) continue;
-    const next: Combination[] = [];
-    for (const combo of combos) {
-      for (const v of values) next.push({ ...combo, [key]: v });
-    }
-    combos = next;
-  }
-  return combos;
+type TableEntry =
+  | { type: 'header'; key: string; axis: VariantAxis }
+  | {
+      type: 'row';
+      key: string;
+      axis: VariantAxis;
+      option: PrimitiveValue;
+      values: VariantValues;
+    };
+
+function toDefaultValues(variants: readonly VariantAxis[]): VariantValues {
+  const result: VariantValues = {};
+  for (const variant of variants) result[variant.key] = variant.defaultValue;
+  return result;
 }
 
 export function VariantTable(props: VariantTableProps) {
-  const { variantMaps, children } = props;
+  const { variants, children } = props;
 
-  const mergedMap = useMemo<VariantMap>(() => {
-    const result: Record<string, readonly PrimitiveValue[]> = {};
-    for (const map of variantMaps) {
-      for (const [k, v] of Object.entries(map)) result[k] = v;
+  const entries = useMemo<TableEntry[]>(() => {
+    const defaults = toDefaultValues(variants);
+    const result: TableEntry[] = [];
+    for (const axis of variants) {
+      result.push({ type: 'header', key: `header-${axis.key}`, axis });
+      for (const option of axis.options) {
+        result.push({
+          type: 'row',
+          key: `row-${axis.key}-${String(option)}`,
+          axis,
+          option,
+          values: { ...defaults, [axis.key]: option },
+        });
+      }
     }
     return result;
-  }, [variantMaps]);
-
-  const keys = useMemo(() => Object.keys(mergedMap), [mergedMap]);
-  const combinations = useMemo(
-    () => generateCombinations(mergedMap),
-    [mergedMap],
-  );
+  }, [variants]);
 
   return (
     <list
@@ -48,44 +55,58 @@ export function VariantTable(props: VariantTableProps) {
       scroll-orientation="vertical"
       style={{ flex: 1, width: '100%' }}
     >
-      <list-item item-key="header" key="header">
-        <view
-          style={{
-            display: 'flex',
-            flexDirection: 'row',
-            alignItems: 'center',
-            paddingTop: '10px',
-            paddingBottom: '10px',
-            paddingLeft: '12px',
-            paddingRight: '12px',
-            backgroundColor: '#f5f5f5',
-            borderBottomWidth: '1px',
-            borderBottomStyle: 'solid',
-            borderBottomColor: '#ddd',
-          }}
-        >
-          <text style={{ fontSize: '11px', fontWeight: 'bold', color: '#333' }}>
-            {keys.length} variants × {combinations.length} combinations
-          </text>
-        </view>
-      </list-item>
-      {combinations.map((combo, i) => (
-        <list-item key={`row-${i}`} item-key={`row-${i}`}>
-          <Row keys={keys} combo={combo} renderComponent={children} />
+      {entries.map((entry) => (
+        <list-item key={entry.key} item-key={entry.key}>
+          {entry.type === 'header' ? (
+            <SectionHeader axis={entry.axis} />
+          ) : (
+            <Row
+              axis={entry.axis}
+              option={entry.option}
+              values={entry.values}
+              renderComponent={children}
+            />
+          )}
         </list-item>
       ))}
     </list>
   );
 }
 
+function SectionHeader({ axis }: { axis: VariantAxis }) {
+  return (
+    <view
+      style={{
+        paddingTop: '14px',
+        paddingBottom: '8px',
+        paddingLeft: '12px',
+        paddingRight: '12px',
+        backgroundColor: '#f5f5f5',
+        borderBottomWidth: '1px',
+        borderBottomStyle: 'solid',
+        borderBottomColor: '#ddd',
+      }}
+    >
+      <text style={{ fontSize: '12px', fontWeight: 'bold', color: '#333' }}>
+        {axis.label ?? axis.key}
+      </text>
+      <text style={{ fontSize: '10px', lineHeight: '14px', color: '#777' }}>
+        {`default: ${String(axis.defaultValue)}`}
+      </text>
+    </view>
+  );
+}
+
 function Row({
-  keys,
-  combo,
+  axis,
+  option,
+  values,
   renderComponent,
 }: {
-  keys: string[];
-  combo: Combination;
-  renderComponent: (combo: Combination) => ReactNode;
+  axis: VariantAxis;
+  option: PrimitiveValue;
+  values: VariantValues;
+  renderComponent: (values: VariantValues) => ReactNode;
 }) {
   return (
     <view
@@ -104,35 +125,42 @@ function Row({
     >
       <view
         style={{
-          width: '50%',
+          width: '36%',
           display: 'flex',
           flexDirection: 'column',
           paddingRight: '12px',
         }}
       >
-        {keys.map((k) => (
-          <text
-            key={k}
-            style={{
-              fontSize: '10px',
-              lineHeight: '14px',
-              color: '#666',
-            }}
-          >
-            {`${k}: ${String(combo[k])}`}
-          </text>
-        ))}
+        <text
+          style={{
+            fontSize: '11px',
+            lineHeight: '16px',
+            fontWeight: 'bold',
+            color: '#333',
+          }}
+        >
+          {String(option)}
+        </text>
+        <text
+          style={{
+            fontSize: '10px',
+            lineHeight: '14px',
+            color: '#777',
+          }}
+        >
+          {axis.label ?? axis.key}
+        </text>
       </view>
       <view
         style={{
-          width: '50%',
+          width: '64%',
           display: 'flex',
           flexDirection: 'row',
           alignItems: 'center',
           justifyContent: 'flex-start',
         }}
       >
-        {renderComponent(combo)}
+        {renderComponent(values)}
       </view>
     </view>
   );

--- a/examples/lynx-spa/src/components/variant-table.tsx
+++ b/examples/lynx-spa/src/components/variant-table.tsx
@@ -1,9 +1,10 @@
 import { type ReactNode, useMemo } from '@lynx-js/react';
 
-import type {
-  PrimitiveValue,
-  VariantAxis,
-  VariantValues,
+import {
+  getVariantDefaultValues,
+  type PrimitiveValue,
+  type VariantAxis,
+  type VariantValues,
 } from './variant-playground.jsx';
 
 export interface VariantTableProps {
@@ -21,17 +22,11 @@ type TableEntry =
       values: VariantValues;
     };
 
-function toDefaultValues(variants: readonly VariantAxis[]): VariantValues {
-  const result: VariantValues = {};
-  for (const variant of variants) result[variant.key] = variant.defaultValue;
-  return result;
-}
-
 export function VariantTable(props: VariantTableProps) {
   const { variants, children } = props;
 
   const entries = useMemo<TableEntry[]>(() => {
-    const defaults = toDefaultValues(variants);
+    const defaults = getVariantDefaultValues(variants);
     const result: TableEntry[] = [];
     for (const axis of variants) {
       result.push({ type: 'header', key: `header-${axis.key}`, axis });

--- a/examples/lynx-spa/src/pages/ActionButtonPage.tsx
+++ b/examples/lynx-spa/src/pages/ActionButtonPage.tsx
@@ -1,14 +1,105 @@
 import IconChevronDownFill from '@karrotmarket/lynx-monochrome-icon/IconChevronDownFill';
 import IconPlusFill from '@karrotmarket/lynx-monochrome-icon/IconPlusFill';
+import { actionButtonVariantMap } from '@seed-design/lynx-css/recipes/action-button';
 
-import { ActionButton } from '../seed-design/ui/action-button';
+import {
+  VariantCatalog,
+  type VariantAxis,
+  type VariantValues,
+} from '../components/variant-catalog.jsx';
+import {
+  ActionButton,
+  type ActionButtonProps,
+} from '../seed-design/ui/action-button';
 
-export function ActionButtonPage() {
+type ActionButtonVariant = NonNullable<ActionButtonProps['variant']>;
+type ActionButtonSize = NonNullable<ActionButtonProps['size']>;
+type ActionButtonLayout = NonNullable<ActionButtonProps['layout']>;
+
+const variants: readonly VariantAxis[] = [
+  {
+    key: 'variant',
+    options: actionButtonVariantMap.variant,
+    defaultValue: 'brandSolid',
+  },
+  {
+    key: 'size',
+    options: actionButtonVariantMap.size,
+    defaultValue: 'medium',
+  },
+  {
+    key: 'layout',
+    options: actionButtonVariantMap.layout,
+    defaultValue: 'withText',
+  },
+  {
+    key: 'disabled',
+    options: actionButtonVariantMap.disabled,
+    defaultValue: false,
+  },
+  {
+    key: 'loading',
+    options: actionButtonVariantMap.loading,
+    defaultValue: false,
+  },
+];
+
+function renderActionButton(values: VariantValues) {
+  const layout = values.layout as ActionButtonLayout;
+  const size = values.size as ActionButtonSize;
+  const variant = values.variant as ActionButtonVariant;
+  const disabled = Boolean(values.disabled);
+  const loading = Boolean(values.loading);
+
+  if (layout === 'iconOnly') {
+    return (
+      <ActionButton
+        layout="iconOnly"
+        variant={variant}
+        size={size}
+        disabled={disabled}
+        loading={loading}
+        icon={<IconPlusFill />}
+        aria-label="Add"
+      />
+    );
+  }
+
   return (
-    <scroll-view scroll-y style={{ display: 'flex', flexDirection: 'column', gap: '12px', flex: 1 }}>
+    <ActionButton
+      variant={variant}
+      size={size}
+      disabled={disabled}
+      loading={loading}
+    >
+      Action
+    </ActionButton>
+  );
+}
+
+function SectionTitle({ children }: { children: string }) {
+  return (
+    <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>
+      {children}
+    </text>
+  );
+}
+
+function ActionButtonExamples() {
+  return (
+    <scroll-view
+      scroll-y
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '12px',
+        flex: 1,
+        padding: '16px',
+      }}
+    >
       <text style={{ fontSize: '20px', fontWeight: 'bold' }}>ActionButton</text>
 
-      <text style={{ fontSize: '16px', fontWeight: 'bold' }}>Variants</text>
+      <SectionTitle>Variants</SectionTitle>
       <view
         style={{
           display: 'flex',
@@ -26,9 +117,7 @@ export function ActionButtonPage() {
         <ActionButton variant="ghost">Ghost</ActionButton>
       </view>
 
-      <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>
-        Sizes
-      </text>
+      <SectionTitle>Sizes</SectionTitle>
       <view
         style={{
           display: 'flex',
@@ -44,9 +133,7 @@ export function ActionButtonPage() {
         <ActionButton size="large">Large</ActionButton>
       </view>
 
-      <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>
-        Disabled
-      </text>
+      <SectionTitle>Disabled</SectionTitle>
       <view
         style={{
           display: 'flex',
@@ -63,9 +150,7 @@ export function ActionButtonPage() {
         </ActionButton>
       </view>
 
-      <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>
-        Prefix / Suffix Icon
-      </text>
+      <SectionTitle>Prefix / Suffix Icon</SectionTitle>
       <view
         style={{
           display: 'flex',
@@ -77,7 +162,10 @@ export function ActionButtonPage() {
         <ActionButton variant="brandSolid" prefixIcon={<IconPlusFill />}>
           Prefix Icon
         </ActionButton>
-        <ActionButton variant="neutralSolid" suffixIcon={<IconChevronDownFill />}>
+        <ActionButton
+          variant="neutralSolid"
+          suffixIcon={<IconChevronDownFill />}
+        >
           Suffix Icon
         </ActionButton>
         <ActionButton
@@ -87,14 +175,16 @@ export function ActionButtonPage() {
         >
           Both
         </ActionButton>
-        <ActionButton variant="brandSolid" disabled prefixIcon={<IconPlusFill />}>
+        <ActionButton
+          variant="brandSolid"
+          disabled
+          prefixIcon={<IconPlusFill />}
+        >
           Disabled
         </ActionButton>
       </view>
 
-      <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>
-        Icon Only
-      </text>
+      <SectionTitle>Icon Only</SectionTitle>
       <view
         style={{
           display: 'flex',
@@ -108,29 +198,37 @@ export function ActionButtonPage() {
           layout="iconOnly"
           variant="brandSolid"
           icon={<IconPlusFill />}
-          aria-label="추가"
+          aria-label="Add"
         />
         <ActionButton
           layout="iconOnly"
           variant="neutralSolid"
           size="small"
           icon={<IconPlusFill />}
-          aria-label="추가"
+          aria-label="Add"
         />
         <ActionButton
           layout="iconOnly"
           variant="brandOutline"
           icon={<IconPlusFill />}
-          aria-label="추가"
+          aria-label="Add"
         />
         <ActionButton
           layout="iconOnly"
           variant="brandSolid"
           disabled
           icon={<IconPlusFill />}
-          aria-label="비활성"
+          aria-label="Disabled"
         />
       </view>
     </scroll-view>
+  );
+}
+
+export function ActionButtonPage() {
+  return (
+    <VariantCatalog variants={variants} examples={<ActionButtonExamples />}>
+      {(values) => renderActionButton(values)}
+    </VariantCatalog>
   );
 }

--- a/examples/lynx-spa/src/pages/ActionButtonPage.tsx
+++ b/examples/lynx-spa/src/pages/ActionButtonPage.tsx
@@ -3,6 +3,10 @@ import IconPlusFill from '@karrotmarket/lynx-monochrome-icon/IconPlusFill';
 import { actionButtonVariantMap } from '@seed-design/lynx-css/recipes/action-button';
 
 import {
+  CatalogExamples,
+  CatalogSectionTitle,
+} from '../components/catalog-examples.jsx';
+import {
   VariantCatalog,
   type VariantAxis,
   type VariantValues,
@@ -77,29 +81,10 @@ function renderActionButton(values: VariantValues) {
   );
 }
 
-function SectionTitle({ children }: { children: string }) {
-  return (
-    <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>
-      {children}
-    </text>
-  );
-}
-
 function ActionButtonExamples() {
   return (
-    <scroll-view
-      scroll-y
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '12px',
-        flex: 1,
-        padding: '16px',
-      }}
-    >
-      <text style={{ fontSize: '20px', fontWeight: 'bold' }}>ActionButton</text>
-
-      <SectionTitle>Variants</SectionTitle>
+    <CatalogExamples title="ActionButton" gap="12px">
+      <CatalogSectionTitle>Variants</CatalogSectionTitle>
       <view
         style={{
           display: 'flex',
@@ -117,7 +102,7 @@ function ActionButtonExamples() {
         <ActionButton variant="ghost">Ghost</ActionButton>
       </view>
 
-      <SectionTitle>Sizes</SectionTitle>
+      <CatalogSectionTitle>Sizes</CatalogSectionTitle>
       <view
         style={{
           display: 'flex',
@@ -133,7 +118,7 @@ function ActionButtonExamples() {
         <ActionButton size="large">Large</ActionButton>
       </view>
 
-      <SectionTitle>Disabled</SectionTitle>
+      <CatalogSectionTitle>Disabled</CatalogSectionTitle>
       <view
         style={{
           display: 'flex',
@@ -150,7 +135,7 @@ function ActionButtonExamples() {
         </ActionButton>
       </view>
 
-      <SectionTitle>Prefix / Suffix Icon</SectionTitle>
+      <CatalogSectionTitle>Prefix / Suffix Icon</CatalogSectionTitle>
       <view
         style={{
           display: 'flex',
@@ -184,7 +169,7 @@ function ActionButtonExamples() {
         </ActionButton>
       </view>
 
-      <SectionTitle>Icon Only</SectionTitle>
+      <CatalogSectionTitle>Icon Only</CatalogSectionTitle>
       <view
         style={{
           display: 'flex',
@@ -221,7 +206,7 @@ function ActionButtonExamples() {
           aria-label="Disabled"
         />
       </view>
-    </scroll-view>
+    </CatalogExamples>
   );
 }
 

--- a/examples/lynx-spa/src/pages/BottomSheetPage.tsx
+++ b/examples/lynx-spa/src/pages/BottomSheetPage.tsx
@@ -4,6 +4,10 @@ import { vars } from '@seed-design/lynx-css/vars';
 import { type BottomSheetRootRef } from '@seed-design/lynx-react';
 
 import {
+  CatalogExamples,
+  CatalogSectionTitle,
+} from '../components/catalog-examples.jsx';
+import {
   VariantCatalog,
   type VariantAxis,
   type VariantValues,
@@ -74,32 +78,13 @@ function renderBottomSheet(values: VariantValues) {
   );
 }
 
-function SectionTitle({ children }: { children: string }) {
-  return (
-    <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>
-      {children}
-    </text>
-  );
-}
-
 function BottomSheetExamples() {
   const uncontrolledRef = useRef<BottomSheetRootRef>(null);
   const [controlledOpen, setControlledOpen] = useState(false);
 
   return (
-    <scroll-view
-      scroll-y
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '16px',
-        flex: 1,
-        padding: '16px',
-      }}
-    >
-      <text style={{ fontSize: '20px', fontWeight: 'bold' }}>BottomSheet</text>
-
-      <SectionTitle>Uncontrolled (Trigger 기반)</SectionTitle>
+    <CatalogExamples title="BottomSheet" gap="16px">
+      <CatalogSectionTitle>Uncontrolled (Trigger 기반)</CatalogSectionTitle>
       <BottomSheetRoot snapPoints={SNAP_POINTS_FIT_80}>
         <BottomSheetTrigger
           style={{
@@ -125,7 +110,7 @@ function BottomSheetExamples() {
         </BottomSheetContent>
       </BottomSheetRoot>
 
-      <SectionTitle>Imperative ref</SectionTitle>
+      <CatalogSectionTitle>Imperative ref</CatalogSectionTitle>
       <view
         style={{
           display: 'flex',
@@ -155,7 +140,7 @@ function BottomSheetExamples() {
         </BottomSheetContent>
       </BottomSheetRoot>
 
-      <SectionTitle>Controlled</SectionTitle>
+      <CatalogSectionTitle>Controlled</CatalogSectionTitle>
       <view style={{ display: 'flex', flexDirection: 'row', gap: '8px' }}>
         <ActionButton bindtap={() => setControlledOpen(true)}>
           open=true
@@ -174,7 +159,7 @@ function BottomSheetExamples() {
           description="backdrop 탭 / drag-to-close 시 onOpenChange로 외부 state가 갱신됩니다."
         />
       </BottomSheetRoot>
-    </scroll-view>
+    </CatalogExamples>
   );
 }
 

--- a/examples/lynx-spa/src/pages/BottomSheetPage.tsx
+++ b/examples/lynx-spa/src/pages/BottomSheetPage.tsx
@@ -1,37 +1,112 @@
-import { useRef, useState } from "@lynx-js/react";
-import { vars } from "@seed-design/lynx-css/vars";
-import { type BottomSheetRootRef } from "@seed-design/lynx-react";
+import { useRef, useState } from '@lynx-js/react';
+import { bottomSheetVariantMap } from '@seed-design/lynx-css/recipes/bottom-sheet';
+import { vars } from '@seed-design/lynx-css/vars';
+import { type BottomSheetRootRef } from '@seed-design/lynx-react';
 
-import { ActionButton } from "../seed-design/ui/action-button";
+import {
+  VariantCatalog,
+  type VariantAxis,
+  type VariantValues,
+} from '../components/variant-catalog.jsx';
+import { ActionButton } from '../seed-design/ui/action-button';
 import {
   BottomSheetBody,
   BottomSheetContent,
   BottomSheetFooter,
   BottomSheetRoot,
   BottomSheetTrigger,
-} from "../seed-design/ui/bottom-sheet";
+  type BottomSheetRootProps,
+} from '../seed-design/ui/bottom-sheet';
 
-const SNAP_POINTS_FIT_80: Array<number | string> = ["fit", "80%"];
-const SNAP_POINTS_FIT: Array<number | string> = ["fit"];
+const SNAP_POINTS_FIT_80: Array<number | string> = ['fit', '80%'];
+const SNAP_POINTS_FIT: Array<number | string> = ['fit'];
 
 const { $color } = vars;
 
-export function BottomSheetPage() {
+type BottomSheetHeaderAlign = NonNullable<BottomSheetRootProps['headerAlign']>;
+
+const variants: readonly VariantAxis[] = [
+  {
+    key: 'headerAlign',
+    options: bottomSheetVariantMap.headerAlign,
+    defaultValue: 'left',
+  },
+  {
+    key: 'skipAnimation',
+    options: bottomSheetVariantMap.skipAnimation,
+    defaultValue: false,
+  },
+];
+
+function renderBottomSheet(values: VariantValues) {
+  const headerAlign = values.headerAlign as BottomSheetHeaderAlign;
+  const skipAnimation = Boolean(values.skipAnimation);
+
+  return (
+    <BottomSheetRoot
+      headerAlign={headerAlign}
+      skipAnimation={skipAnimation}
+      snapPoints={SNAP_POINTS_FIT_80}
+    >
+      <BottomSheetTrigger
+        style={{
+          padding: '10px 16px',
+          backgroundColor: $color.bg.brandSolid,
+          borderRadius: '8px',
+          alignSelf: 'flex-start',
+        }}
+      >
+        <text style={{ color: $color.fg.brandContrast }}>Open sheet</text>
+      </BottomSheetTrigger>
+      <BottomSheetContent
+        title={`Header ${headerAlign}`}
+        description={skipAnimation ? 'Animation skipped' : 'Default animation'}
+        showHandle
+      >
+        <BottomSheetBody>
+          <text>Use the trigger to inspect this variant.</text>
+        </BottomSheetBody>
+        <BottomSheetFooter>
+          <text>Footer area</text>
+        </BottomSheetFooter>
+      </BottomSheetContent>
+    </BottomSheetRoot>
+  );
+}
+
+function SectionTitle({ children }: { children: string }) {
+  return (
+    <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>
+      {children}
+    </text>
+  );
+}
+
+function BottomSheetExamples() {
   const uncontrolledRef = useRef<BottomSheetRootRef>(null);
   const [controlledOpen, setControlledOpen] = useState(false);
 
   return (
-    <scroll-view scroll-y style={{ display: "flex", flexDirection: "column", gap: "16px", flex: 1 }}>
-      <text style={{ fontSize: "20px", fontWeight: "bold" }}>BottomSheet</text>
+    <scroll-view
+      scroll-y
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+        flex: 1,
+        padding: '16px',
+      }}
+    >
+      <text style={{ fontSize: '20px', fontWeight: 'bold' }}>BottomSheet</text>
 
-      <text style={{ fontSize: "16px", fontWeight: "bold" }}>Uncontrolled (Trigger 기반)</text>
+      <SectionTitle>Uncontrolled (Trigger 기반)</SectionTitle>
       <BottomSheetRoot snapPoints={SNAP_POINTS_FIT_80}>
         <BottomSheetTrigger
           style={{
-            padding: "10px 16px",
+            padding: '10px 16px',
             backgroundColor: $color.bg.brandSolid,
-            borderRadius: "8px",
-            alignSelf: "flex-start",
+            borderRadius: '8px',
+            alignSelf: 'flex-start',
           }}
         >
           <text style={{ color: $color.fg.brandContrast }}>Trigger 탭</text>
@@ -50,12 +125,27 @@ export function BottomSheetPage() {
         </BottomSheetContent>
       </BottomSheetRoot>
 
-      <text style={{ fontSize: "16px", fontWeight: "bold", marginTop: "8px" }}>Imperative ref</text>
-      <view style={{ display: "flex", flexDirection: "row", gap: "8px", flexWrap: "wrap" }}>
-        <ActionButton bindtap={() => uncontrolledRef.current?.open()}>open()</ActionButton>
-        <ActionButton bindtap={() => uncontrolledRef.current?.snapTo(0)}>snapTo(0)</ActionButton>
-        <ActionButton bindtap={() => uncontrolledRef.current?.snapTo(1)}>snapTo(1)</ActionButton>
-        <ActionButton bindtap={() => uncontrolledRef.current?.close()}>close()</ActionButton>
+      <SectionTitle>Imperative ref</SectionTitle>
+      <view
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: '8px',
+          flexWrap: 'wrap',
+        }}
+      >
+        <ActionButton bindtap={() => uncontrolledRef.current?.open()}>
+          open()
+        </ActionButton>
+        <ActionButton bindtap={() => uncontrolledRef.current?.snapTo(0)}>
+          snapTo(0)
+        </ActionButton>
+        <ActionButton bindtap={() => uncontrolledRef.current?.snapTo(1)}>
+          snapTo(1)
+        </ActionButton>
+        <ActionButton bindtap={() => uncontrolledRef.current?.close()}>
+          close()
+        </ActionButton>
       </view>
       <BottomSheetRoot ref={uncontrolledRef} snapPoints={SNAP_POINTS_FIT_80}>
         <BottomSheetContent title="Imperative 예제" showHandle>
@@ -65,10 +155,14 @@ export function BottomSheetPage() {
         </BottomSheetContent>
       </BottomSheetRoot>
 
-      <text style={{ fontSize: "16px", fontWeight: "bold", marginTop: "8px" }}>Controlled</text>
-      <view style={{ display: "flex", flexDirection: "row", gap: "8px" }}>
-        <ActionButton bindtap={() => setControlledOpen(true)}>open=true</ActionButton>
-        <ActionButton bindtap={() => setControlledOpen(false)}>open=false</ActionButton>
+      <SectionTitle>Controlled</SectionTitle>
+      <view style={{ display: 'flex', flexDirection: 'row', gap: '8px' }}>
+        <ActionButton bindtap={() => setControlledOpen(true)}>
+          open=true
+        </ActionButton>
+        <ActionButton bindtap={() => setControlledOpen(false)}>
+          open=false
+        </ActionButton>
       </view>
       <BottomSheetRoot
         open={controlledOpen}
@@ -81,5 +175,13 @@ export function BottomSheetPage() {
         />
       </BottomSheetRoot>
     </scroll-view>
+  );
+}
+
+export function BottomSheetPage() {
+  return (
+    <VariantCatalog variants={variants} examples={<BottomSheetExamples />}>
+      {(values) => renderBottomSheet(values)}
+    </VariantCatalog>
   );
 }

--- a/examples/lynx-spa/src/pages/CheckboxPage.tsx
+++ b/examples/lynx-spa/src/pages/CheckboxPage.tsx
@@ -1,35 +1,77 @@
-import IconCheckmarkFatFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkFatFill';
-import IconMinusFatFill from '@karrotmarket/lynx-monochrome-icon/IconMinusFatFill';
 import { checkboxVariantMap } from '@seed-design/lynx-css/recipes/checkbox';
 import { checkmarkVariantMap } from '@seed-design/lynx-css/recipes/checkmark';
-import { Checkbox } from '@seed-design/lynx-react';
 
-import { VariantCatalog } from '../components/variant-catalog.jsx';
+import {
+  VariantCatalog,
+  type SetVariantValue,
+  type VariantAxis,
+  type VariantValues,
+} from '../components/variant-catalog.jsx';
+import { Checkbox, type CheckboxProps } from '../seed-design/ui/checkbox';
+
+type CheckboxWeight = NonNullable<CheckboxProps['weight']>;
+type CheckboxSize = NonNullable<CheckboxProps['size']>;
+type CheckboxTone = NonNullable<CheckboxProps['tone']>;
+type CheckboxVariant = NonNullable<CheckboxProps['variant']>;
+
+const variants: readonly VariantAxis[] = [
+  {
+    key: 'weight',
+    options: checkboxVariantMap.weight,
+    defaultValue: 'regular',
+  },
+  {
+    key: 'size',
+    options: checkboxVariantMap.size,
+    defaultValue: 'medium',
+  },
+  {
+    key: 'disabled',
+    options: checkboxVariantMap.disabled,
+    defaultValue: false,
+  },
+  {
+    key: 'variant',
+    options: checkmarkVariantMap.variant,
+    defaultValue: 'square',
+  },
+  {
+    key: 'tone',
+    options: checkmarkVariantMap.tone,
+    defaultValue: 'brand',
+  },
+  {
+    key: 'checked',
+    options: checkmarkVariantMap.checked,
+    defaultValue: false,
+  },
+  {
+    key: 'indeterminate',
+    options: checkmarkVariantMap.indeterminate,
+    defaultValue: false,
+  },
+];
+
+function renderCheckbox(values: VariantValues, setValue: SetVariantValue) {
+  return (
+    <Checkbox
+      label="Checkbox"
+      weight={values.weight as CheckboxWeight}
+      size={values.size as CheckboxSize}
+      tone={values.tone as CheckboxTone}
+      variant={values.variant as CheckboxVariant}
+      checked={Boolean(values.checked)}
+      indeterminate={Boolean(values.indeterminate)}
+      disabled={Boolean(values.disabled)}
+      onCheckedChange={(next) => setValue('checked', next)}
+    />
+  );
+}
 
 export function CheckboxPage() {
   return (
-    <VariantCatalog variantMaps={[checkboxVariantMap, checkmarkVariantMap]}>
-      {(v, setValue) => (
-        <Checkbox.Root
-          weight={v.weight as 'regular' | 'bold'}
-          size={v.size as 'medium' | 'large'}
-          tone={v.tone as 'brand' | 'neutral'}
-          variant={v.variant as 'square' | 'ghost'}
-          checked={Boolean(v.checked)}
-          indeterminate={Boolean(v.indeterminate)}
-          disabled={Boolean(v.disabled)}
-          onCheckedChange={(next) => setValue('checked', next)}
-        >
-          <Checkbox.Control>
-            <Checkbox.Indicator
-              unchecked={<IconCheckmarkFatFill />}
-              checked={<IconCheckmarkFatFill />}
-              indeterminate={<IconMinusFatFill />}
-            />
-          </Checkbox.Control>
-          <Checkbox.Label>Checkbox</Checkbox.Label>
-        </Checkbox.Root>
-      )}
+    <VariantCatalog variants={variants}>
+      {(values, setValue) => renderCheckbox(values, setValue)}
     </VariantCatalog>
   );
 }

--- a/examples/lynx-spa/src/pages/ProgressCirclePage.tsx
+++ b/examples/lynx-spa/src/pages/ProgressCirclePage.tsx
@@ -1,5 +1,97 @@
-import { useEffect, useState } from "@lynx-js/react";
-import { ProgressCircle } from "@seed-design/lynx-react";
+import { useEffect, useState } from '@lynx-js/react';
+import { progressCircleVariantMap } from '@seed-design/lynx-css/recipes/progress-circle';
+
+import {
+  VariantCatalog,
+  type VariantAxis,
+  type VariantValues,
+} from '../components/variant-catalog.jsx';
+import {
+  ProgressCircle,
+  type ProgressCircleProps,
+} from '../seed-design/ui/progress-circle';
+
+type ProgressCircleTone = NonNullable<ProgressCircleProps['tone']>;
+type ProgressCircleSize = NonNullable<ProgressCircleProps['size']>;
+type ProgressState = 'indeterminate' | '25%' | '50%' | '75%' | '100%';
+
+const progressValueMap: Record<
+  Exclude<ProgressState, 'indeterminate'>,
+  number
+> = {
+  '25%': 0.25,
+  '50%': 0.5,
+  '75%': 0.75,
+  '100%': 1,
+};
+
+const variants: readonly VariantAxis[] = [
+  {
+    key: 'tone',
+    options: progressCircleVariantMap.tone,
+    defaultValue: 'neutral',
+  },
+  {
+    key: 'size',
+    options: progressCircleVariantMap.size,
+    defaultValue: '40',
+  },
+  {
+    key: 'progressState',
+    label: 'progress',
+    options: ['indeterminate', '25%', '50%', '75%', '100%'],
+    defaultValue: 'indeterminate',
+  },
+];
+
+function renderProgressCircle(values: VariantValues) {
+  const tone = values.tone as ProgressCircleTone;
+  const size = values.size as ProgressCircleSize;
+  const progressState = values.progressState as ProgressState;
+  const progressValue =
+    progressState === 'indeterminate'
+      ? undefined
+      : progressValueMap[progressState];
+
+  const circle =
+    progressValue == null ? (
+      <ProgressCircle tone={tone} size={size} />
+    ) : (
+      <ProgressCircle
+        tone={tone}
+        size={size}
+        minValue={0}
+        maxValue={1}
+        value={progressValue}
+      />
+    );
+
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        gap: '12px',
+        alignItems: 'center',
+      }}
+    >
+      {tone === 'staticWhite' ? (
+        <view
+          style={{
+            backgroundColor: '#222',
+            borderRadius: '8px',
+            padding: '8px',
+          }}
+        >
+          {circle}
+        </view>
+      ) : (
+        circle
+      )}
+      <text style={{ fontSize: '13px' }}>{progressState}</text>
+    </view>
+  );
+}
 
 function AutoProgressTest() {
   const [value, setValue] = useState(0);
@@ -14,150 +106,177 @@ function AutoProgressTest() {
   return (
     <view
       style={{
-        display: "flex",
-        flexDirection: "row",
-        gap: "16px",
-        alignItems: "center",
+        display: 'flex',
+        flexDirection: 'row',
+        gap: '16px',
+        alignItems: 'center',
       }}
     >
-      <ProgressCircle.Root tone="brand" size="40" minValue={0} maxValue={1} value={value}>
-
-        <ProgressCircle.Range />
-      </ProgressCircle.Root>
-      <text style={{ fontSize: "14px" }}>{`${Math.round(value * 100)}%`}</text>
+      <ProgressCircle
+        tone="brand"
+        size="40"
+        minValue={0}
+        maxValue={1}
+        value={value}
+      />
+      <text style={{ fontSize: '14px' }}>{`${Math.round(value * 100)}%`}</text>
     </view>
   );
 }
 
-export function ProgressCirclePage() {
+function SectionTitle({ children }: { children: string }) {
+  return (
+    <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>
+      {children}
+    </text>
+  );
+}
+
+function ProgressCircleExamples() {
   const [progress, setProgress] = useState(0.3);
 
   return (
     <scroll-view
       scroll-y
-      style={{ display: "flex", flexDirection: "column", gap: "12px", flex: 1 }}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '12px',
+        flex: 1,
+        padding: '16px',
+      }}
     >
-      <text style={{ fontSize: "20px", fontWeight: "bold" }}>ProgressCircle</text>
+      <text style={{ fontSize: '20px', fontWeight: 'bold' }}>
+        ProgressCircle
+      </text>
 
-      <text style={{ fontSize: "16px", fontWeight: "bold" }}>Indeterminate</text>
+      <SectionTitle>Indeterminate</SectionTitle>
       <view
         style={{
-          display: "flex",
-          flexDirection: "row",
-          gap: "16px",
-          alignItems: "center",
+          display: 'flex',
+          flexDirection: 'row',
+          gap: '16px',
+          alignItems: 'center',
         }}
       >
-        <ProgressCircle.Root tone="neutral" size="40">
-  
-          <ProgressCircle.Range />
-        </ProgressCircle.Root>
-        <ProgressCircle.Root tone="brand" size="40">
-  
-          <ProgressCircle.Range />
-        </ProgressCircle.Root>
+        <ProgressCircle tone="neutral" size="40" />
+        <ProgressCircle tone="brand" size="40" />
         <view
           style={{
-            backgroundColor: "#222",
-            borderRadius: "8px",
-            padding: "8px",
+            backgroundColor: '#222',
+            borderRadius: '8px',
+            padding: '8px',
           }}
         >
-          <ProgressCircle.Root tone="staticWhite" size="40">
-    
-            <ProgressCircle.Range />
-          </ProgressCircle.Root>
+          <ProgressCircle tone="staticWhite" size="40" />
         </view>
       </view>
 
-      <text style={{ fontSize: "16px", fontWeight: "bold", marginTop: "8px" }}>Sizes</text>
+      <SectionTitle>Sizes</SectionTitle>
       <view
         style={{
-          display: "flex",
-          flexDirection: "row",
-          gap: "16px",
-          alignItems: "center",
+          display: 'flex',
+          flexDirection: 'row',
+          gap: '16px',
+          alignItems: 'center',
         }}
       >
-        <ProgressCircle.Root tone="brand" size="24">
-  
-          <ProgressCircle.Range />
-        </ProgressCircle.Root>
-        <ProgressCircle.Root tone="brand" size="40">
-  
-          <ProgressCircle.Range />
-        </ProgressCircle.Root>
+        <ProgressCircle tone="brand" size="24" />
+        <ProgressCircle tone="brand" size="40" />
       </view>
 
-      <text style={{ fontSize: "16px", fontWeight: "bold", marginTop: "8px" }}>Determinate</text>
+      <SectionTitle>Determinate</SectionTitle>
       <view
         style={{
-          display: "flex",
-          flexDirection: "row",
-          gap: "16px",
-          alignItems: "center",
+          display: 'flex',
+          flexDirection: 'row',
+          gap: '16px',
+          alignItems: 'center',
         }}
       >
-        <ProgressCircle.Root tone="neutral" size="40" minValue={0} maxValue={1} value={0.25}>
-  
-          <ProgressCircle.Range />
-        </ProgressCircle.Root>
-        <ProgressCircle.Root tone="brand" size="40" minValue={0} maxValue={1} value={0.5}>
-  
-          <ProgressCircle.Range />
-        </ProgressCircle.Root>
-        <ProgressCircle.Root tone="brand" size="40" minValue={0} maxValue={1} value={0.75}>
-  
-          <ProgressCircle.Range />
-        </ProgressCircle.Root>
-        <ProgressCircle.Root tone="brand" size="40" minValue={0} maxValue={1} value={1}>
-  
-          <ProgressCircle.Range />
-        </ProgressCircle.Root>
+        <ProgressCircle
+          tone="neutral"
+          size="40"
+          minValue={0}
+          maxValue={1}
+          value={0.25}
+        />
+        <ProgressCircle
+          tone="brand"
+          size="40"
+          minValue={0}
+          maxValue={1}
+          value={0.5}
+        />
+        <ProgressCircle
+          tone="brand"
+          size="40"
+          minValue={0}
+          maxValue={1}
+          value={0.75}
+        />
+        <ProgressCircle
+          tone="brand"
+          size="40"
+          minValue={0}
+          maxValue={1}
+          value={1}
+        />
       </view>
 
-      <text style={{ fontSize: "16px", fontWeight: "bold", marginTop: "8px" }}>Interactive</text>
+      <SectionTitle>Interactive</SectionTitle>
       <view
         style={{
-          display: "flex",
-          flexDirection: "row",
-          gap: "16px",
-          alignItems: "center",
+          display: 'flex',
+          flexDirection: 'row',
+          gap: '16px',
+          alignItems: 'center',
         }}
       >
-        <ProgressCircle.Root tone="brand" size="40" minValue={0} maxValue={1} value={progress}>
-  
-          <ProgressCircle.Range />
-        </ProgressCircle.Root>
-        <text style={{ fontSize: "14px" }}>{`${Math.round(progress * 100)}%`}</text>
+        <ProgressCircle
+          tone="brand"
+          size="40"
+          minValue={0}
+          maxValue={1}
+          value={progress}
+        />
+        <text
+          style={{ fontSize: '14px' }}
+        >{`${Math.round(progress * 100)}%`}</text>
       </view>
-      <view style={{ display: "flex", flexDirection: "row", gap: "8px" }}>
+      <view style={{ display: 'flex', flexDirection: 'row', gap: '8px' }}>
         <view
           bindtap={() => setProgress((p) => Math.max(0, p - 0.1))}
           style={{
-            padding: "8px 16px",
-            backgroundColor: "#eee",
-            borderRadius: "6px",
+            padding: '8px 16px',
+            backgroundColor: '#eee',
+            borderRadius: '6px',
           }}
         >
-          <text style={{ fontSize: "14px" }}>- 10%</text>
+          <text style={{ fontSize: '14px' }}>- 10%</text>
         </view>
         <view
           bindtap={() => setProgress((p) => Math.min(1, p + 0.1))}
           style={{
-            padding: "8px 16px",
-            backgroundColor: "#eee",
-            borderRadius: "6px",
+            padding: '8px 16px',
+            backgroundColor: '#eee',
+            borderRadius: '6px',
           }}
         >
-          <text style={{ fontSize: "14px" }}>+ 10%</text>
+          <text style={{ fontSize: '14px' }}>+ 10%</text>
         </view>
       </view>
 
-      <text style={{ fontSize: "16px", fontWeight: "bold", marginTop: "8px" }}>
-        Transition Test (auto +10% every 1s)
-      </text>
+      <SectionTitle>Transition Test (auto +10% every 1s)</SectionTitle>
       <AutoProgressTest />
     </scroll-view>
+  );
+}
+
+export function ProgressCirclePage() {
+  return (
+    <VariantCatalog variants={variants} examples={<ProgressCircleExamples />}>
+      {(values) => renderProgressCircle(values)}
+    </VariantCatalog>
   );
 }

--- a/examples/lynx-spa/src/pages/ProgressCirclePage.tsx
+++ b/examples/lynx-spa/src/pages/ProgressCirclePage.tsx
@@ -2,6 +2,10 @@ import { useEffect, useState } from '@lynx-js/react';
 import { progressCircleVariantMap } from '@seed-design/lynx-css/recipes/progress-circle';
 
 import {
+  CatalogExamples,
+  CatalogSectionTitle,
+} from '../components/catalog-examples.jsx';
+import {
   VariantCatalog,
   type VariantAxis,
   type VariantValues,
@@ -124,33 +128,12 @@ function AutoProgressTest() {
   );
 }
 
-function SectionTitle({ children }: { children: string }) {
-  return (
-    <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>
-      {children}
-    </text>
-  );
-}
-
 function ProgressCircleExamples() {
   const [progress, setProgress] = useState(0.3);
 
   return (
-    <scroll-view
-      scroll-y
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '12px',
-        flex: 1,
-        padding: '16px',
-      }}
-    >
-      <text style={{ fontSize: '20px', fontWeight: 'bold' }}>
-        ProgressCircle
-      </text>
-
-      <SectionTitle>Indeterminate</SectionTitle>
+    <CatalogExamples title="ProgressCircle" gap="12px">
+      <CatalogSectionTitle>Indeterminate</CatalogSectionTitle>
       <view
         style={{
           display: 'flex',
@@ -172,7 +155,7 @@ function ProgressCircleExamples() {
         </view>
       </view>
 
-      <SectionTitle>Sizes</SectionTitle>
+      <CatalogSectionTitle>Sizes</CatalogSectionTitle>
       <view
         style={{
           display: 'flex',
@@ -185,7 +168,7 @@ function ProgressCircleExamples() {
         <ProgressCircle tone="brand" size="40" />
       </view>
 
-      <SectionTitle>Determinate</SectionTitle>
+      <CatalogSectionTitle>Determinate</CatalogSectionTitle>
       <view
         style={{
           display: 'flex',
@@ -224,7 +207,7 @@ function ProgressCircleExamples() {
         />
       </view>
 
-      <SectionTitle>Interactive</SectionTitle>
+      <CatalogSectionTitle>Interactive</CatalogSectionTitle>
       <view
         style={{
           display: 'flex',
@@ -267,9 +250,11 @@ function ProgressCircleExamples() {
         </view>
       </view>
 
-      <SectionTitle>Transition Test (auto +10% every 1s)</SectionTitle>
+      <CatalogSectionTitle>
+        Transition Test (auto +10% every 1s)
+      </CatalogSectionTitle>
       <AutoProgressTest />
-    </scroll-view>
+    </CatalogExamples>
   );
 }
 

--- a/examples/lynx-spa/src/pages/RadioGroupPage.tsx
+++ b/examples/lynx-spa/src/pages/RadioGroupPage.tsx
@@ -1,32 +1,68 @@
 import { radioVariantMap } from '@seed-design/lynx-css/recipes/radio';
 import { radiomarkVariantMap } from '@seed-design/lynx-css/recipes/radiomark';
-import { RadioGroup } from '@seed-design/lynx-react';
 
-import { VariantCatalog } from '../components/variant-catalog.jsx';
+import {
+  VariantCatalog,
+  type VariantAxis,
+  type VariantValues,
+} from '../components/variant-catalog.jsx';
+import {
+  Radio,
+  RadioGroup,
+  type RadioGroupProps,
+} from '../seed-design/ui/radio-group';
+
+type RadioWeight = NonNullable<RadioGroupProps['weight']>;
+type RadioSize = NonNullable<RadioGroupProps['size']>;
+type RadioTone = NonNullable<RadioGroupProps['tone']>;
+
+const variants: readonly VariantAxis[] = [
+  {
+    key: 'weight',
+    options: radioVariantMap.weight,
+    defaultValue: 'regular',
+  },
+  {
+    key: 'size',
+    options: radioVariantMap.size,
+    defaultValue: 'medium',
+  },
+  {
+    key: 'tone',
+    options: radiomarkVariantMap.tone,
+    defaultValue: 'brand',
+  },
+  {
+    key: 'disabled',
+    options: radioVariantMap.disabled,
+    defaultValue: false,
+  },
+];
+
+function renderRadioGroup(values: VariantValues) {
+  return (
+    <RadioGroup
+      weight={values.weight as RadioWeight}
+      size={values.size as RadioSize}
+      tone={values.tone as RadioTone}
+      disabled={Boolean(values.disabled)}
+      defaultValue="option1"
+    >
+      {['option1', 'option2', 'option3'].map((value) => (
+        <Radio
+          key={value}
+          value={value}
+          label={`Option ${value.replace('option', '')}`}
+        />
+      ))}
+    </RadioGroup>
+  );
+}
 
 export function RadioGroupPage() {
   return (
-    <VariantCatalog variantMaps={[radioVariantMap, radiomarkVariantMap]}>
-      {(v) => (
-        <RadioGroup.Root
-          weight={v.weight as 'regular' | 'bold'}
-          size={v.size as 'medium' | 'large'}
-          tone={v.tone as 'brand' | 'neutral'}
-          disabled={Boolean(v.disabled)}
-          defaultValue="option1"
-        >
-          {['option1', 'option2', 'option3'].map((value) => (
-            <RadioGroup.Item key={value} value={value}>
-              <RadioGroup.ItemControl>
-                <RadioGroup.ItemIndicator />
-              </RadioGroup.ItemControl>
-              <RadioGroup.ItemLabel>
-                Option {value.replace('option', '')}
-              </RadioGroup.ItemLabel>
-            </RadioGroup.Item>
-          ))}
-        </RadioGroup.Root>
-      )}
+    <VariantCatalog variants={variants}>
+      {(values) => renderRadioGroup(values)}
     </VariantCatalog>
   );
 }

--- a/examples/lynx-spa/src/pages/SwitchPage.tsx
+++ b/examples/lynx-spa/src/pages/SwitchPage.tsx
@@ -1,5 +1,10 @@
 import { useState } from '@lynx-js/react';
-import { Switch as SeedSwitch } from '@seed-design/lynx-react';
+import {
+  SwitchControl,
+  SwitchLabel,
+  SwitchRoot,
+  SwitchThumb,
+} from '@seed-design/lynx-react';
 import { switchVariantMap } from '@seed-design/lynx-css/recipes/switch';
 import { switchmarkVariantMap } from '@seed-design/lynx-css/recipes/switchmark';
 
@@ -137,12 +142,12 @@ function SwitchExamples() {
           alignItems: 'center',
         }}
       >
-        <SeedSwitch.Root tone="brand" defaultChecked>
-          <SeedSwitch.Control tone="neutral">
-            <SeedSwitch.Thumb />
-          </SeedSwitch.Control>
-          <SeedSwitch.Label>Override</SeedSwitch.Label>
-        </SeedSwitch.Root>
+        <SwitchRoot tone="brand" defaultChecked>
+          <SwitchControl tone="neutral">
+            <SwitchThumb />
+          </SwitchControl>
+          <SwitchLabel>Override</SwitchLabel>
+        </SwitchRoot>
       </view>
     </CatalogExamples>
   );

--- a/examples/lynx-spa/src/pages/SwitchPage.tsx
+++ b/examples/lynx-spa/src/pages/SwitchPage.tsx
@@ -4,6 +4,10 @@ import { switchVariantMap } from '@seed-design/lynx-css/recipes/switch';
 import { switchmarkVariantMap } from '@seed-design/lynx-css/recipes/switchmark';
 
 import {
+  CatalogExamples,
+  CatalogSectionTitle,
+} from '../components/catalog-examples.jsx';
+import {
   VariantCatalog,
   type SetVariantValue,
   type VariantAxis,
@@ -51,31 +55,12 @@ function renderSwitch(values: VariantValues, setValue: SetVariantValue) {
   );
 }
 
-function SectionTitle({ children }: { children: string }) {
-  return (
-    <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>
-      {children}
-    </text>
-  );
-}
-
 function SwitchExamples() {
   const [controlled, setControlled] = useState(false);
 
   return (
-    <scroll-view
-      scroll-y
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '12px',
-        flex: 1,
-        padding: '16px',
-      }}
-    >
-      <text style={{ fontSize: '20px', fontWeight: 'bold' }}>Switch</text>
-
-      <SectionTitle>Default (uncontrolled)</SectionTitle>
+    <CatalogExamples title="Switch" gap="12px">
+      <CatalogSectionTitle>Default (uncontrolled)</CatalogSectionTitle>
       <view
         style={{
           display: 'flex',
@@ -88,13 +73,13 @@ function SwitchExamples() {
         <Switchmark defaultChecked />
       </view>
 
-      <SectionTitle>With Label</SectionTitle>
+      <CatalogSectionTitle>With Label</CatalogSectionTitle>
       <view style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
         <Switch label="알림 받기" defaultChecked />
         <Switch label="자동 로그인" />
       </view>
 
-      <SectionTitle>Controlled</SectionTitle>
+      <CatalogSectionTitle>Controlled</CatalogSectionTitle>
       <view
         style={{
           display: 'flex',
@@ -110,7 +95,7 @@ function SwitchExamples() {
         />
       </view>
 
-      <SectionTitle>Sizes</SectionTitle>
+      <CatalogSectionTitle>Sizes</CatalogSectionTitle>
       <view
         style={{
           display: 'flex',
@@ -124,7 +109,7 @@ function SwitchExamples() {
         <Switchmark size="32" defaultChecked />
       </view>
 
-      <SectionTitle>Tones</SectionTitle>
+      <CatalogSectionTitle>Tones</CatalogSectionTitle>
       <view
         style={{
           display: 'flex',
@@ -137,15 +122,13 @@ function SwitchExamples() {
         <Switch label="Neutral" tone="neutral" defaultChecked />
       </view>
 
-      <SectionTitle>Disabled</SectionTitle>
+      <CatalogSectionTitle>Disabled</CatalogSectionTitle>
       <view style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
         <Switch label="Disabled Off" disabled />
         <Switch label="Disabled On" disabled defaultChecked />
       </view>
 
-      <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>
-        Compound: Control override (Root=brand, Control=neutral)
-      </text>
+      <CatalogSectionTitle>Compound: Control override</CatalogSectionTitle>
       <view
         style={{
           display: 'flex',
@@ -161,7 +144,7 @@ function SwitchExamples() {
           <SeedSwitch.Label>Override</SeedSwitch.Label>
         </SeedSwitch.Root>
       </view>
-    </scroll-view>
+    </CatalogExamples>
   );
 }
 

--- a/examples/lynx-spa/src/pages/SwitchPage.tsx
+++ b/examples/lynx-spa/src/pages/SwitchPage.tsx
@@ -1,46 +1,143 @@
 import { useState } from '@lynx-js/react';
 import { Switch as SeedSwitch } from '@seed-design/lynx-react';
+import { switchVariantMap } from '@seed-design/lynx-css/recipes/switch';
+import { switchmarkVariantMap } from '@seed-design/lynx-css/recipes/switchmark';
 
-import { Switch, Switchmark } from '../seed-design/ui/switch';
+import {
+  VariantCatalog,
+  type SetVariantValue,
+  type VariantAxis,
+  type VariantValues,
+} from '../components/variant-catalog.jsx';
+import { Switch, Switchmark, type SwitchProps } from '../seed-design/ui/switch';
 
-export function SwitchPage() {
+type SwitchSize = NonNullable<SwitchProps['size']>;
+type SwitchTone = NonNullable<SwitchProps['tone']>;
+
+const variants: readonly VariantAxis[] = [
+  {
+    key: 'size',
+    options: switchVariantMap.size,
+    defaultValue: '32',
+  },
+  {
+    key: 'tone',
+    options: switchmarkVariantMap.tone,
+    defaultValue: 'brand',
+  },
+  {
+    key: 'checked',
+    options: switchmarkVariantMap.checked,
+    defaultValue: false,
+  },
+  {
+    key: 'disabled',
+    options: switchVariantMap.disabled,
+    defaultValue: false,
+  },
+];
+
+function renderSwitch(values: VariantValues, setValue: SetVariantValue) {
+  const checked = Boolean(values.checked);
+  return (
+    <Switch
+      label={checked ? 'On' : 'Off'}
+      size={values.size as SwitchSize}
+      tone={values.tone as SwitchTone}
+      checked={checked}
+      disabled={Boolean(values.disabled)}
+      onCheckedChange={(next) => setValue('checked', next)}
+    />
+  );
+}
+
+function SectionTitle({ children }: { children: string }) {
+  return (
+    <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>
+      {children}
+    </text>
+  );
+}
+
+function SwitchExamples() {
   const [controlled, setControlled] = useState(false);
 
   return (
-    <scroll-view scroll-y style={{ display: 'flex', flexDirection: 'column', gap: '12px', flex: 1 }}>
+    <scroll-view
+      scroll-y
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '12px',
+        flex: 1,
+        padding: '16px',
+      }}
+    >
       <text style={{ fontSize: '20px', fontWeight: 'bold' }}>Switch</text>
 
-      <text style={{ fontSize: '16px', fontWeight: 'bold' }}>Default (uncontrolled)</text>
-      <view style={{ display: 'flex', flexDirection: 'row', gap: '16px', alignItems: 'center' }}>
+      <SectionTitle>Default (uncontrolled)</SectionTitle>
+      <view
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: '16px',
+          alignItems: 'center',
+        }}
+      >
         <Switchmark />
         <Switchmark defaultChecked />
       </view>
 
-      <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>With Label</text>
+      <SectionTitle>With Label</SectionTitle>
       <view style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
         <Switch label="알림 받기" defaultChecked />
         <Switch label="자동 로그인" />
       </view>
 
-      <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>Controlled</text>
-      <view style={{ display: 'flex', flexDirection: 'row', gap: '16px', alignItems: 'center' }}>
-        <Switch label={controlled ? 'On' : 'Off'} checked={controlled} onCheckedChange={setControlled} />
+      <SectionTitle>Controlled</SectionTitle>
+      <view
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: '16px',
+          alignItems: 'center',
+        }}
+      >
+        <Switch
+          label={controlled ? 'On' : 'Off'}
+          checked={controlled}
+          onCheckedChange={setControlled}
+        />
       </view>
 
-      <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>Sizes</text>
-      <view style={{ display: 'flex', flexDirection: 'row', gap: '16px', alignItems: 'center' }}>
+      <SectionTitle>Sizes</SectionTitle>
+      <view
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: '16px',
+          alignItems: 'center',
+        }}
+      >
         <Switchmark size="16" defaultChecked />
         <Switchmark size="24" defaultChecked />
         <Switchmark size="32" defaultChecked />
       </view>
 
-      <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>Tones</text>
-      <view style={{ display: 'flex', flexDirection: 'row', gap: '16px', alignItems: 'center' }}>
+      <SectionTitle>Tones</SectionTitle>
+      <view
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: '16px',
+          alignItems: 'center',
+        }}
+      >
         <Switch label="Brand" tone="brand" defaultChecked />
         <Switch label="Neutral" tone="neutral" defaultChecked />
       </view>
 
-      <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>Disabled</text>
+      <SectionTitle>Disabled</SectionTitle>
       <view style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
         <Switch label="Disabled Off" disabled />
         <Switch label="Disabled On" disabled defaultChecked />
@@ -49,7 +146,14 @@ export function SwitchPage() {
       <text style={{ fontSize: '16px', fontWeight: 'bold', marginTop: '8px' }}>
         Compound: Control override (Root=brand, Control=neutral)
       </text>
-      <view style={{ display: 'flex', flexDirection: 'row', gap: '16px', alignItems: 'center' }}>
+      <view
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: '16px',
+          alignItems: 'center',
+        }}
+      >
         <SeedSwitch.Root tone="brand" defaultChecked>
           <SeedSwitch.Control tone="neutral">
             <SeedSwitch.Thumb />
@@ -58,5 +162,13 @@ export function SwitchPage() {
         </SeedSwitch.Root>
       </view>
     </scroll-view>
+  );
+}
+
+export function SwitchPage() {
+  return (
+    <VariantCatalog variants={variants} examples={<SwitchExamples />}>
+      {(values, setValue) => renderSwitch(values, setValue)}
+    </VariantCatalog>
   );
 }

--- a/examples/lynx-spa/src/pages/TagGroupPage.tsx
+++ b/examples/lynx-spa/src/pages/TagGroupPage.tsx
@@ -1,7 +1,10 @@
 import { tagGroupVariantMap } from '@seed-design/lynx-css/recipes/tag-group';
 import { tagGroupItemVariantMap } from '@seed-design/lynx-css/recipes/tag-group-item';
-import { vars } from '@seed-design/lynx-css/vars';
 
+import {
+  CatalogExamples,
+  CatalogSectionHeader,
+} from '../components/catalog-examples.jsx';
 import {
   VariantCatalog,
   type VariantAxis,
@@ -13,8 +16,6 @@ import {
   TagGroupRoot,
   type TagGroupRootProps,
 } from '../seed-design/ui/tag-group';
-
-const { $color } = vars;
 
 type TagGroupSize = NonNullable<TagGroupRootProps['size']>;
 type TagGroupWeight = NonNullable<TagGroupRootProps['weight']>;
@@ -58,36 +59,12 @@ function renderTagGroup(values: VariantValues) {
   );
 }
 
-function SectionHeader({ children }: { children: string }) {
-  return (
-    <text
-      style={{
-        fontSize: '14px',
-        fontWeight: 'bold',
-        marginTop: '16px',
-        marginBottom: '8px',
-        color: $color.fg.neutralSubtle,
-      }}
-    >
-      {children}
-    </text>
-  );
-}
-
 function TagGroupExamples() {
   return (
-    <scroll-view
-      scroll-y
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        flex: 1,
-        padding: '16px',
-      }}
-    >
-      <text style={{ fontSize: '20px', fontWeight: 'bold' }}>TagGroup</text>
-
-      <SectionHeader>Default (neutralSubtle · regular)</SectionHeader>
+    <CatalogExamples title="TagGroup">
+      <CatalogSectionHeader>
+        Default (neutralSubtle · regular)
+      </CatalogSectionHeader>
       <TagGroupRoot size="t2">
         <TagGroupItem>
           <TagGroupItemLabel>동네 인증</TagGroupItemLabel>
@@ -100,7 +77,7 @@ function TagGroupExamples() {
         </TagGroupItem>
       </TagGroupRoot>
 
-      <SectionHeader>Weight: bold</SectionHeader>
+      <CatalogSectionHeader>Weight: bold</CatalogSectionHeader>
       <TagGroupRoot size="t2" weight="bold">
         <TagGroupItem>
           <TagGroupItemLabel>전체</TagGroupItemLabel>
@@ -113,7 +90,7 @@ function TagGroupExamples() {
         </TagGroupItem>
       </TagGroupRoot>
 
-      <SectionHeader>Tone: neutral</SectionHeader>
+      <CatalogSectionHeader>Tone: neutral</CatalogSectionHeader>
       <TagGroupRoot size="t2" tone="neutral">
         <TagGroupItem>
           <TagGroupItemLabel>새 상품</TagGroupItemLabel>
@@ -123,7 +100,7 @@ function TagGroupExamples() {
         </TagGroupItem>
       </TagGroupRoot>
 
-      <SectionHeader>Tone: brand</SectionHeader>
+      <CatalogSectionHeader>Tone: brand</CatalogSectionHeader>
       <TagGroupRoot size="t2" tone="brand" weight="bold">
         <TagGroupItem>
           <TagGroupItemLabel>추천</TagGroupItemLabel>
@@ -133,7 +110,7 @@ function TagGroupExamples() {
         </TagGroupItem>
       </TagGroupRoot>
 
-      <SectionHeader>Per-item override</SectionHeader>
+      <CatalogSectionHeader>Per-item override</CatalogSectionHeader>
       <TagGroupRoot size="t2">
         <TagGroupItem tone="brand" weight="bold">
           <TagGroupItemLabel>NEW</TagGroupItemLabel>
@@ -146,7 +123,7 @@ function TagGroupExamples() {
         </TagGroupItem>
       </TagGroupRoot>
 
-      <SectionHeader>Wrap behaviour</SectionHeader>
+      <CatalogSectionHeader>Wrap behaviour</CatalogSectionHeader>
       <TagGroupRoot size="t2">
         <TagGroupItem>
           <TagGroupItemLabel>관악구 봉천동</TagGroupItemLabel>
@@ -165,7 +142,7 @@ function TagGroupExamples() {
         </TagGroupItem>
       </TagGroupRoot>
 
-      <SectionHeader>Custom separator</SectionHeader>
+      <CatalogSectionHeader>Custom separator</CatalogSectionHeader>
       <TagGroupRoot size="t2" separator=" / ">
         <TagGroupItem>
           <TagGroupItemLabel>서울</TagGroupItemLabel>
@@ -177,7 +154,7 @@ function TagGroupExamples() {
           <TagGroupItemLabel>봉천동</TagGroupItemLabel>
         </TagGroupItem>
       </TagGroupRoot>
-    </scroll-view>
+    </CatalogExamples>
   );
 }
 

--- a/examples/lynx-spa/src/pages/TagGroupPage.tsx
+++ b/examples/lynx-spa/src/pages/TagGroupPage.tsx
@@ -1,24 +1,71 @@
-import { useState } from "@lynx-js/react";
+import { tagGroupVariantMap } from '@seed-design/lynx-css/recipes/tag-group';
+import { tagGroupItemVariantMap } from '@seed-design/lynx-css/recipes/tag-group-item';
+import { vars } from '@seed-design/lynx-css/vars';
+
+import {
+  VariantCatalog,
+  type VariantAxis,
+  type VariantValues,
+} from '../components/variant-catalog.jsx';
 import {
   TagGroupItem,
   TagGroupItemLabel,
   TagGroupRoot,
   type TagGroupRootProps,
-} from "../seed-design/ui/tag-group";
-import { vars } from "@seed-design/lynx-css/vars";
+} from '../seed-design/ui/tag-group';
 
 const { $color } = vars;
 
-type Size = NonNullable<TagGroupRootProps["size"]>;
+type TagGroupSize = NonNullable<TagGroupRootProps['size']>;
+type TagGroupWeight = NonNullable<TagGroupRootProps['weight']>;
+type TagGroupTone = NonNullable<TagGroupRootProps['tone']>;
+
+const variants: readonly VariantAxis[] = [
+  {
+    key: 'size',
+    options: tagGroupVariantMap.size,
+    defaultValue: 't2',
+  },
+  {
+    key: 'weight',
+    options: tagGroupItemVariantMap.weight,
+    defaultValue: 'regular',
+  },
+  {
+    key: 'tone',
+    options: tagGroupItemVariantMap.tone,
+    defaultValue: 'neutralSubtle',
+  },
+];
+
+function renderTagGroup(values: VariantValues) {
+  return (
+    <TagGroupRoot
+      size={values.size as TagGroupSize}
+      weight={values.weight as TagGroupWeight}
+      tone={values.tone as TagGroupTone}
+    >
+      <TagGroupItem>
+        <TagGroupItemLabel>동네 인증</TagGroupItemLabel>
+      </TagGroupItem>
+      <TagGroupItem>
+        <TagGroupItemLabel>매너 온도 42.0°C</TagGroupItemLabel>
+      </TagGroupItem>
+      <TagGroupItem>
+        <TagGroupItemLabel>재거래 희망률 89%</TagGroupItemLabel>
+      </TagGroupItem>
+    </TagGroupRoot>
+  );
+}
 
 function SectionHeader({ children }: { children: string }) {
   return (
     <text
       style={{
-        fontSize: "14px",
-        fontWeight: "bold",
-        marginTop: "16px",
-        marginBottom: "8px",
+        fontSize: '14px',
+        fontWeight: 'bold',
+        marginTop: '16px',
+        marginBottom: '8px',
         color: $color.fg.neutralSubtle,
       }}
     >
@@ -27,58 +74,21 @@ function SectionHeader({ children }: { children: string }) {
   );
 }
 
-function Toggle({
-  label,
-  active,
-  onTap,
-}: {
-  label: string;
-  active: boolean;
-  onTap: () => void;
-}) {
+function TagGroupExamples() {
   return (
-    <view
-      bindtap={onTap}
+    <scroll-view
+      scroll-y
       style={{
-        paddingLeft: "12px",
-        paddingRight: "12px",
-        paddingTop: "6px",
-        paddingBottom: "6px",
-        borderRadius: "8px",
-        borderWidth: "1px",
-        borderColor: active ? $color.stroke.brandSolid : $color.stroke.neutralMuted,
-        backgroundColor: active ? $color.bg.brandSolid : $color.bg.neutralWeak,
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        padding: '16px',
       }}
     >
-      <text
-        style={{
-          fontSize: "13px",
-          color: active ? $color.fg.brandContrast : $color.fg.neutral,
-          fontWeight: "bold",
-        }}
-      >
-        {label}
-      </text>
-    </view>
-  );
-}
-
-export function TagGroupPage() {
-  const [size, setSize] = useState<Size>("t2");
-
-  return (
-    <scroll-view scroll-y style={{ display: "flex", flexDirection: "column", flex: 1 }}>
-      <text style={{ fontSize: "20px", fontWeight: "bold" }}>TagGroup</text>
-
-      <SectionHeader>Size</SectionHeader>
-      <view style={{ display: "flex", flexDirection: "row", gap: "8px" }}>
-        {(["t2", "t3", "t4"] as const).map((s) => (
-          <Toggle key={s} label={s} active={size === s} onTap={() => setSize(s)} />
-        ))}
-      </view>
+      <text style={{ fontSize: '20px', fontWeight: 'bold' }}>TagGroup</text>
 
       <SectionHeader>Default (neutralSubtle · regular)</SectionHeader>
-      <TagGroupRoot size={size}>
+      <TagGroupRoot size="t2">
         <TagGroupItem>
           <TagGroupItemLabel>동네 인증</TagGroupItemLabel>
         </TagGroupItem>
@@ -91,7 +101,7 @@ export function TagGroupPage() {
       </TagGroupRoot>
 
       <SectionHeader>Weight: bold</SectionHeader>
-      <TagGroupRoot size={size} weight="bold">
+      <TagGroupRoot size="t2" weight="bold">
         <TagGroupItem>
           <TagGroupItemLabel>전체</TagGroupItemLabel>
         </TagGroupItem>
@@ -104,7 +114,7 @@ export function TagGroupPage() {
       </TagGroupRoot>
 
       <SectionHeader>Tone: neutral</SectionHeader>
-      <TagGroupRoot size={size} tone="neutral">
+      <TagGroupRoot size="t2" tone="neutral">
         <TagGroupItem>
           <TagGroupItemLabel>새 상품</TagGroupItemLabel>
         </TagGroupItem>
@@ -114,7 +124,7 @@ export function TagGroupPage() {
       </TagGroupRoot>
 
       <SectionHeader>Tone: brand</SectionHeader>
-      <TagGroupRoot size={size} tone="brand" weight="bold">
+      <TagGroupRoot size="t2" tone="brand" weight="bold">
         <TagGroupItem>
           <TagGroupItemLabel>추천</TagGroupItemLabel>
         </TagGroupItem>
@@ -124,7 +134,7 @@ export function TagGroupPage() {
       </TagGroupRoot>
 
       <SectionHeader>Per-item override</SectionHeader>
-      <TagGroupRoot size={size}>
+      <TagGroupRoot size="t2">
         <TagGroupItem tone="brand" weight="bold">
           <TagGroupItemLabel>NEW</TagGroupItemLabel>
         </TagGroupItem>
@@ -137,7 +147,7 @@ export function TagGroupPage() {
       </TagGroupRoot>
 
       <SectionHeader>Wrap behaviour</SectionHeader>
-      <TagGroupRoot size={size}>
+      <TagGroupRoot size="t2">
         <TagGroupItem>
           <TagGroupItemLabel>관악구 봉천동</TagGroupItemLabel>
         </TagGroupItem>
@@ -156,7 +166,7 @@ export function TagGroupPage() {
       </TagGroupRoot>
 
       <SectionHeader>Custom separator</SectionHeader>
-      <TagGroupRoot size={size} separator=" / ">
+      <TagGroupRoot size="t2" separator=" / ">
         <TagGroupItem>
           <TagGroupItemLabel>서울</TagGroupItemLabel>
         </TagGroupItem>
@@ -168,5 +178,13 @@ export function TagGroupPage() {
         </TagGroupItem>
       </TagGroupRoot>
     </scroll-view>
+  );
+}
+
+export function TagGroupPage() {
+  return (
+    <VariantCatalog variants={variants} examples={<TagGroupExamples />}>
+      {(values) => renderTagGroup(values)}
+    </VariantCatalog>
   );
 }

--- a/examples/lynx-spa/src/seed-design/ui/checkbox.tsx
+++ b/examples/lynx-spa/src/seed-design/ui/checkbox.tsx
@@ -4,12 +4,20 @@
  * @requires @seed-design/lynx-css@~0.1.0-alpha.0
  **/
 
-import * as React from "@lynx-js/react";
-import IconCheckmarkFatFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkFatFill";
-import IconMinusFatFill from "@karrotmarket/lynx-monochrome-icon/IconMinusFatFill";
-import { Checkbox as SeedCheckbox } from "@seed-design/lynx-react";
+import * as React from '@lynx-js/react';
+import IconCheckmarkFatFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkFatFill';
+import IconMinusFatFill from '@karrotmarket/lynx-monochrome-icon/IconMinusFatFill';
+import {
+  CheckboxControl,
+  CheckboxGroup,
+  CheckboxIndicator,
+  CheckboxLabel,
+  CheckboxRoot,
+  type CheckboxGroupProps,
+  type CheckboxRootProps,
+} from '@seed-design/lynx-react';
 
-export interface CheckboxProps extends SeedCheckbox.RootProps {
+export interface CheckboxProps extends CheckboxRootProps {
   label?: React.ReactNode;
 }
 
@@ -19,43 +27,45 @@ export interface CheckboxProps extends SeedCheckbox.RootProps {
 export const Checkbox = React.forwardRef<unknown, CheckboxProps>(
   ({ label, children, ...otherProps }, ref) => {
     return (
-      <SeedCheckbox.Root ref={ref} {...otherProps}>
-        <SeedCheckbox.Control>
-          <SeedCheckbox.Indicator
+      <CheckboxRoot ref={ref} {...otherProps}>
+        <CheckboxControl>
+          <CheckboxIndicator
             unchecked={<IconCheckmarkFatFill />}
             checked={<IconCheckmarkFatFill />}
             indeterminate={<IconMinusFatFill />}
           />
-        </SeedCheckbox.Control>
-        {label != null ? <SeedCheckbox.Label>{label}</SeedCheckbox.Label> : null}
+        </CheckboxControl>
+        {label != null ? <CheckboxLabel>{label}</CheckboxLabel> : null}
         {children}
-      </SeedCheckbox.Root>
+      </CheckboxRoot>
     );
   },
 );
-Checkbox.displayName = "Checkbox";
+Checkbox.displayName = 'Checkbox';
 
-export interface CheckmarkProps extends Omit<SeedCheckbox.RootProps, "children"> {}
+export interface CheckmarkProps extends Omit<CheckboxRootProps, 'children'> {}
 
 /**
  * @see https://seed-design.io/lynx/components/checkbox
  */
-export const Checkmark = React.forwardRef<unknown, CheckmarkProps>((props, ref) => {
-  return (
-    <SeedCheckbox.Root ref={ref} {...props}>
-      <SeedCheckbox.Control>
-        <SeedCheckbox.Indicator
-          checked={<IconCheckmarkFatFill />}
-          indeterminate={<IconMinusFatFill />}
-        />
-      </SeedCheckbox.Control>
-    </SeedCheckbox.Root>
-  );
-});
-Checkmark.displayName = "Checkmark";
+export const Checkmark = React.forwardRef<unknown, CheckmarkProps>(
+  (props, ref) => {
+    return (
+      <CheckboxRoot ref={ref} {...props}>
+        <CheckboxControl>
+          <CheckboxIndicator
+            checked={<IconCheckmarkFatFill />}
+            indeterminate={<IconMinusFatFill />}
+          />
+        </CheckboxControl>
+      </CheckboxRoot>
+    );
+  },
+);
+Checkmark.displayName = 'Checkmark';
 
-export const CheckboxGroup = SeedCheckbox.Group;
-export type CheckboxGroupProps = SeedCheckbox.GroupProps;
+export { CheckboxGroup };
+export type { CheckboxGroupProps };
 
 /**
  * This file is a snippet from SEED Design, helping you get started quickly with @seed-design/* packages.

--- a/examples/lynx-spa/src/seed-design/ui/radio-group.tsx
+++ b/examples/lynx-spa/src/seed-design/ui/radio-group.tsx
@@ -4,10 +4,18 @@
  * @requires @seed-design/lynx-css@~0.1.0-alpha.0
  **/
 
-import * as React from "@lynx-js/react";
-import { RadioGroup as SeedRadioGroup } from "@seed-design/lynx-react";
+import * as React from '@lynx-js/react';
+import {
+  RadioGroupItem,
+  RadioGroupItemControl,
+  RadioGroupItemIndicator,
+  RadioGroupItemLabel,
+  RadioGroupRoot,
+  type RadioGroupItemProps,
+  type RadioGroupRootProps,
+} from '@seed-design/lynx-react';
 
-export interface RadioGroupProps extends SeedRadioGroup.RootProps {}
+export interface RadioGroupProps extends RadioGroupRootProps {}
 
 /**
  * @see https://seed-design.io/lynx/components/radio-group
@@ -15,15 +23,15 @@ export interface RadioGroupProps extends SeedRadioGroup.RootProps {}
 export const RadioGroup = React.forwardRef<unknown, RadioGroupProps>(
   ({ children, ...otherProps }, ref) => {
     return (
-      <SeedRadioGroup.Root ref={ref} {...otherProps}>
+      <RadioGroupRoot ref={ref} {...otherProps}>
         {children}
-      </SeedRadioGroup.Root>
+      </RadioGroupRoot>
     );
   },
 );
-RadioGroup.displayName = "RadioGroup";
+RadioGroup.displayName = 'RadioGroup';
 
-export interface RadioProps extends SeedRadioGroup.ItemProps {
+export interface RadioProps extends RadioGroupItemProps {
   label?: React.ReactNode;
 }
 
@@ -33,17 +41,19 @@ export interface RadioProps extends SeedRadioGroup.ItemProps {
 export const Radio = React.forwardRef<unknown, RadioProps>(
   ({ label, children, ...otherProps }, ref) => {
     return (
-      <SeedRadioGroup.Item ref={ref} {...otherProps}>
-        <SeedRadioGroup.ItemControl>
-          <SeedRadioGroup.ItemIndicator />
-        </SeedRadioGroup.ItemControl>
-        {label != null ? <SeedRadioGroup.ItemLabel>{label}</SeedRadioGroup.ItemLabel> : null}
+      <RadioGroupItem ref={ref} {...otherProps}>
+        <RadioGroupItemControl>
+          <RadioGroupItemIndicator />
+        </RadioGroupItemControl>
+        {label != null ? (
+          <RadioGroupItemLabel>{label}</RadioGroupItemLabel>
+        ) : null}
         {children}
-      </SeedRadioGroup.Item>
+      </RadioGroupItem>
     );
   },
 );
-Radio.displayName = "Radio";
+Radio.displayName = 'Radio';
 
 /**
  * This file is a snippet from SEED Design, helping you get started quickly with @seed-design/* packages.

--- a/examples/lynx-spa/src/seed-design/ui/switch.tsx
+++ b/examples/lynx-spa/src/seed-design/ui/switch.tsx
@@ -4,10 +4,16 @@
  * @requires @seed-design/lynx-css@~0.1.0-alpha.0
  **/
 
-import * as React from "@lynx-js/react";
-import { Switch as SeedSwitch } from "@seed-design/lynx-react";
+import * as React from '@lynx-js/react';
+import {
+  SwitchControl,
+  SwitchLabel,
+  SwitchRoot,
+  SwitchThumb,
+  type SwitchRootProps,
+} from '@seed-design/lynx-react';
 
-export interface SwitchProps extends SeedSwitch.RootProps {
+export interface SwitchProps extends SwitchRootProps {
   label?: React.ReactNode;
 }
 
@@ -17,33 +23,35 @@ export interface SwitchProps extends SeedSwitch.RootProps {
 export const Switch = React.forwardRef<unknown, SwitchProps>(
   ({ label, children, ...otherProps }, ref) => {
     return (
-      <SeedSwitch.Root ref={ref} {...otherProps}>
-        <SeedSwitch.Control>
-          <SeedSwitch.Thumb />
-        </SeedSwitch.Control>
-        {label != null ? <SeedSwitch.Label>{label}</SeedSwitch.Label> : null}
+      <SwitchRoot ref={ref} {...otherProps}>
+        <SwitchControl>
+          <SwitchThumb />
+        </SwitchControl>
+        {label != null ? <SwitchLabel>{label}</SwitchLabel> : null}
         {children}
-      </SeedSwitch.Root>
+      </SwitchRoot>
     );
   },
 );
-Switch.displayName = "Switch";
+Switch.displayName = 'Switch';
 
-export interface SwitchmarkProps extends Omit<SeedSwitch.RootProps, "children"> {}
+export interface SwitchmarkProps extends Omit<SwitchRootProps, 'children'> {}
 
 /**
  * @see https://seed-design.io/lynx/components/switch
  */
-export const Switchmark = React.forwardRef<unknown, SwitchmarkProps>((props, ref) => {
-  return (
-    <SeedSwitch.Root ref={ref} {...props}>
-      <SeedSwitch.Control>
-        <SeedSwitch.Thumb />
-      </SeedSwitch.Control>
-    </SeedSwitch.Root>
-  );
-});
-Switchmark.displayName = "Switchmark";
+export const Switchmark = React.forwardRef<unknown, SwitchmarkProps>(
+  (props, ref) => {
+    return (
+      <SwitchRoot ref={ref} {...props}>
+        <SwitchControl>
+          <SwitchThumb />
+        </SwitchControl>
+      </SwitchRoot>
+    );
+  },
+);
+Switchmark.displayName = 'Switchmark';
 
 /**
  * This file is a snippet from SEED Design, helping you get started quickly with @seed-design/* packages.

--- a/examples/lynx-spa/src/seed-design/ui/tag-group.tsx
+++ b/examples/lynx-spa/src/seed-design/ui/tag-group.tsx
@@ -7,19 +7,14 @@
 /**
  * @see https://seed-design.io/lynx/components/tag-group
  */
-import { TagGroup as SeedTagGroup } from "@seed-design/lynx-react";
-
-export interface TagGroupRootProps extends SeedTagGroup.RootProps {}
-
-export const TagGroupRoot = SeedTagGroup.Root;
-
-export interface TagGroupItemProps extends SeedTagGroup.ItemProps {}
-
-export const TagGroupItem = SeedTagGroup.Item;
-
-export interface TagGroupItemLabelProps extends SeedTagGroup.ItemLabelProps {}
-
-export const TagGroupItemLabel = SeedTagGroup.ItemLabel;
+export {
+  TagGroupItem,
+  TagGroupItemLabel,
+  TagGroupRoot,
+  type TagGroupItemLabelProps,
+  type TagGroupItemProps,
+  type TagGroupRootProps,
+} from '@seed-design/lynx-react';
 
 /**
  * This file is a snippet from SEED Design, helping you get started quickly with @seed-design/* packages.


### PR DESCRIPTION
## 요약

- `examples/lynx-spa` Components 섹션의 catalog shell을 Checkbox와 같은 Playground/Table 기반 구조로 통일했습니다.
- `VariantCatalog`를 explicit `variants` API로 바꾸고, Table은 모든 조합 대신 axis별 옵션 비교 표로 재정의했습니다.
- ActionButton, Checkbox, RadioGroup, Switch, ProgressCircle, TagGroup, BottomSheet 페이지에 public prop 축만 노출했습니다.
- BottomSheet는 Playground/Table trigger preview와 기존 Examples 흐름을 함께 유지했습니다.

## 검증

- ✅ `bun install --frozen-lockfile`
- ✅ `bun --filter lynx-spa build`
- ❌ `bun --filter lynx-spa test`
  - `@lynx-js/internal-preact`에서 `preact` package를 찾지 못해 `src/__tests__/index.test.tsx` 수집 전에 실패합니다.
- ❌ `bun generate:all`
  - `@seed-design/css qvism:generate` 단계에서 `packages/css/qvism.config.mjs` 로딩 중 `ERR_REQUIRE_CYCLE_MODULE`로 실패합니다.
- ❌ `bun test:all`
  - workspace test 중 `react/jsx-dev-runtime`, `@seed-design/dom-utils`, `@seed-design/react-field` 등 module resolution 실패가 재현됩니다.
