### PR TITLE
fix(lynx-react): Bottom Sheet skipAnimation 동작 수정

### DIFF
--- a/.changeset/brave-sheets-skip.md
+++ b/.changeset/brave-sheets-skip.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/lynx-react": patch
+---
+
+Lynx Bottom Sheet의 `skipAnimation`이 열림/닫힘 애니메이션을 실제로 건너뛰도록 수정합니다.

--- a/examples/lynx-spa/src/pages/BottomSheetPage.tsx
+++ b/examples/lynx-spa/src/pages/BottomSheetPage.tsx
@@ -1,6 +1,5 @@
 import { useRef, useState } from '@lynx-js/react';
 import { bottomSheetVariantMap } from '@seed-design/lynx-css/recipes/bottom-sheet';
-import { vars } from '@seed-design/lynx-css/vars';
 import { type BottomSheetRootRef } from '@seed-design/lynx-react';
 
 import {
@@ -24,8 +23,6 @@ import {
 
 const SNAP_POINTS_FIT_80: Array<number | string> = ['fit', '80%'];
 const SNAP_POINTS_FIT: Array<number | string> = ['fit'];
-
-const { $color } = vars;
 
 type BottomSheetHeaderAlign = NonNullable<BottomSheetRootProps['headerAlign']>;
 
@@ -52,15 +49,8 @@ function renderBottomSheet(values: VariantValues) {
       skipAnimation={skipAnimation}
       snapPoints={SNAP_POINTS_FIT_80}
     >
-      <BottomSheetTrigger
-        style={{
-          padding: '10px 16px',
-          backgroundColor: $color.bg.brandSolid,
-          borderRadius: '8px',
-          alignSelf: 'flex-start',
-        }}
-      >
-        <text style={{ color: $color.fg.brandContrast }}>Open sheet</text>
+      <BottomSheetTrigger style={{ alignSelf: 'flex-start' }}>
+        <ActionButton variant="brandSolid">Open sheet</ActionButton>
       </BottomSheetTrigger>
       <BottomSheetContent
         title={`Header ${headerAlign}`}
@@ -86,15 +76,8 @@ function BottomSheetExamples() {
     <CatalogExamples title="BottomSheet" gap="16px">
       <CatalogSectionTitle>Uncontrolled (Trigger 기반)</CatalogSectionTitle>
       <BottomSheetRoot snapPoints={SNAP_POINTS_FIT_80}>
-        <BottomSheetTrigger
-          style={{
-            padding: '10px 16px',
-            backgroundColor: $color.bg.brandSolid,
-            borderRadius: '8px',
-            alignSelf: 'flex-start',
-          }}
-        >
-          <text style={{ color: $color.fg.brandContrast }}>Trigger 탭</text>
+        <BottomSheetTrigger style={{ alignSelf: 'flex-start' }}>
+          <ActionButton variant="brandSolid">Trigger 탭</ActionButton>
         </BottomSheetTrigger>
         <BottomSheetContent
           title="기본 Bottom Sheet"

--- a/packages/lynx-react/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/lynx-react/src/components/BottomSheet/BottomSheet.tsx
@@ -38,6 +38,10 @@ type BottomSheetClassNames = ReturnType<typeof bottomSheet>;
 const { ClassNamesProvider, useClassNames, withContext } = createSlotRecipeContext(bottomSheet);
 
 const DEFAULT_SNAP_POINTS: Array<number | string> = ["fit"];
+const SKIP_ANIMATION_TRANSITION: SheetTransition = {
+  type: "tween",
+  duration: 0,
+};
 
 ////////////////////////////////////////////////////////////////////////////////////
 // SEED Transitions — 웹 SEED BottomSheet (recipe: d6/d4 + enter-expressive/enter/exit)
@@ -76,6 +80,7 @@ const SEED_EXIT_ANIMATION: SheetTransition = {
  * Trigger가 Root의 imperative API(`open` 등)를 호출할 수 있도록 `SheetRootRef`를 공유하는 내부 컨텍스트.
  */
 const RootRefContext = createContext<RefObject<SheetRootRef | null> | null>(null);
+const SkipAnimationContext = createContext(false);
 
 function useRootRef(): RefObject<SheetRootRef | null> {
   const ctx = useContext(RootRefContext);
@@ -83,6 +88,10 @@ function useRootRef(): RefObject<SheetRootRef | null> {
     throw new Error("BottomSheet compound components must be used within BottomSheetRoot");
   }
   return ctx;
+}
+
+function useSkipAnimation(): boolean {
+  return useContext(SkipAnimationContext);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////
@@ -148,21 +157,24 @@ export const BottomSheetRoot = forwardRef<SheetRootRef, BottomSheetRootProps>(
       // variantProps 객체는 매 렌더 새로 생성되므로 개별 variant 값으로 의존성을 고정한다.
       [headerAlign, skipAnimation],
     );
+    const shouldSkipAnimation = skipAnimation === true;
 
     return (
       <RootRefContext.Provider value={internalRef}>
-        <ClassNamesProvider value={classNames}>
-          <SheetRoot
-            ref={mergedRef}
-            show={open}
-            defaultShow={defaultOpen}
-            onShowChange={onOpenChange}
-            snapPoints={snapPoints ?? DEFAULT_SNAP_POINTS}
-            {...nativeProps}
-          >
-            {children}
-          </SheetRoot>
-        </ClassNamesProvider>
+        <SkipAnimationContext.Provider value={shouldSkipAnimation}>
+          <ClassNamesProvider value={classNames}>
+            <SheetRoot
+              ref={mergedRef}
+              show={open}
+              defaultShow={defaultOpen}
+              onShowChange={onOpenChange}
+              snapPoints={snapPoints ?? DEFAULT_SNAP_POINTS}
+              {...nativeProps}
+            >
+              {children}
+            </SheetRoot>
+          </ClassNamesProvider>
+        </SkipAnimationContext.Provider>
       </RootRefContext.Provider>
     );
   },
@@ -183,12 +195,18 @@ export interface BottomSheetTriggerProps {
 export const BottomSheetTrigger = forwardRef<unknown, BottomSheetTriggerProps>((props, ref) => {
   const { children, className, style, bindtap: userBindtap } = props;
   const rootRef = useRootRef();
+  const skipAnimation = useSkipAnimation();
 
   // `bindtap`을 직접 prop으로 쓰면 React DOM `<view>` 타입(SVG)이 적용되어 TS가 거부한다.
   // Lynx JSX 런타임은 이 prop을 올바르게 처리하므로 spread로 우회한다 (ActionButton과 동일 패턴).
   const handlers = {
     bindtap: () => {
-      rootRef.current?.open();
+      if (skipAnimation) {
+        rootRef.current?.open({ animate: false });
+      } else {
+        rootRef.current?.open();
+      }
+
       userBindtap?.();
     },
   };
@@ -247,17 +265,24 @@ BottomSheetBackdrop.displayName = "BottomSheetBackdrop";
 
 export interface BottomSheetContentProps extends SheetContentProps {}
 
-export const BottomSheetContent = withContext<unknown, BottomSheetContentProps>(
-  SheetContent,
-  "content",
-  {
-    defaultProps: {
-      snapAnimation: SEED_SNAP_ANIMATION,
-      enterAnimation: SEED_ENTER_ANIMATION,
-      exitAnimation: SEED_EXIT_ANIMATION,
-    },
-  },
-);
+export const BottomSheetContent = forwardRef<unknown, BottomSheetContentProps>((props, ref) => {
+  const { className, snapAnimation, enterAnimation, exitAnimation, ...restProps } = props;
+  const classNames = useClassNames();
+  const skipAnimation = useSkipAnimation();
+
+  const defaultAnimation = skipAnimation ? SKIP_ANIMATION_TRANSITION : undefined;
+
+  return (
+    <SheetContent
+      {...(ref ? { ref } : {})}
+      {...restProps}
+      className={clsx(classNames.content, className)}
+      snapAnimation={snapAnimation ?? defaultAnimation ?? SEED_SNAP_ANIMATION}
+      enterAnimation={enterAnimation ?? defaultAnimation ?? SEED_ENTER_ANIMATION}
+      exitAnimation={exitAnimation ?? defaultAnimation ?? SEED_EXIT_ANIMATION}
+    />
+  );
+});
 BottomSheetContent.displayName = "BottomSheetContent";
 
 ////////////////////////////////////////////////////////////////////////////////////

--- a/packages/lynx-react/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/lynx-react/src/components/BottomSheet/BottomSheet.tsx
@@ -77,21 +77,23 @@ const SEED_EXIT_ANIMATION: SheetTransition = {
 };
 
 /**
- * Trigger가 Root의 imperative API(`open` 등)를 호출할 수 있도록 `SheetRootRef`를 공유하는 내부 컨텍스트.
+ * Trigger와 Content가 Root의 imperative API와 동작 옵션을 공유하는 내부 컨텍스트.
  */
-const RootRefContext = createContext<RefObject<SheetRootRef | null> | null>(null);
-const SkipAnimationContext = createContext(false);
+interface BottomSheetContextValue {
+  rootRef: RefObject<SheetRootRef | null>;
+  options: {
+    skipAnimation: boolean;
+  };
+}
 
-function useRootRef(): RefObject<SheetRootRef | null> {
-  const ctx = useContext(RootRefContext);
+const BottomSheetContext = createContext<BottomSheetContextValue | null>(null);
+
+function useBottomSheetContext(): BottomSheetContextValue {
+  const ctx = useContext(BottomSheetContext);
   if (!ctx) {
     throw new Error("BottomSheet compound components must be used within BottomSheetRoot");
   }
   return ctx;
-}
-
-function useSkipAnimation(): boolean {
-  return useContext(SkipAnimationContext);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////
@@ -158,24 +160,31 @@ export const BottomSheetRoot = forwardRef<SheetRootRef, BottomSheetRootProps>(
       [headerAlign, skipAnimation],
     );
     const shouldSkipAnimation = skipAnimation === true;
+    const context = useMemo(
+      () => ({
+        rootRef: internalRef,
+        options: {
+          skipAnimation: shouldSkipAnimation,
+        },
+      }),
+      [shouldSkipAnimation],
+    );
 
     return (
-      <RootRefContext.Provider value={internalRef}>
-        <SkipAnimationContext.Provider value={shouldSkipAnimation}>
-          <ClassNamesProvider value={classNames}>
-            <SheetRoot
-              ref={mergedRef}
-              show={open}
-              defaultShow={defaultOpen}
-              onShowChange={onOpenChange}
-              snapPoints={snapPoints ?? DEFAULT_SNAP_POINTS}
-              {...nativeProps}
-            >
-              {children}
-            </SheetRoot>
-          </ClassNamesProvider>
-        </SkipAnimationContext.Provider>
-      </RootRefContext.Provider>
+      <BottomSheetContext.Provider value={context}>
+        <ClassNamesProvider value={classNames}>
+          <SheetRoot
+            ref={mergedRef}
+            show={open}
+            defaultShow={defaultOpen}
+            onShowChange={onOpenChange}
+            snapPoints={snapPoints ?? DEFAULT_SNAP_POINTS}
+            {...nativeProps}
+          >
+            {children}
+          </SheetRoot>
+        </ClassNamesProvider>
+      </BottomSheetContext.Provider>
     );
   },
 );
@@ -194,14 +203,13 @@ export interface BottomSheetTriggerProps {
 
 export const BottomSheetTrigger = forwardRef<unknown, BottomSheetTriggerProps>((props, ref) => {
   const { children, className, style, bindtap: userBindtap } = props;
-  const rootRef = useRootRef();
-  const skipAnimation = useSkipAnimation();
+  const { rootRef, options } = useBottomSheetContext();
 
   // `bindtap`을 직접 prop으로 쓰면 React DOM `<view>` 타입(SVG)이 적용되어 TS가 거부한다.
   // Lynx JSX 런타임은 이 prop을 올바르게 처리하므로 spread로 우회한다 (ActionButton과 동일 패턴).
   const handlers = {
     bindtap: () => {
-      if (skipAnimation) {
+      if (options.skipAnimation) {
         rootRef.current?.open({ animate: false });
       } else {
         rootRef.current?.open();
@@ -268,9 +276,9 @@ export interface BottomSheetContentProps extends SheetContentProps {}
 export const BottomSheetContent = forwardRef<unknown, BottomSheetContentProps>((props, ref) => {
   const { className, snapAnimation, enterAnimation, exitAnimation, ...restProps } = props;
   const classNames = useClassNames();
-  const skipAnimation = useSkipAnimation();
+  const { options } = useBottomSheetContext();
 
-  const defaultAnimation = skipAnimation ? SKIP_ANIMATION_TRANSITION : undefined;
+  const defaultAnimation = options.skipAnimation ? SKIP_ANIMATION_TRANSITION : undefined;
 
   return (
     <SheetContent

--- a/packages/lynx-react/src/components/BottomSheet/__tests__/BottomSheet.test.tsx
+++ b/packages/lynx-react/src/components/BottomSheet/__tests__/BottomSheet.test.tsx
@@ -1,0 +1,119 @@
+import { fireEvent, render } from "@lynx-js/react/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sheetMocks = vi.hoisted(() => ({
+  contentProps: [] as Array<Record<string, unknown>>,
+  rootRef: {
+    open: vi.fn(),
+  },
+}));
+
+vi.mock("@lynx-js/lynx-ui-sheet", async () => {
+  const React = await vi.importActual<typeof import("@lynx-js/react")>("@lynx-js/react");
+
+  const SheetRoot = React.forwardRef<unknown, { children?: React.ReactNode }>((props, ref) => {
+    React.useImperativeHandle(ref, () => sheetMocks.rootRef);
+    return <>{props.children}</>;
+  });
+  SheetRoot.displayName = "MockSheetRoot";
+
+  const SheetView = React.forwardRef<unknown, { children?: React.ReactNode }>((props) => {
+    return <>{props.children}</>;
+  });
+  SheetView.displayName = "MockSheetView";
+
+  const SheetContent = React.forwardRef<unknown, Record<string, unknown>>((props) => {
+    sheetMocks.contentProps.push(props);
+    return <>{props.children as React.ReactNode}</>;
+  });
+  SheetContent.displayName = "MockSheetContent";
+
+  const passthrough = (displayName: string) => {
+    const Component = React.forwardRef<unknown, { children?: React.ReactNode }>((props) => {
+      return <>{props.children}</>;
+    });
+    Component.displayName = displayName;
+    return Component;
+  };
+
+  return {
+    SheetBackdrop: passthrough("MockSheetBackdrop"),
+    SheetContent,
+    SheetHandle: passthrough("MockSheetHandle"),
+    SheetRoot,
+    SheetView,
+  };
+});
+
+import * as BottomSheet from "../BottomSheet.namespace";
+
+describe("BottomSheet", () => {
+  beforeEach(() => {
+    sheetMocks.contentProps = [];
+    sheetMocks.rootRef.open.mockClear();
+  });
+
+  it("skips motion-engine animations when Root has skipAnimation", () => {
+    render(
+      <BottomSheet.Root skipAnimation>
+        <BottomSheet.Content />
+      </BottomSheet.Root>,
+    );
+
+    expect(sheetMocks.contentProps.at(-1)).toMatchObject({
+      snapAnimation: { type: "tween", duration: 0 },
+      enterAnimation: { type: "tween", duration: 0 },
+      exitAnimation: { type: "tween", duration: 0 },
+    });
+  });
+
+  it("preserves user-provided animations when Root has skipAnimation", () => {
+    const snapAnimation = { type: "tween", duration: 120 };
+    const enterAnimation = { type: "tween", duration: 140 };
+    const exitAnimation = { type: "tween", duration: 90 };
+
+    render(
+      <BottomSheet.Root skipAnimation>
+        <BottomSheet.Content
+          snapAnimation={snapAnimation}
+          enterAnimation={enterAnimation}
+          exitAnimation={exitAnimation}
+        />
+      </BottomSheet.Root>,
+    );
+
+    expect(sheetMocks.contentProps.at(-1)).toMatchObject({
+      snapAnimation,
+      enterAnimation,
+      exitAnimation,
+    });
+  });
+
+  it("opens with default animation when Root does not skip animation", () => {
+    const { getByText } = render(
+      <BottomSheet.Root>
+        <BottomSheet.Trigger>
+          <text>Open sheet</text>
+        </BottomSheet.Trigger>
+      </BottomSheet.Root>,
+    );
+
+    fireEvent.tap(getByText("Open sheet").parentElement!);
+
+    expect(sheetMocks.rootRef.open).toHaveBeenCalledWith();
+  });
+
+  it("opens without animation when Trigger is tapped inside a skipping Root", () => {
+    const { getByText } = render(
+      <BottomSheet.Root skipAnimation>
+        <BottomSheet.Trigger>
+          <text>Open sheet</text>
+        </BottomSheet.Trigger>
+      </BottomSheet.Root>,
+    );
+
+    fireEvent.tap(getByText("Open sheet").parentElement!);
+
+    expect(sheetMocks.rootRef.open).toHaveBeenCalledWith({ animate: false });
+  });
+});


### PR DESCRIPTION
## Summary
- `@seed-design/lynx-react` Bottom Sheet의 `skipAnimation` 값을 내부 context로 전달합니다.
- Trigger open은 `skipAnimation=true`일 때 `open({ animate: false })`를 사용하고, 기본값은 기존 `open()` 호출을 유지합니다.
- Content의 기본 sheet animation은 `skipAnimation=true`일 때 0ms tween으로 바꾸되, 사용자가 넘긴 animation prop은 그대로 우선합니다.
- `examples/lynx-spa` Bottom Sheet 예제의 inline trigger 버튼을 `ActionButton variant="brandSolid"`로 교체합니다.
- `@seed-design/lynx-react` patch changeset을 추가합니다.

## Root Cause
`skipAnimation`은 recipe variant/className에는 반영됐지만, `@lynx-js/lynx-ui-sheet`의 imperative open 옵션과 Content animation prop 기본값에는 전달되지 않았습니다. 그래서 실제 열림/닫힘 motion은 기존 spring animation을 계속 사용했습니다.

## Validation
- `bun --filter @seed-design/lynx-react test src/components/BottomSheet/__tests__/BottomSheet.test.tsx`
- `bun lynx-react:test`
- `bun --filter @seed-design/lynx-react build`
- `bun generate:all`
- `cd examples/lynx-spa && bun run build`

## Notes
- `bun test:all`은 `examples/lynx-spa/src/__tests__/index.test.tsx`에서 `react/jsx-dev-runtime`을 찾지 못하는 기존 예제 테스트 환경 문제로 중단되었습니다. 패키지 focused/full test와 예제 build는 통과했습니다.
