### PR TITLE
chore(app-bar): deprecate divider option

### DIFF
--- a/.changeset/steady-bars-remove.md
+++ b/.changeset/steady-bars-remove.md
@@ -1,0 +1,10 @@
+---
+"@seed-design/css": patch
+"@seed-design/rootage-artifacts": patch
+"@seed-design/stackflow": patch
+---
+
+Top Navigation과 AppBar의 `divider` 옵션을 deprecated 처리합니다.
+
+- 1.x에서는 기존 `divider` 동작을 유지하므로 하단 stroke가 바로 사라지지 않습니다.
+- `divider` 옵션은 2.0.0에서 제거될 예정입니다. 새 코드에서는 `divider` prop 또는 `appBar({ divider })` 사용을 제거하세요.

--- a/docs/content/docs/migration/deprecations.mdx
+++ b/docs/content/docs/migration/deprecations.mdx
@@ -7,12 +7,13 @@ description: Deprecated 항목의 현황과 제거 계획을 관리합니다.
 
 ## Deprecated 현황
 
-| 항목                          | 종류          | Deprecated 버전 | 제거 예정 버전 | 대체안                 | 비고                                       |
-| ----------------------------- | ------------- | --------------- | -------------- | ---------------------- | ------------------------------------------ |
-| Image Frame - rounded 옵션    | 컴포넌트 옵션 | 1.2.x           | 1.3.0          | borderRadius="r2"      | rootage image-frame 옵션 정리              |
-| $color.bg.layer-fill          | 디자인 토큰   | 1.2.x           | 1.3.0          | $color.bg.neutral-weak | 더이상 사용하지 않음 (elevation 문서 안내) |
-| $gradient.fade-layer-floating | 디자인 토큰   | 1.2.x           | 1.3.0          | -                      | 대체안 미정                                |
-| $gradient.fade-layer-default  | 디자인 토큰   | 1.2.x           | 1.3.0          | -                      | 대체안 미정                                |
+| 항목                                | 종류          | Deprecated 버전                    | 제거 예정 버전 | 대체안                 | 비고                                       |
+| ----------------------------------- | ------------- | ---------------------------------- | -------------- | ---------------------- | ------------------------------------------ |
+| Top Navigation/AppBar - divider 옵션 | 컴포넌트 옵션 | css/rootage 1.2.x, stackflow 1.1.x | 2.0.0          | divider 제거           | AppBar 하단 stroke 옵션 제거 예정          |
+| Image Frame - rounded 옵션          | 컴포넌트 옵션 | 1.2.x                              | 1.3.0          | borderRadius="r2"      | rootage image-frame 옵션 정리              |
+| $color.bg.layer-fill                | 디자인 토큰   | 1.2.x                              | 1.3.0          | $color.bg.neutral-weak | 더이상 사용하지 않음 (elevation 문서 안내) |
+| $gradient.fade-layer-floating       | 디자인 토큰   | 1.2.x                              | 1.3.0          | -                      | 대체안 미정                                |
+| $gradient.fade-layer-default        | 디자인 토큰   | 1.2.x                              | 1.3.0          | -                      | 대체안 미정                                |
 
 ## 제거 완료 히스토리
 

--- a/docs/examples/react/pull-to-refresh/prevent-pull.tsx
+++ b/docs/examples/react/pull-to-refresh/prevent-pull.tsx
@@ -20,7 +20,7 @@ const PullToRefreshPreventPull: ActivityComponentType<
   // AppScreen snippet is integrating PullToRefresh, so it's not necessary to use it here.
   return (
     <AppScreen.Root>
-      <AppBar.Root divider>
+      <AppBar.Root>
         <AppBar.Main>
           <AppBar.Title>Pull To Refresh</AppBar.Title>
         </AppBar.Main>

--- a/docs/examples/react/pull-to-refresh/preview.tsx
+++ b/docs/examples/react/pull-to-refresh/preview.tsx
@@ -18,7 +18,7 @@ const PullToRefreshPreview: ActivityComponentType<"react/pull-to-refresh/preview
   // AppScreen snippet is integrating PullToRefresh, so it's not necessary to use it here.
   return (
     <AppScreen.Root>
-      <AppBar.Root divider>
+      <AppBar.Root>
         <AppBar.Main>
           <AppBar.Title>Pull To Refresh</AppBar.Title>
         </AppBar.Main>

--- a/docs/public/rootage/components/top-navigation.json
+++ b/docs/public/rootage/components/top-navigation.json
@@ -21,10 +21,12 @@
               "type": "color"
             },
             "strokeColor": {
-              "type": "color"
+              "type": "color",
+              "description": "divider=true일 때 적용되는 하단 stroke 색상입니다.\n@deprecated divider 옵션은 @seed-design/rootage-artifacts@2.0.0에서 제거될 예정입니다. divider 사용을 제거하세요.\nReason: Top Navigation/AppBar의 하단 stroke 옵션을 제거합니다.\n"
             },
             "strokeWidth": {
-              "type": "dimension"
+              "type": "dimension",
+              "description": "divider=true일 때 적용되는 하단 stroke 두께입니다.\n@deprecated divider 옵션은 @seed-design/rootage-artifacts@2.0.0에서 제거될 예정입니다. divider 사용을 제거하세요.\nReason: Top Navigation/AppBar의 하단 stroke 옵션을 제거합니다.\n"
             },
             "gradient": {
               "type": "gradient"
@@ -137,10 +139,15 @@
         },
         "divider": {
           "values": {
-            "true": {},
-            "false": {}
+            "true": {
+              "description": "하단 stroke를 표시합니다.\n@deprecated divider 옵션은 @seed-design/rootage-artifacts@2.0.0에서 제거될 예정입니다. divider 사용을 제거하세요.\nReason: Top Navigation/AppBar의 하단 stroke 옵션을 제거합니다.\n"
+            },
+            "false": {
+              "description": "하단 stroke를 표시하지 않습니다.\n@deprecated divider 옵션은 @seed-design/rootage-artifacts@2.0.0에서 제거될 예정입니다. divider 사용을 제거하세요.\nReason: Top Navigation/AppBar의 하단 stroke 옵션을 제거합니다.\n"
+            }
           },
-          "defaultValue": "true"
+          "defaultValue": "true",
+          "description": "하단 stroke 표시 여부입니다.\n@deprecated divider 옵션은 @seed-design/rootage-artifacts@2.0.0에서 제거될 예정입니다. divider 사용을 제거하세요.\nReason: Top Navigation/AppBar의 하단 stroke 옵션을 제거합니다.\n"
         },
         "titleLayout": {
           "values": {

--- a/examples/stackflow-spa/src/activities/ActivityLayerBar.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityLayerBar.tsx
@@ -30,7 +30,7 @@ const ActivityLayerBar: StaticActivityComponentType<"ActivityLayerBar"> = () => 
 
   return (
     <AppScreen>
-      <AppBar divider>
+      <AppBar>
         <AppBarLeft>
           {Array.from({ length: counts.left }).map((_, index) => (
             <AppBarIconButton key={index}>

--- a/examples/stackflow-spa/src/activities/ActivityPartialDarkMode.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityPartialDarkMode.tsx
@@ -24,7 +24,7 @@ const ActivityPartialDarkMode: StaticActivityComponentType<"ActivityPartialDarkM
 
   return (
     <AppScreen>
-      <AppBar divider>
+      <AppBar>
         <AppBarLeft>
           <AppBarBackButton />
         </AppBarLeft>

--- a/packages/css/vars/component/top-navigation.d.ts
+++ b/packages/css/vars/component/top-navigation.d.ts
@@ -64,14 +64,34 @@ export declare const vars: {
       }
     }
   },
+  /**
+   * 하단 stroke를 표시합니다.
+@deprecated divider 옵션은 @seed-design/rootage-artifacts@2.0.0에서 제거될 예정입니다. divider 사용을 제거하세요.
+Reason: Top Navigation/AppBar의 하단 stroke 옵션을 제거합니다.
+
+   */
   "dividerTrue": {
     "enabled": {
       "root": {
+        /** divider=true일 때 적용되는 하단 stroke 색상입니다.
+@deprecated divider 옵션은 @seed-design/rootage-artifacts@2.0.0에서 제거될 예정입니다. divider 사용을 제거하세요.
+Reason: Top Navigation/AppBar의 하단 stroke 옵션을 제거합니다.
+ */
         "strokeColor": "var(--seed-color-stroke-neutral-subtle)",
+        /** divider=true일 때 적용되는 하단 stroke 두께입니다.
+@deprecated divider 옵션은 @seed-design/rootage-artifacts@2.0.0에서 제거될 예정입니다. divider 사용을 제거하세요.
+Reason: Top Navigation/AppBar의 하단 stroke 옵션을 제거합니다.
+ */
         "strokeWidth": "1px"
       }
     }
   },
+  /**
+   * 하단 stroke를 표시하지 않습니다.
+@deprecated divider 옵션은 @seed-design/rootage-artifacts@2.0.0에서 제거될 예정입니다. divider 사용을 제거하세요.
+Reason: Top Navigation/AppBar의 하단 stroke 옵션을 제거합니다.
+
+   */
   "dividerFalse": {},
   "titleLayoutTitleOnly": {
     "enabled": {

--- a/packages/qvism-preset/src/vars/component/top-navigation.d.ts
+++ b/packages/qvism-preset/src/vars/component/top-navigation.d.ts
@@ -64,14 +64,34 @@ export declare const vars: {
       }
     }
   },
+  /**
+   * 하단 stroke를 표시합니다.
+@deprecated divider 옵션은 @seed-design/rootage-artifacts@2.0.0에서 제거될 예정입니다. divider 사용을 제거하세요.
+Reason: Top Navigation/AppBar의 하단 stroke 옵션을 제거합니다.
+
+   */
   "dividerTrue": {
     "enabled": {
       "root": {
+        /** divider=true일 때 적용되는 하단 stroke 색상입니다.
+@deprecated divider 옵션은 @seed-design/rootage-artifacts@2.0.0에서 제거될 예정입니다. divider 사용을 제거하세요.
+Reason: Top Navigation/AppBar의 하단 stroke 옵션을 제거합니다.
+ */
         "strokeColor": "var(--seed-color-stroke-neutral-subtle)",
+        /** divider=true일 때 적용되는 하단 stroke 두께입니다.
+@deprecated divider 옵션은 @seed-design/rootage-artifacts@2.0.0에서 제거될 예정입니다. divider 사용을 제거하세요.
+Reason: Top Navigation/AppBar의 하단 stroke 옵션을 제거합니다.
+ */
         "strokeWidth": "1px"
       }
     }
   },
+  /**
+   * 하단 stroke를 표시하지 않습니다.
+@deprecated divider 옵션은 @seed-design/rootage-artifacts@2.0.0에서 제거될 예정입니다. divider 사용을 제거하세요.
+Reason: Top Navigation/AppBar의 하단 stroke 옵션을 제거합니다.
+
+   */
   "dividerFalse": {},
   "titleLayoutTitleOnly": {
     "enabled": {

--- a/packages/rootage/components/top-navigation.yaml
+++ b/packages/rootage/components/top-navigation.yaml
@@ -16,8 +16,16 @@ data:
             type: color
           strokeColor:
             type: color
+            description: |
+              divider=true일 때 적용되는 하단 stroke 색상입니다.
+              @deprecated divider 옵션은 @seed-design/rootage-artifacts@2.0.0에서 제거될 예정입니다. divider 사용을 제거하세요.
+              Reason: Top Navigation/AppBar의 하단 stroke 옵션을 제거합니다.
           strokeWidth:
             type: dimension
+            description: |
+              divider=true일 때 적용되는 하단 stroke 두께입니다.
+              @deprecated divider 옵션은 @seed-design/rootage-artifacts@2.0.0에서 제거될 예정입니다. divider 사용을 제거하세요.
+              Reason: Top Navigation/AppBar의 하단 stroke 옵션을 제거합니다.
           gradient:
             type: gradient
           bleedBottom:
@@ -83,6 +91,22 @@ data:
             description: false로 사용하는 것을 권장하지 않습니다. gradient 없이 사용하면 Top Navigation의 콘텐츠 가독성을
               직접 확보해야 합니다. 스크린 배경 색상이 Top Navigation에 보이기를 원하는 경우 tone=layer를
               사용하세요.
+      divider:
+        description: |
+          하단 stroke 표시 여부입니다.
+          @deprecated divider 옵션은 @seed-design/rootage-artifacts@2.0.0에서 제거될 예정입니다. divider 사용을 제거하세요.
+          Reason: Top Navigation/AppBar의 하단 stroke 옵션을 제거합니다.
+        values:
+          "true":
+            description: |
+              하단 stroke를 표시합니다.
+              @deprecated divider 옵션은 @seed-design/rootage-artifacts@2.0.0에서 제거될 예정입니다. divider 사용을 제거하세요.
+              Reason: Top Navigation/AppBar의 하단 stroke 옵션을 제거합니다.
+          "false":
+            description: |
+              하단 stroke를 표시하지 않습니다.
+              @deprecated divider 옵션은 @seed-design/rootage-artifacts@2.0.0에서 제거될 예정입니다. divider 사용을 제거하세요.
+              Reason: Top Navigation/AppBar의 하단 stroke 옵션을 제거합니다.
   definitions:
     theme=ios:
       enabled:

--- a/packages/stackflow/src/components/AppBar/AppBar.tsx
+++ b/packages/stackflow/src/components/AppBar/AppBar.tsx
@@ -26,7 +26,12 @@ export const AppBarPropsProvider = PropsProvider;
 export interface AppBarProps
   extends AppBarVariantProps,
     AppBarPrimitive.RootProps,
-    BoxBackgroundProps {}
+    BoxBackgroundProps {
+  /**
+   * @deprecated Deprecated in @seed-design/stackflow@1.1.x; will be removed in 2.0.0. Remove divider; AppBar should render without the bottom stroke.
+   */
+  divider?: AppBarVariantProps["divider"];
+}
 
 export const AppBarRoot = forwardRef<HTMLDivElement, AppBarProps>((props, ref) => {
   const { style: boxStyle, restProps: propsWithoutBoxProps } = useBoxBackgroundProps(props);


### PR DESCRIPTION
## Summary

- Top Navigation/AppBar의 `divider` 옵션을 1.x 호환 경로로 유지하되 deprecated로 명시합니다.
- `divider` 관련 Rootage description과 migration deprecations 문서, changeset을 추가합니다.
- 새 예제 코드에서는 deprecated `divider` 사용을 제거합니다.

## Validation

- `bun generate:all`
- `bun --filter @seed-design/qvism-preset typecheck`
- `bun --cwd examples/stackflow-spa tsc --noEmit --project tsconfig.json`
- `bun --cwd docs tsc --noEmit --project tsconfig.json`
- `git diff --check`
- `bun test:all`