### PR TITLE
feat(lynx-spa): virtualize icon catalogs

### DIFF
--- a/examples/lynx-spa/scripts/generate-icon-pages.js
+++ b/examples/lynx-spa/scripts/generate-icon-pages.js
@@ -8,45 +8,106 @@
  * Usage: node scripts/generate-icon-pages.js
  */
 
-import { readdirSync, writeFileSync } from "node:fs";
-import { resolve, dirname } from "node:path";
-import { createRequire } from "node:module";
-import { fileURLToPath } from "node:url";
+import { readdirSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
+
+function isDigit(char) {
+  return char >= '0' && char <= '9';
+}
+
+function isUppercaseLetter(char) {
+  return char.toLowerCase() !== char && char.toUpperCase() === char;
+}
+
+function compareIconNames(a, b) {
+  let aIndex = 0;
+  let bIndex = 0;
+
+  while (aIndex < a.length && bIndex < b.length) {
+    const aChar = a[aIndex];
+    const bChar = b[bIndex];
+
+    if (isDigit(aChar) && isDigit(bChar)) {
+      let aEnd = aIndex + 1;
+      let bEnd = bIndex + 1;
+
+      while (isDigit(a[aEnd])) aEnd += 1;
+      while (isDigit(b[bEnd])) bEnd += 1;
+
+      const numberDiff =
+        Number(a.slice(aIndex, aEnd)) - Number(b.slice(bIndex, bEnd));
+      if (numberDiff !== 0) return numberDiff;
+
+      aIndex = aEnd;
+      bIndex = bEnd;
+      continue;
+    }
+
+    const aLower = aChar.toLowerCase();
+    const bLower = bChar.toLowerCase();
+
+    if (aLower !== bLower) {
+      return aLower < bLower ? -1 : 1;
+    }
+
+    if (aChar !== bChar) {
+      const aUpper = isUppercaseLetter(aChar);
+      const bUpper = isUppercaseLetter(bChar);
+      if (aUpper !== bUpper) return aUpper ? -1 : 1;
+
+      return aChar < bChar ? -1 : 1;
+    }
+
+    aIndex += 1;
+    bIndex += 1;
+  }
+
+  return a.length - b.length;
+}
 
 function getIconNames(packageName) {
   const entryPath = require.resolve(packageName);
   const libDir = dirname(entryPath);
   return readdirSync(libDir)
-    .filter((f) => f.endsWith(".js") && !f.endsWith(".cjs") && f.startsWith("Icon"))
-    .map((f) => f.replace(".js", ""))
-    .sort();
+    .filter(
+      (f) => f.endsWith('.js') && !f.endsWith('.cjs') && f.startsWith('Icon'),
+    )
+    .map((f) => f.replace('.js', ''))
+    .sort(compareIconNames);
 }
 
 function generateMonochromePage(iconNames) {
   const imports = iconNames
-    .map((name) => `import ${name} from "@karrotmarket/lynx-monochrome-icon/${name}";`)
-    .join("\n");
+    .map(
+      (name) =>
+        `import ${name} from '@karrotmarket/lynx-monochrome-icon/${name}';`,
+    )
+    .join('\n');
 
   const entries = iconNames
     .map((name) => {
-      const label = name.replace(/^Icon/, "");
-      return `  { component: ${name}, name: "${label}" },`;
+      const label = name.replace(/^Icon/, '');
+      return `  {
+    component: ${name},
+    name: '${label}',
+  },`;
     })
-    .join("\n");
+    .join('\n');
 
-  return `import { vars } from "@seed-design/lynx-css/vars";
+  return `${imports}
 
-${imports}
+import { vars } from '@seed-design/lynx-css/vars';
+import {
+  type IconEntry,
+  VirtualIconGrid,
+} from '../components/icon-virtual-grid.jsx';
 
 const { $color } = vars;
-
-interface IconEntry {
-  component: (props: { size?: number; color: string }) => JSX.Element;
-  name: string;
-}
 
 const icons: IconEntry[] = [
 ${entries}
@@ -54,52 +115,12 @@ ${entries}
 
 export function FoundationMonochromeIconPage() {
   return (
-    <scroll-view scroll-y style={{ display: "flex", flexDirection: "column", flex: 1 }}>
-      <text style={{ fontSize: "20px", fontWeight: "bold" }}>Monochrome Icon</text>
-      <text
-        style={{
-          fontSize: "13px",
-          color: $color.fg.neutralSubtle,
-          marginBottom: "8px",
-        }}
-      >
-        @karrotmarket/lynx-monochrome-icon — {icons.length} icons
-      </text>
-
-      <view
-        style={{
-          display: "flex",
-          flexDirection: "row",
-          flexWrap: "wrap",
-        }}
-      >
-        {icons.map(({ component: IconComp, name }) => (
-          <view
-            key={name}
-            style={{
-              width: "25%",
-              padding: "8px 4px",
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              gap: "4px",
-            }}
-          >
-            <IconComp size={24} color={$color.fg.neutral} />
-            <text
-              style={{
-                fontSize: "9px",
-                color: $color.fg.neutralMuted,
-                textAlign: "center",
-                wordBreak: "break-all",
-              }}
-            >
-              {name}
-            </text>
-          </view>
-        ))}
-      </view>
-    </scroll-view>
+    <VirtualIconGrid
+      title="Monochrome Icon"
+      packageName="@karrotmarket/lynx-monochrome-icon"
+      icons={icons}
+      iconColor={$color.fg.neutral}
+    />
   );
 }
 `;
@@ -107,26 +128,28 @@ export function FoundationMonochromeIconPage() {
 
 function generateMulticolorPage(iconNames) {
   const imports = iconNames
-    .map((name) => `import ${name} from "@karrotmarket/lynx-multicolor-icon/${name}";`)
-    .join("\n");
+    .map(
+      (name) =>
+        `import ${name} from '@karrotmarket/lynx-multicolor-icon/${name}';`,
+    )
+    .join('\n');
 
   const entries = iconNames
     .map((name) => {
-      const label = name.replace(/^Icon/, "");
-      return `  { component: ${name}, name: "${label}" },`;
+      const label = name.replace(/^Icon/, '');
+      return `  {
+    component: ${name},
+    name: '${label}',
+  },`;
     })
-    .join("\n");
+    .join('\n');
 
-  return `import { vars } from "@seed-design/lynx-css/vars";
+  return `${imports}
 
-${imports}
-
-const { $color } = vars;
-
-interface IconEntry {
-  component: (props: { size?: number }) => JSX.Element;
-  name: string;
-}
+import {
+  type IconEntry,
+  VirtualIconGrid,
+} from '../components/icon-virtual-grid.jsx';
 
 const icons: IconEntry[] = [
 ${entries}
@@ -134,70 +157,33 @@ ${entries}
 
 export function FoundationMulticolorIconPage() {
   return (
-    <scroll-view scroll-y style={{ display: "flex", flexDirection: "column", flex: 1 }}>
-      <text style={{ fontSize: "20px", fontWeight: "bold" }}>Multicolor Icon</text>
-      <text
-        style={{
-          fontSize: "13px",
-          color: $color.fg.neutralSubtle,
-          marginBottom: "8px",
-        }}
-      >
-        @karrotmarket/lynx-multicolor-icon — {icons.length} icons
-      </text>
-
-      <view
-        style={{
-          display: "flex",
-          flexDirection: "row",
-          flexWrap: "wrap",
-        }}
-      >
-        {icons.map(({ component: IconComp, name }) => (
-          <view
-            key={name}
-            style={{
-              width: "25%",
-              padding: "8px 4px",
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              gap: "4px",
-            }}
-          >
-            <IconComp size={24} />
-            <text
-              style={{
-                fontSize: "9px",
-                color: $color.fg.neutralMuted,
-                textAlign: "center",
-                wordBreak: "break-all",
-              }}
-            >
-              {name}
-            </text>
-          </view>
-        ))}
-      </view>
-    </scroll-view>
+    <VirtualIconGrid
+      title="Multicolor Icon"
+      packageName="@karrotmarket/lynx-multicolor-icon"
+      icons={icons}
+    />
   );
 }
 `;
 }
 
-const monoIcons = getIconNames("@karrotmarket/lynx-monochrome-icon");
-const multiIcons = getIconNames("@karrotmarket/lynx-multicolor-icon");
+const monoIcons = getIconNames('@karrotmarket/lynx-monochrome-icon');
+const multiIcons = getIconNames('@karrotmarket/lynx-multicolor-icon');
 
-const outDir = resolve(__dirname, "../src/pages");
+const outDir = resolve(__dirname, '../src/pages');
 
 writeFileSync(
-  resolve(outDir, "FoundationMonochromeIconPage.tsx"),
+  resolve(outDir, 'FoundationMonochromeIconPage.tsx'),
   generateMonochromePage(monoIcons),
 );
-console.log(`Generated FoundationMonochromeIconPage.tsx (${monoIcons.length} icons)`);
+console.log(
+  `Generated FoundationMonochromeIconPage.tsx (${monoIcons.length} icons)`,
+);
 
 writeFileSync(
-  resolve(outDir, "FoundationMulticolorIconPage.tsx"),
+  resolve(outDir, 'FoundationMulticolorIconPage.tsx'),
   generateMulticolorPage(multiIcons),
 );
-console.log(`Generated FoundationMulticolorIconPage.tsx (${multiIcons.length} icons)`);
+console.log(
+  `Generated FoundationMulticolorIconPage.tsx (${multiIcons.length} icons)`,
+);

--- a/examples/lynx-spa/src/App.tsx
+++ b/examples/lynx-spa/src/App.tsx
@@ -1,29 +1,35 @@
-import { Suspense, lazy, useState } from '@lynx-js/react';
+import { lazy, Suspense, useState } from '@lynx-js/react';
 import { vars } from '@seed-design/lynx-css/vars';
 
 import { ActionButtonPage } from './pages/ActionButtonPage.jsx';
 import { BottomSheetPage } from './pages/BottomSheetPage.jsx';
 import { CheckboxPage } from './pages/CheckboxPage.jsx';
+import { CSSSelectorTestPage } from './pages/CSSSelectorTestPage.jsx';
 import { FoundationColorPage } from './pages/FoundationColorPage.jsx';
-import { FoundationMonochromeIconPage } from './pages/FoundationMonochromeIconPage.jsx';
-import { FoundationMulticolorIconPage } from './pages/FoundationMulticolorIconPage.jsx';
 import { FoundationTypographyPage } from './pages/FoundationTypographyPage.jsx';
 import { HomePage } from './pages/HomePage.jsx';
-import { TailwindDemoPage } from './pages/TailwindDemoPage.jsx';
-import { TestNativeBoxPage } from './pages/TestNativeBoxPage.jsx';
-import { TestTailwindBoxPage } from './pages/TestTailwindBoxPage.jsx';
+import { IconColorPOCPage } from './pages/IconColorPOCPage.jsx';
 import { NestedVarsTestPage } from './pages/NestedVarsTestPage.jsx';
 import { ProgressCirclePage } from './pages/ProgressCirclePage.jsx';
 import { RadioGroupPage } from './pages/RadioGroupPage.jsx';
 import { SwitchPage } from './pages/SwitchPage.jsx';
 import { TagGroupPage } from './pages/TagGroupPage.jsx';
+import { TailwindDemoPage } from './pages/TailwindDemoPage.jsx';
+import { TestNativeBoxPage } from './pages/TestNativeBoxPage.jsx';
+import { TestTailwindBoxPage } from './pages/TestTailwindBoxPage.jsx';
 import { ThemingPage } from './pages/ThemingPage.jsx';
-import { CSSSelectorTestPage } from './pages/CSSSelectorTestPage.jsx';
-import { IconColorPOCPage } from './pages/IconColorPOCPage.jsx';
 import { UseControllableStatePage } from './pages/UseControllableStatePage.jsx';
 import { UsePressTapPage } from './pages/UsePressTapPage.jsx';
 
 const LynxConsole = lazy(() => import('lynx-console'));
+const FoundationMonochromeIconPage = lazy(async () => ({
+  default: (await import('./pages/FoundationMonochromeIconPage.jsx'))
+    .FoundationMonochromeIconPage,
+}));
+const FoundationMulticolorIconPage = lazy(async () => ({
+  default: (await import('./pages/FoundationMulticolorIconPage.jsx'))
+    .FoundationMulticolorIconPage,
+}));
 
 export type Page =
   | 'home'
@@ -64,9 +70,8 @@ function BackButton({ onBack }: { onBack: () => void }) {
   );
 }
 
-// Variant catalog pages use a fullscreen flex shell so previews, tabs, and
-// controls can own their own scroll areas.
-const CATALOG_PAGES = new Set<Page>([
+// Pages that own their own scroll areas use a fullscreen flex shell.
+const FULLSCREEN_PAGES = new Set<Page>([
   'action-button',
   'bottom-sheet',
   'checkbox',
@@ -74,13 +79,15 @@ const CATALOG_PAGES = new Set<Page>([
   'radio-group',
   'switch',
   'tag-group',
+  'foundation-monochrome-icon',
+  'foundation-multicolor-icon',
 ]);
 
 export function App(props: { onRender?: () => void }) {
   const [currentPage, setCurrentPage] = useState<Page>('home');
   props.onRender?.();
 
-  if (CATALOG_PAGES.has(currentPage)) {
+  if (FULLSCREEN_PAGES.has(currentPage)) {
     return (
       <view
         style={{
@@ -101,6 +108,14 @@ export function App(props: { onRender?: () => void }) {
         {currentPage === 'radio-group' && <RadioGroupPage />}
         {currentPage === 'switch' && <SwitchPage />}
         {currentPage === 'tag-group' && <TagGroupPage />}
+        <Suspense>
+          {currentPage === 'foundation-monochrome-icon' && (
+            <FoundationMonochromeIconPage />
+          )}
+          {currentPage === 'foundation-multicolor-icon' && (
+            <FoundationMulticolorIconPage />
+          )}
+        </Suspense>
         <Suspense>
           <LynxConsole theme="light" />
         </Suspense>
@@ -127,12 +142,6 @@ export function App(props: { onRender?: () => void }) {
       {currentPage === 'theming' && <ThemingPage />}
       {currentPage === 'nested-vars-test' && <NestedVarsTestPage />}
       {currentPage === 'foundation-color' && <FoundationColorPage />}
-      {currentPage === 'foundation-monochrome-icon' && (
-        <FoundationMonochromeIconPage />
-      )}
-      {currentPage === 'foundation-multicolor-icon' && (
-        <FoundationMulticolorIconPage />
-      )}
       {currentPage === 'foundation-typography' && <FoundationTypographyPage />}
       {currentPage === 'tailwind-demo' && <TailwindDemoPage />}
       {currentPage === 'test-native-box' && <TestNativeBoxPage />}

--- a/examples/lynx-spa/src/components/icon-virtual-grid.tsx
+++ b/examples/lynx-spa/src/components/icon-virtual-grid.tsx
@@ -1,0 +1,103 @@
+import type { ComponentType } from '@lynx-js/react';
+import { vars } from '@seed-design/lynx-css/vars';
+
+const { $color } = vars;
+
+const COLUMN_COUNT = 4;
+const ITEM_HEIGHT = 76;
+const PRELOAD_ITEM_COUNT = COLUMN_COUNT * 8;
+
+interface IconProps {
+  color?: string;
+  size?: number;
+}
+
+export interface IconEntry {
+  component: ComponentType<IconProps>;
+  name: string;
+}
+
+interface VirtualIconGridProps {
+  iconColor?: string;
+  icons: IconEntry[];
+  packageName: string;
+  title: string;
+}
+
+export function VirtualIconGrid({
+  iconColor,
+  icons,
+  packageName,
+  title,
+}: VirtualIconGridProps) {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flex: 1,
+        flexDirection: 'column',
+        minHeight: 0,
+        paddingLeft: '16px',
+        paddingRight: '16px',
+      }}
+    >
+      <text style={{ fontSize: '20px', fontWeight: 'bold' }}>{title}</text>
+      <text
+        style={{
+          fontSize: '13px',
+          color: $color.fg.neutralSubtle,
+          marginBottom: '8px',
+        }}
+      >
+        {packageName} — {icons.length} icons
+      </text>
+
+      <list
+        list-type="flow"
+        span-count={COLUMN_COUNT}
+        scroll-orientation="vertical"
+        preload-buffer-count={PRELOAD_ITEM_COUNT}
+        style={{ flex: 1, height: '100%', width: '100%' }}
+      >
+        {icons.map(({ component: IconComp, name }) => (
+          <list-item
+            key={name}
+            item-key={name}
+            estimated-main-axis-size-px={ITEM_HEIGHT}
+            reuse-identifier="icon-cell"
+          >
+            <view
+              style={{
+                height: `${ITEM_HEIGHT}px`,
+                padding: '8px 4px',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: '4px',
+              }}
+            >
+              {iconColor == null ? (
+                <IconComp size={24} />
+              ) : (
+                <IconComp size={24} color={iconColor} />
+              )}
+              <text
+                style={{
+                  height: '24px',
+                  fontSize: '9px',
+                  lineHeight: '10px',
+                  color: $color.fg.neutralMuted,
+                  textAlign: 'center',
+                  wordBreak: 'break-all',
+                }}
+              >
+                {name}
+              </text>
+            </view>
+          </list-item>
+        ))}
+      </list>
+    </view>
+  );
+}

--- a/examples/lynx-spa/src/pages/FoundationMonochromeIconPage.tsx
+++ b/examples/lynx-spa/src/pages/FoundationMonochromeIconPage.tsx
@@ -1,1611 +1,3252 @@
-import { vars } from "@seed-design/lynx-css/vars";
+import IconAndroidshareFill from '@karrotmarket/lynx-monochrome-icon/IconAndroidshareFill';
+import IconAndroidshareLine from '@karrotmarket/lynx-monochrome-icon/IconAndroidshareLine';
+import IconAppleFill from '@karrotmarket/lynx-monochrome-icon/IconAppleFill';
+import IconAppleLine from '@karrotmarket/lynx-monochrome-icon/IconAppleLine';
+import IconArrow2ClockwiseCircularFill from '@karrotmarket/lynx-monochrome-icon/IconArrow2ClockwiseCircularFill';
+import IconArrow2ClockwiseCircularLine from '@karrotmarket/lynx-monochrome-icon/IconArrow2ClockwiseCircularLine';
+import IconArrowClockwiseCircularFill from '@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseCircularFill';
+import IconArrowClockwiseCircularLine from '@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseCircularLine';
+import IconArrowClockwiseOvalFill from '@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseOvalFill';
+import IconArrowClockwiseOvalLine from '@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseOvalLine';
+import IconArrowCounterclockwiseCircularFill from '@karrotmarket/lynx-monochrome-icon/IconArrowCounterclockwiseCircularFill';
+import IconArrowCounterclockwiseCircularLine from '@karrotmarket/lynx-monochrome-icon/IconArrowCounterclockwiseCircularLine';
+import IconArrowDownFill from '@karrotmarket/lynx-monochrome-icon/IconArrowDownFill';
+import IconArrowDownHorizlineFill from '@karrotmarket/lynx-monochrome-icon/IconArrowDownHorizlineFill';
+import IconArrowDownHorizlineLine from '@karrotmarket/lynx-monochrome-icon/IconArrowDownHorizlineLine';
+import IconArrowDownLine from '@karrotmarket/lynx-monochrome-icon/IconArrowDownLine';
+import IconArrowDownLineVerticalArrowUpSquareFill from '@karrotmarket/lynx-monochrome-icon/IconArrowDownLineVerticalArrowUpSquareFill';
+import IconArrowDownLineVerticalArrowUpSquareLine from '@karrotmarket/lynx-monochrome-icon/IconArrowDownLineVerticalArrowUpSquareLine';
+import IconArrowDownRightArrowUpLeftFill from '@karrotmarket/lynx-monochrome-icon/IconArrowDownRightArrowUpLeftFill';
+import IconArrowDownRightArrowUpLeftLine from '@karrotmarket/lynx-monochrome-icon/IconArrowDownRightArrowUpLeftLine';
+import IconArrowLeftBracketRightFill from '@karrotmarket/lynx-monochrome-icon/IconArrowLeftBracketRightFill';
+import IconArrowLeftBracketRightLine from '@karrotmarket/lynx-monochrome-icon/IconArrowLeftBracketRightLine';
+import IconArrowLeftFill from '@karrotmarket/lynx-monochrome-icon/IconArrowLeftFill';
+import IconArrowLeftLine from '@karrotmarket/lynx-monochrome-icon/IconArrowLeftLine';
+import IconArrowRightAngledFill from '@karrotmarket/lynx-monochrome-icon/IconArrowRightAngledFill';
+import IconArrowRightAngledLine from '@karrotmarket/lynx-monochrome-icon/IconArrowRightAngledLine';
+import IconArrowRightArrowLeftFill from '@karrotmarket/lynx-monochrome-icon/IconArrowRightArrowLeftFill';
+import IconArrowRightArrowLeftLine from '@karrotmarket/lynx-monochrome-icon/IconArrowRightArrowLeftLine';
+import IconArrowRightFill from '@karrotmarket/lynx-monochrome-icon/IconArrowRightFill';
+import IconArrowRightLine from '@karrotmarket/lynx-monochrome-icon/IconArrowRightLine';
+import IconArrowUpArrowDownFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpArrowDownFill';
+import IconArrowUpArrowDownLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpArrowDownLine';
+import IconArrowUpBracketDownFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpBracketDownFill';
+import IconArrowUpBracketDownLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpBracketDownLine';
+import IconArrowUpFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpFill';
+import IconArrowUpLeftFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpLeftFill';
+import IconArrowUpLeftLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpLeftLine';
+import IconArrowUpLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpLine';
+import IconArrowUpRightArrowDownLeftFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftFill';
+import IconArrowUpRightArrowDownLeftLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftLine';
+import IconArrowUpRightArrowDownLeftSquareFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftSquareFill';
+import IconArrowUpRightArrowDownLeftSquareLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftSquareLine';
+import IconArrowUpRightFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightFill';
+import IconArrowUpRightLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightLine';
+import IconArrowUpRightShoppingbagTiltedFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightShoppingbagTiltedFill';
+import IconArrowUpRightShoppingbagTiltedLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUpRightShoppingbagTiltedLine';
+import IconArrowUturnLeftFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUturnLeftFill';
+import IconArrowUturnLeftLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUturnLeftLine';
+import IconArrowUturnRightFill from '@karrotmarket/lynx-monochrome-icon/IconArrowUturnRightFill';
+import IconArrowUturnRightLine from '@karrotmarket/lynx-monochrome-icon/IconArrowUturnRightLine';
+import IconArticleFill from '@karrotmarket/lynx-monochrome-icon/IconArticleFill';
+import IconArticleLine from '@karrotmarket/lynx-monochrome-icon/IconArticleLine';
+import IconAsteriskHorizrectangleCoolwave3Fill from '@karrotmarket/lynx-monochrome-icon/IconAsteriskHorizrectangleCoolwave3Fill';
+import IconAsteriskHorizrectangleCoolwave3Line from '@karrotmarket/lynx-monochrome-icon/IconAsteriskHorizrectangleCoolwave3Line';
+import IconAtFill from '@karrotmarket/lynx-monochrome-icon/IconAtFill';
+import IconAtLine from '@karrotmarket/lynx-monochrome-icon/IconAtLine';
+import IconAUppercaseALowercaseFill from '@karrotmarket/lynx-monochrome-icon/IconAUppercaseALowercaseFill';
+import IconAUppercaseALowercaseLine from '@karrotmarket/lynx-monochrome-icon/IconAUppercaseALowercaseLine';
+import IconAUppercaseOutlineFill from '@karrotmarket/lynx-monochrome-icon/IconAUppercaseOutlineFill';
+import IconAUppercaseOutlineLine from '@karrotmarket/lynx-monochrome-icon/IconAUppercaseOutlineLine';
+import IconAUppercaseSquareFill from '@karrotmarket/lynx-monochrome-icon/IconAUppercaseSquareFill';
+import IconAUppercaseSquareLine from '@karrotmarket/lynx-monochrome-icon/IconAUppercaseSquareLine';
+import IconBackspacekeyFill from '@karrotmarket/lynx-monochrome-icon/IconBackspacekeyFill';
+import IconBackspacekeyLine from '@karrotmarket/lynx-monochrome-icon/IconBackspacekeyLine';
+import IconBarchartBoardFill from '@karrotmarket/lynx-monochrome-icon/IconBarchartBoardFill';
+import IconBarchartBoardLine from '@karrotmarket/lynx-monochrome-icon/IconBarchartBoardLine';
+import IconBarchartSquareFill from '@karrotmarket/lynx-monochrome-icon/IconBarchartSquareFill';
+import IconBarchartSquareLine from '@karrotmarket/lynx-monochrome-icon/IconBarchartSquareLine';
+import IconBedFrontsideFill from '@karrotmarket/lynx-monochrome-icon/IconBedFrontsideFill';
+import IconBedFrontsideLine from '@karrotmarket/lynx-monochrome-icon/IconBedFrontsideLine';
+import IconBellFill from '@karrotmarket/lynx-monochrome-icon/IconBellFill';
+import IconBellLine from '@karrotmarket/lynx-monochrome-icon/IconBellLine';
+import IconBellSlashFill from '@karrotmarket/lynx-monochrome-icon/IconBellSlashFill';
+import IconBellSlashLine from '@karrotmarket/lynx-monochrome-icon/IconBellSlashLine';
+import IconBluetoothFill from '@karrotmarket/lynx-monochrome-icon/IconBluetoothFill';
+import IconBluetoothLine from '@karrotmarket/lynx-monochrome-icon/IconBluetoothLine';
+import IconBookFill from '@karrotmarket/lynx-monochrome-icon/IconBookFill';
+import IconBookLine from '@karrotmarket/lynx-monochrome-icon/IconBookLine';
+import IconBookmarkFill from '@karrotmarket/lynx-monochrome-icon/IconBookmarkFill';
+import IconBookmarkLine from '@karrotmarket/lynx-monochrome-icon/IconBookmarkLine';
+import IconBookOpenFill from '@karrotmarket/lynx-monochrome-icon/IconBookOpenFill';
+import IconBookOpenLine from '@karrotmarket/lynx-monochrome-icon/IconBookOpenLine';
+import IconBoxFlapFill from '@karrotmarket/lynx-monochrome-icon/IconBoxFlapFill';
+import IconBoxFlapLine from '@karrotmarket/lynx-monochrome-icon/IconBoxFlapLine';
+import IconBracketLeftArrowRightFill from '@karrotmarket/lynx-monochrome-icon/IconBracketLeftArrowRightFill';
+import IconBracketLeftArrowRightLine from '@karrotmarket/lynx-monochrome-icon/IconBracketLeftArrowRightLine';
+import IconBUppercaseFill from '@karrotmarket/lynx-monochrome-icon/IconBUppercaseFill';
+import IconBUppercaseLine from '@karrotmarket/lynx-monochrome-icon/IconBUppercaseLine';
+import IconBuilding2Fill from '@karrotmarket/lynx-monochrome-icon/IconBuilding2Fill';
+import IconBuilding2Line from '@karrotmarket/lynx-monochrome-icon/IconBuilding2Line';
+import IconCalendarFill from '@karrotmarket/lynx-monochrome-icon/IconCalendarFill';
+import IconCalendarLine from '@karrotmarket/lynx-monochrome-icon/IconCalendarLine';
+import IconCamcorderFill from '@karrotmarket/lynx-monochrome-icon/IconCamcorderFill';
+import IconCamcorderLine from '@karrotmarket/lynx-monochrome-icon/IconCamcorderLine';
+import IconCameraFill from '@karrotmarket/lynx-monochrome-icon/IconCameraFill';
+import IconCameraLine from '@karrotmarket/lynx-monochrome-icon/IconCameraLine';
+import IconCardFill from '@karrotmarket/lynx-monochrome-icon/IconCardFill';
+import IconCardLine from '@karrotmarket/lynx-monochrome-icon/IconCardLine';
+import IconCarFill from '@karrotmarket/lynx-monochrome-icon/IconCarFill';
+import IconCarFrontsideFill from '@karrotmarket/lynx-monochrome-icon/IconCarFrontsideFill';
+import IconCarFrontsideLine from '@karrotmarket/lynx-monochrome-icon/IconCarFrontsideLine';
+import IconCarFrontUpsideWave2ReversedUpFill from '@karrotmarket/lynx-monochrome-icon/IconCarFrontUpsideWave2ReversedUpFill';
+import IconCarFrontUpsideWave2ReversedUpLine from '@karrotmarket/lynx-monochrome-icon/IconCarFrontUpsideWave2ReversedUpLine';
+import IconCarLine from '@karrotmarket/lynx-monochrome-icon/IconCarLine';
+import IconCarRearTrunkOpenLeftsideFill from '@karrotmarket/lynx-monochrome-icon/IconCarRearTrunkOpenLeftsideFill';
+import IconCarRearTrunkOpenLeftsideLine from '@karrotmarket/lynx-monochrome-icon/IconCarRearTrunkOpenLeftsideLine';
+import IconCarRearUpsideSectorDownFill from '@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideSectorDownFill';
+import IconCarRearUpsideSectorDownLine from '@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideSectorDownLine';
+import IconCarRearUpsideWave2ReversedDownFill from '@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownFill';
+import IconCarRearUpsideWave2ReversedDownLeftFill from '@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownLeftFill';
+import IconCarRearUpsideWave2ReversedDownLeftLine from '@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownLeftLine';
+import IconCarRearUpsideWave2ReversedDownLine from '@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownLine';
+import IconCarrotFill from '@karrotmarket/lynx-monochrome-icon/IconCarrotFill';
+import IconCarrotLine from '@karrotmarket/lynx-monochrome-icon/IconCarrotLine';
+import IconCartFill from '@karrotmarket/lynx-monochrome-icon/IconCartFill';
+import IconCartItemsFill from '@karrotmarket/lynx-monochrome-icon/IconCartItemsFill';
+import IconCartItemsLine from '@karrotmarket/lynx-monochrome-icon/IconCartItemsLine';
+import IconCartLine from '@karrotmarket/lynx-monochrome-icon/IconCartLine';
+import IconCartLoadFill from '@karrotmarket/lynx-monochrome-icon/IconCartLoadFill';
+import IconCartLoadLine from '@karrotmarket/lynx-monochrome-icon/IconCartLoadLine';
+import IconCheckmarkBadgeFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkBadgeFill';
+import IconCheckmarkBadgeLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkBadgeLine';
+import IconCheckmarkBallotboxFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkBallotboxFill';
+import IconCheckmarkBallotboxLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkBallotboxLine';
+import IconCheckmarkCalendarFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkCalendarFill';
+import IconCheckmarkCalendarLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkCalendarLine';
+import IconCheckmarkChatbubbleLeftFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkChatbubbleLeftFill';
+import IconCheckmarkChatbubbleLeftLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkChatbubbleLeftLine';
+import IconCheckmarkCircleFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkCircleFill';
+import IconCheckmarkCircleLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkCircleLine';
+import IconCheckmarkClipboardFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkClipboardFill';
+import IconCheckmarkClipboardLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkClipboardLine';
+import IconCheckmarkCouponFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkCouponFill';
+import IconCheckmarkCouponLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkCouponLine';
+import IconCheckmarkFatFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkFatFill';
+import IconCheckmarkFatLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkFatLine';
+import IconCheckmarkFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkFill';
+import IconCheckmarkFlowerFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkFlowerFill';
+import IconCheckmarkFlowerLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkFlowerLine';
+import IconCheckmarkHorizlineFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkHorizlineFill';
+import IconCheckmarkHorizlineLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkHorizlineLine';
+import IconCheckmarkhorizline2VerticalFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkhorizline2VerticalFill';
+import IconCheckmarkhorizline2VerticalLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkhorizline2VerticalLine';
+import IconCheckmarkLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkLine';
+import IconCheckmarkScaleFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkScaleFill';
+import IconCheckmarkScaleLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkScaleLine';
+import IconCheckmarkShieldFill from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkShieldFill';
+import IconCheckmarkShieldLine from '@karrotmarket/lynx-monochrome-icon/IconCheckmarkShieldLine';
+import IconChevronDownFill from '@karrotmarket/lynx-monochrome-icon/IconChevronDownFill';
+import IconChevronDownLine from '@karrotmarket/lynx-monochrome-icon/IconChevronDownLine';
+import IconChevronDownSmallFill from '@karrotmarket/lynx-monochrome-icon/IconChevronDownSmallFill';
+import IconChevronDownSmallLine from '@karrotmarket/lynx-monochrome-icon/IconChevronDownSmallLine';
+import IconChevronLeftFill from '@karrotmarket/lynx-monochrome-icon/IconChevronLeftFill';
+import IconChevronLeftLine from '@karrotmarket/lynx-monochrome-icon/IconChevronLeftLine';
+import IconChevronLeftSmallFill from '@karrotmarket/lynx-monochrome-icon/IconChevronLeftSmallFill';
+import IconChevronLeftSmallLine from '@karrotmarket/lynx-monochrome-icon/IconChevronLeftSmallLine';
+import IconChevronRightFill from '@karrotmarket/lynx-monochrome-icon/IconChevronRightFill';
+import IconChevronRightLine from '@karrotmarket/lynx-monochrome-icon/IconChevronRightLine';
+import IconChevronRightSmallFill from '@karrotmarket/lynx-monochrome-icon/IconChevronRightSmallFill';
+import IconChevronRightSmallLine from '@karrotmarket/lynx-monochrome-icon/IconChevronRightSmallLine';
+import IconChevronUpFill from '@karrotmarket/lynx-monochrome-icon/IconChevronUpFill';
+import IconChevronUpLine from '@karrotmarket/lynx-monochrome-icon/IconChevronUpLine';
+import IconChevronUpSmallFill from '@karrotmarket/lynx-monochrome-icon/IconChevronUpSmallFill';
+import IconChevronUpSmallLine from '@karrotmarket/lynx-monochrome-icon/IconChevronUpSmallLine';
+import IconCircle4SquareFill from '@karrotmarket/lynx-monochrome-icon/IconCircle4SquareFill';
+import IconCircle4SquareLine from '@karrotmarket/lynx-monochrome-icon/IconCircle4SquareLine';
+import IconClockFill from '@karrotmarket/lynx-monochrome-icon/IconClockFill';
+import IconClockLine from '@karrotmarket/lynx-monochrome-icon/IconClockLine';
+import IconCompassFill from '@karrotmarket/lynx-monochrome-icon/IconCompassFill';
+import IconCompassLine from '@karrotmarket/lynx-monochrome-icon/IconCompassLine';
+import IconCorner4InwardFill from '@karrotmarket/lynx-monochrome-icon/IconCorner4InwardFill';
+import IconCorner4InwardLine from '@karrotmarket/lynx-monochrome-icon/IconCorner4InwardLine';
+import IconCorner4OutwardFill from '@karrotmarket/lynx-monochrome-icon/IconCorner4OutwardFill';
+import IconCorner4OutwardLine from '@karrotmarket/lynx-monochrome-icon/IconCorner4OutwardLine';
+import IconCornerDownLeftFill from '@karrotmarket/lynx-monochrome-icon/IconCornerDownLeftFill';
+import IconCornerDownLeftLine from '@karrotmarket/lynx-monochrome-icon/IconCornerDownLeftLine';
+import IconCouponFill from '@karrotmarket/lynx-monochrome-icon/IconCouponFill';
+import IconCouponLine from '@karrotmarket/lynx-monochrome-icon/IconCouponLine';
+import IconCropmarkFill from '@karrotmarket/lynx-monochrome-icon/IconCropmarkFill';
+import IconCropmarkLine from '@karrotmarket/lynx-monochrome-icon/IconCropmarkLine';
+import IconCrosshairFill from '@karrotmarket/lynx-monochrome-icon/IconCrosshairFill';
+import IconCrosshairLine from '@karrotmarket/lynx-monochrome-icon/IconCrosshairLine';
+import IconCrosshairQuestionmarkFill from '@karrotmarket/lynx-monochrome-icon/IconCrosshairQuestionmarkFill';
+import IconCrosshairQuestionmarkLine from '@karrotmarket/lynx-monochrome-icon/IconCrosshairQuestionmarkLine';
+import IconCrownFill from '@karrotmarket/lynx-monochrome-icon/IconCrownFill';
+import IconCrownLine from '@karrotmarket/lynx-monochrome-icon/IconCrownLine';
+import IconCupHeatwaveFill from '@karrotmarket/lynx-monochrome-icon/IconCupHeatwaveFill';
+import IconCupHeatwaveLine from '@karrotmarket/lynx-monochrome-icon/IconCupHeatwaveLine';
+import IconDiamondFill from '@karrotmarket/lynx-monochrome-icon/IconDiamondFill';
+import IconDiamondLine from '@karrotmarket/lynx-monochrome-icon/IconDiamondLine';
+import IconDocumentArrowLeftFill from '@karrotmarket/lynx-monochrome-icon/IconDocumentArrowLeftFill';
+import IconDocumentArrowLeftLine from '@karrotmarket/lynx-monochrome-icon/IconDocumentArrowLeftLine';
+import IconDocumentCheckmarkFill from '@karrotmarket/lynx-monochrome-icon/IconDocumentCheckmarkFill';
+import IconDocumentCheckmarkLine from '@karrotmarket/lynx-monochrome-icon/IconDocumentCheckmarkLine';
+import IconDocumentFill from '@karrotmarket/lynx-monochrome-icon/IconDocumentFill';
+import IconDocumentLine from '@karrotmarket/lynx-monochrome-icon/IconDocumentLine';
+import IconDocumentMagnifyingglassFill from '@karrotmarket/lynx-monochrome-icon/IconDocumentMagnifyingglassFill';
+import IconDocumentMagnifyingglassLine from '@karrotmarket/lynx-monochrome-icon/IconDocumentMagnifyingglassLine';
+import IconDocumentPenFill from '@karrotmarket/lynx-monochrome-icon/IconDocumentPenFill';
+import IconDocumentPenLine from '@karrotmarket/lynx-monochrome-icon/IconDocumentPenLine';
+import IconDocumentPlusFill from '@karrotmarket/lynx-monochrome-icon/IconDocumentPlusFill';
+import IconDocumentPlusLine from '@karrotmarket/lynx-monochrome-icon/IconDocumentPlusLine';
+import IconDollarCircleArrowRightFill from '@karrotmarket/lynx-monochrome-icon/IconDollarCircleArrowRightFill';
+import IconDollarCircleArrowRightLine from '@karrotmarket/lynx-monochrome-icon/IconDollarCircleArrowRightLine';
+import IconDollarCircleFill from '@karrotmarket/lynx-monochrome-icon/IconDollarCircleFill';
+import IconDollarCircleLine from '@karrotmarket/lynx-monochrome-icon/IconDollarCircleLine';
+import IconDollarFill from '@karrotmarket/lynx-monochrome-icon/IconDollarFill';
+import IconDollarLine from '@karrotmarket/lynx-monochrome-icon/IconDollarLine';
+import IconDot3CircleFill from '@karrotmarket/lynx-monochrome-icon/IconDot3CircleFill';
+import IconDot3CircleLine from '@karrotmarket/lynx-monochrome-icon/IconDot3CircleLine';
+import IconDot3HorizontalChatbubbleLeftFill from '@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftFill';
+import IconDot3HorizontalChatbubbleLeftLine from '@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftLine';
+import IconDot3HorizontalChatbubbleLeftSlashFill from '@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftSlashFill';
+import IconDot3HorizontalChatbubbleLeftSlashLine from '@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftSlashLine';
+import IconDot3HorizontalFill from '@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalFill';
+import IconDot3HorizontalLine from '@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalLine';
+import IconDot3VerticalFill from '@karrotmarket/lynx-monochrome-icon/IconDot3VerticalFill';
+import IconDot3VerticalLine from '@karrotmarket/lynx-monochrome-icon/IconDot3VerticalLine';
+import IconDothorizline3VerticalFill from '@karrotmarket/lynx-monochrome-icon/IconDothorizline3VerticalFill';
+import IconDothorizline3VerticalLine from '@karrotmarket/lynx-monochrome-icon/IconDothorizline3VerticalLine';
+import IconDumbbellFill from '@karrotmarket/lynx-monochrome-icon/IconDumbbellFill';
+import IconDumbbellLine from '@karrotmarket/lynx-monochrome-icon/IconDumbbellLine';
+import IconEarthFill from '@karrotmarket/lynx-monochrome-icon/IconEarthFill';
+import IconEarthLine from '@karrotmarket/lynx-monochrome-icon/IconEarthLine';
+import IconEnvelopeFill from '@karrotmarket/lynx-monochrome-icon/IconEnvelopeFill';
+import IconEnvelopeLine from '@karrotmarket/lynx-monochrome-icon/IconEnvelopeLine';
+import IconEpbFill from '@karrotmarket/lynx-monochrome-icon/IconEpbFill';
+import IconEpbLine from '@karrotmarket/lynx-monochrome-icon/IconEpbLine';
+import IconEraserHorizlineFill from '@karrotmarket/lynx-monochrome-icon/IconEraserHorizlineFill';
+import IconEraserHorizlineLine from '@karrotmarket/lynx-monochrome-icon/IconEraserHorizlineLine';
+import IconExclamationmarkChatbubbleRectangularCenterFill from '@karrotmarket/lynx-monochrome-icon/IconExclamationmarkChatbubbleRectangularCenterFill';
+import IconExclamationmarkChatbubbleRectangularCenterLine from '@karrotmarket/lynx-monochrome-icon/IconExclamationmarkChatbubbleRectangularCenterLine';
+import IconExclamationmarkCircleFill from '@karrotmarket/lynx-monochrome-icon/IconExclamationmarkCircleFill';
+import IconExclamationmarkCircleLine from '@karrotmarket/lynx-monochrome-icon/IconExclamationmarkCircleLine';
+import IconEyeFill from '@karrotmarket/lynx-monochrome-icon/IconEyeFill';
+import IconEyeLine from '@karrotmarket/lynx-monochrome-icon/IconEyeLine';
+import IconEyeSlashFill from '@karrotmarket/lynx-monochrome-icon/IconEyeSlashFill';
+import IconEyeSlashLine from '@karrotmarket/lynx-monochrome-icon/IconEyeSlashLine';
+import IconFaceFrustratedCircleFill from '@karrotmarket/lynx-monochrome-icon/IconFaceFrustratedCircleFill';
+import IconFaceFrustratedCircleLine from '@karrotmarket/lynx-monochrome-icon/IconFaceFrustratedCircleLine';
+import IconFaceSadCircleFill from '@karrotmarket/lynx-monochrome-icon/IconFaceSadCircleFill';
+import IconFaceSadCircleLine from '@karrotmarket/lynx-monochrome-icon/IconFaceSadCircleLine';
+import IconFaceSmileCircleFill from '@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleFill';
+import IconFaceSmileCircleFoldedFill from '@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleFoldedFill';
+import IconFaceSmileCircleFoldedLine from '@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleFoldedLine';
+import IconFaceSmileCircleLine from '@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleLine';
+import IconFaceSurprisedCircleFill from '@karrotmarket/lynx-monochrome-icon/IconFaceSurprisedCircleFill';
+import IconFaceSurprisedCircleLine from '@karrotmarket/lynx-monochrome-icon/IconFaceSurprisedCircleLine';
+import IconFaceViewfinderFill from '@karrotmarket/lynx-monochrome-icon/IconFaceViewfinderFill';
+import IconFaceViewfinderLine from '@karrotmarket/lynx-monochrome-icon/IconFaceViewfinderLine';
+import IconFigureBikeFill from '@karrotmarket/lynx-monochrome-icon/IconFigureBikeFill';
+import IconFigureBikeLine from '@karrotmarket/lynx-monochrome-icon/IconFigureBikeLine';
+import IconFigureOvalFill from '@karrotmarket/lynx-monochrome-icon/IconFigureOvalFill';
+import IconFigureOvalLine from '@karrotmarket/lynx-monochrome-icon/IconFigureOvalLine';
+import IconFigureRunFill from '@karrotmarket/lynx-monochrome-icon/IconFigureRunFill';
+import IconFigureRunLine from '@karrotmarket/lynx-monochrome-icon/IconFigureRunLine';
+import IconFigureWalkFill from '@karrotmarket/lynx-monochrome-icon/IconFigureWalkFill';
+import IconFigureWalkLine from '@karrotmarket/lynx-monochrome-icon/IconFigureWalkLine';
+import IconFigureWheelchairFill from '@karrotmarket/lynx-monochrome-icon/IconFigureWheelchairFill';
+import IconFigureWheelchairLine from '@karrotmarket/lynx-monochrome-icon/IconFigureWheelchairLine';
+import IconFingerprintFill from '@karrotmarket/lynx-monochrome-icon/IconFingerprintFill';
+import IconFingerprintLine from '@karrotmarket/lynx-monochrome-icon/IconFingerprintLine';
+import IconFireworkFill from '@karrotmarket/lynx-monochrome-icon/IconFireworkFill';
+import IconFireworkLine from '@karrotmarket/lynx-monochrome-icon/IconFireworkLine';
+import IconFishWave2Fill from '@karrotmarket/lynx-monochrome-icon/IconFishWave2Fill';
+import IconFishWave2Line from '@karrotmarket/lynx-monochrome-icon/IconFishWave2Line';
+import IconFlagFill from '@karrotmarket/lynx-monochrome-icon/IconFlagFill';
+import IconFlagHillFill from '@karrotmarket/lynx-monochrome-icon/IconFlagHillFill';
+import IconFlagHillLine from '@karrotmarket/lynx-monochrome-icon/IconFlagHillLine';
+import IconFlagLine from '@karrotmarket/lynx-monochrome-icon/IconFlagLine';
+import IconFlameFill from '@karrotmarket/lynx-monochrome-icon/IconFlameFill';
+import IconFlameLine from '@karrotmarket/lynx-monochrome-icon/IconFlameLine';
+import IconFlaskFill from '@karrotmarket/lynx-monochrome-icon/IconFlaskFill';
+import IconFlaskLine from '@karrotmarket/lynx-monochrome-icon/IconFlaskLine';
+import IconForkSpoonBagFill from '@karrotmarket/lynx-monochrome-icon/IconForkSpoonBagFill';
+import IconForkSpoonBagLine from '@karrotmarket/lynx-monochrome-icon/IconForkSpoonBagLine';
+import IconForkSpoonFill from '@karrotmarket/lynx-monochrome-icon/IconForkSpoonFill';
+import IconForkSpoonLine from '@karrotmarket/lynx-monochrome-icon/IconForkSpoonLine';
+import IconFridgeFill from '@karrotmarket/lynx-monochrome-icon/IconFridgeFill';
+import IconFridgeLine from '@karrotmarket/lynx-monochrome-icon/IconFridgeLine';
+import IconGearFill from '@karrotmarket/lynx-monochrome-icon/IconGearFill';
+import IconGearLine from '@karrotmarket/lynx-monochrome-icon/IconGearLine';
+import IconGiftFill from '@karrotmarket/lynx-monochrome-icon/IconGiftFill';
+import IconGiftLine from '@karrotmarket/lynx-monochrome-icon/IconGiftLine';
+import IconGlobeFill from '@karrotmarket/lynx-monochrome-icon/IconGlobeFill';
+import IconGlobeLine from '@karrotmarket/lynx-monochrome-icon/IconGlobeLine';
+import IconGraduationcapFill from '@karrotmarket/lynx-monochrome-icon/IconGraduationcapFill';
+import IconGraduationcapLine from '@karrotmarket/lynx-monochrome-icon/IconGraduationcapLine';
+import IconGridDot5Fill from '@karrotmarket/lynx-monochrome-icon/IconGridDot5Fill';
+import IconGridDot5Line from '@karrotmarket/lynx-monochrome-icon/IconGridDot5Line';
+import IconGridFill from '@karrotmarket/lynx-monochrome-icon/IconGridFill';
+import IconGridHeartFill from '@karrotmarket/lynx-monochrome-icon/IconGridHeartFill';
+import IconGridHeartLine from '@karrotmarket/lynx-monochrome-icon/IconGridHeartLine';
+import IconGridLine from '@karrotmarket/lynx-monochrome-icon/IconGridLine';
+import IconHandPointUpFill from '@karrotmarket/lynx-monochrome-icon/IconHandPointUpFill';
+import IconHandPointUpLine from '@karrotmarket/lynx-monochrome-icon/IconHandPointUpLine';
+import IconHandWaveFill from '@karrotmarket/lynx-monochrome-icon/IconHandWaveFill';
+import IconHandWaveLine from '@karrotmarket/lynx-monochrome-icon/IconHandWaveLine';
+import IconHashFill from '@karrotmarket/lynx-monochrome-icon/IconHashFill';
+import IconHashLine from '@karrotmarket/lynx-monochrome-icon/IconHashLine';
+import IconHeadphoneFill from '@karrotmarket/lynx-monochrome-icon/IconHeadphoneFill';
+import IconHeadphoneLine from '@karrotmarket/lynx-monochrome-icon/IconHeadphoneLine';
+import IconHeadsetFill from '@karrotmarket/lynx-monochrome-icon/IconHeadsetFill';
+import IconHeadsetLine from '@karrotmarket/lynx-monochrome-icon/IconHeadsetLine';
+import IconHeartFill from '@karrotmarket/lynx-monochrome-icon/IconHeartFill';
+import IconHeartLine from '@karrotmarket/lynx-monochrome-icon/IconHeartLine';
+import IconHorizline2VerticalChatbubbleRectangularRightFill from '@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightFill';
+import IconHorizline2VerticalChatbubbleRectangularRightLine from '@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightLine';
+import IconHorizline2VerticalChatbubbleRectangularRightSlashFill from '@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightSlashFill';
+import IconHorizline2VerticalChatbubbleRectangularRightSlashLine from '@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightSlashLine';
+import IconHorizline3VerticalCheckmarkFill from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalCheckmarkFill';
+import IconHorizline3VerticalCheckmarkLine from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalCheckmarkLine';
+import IconHorizline3VerticalFill from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalFill';
+import IconHorizline3VerticalLine from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalLine';
+import IconHorizline3VerticalStarFill from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalStarFill';
+import IconHorizline3VerticalStarLine from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalStarLine';
+import IconHorizline3VerticalTightFill from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalTightFill';
+import IconHorizline3VerticalTightLine from '@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalTightLine';
+import IconHorizlineViewfinderFill from '@karrotmarket/lynx-monochrome-icon/IconHorizlineViewfinderFill';
+import IconHorizlineViewfinderLine from '@karrotmarket/lynx-monochrome-icon/IconHorizlineViewfinderLine';
+import IconHorizrectangleHorizline2VerticalFill from '@karrotmarket/lynx-monochrome-icon/IconHorizrectangleHorizline2VerticalFill';
+import IconHorizrectangleHorizline2VerticalLine from '@karrotmarket/lynx-monochrome-icon/IconHorizrectangleHorizline2VerticalLine';
+import IconHospitalcrossBuildingFill from '@karrotmarket/lynx-monochrome-icon/IconHospitalcrossBuildingFill';
+import IconHospitalcrossBuildingLine from '@karrotmarket/lynx-monochrome-icon/IconHospitalcrossBuildingLine';
+import IconHospitalcrossSquareFill from '@karrotmarket/lynx-monochrome-icon/IconHospitalcrossSquareFill';
+import IconHospitalcrossSquareLine from '@karrotmarket/lynx-monochrome-icon/IconHospitalcrossSquareLine';
+import IconHouseCardFill from '@karrotmarket/lynx-monochrome-icon/IconHouseCardFill';
+import IconHouseCardLine from '@karrotmarket/lynx-monochrome-icon/IconHouseCardLine';
+import IconHouseFill from '@karrotmarket/lynx-monochrome-icon/IconHouseFill';
+import IconHouseLine from '@karrotmarket/lynx-monochrome-icon/IconHouseLine';
+import IconHousePlusFill from '@karrotmarket/lynx-monochrome-icon/IconHousePlusFill';
+import IconHousePlusLine from '@karrotmarket/lynx-monochrome-icon/IconHousePlusLine';
+import IconHouseSquareFill from '@karrotmarket/lynx-monochrome-icon/IconHouseSquareFill';
+import IconHouseSquareLine from '@karrotmarket/lynx-monochrome-icon/IconHouseSquareLine';
+import IconILowercaseSerifCircleFill from '@karrotmarket/lynx-monochrome-icon/IconILowercaseSerifCircleFill';
+import IconILowercaseSerifCircleLine from '@karrotmarket/lynx-monochrome-icon/IconILowercaseSerifCircleLine';
+import IconKeyboardChevronDownFill from '@karrotmarket/lynx-monochrome-icon/IconKeyboardChevronDownFill';
+import IconKeyboardChevronDownLine from '@karrotmarket/lynx-monochrome-icon/IconKeyboardChevronDownLine';
+import IconKeyholeShieldFill from '@karrotmarket/lynx-monochrome-icon/IconKeyholeShieldFill';
+import IconKeyholeShieldLine from '@karrotmarket/lynx-monochrome-icon/IconKeyholeShieldLine';
+import IconLaptopFill from '@karrotmarket/lynx-monochrome-icon/IconLaptopFill';
+import IconLaptopLine from '@karrotmarket/lynx-monochrome-icon/IconLaptopLine';
+import IconLeafFill from '@karrotmarket/lynx-monochrome-icon/IconLeafFill';
+import IconLeafLine from '@karrotmarket/lynx-monochrome-icon/IconLeafLine';
+import IconLightbulbDot5Fill from '@karrotmarket/lynx-monochrome-icon/IconLightbulbDot5Fill';
+import IconLightbulbDot5Line from '@karrotmarket/lynx-monochrome-icon/IconLightbulbDot5Line';
+import IconLightningFill from '@karrotmarket/lynx-monochrome-icon/IconLightningFill';
+import IconLightningLine from '@karrotmarket/lynx-monochrome-icon/IconLightningLine';
+import IconLightningSlashFill from '@karrotmarket/lynx-monochrome-icon/IconLightningSlashFill';
+import IconLightningSlashLine from '@karrotmarket/lynx-monochrome-icon/IconLightningSlashLine';
+import IconLinechartUpXaxisFill from '@karrotmarket/lynx-monochrome-icon/IconLinechartUpXaxisFill';
+import IconLinechartUpXaxisLine from '@karrotmarket/lynx-monochrome-icon/IconLinechartUpXaxisLine';
+import IconLocationpinFill from '@karrotmarket/lynx-monochrome-icon/IconLocationpinFill';
+import IconLocationpinLine from '@karrotmarket/lynx-monochrome-icon/IconLocationpinLine';
+import IconLockFill from '@karrotmarket/lynx-monochrome-icon/IconLockFill';
+import IconLockLine from '@karrotmarket/lynx-monochrome-icon/IconLockLine';
+import IconLockOpenedFill from '@karrotmarket/lynx-monochrome-icon/IconLockOpenedFill';
+import IconLockOpenedLine from '@karrotmarket/lynx-monochrome-icon/IconLockOpenedLine';
+import IconMagnifyingglassFill from '@karrotmarket/lynx-monochrome-icon/IconMagnifyingglassFill';
+import IconMagnifyingglassLine from '@karrotmarket/lynx-monochrome-icon/IconMagnifyingglassLine';
+import IconMalesymbolFemalesymbolFill from '@karrotmarket/lynx-monochrome-icon/IconMalesymbolFemalesymbolFill';
+import IconMalesymbolFemalesymbolLine from '@karrotmarket/lynx-monochrome-icon/IconMalesymbolFemalesymbolLine';
+import IconMapFill from '@karrotmarket/lynx-monochrome-icon/IconMapFill';
+import IconMapLine from '@karrotmarket/lynx-monochrome-icon/IconMapLine';
+import IconMapLocationpinFill from '@karrotmarket/lynx-monochrome-icon/IconMapLocationpinFill';
+import IconMapLocationpinLine from '@karrotmarket/lynx-monochrome-icon/IconMapLocationpinLine';
+import IconMegaphoneFill from '@karrotmarket/lynx-monochrome-icon/IconMegaphoneFill';
+import IconMegaphoneLine from '@karrotmarket/lynx-monochrome-icon/IconMegaphoneLine';
+import IconMegaphoneTiltedFill from '@karrotmarket/lynx-monochrome-icon/IconMegaphoneTiltedFill';
+import IconMegaphoneTiltedLine from '@karrotmarket/lynx-monochrome-icon/IconMegaphoneTiltedLine';
+import IconMetroFrontsideFill from '@karrotmarket/lynx-monochrome-icon/IconMetroFrontsideFill';
+import IconMetroFrontsideLine from '@karrotmarket/lynx-monochrome-icon/IconMetroFrontsideLine';
+import IconMicrophoneFill from '@karrotmarket/lynx-monochrome-icon/IconMicrophoneFill';
+import IconMicrophoneLine from '@karrotmarket/lynx-monochrome-icon/IconMicrophoneLine';
+import IconMicrophoneSlashFill from '@karrotmarket/lynx-monochrome-icon/IconMicrophoneSlashFill';
+import IconMicrophoneSlashLine from '@karrotmarket/lynx-monochrome-icon/IconMicrophoneSlashLine';
+import IconMicrowaveFill from '@karrotmarket/lynx-monochrome-icon/IconMicrowaveFill';
+import IconMicrowaveLine from '@karrotmarket/lynx-monochrome-icon/IconMicrowaveLine';
+import IconMidcutSquareFill from '@karrotmarket/lynx-monochrome-icon/IconMidcutSquareFill';
+import IconMidcutSquareLine from '@karrotmarket/lynx-monochrome-icon/IconMidcutSquareLine';
+import IconMinusCircleFill from '@karrotmarket/lynx-monochrome-icon/IconMinusCircleFill';
+import IconMinusCircleLine from '@karrotmarket/lynx-monochrome-icon/IconMinusCircleLine';
+import IconMinusFatFill from '@karrotmarket/lynx-monochrome-icon/IconMinusFatFill';
+import IconMinusFatLine from '@karrotmarket/lynx-monochrome-icon/IconMinusFatLine';
+import IconMinusFill from '@karrotmarket/lynx-monochrome-icon/IconMinusFill';
+import IconMinusLine from '@karrotmarket/lynx-monochrome-icon/IconMinusLine';
+import IconMobileFill from '@karrotmarket/lynx-monochrome-icon/IconMobileFill';
+import IconMobileLine from '@karrotmarket/lynx-monochrome-icon/IconMobileLine';
+import IconMoonFill from '@karrotmarket/lynx-monochrome-icon/IconMoonFill';
+import IconMoonLine from '@karrotmarket/lynx-monochrome-icon/IconMoonLine';
+import IconMusicalnoteDoubleFill from '@karrotmarket/lynx-monochrome-icon/IconMusicalnoteDoubleFill';
+import IconMusicalnoteDoubleLine from '@karrotmarket/lynx-monochrome-icon/IconMusicalnoteDoubleLine';
+import IconNailpolishFill from '@karrotmarket/lynx-monochrome-icon/IconNailpolishFill';
+import IconNailpolishLine from '@karrotmarket/lynx-monochrome-icon/IconNailpolishLine';
+import IconNeedleScaleFill from '@karrotmarket/lynx-monochrome-icon/IconNeedleScaleFill';
+import IconNeedleScaleLine from '@karrotmarket/lynx-monochrome-icon/IconNeedleScaleLine';
+import IconNUppercaseCircleFill from '@karrotmarket/lynx-monochrome-icon/IconNUppercaseCircleFill';
+import IconNUppercaseCircleLine from '@karrotmarket/lynx-monochrome-icon/IconNUppercaseCircleLine';
+import IconPaintrollerFill from '@karrotmarket/lynx-monochrome-icon/IconPaintrollerFill';
+import IconPaintrollerLine from '@karrotmarket/lynx-monochrome-icon/IconPaintrollerLine';
+import IconPaletteFill from '@karrotmarket/lynx-monochrome-icon/IconPaletteFill';
+import IconPaletteLine from '@karrotmarket/lynx-monochrome-icon/IconPaletteLine';
+import IconPaperclipFill from '@karrotmarket/lynx-monochrome-icon/IconPaperclipFill';
+import IconPaperclipLine from '@karrotmarket/lynx-monochrome-icon/IconPaperclipLine';
+import IconPaperplaneFill from '@karrotmarket/lynx-monochrome-icon/IconPaperplaneFill';
+import IconPaperplaneLine from '@karrotmarket/lynx-monochrome-icon/IconPaperplaneLine';
+import IconPaperplaneTiltedFill from '@karrotmarket/lynx-monochrome-icon/IconPaperplaneTiltedFill';
+import IconPaperplaneTiltedLine from '@karrotmarket/lynx-monochrome-icon/IconPaperplaneTiltedLine';
+import IconPawprintFill from '@karrotmarket/lynx-monochrome-icon/IconPawprintFill';
+import IconPawprintLine from '@karrotmarket/lynx-monochrome-icon/IconPawprintLine';
+import IconPencilFill from '@karrotmarket/lynx-monochrome-icon/IconPencilFill';
+import IconPencilLine from '@karrotmarket/lynx-monochrome-icon/IconPencilLine';
+import IconPenHorizlineFill from '@karrotmarket/lynx-monochrome-icon/IconPenHorizlineFill';
+import IconPenHorizlineLine from '@karrotmarket/lynx-monochrome-icon/IconPenHorizlineLine';
+import IconPeople3Fill from '@karrotmarket/lynx-monochrome-icon/IconPeople3Fill';
+import IconPeople3Line from '@karrotmarket/lynx-monochrome-icon/IconPeople3Line';
+import IconPercentFill from '@karrotmarket/lynx-monochrome-icon/IconPercentFill';
+import IconPercentFlowerFill from '@karrotmarket/lynx-monochrome-icon/IconPercentFlowerFill';
+import IconPercentFlowerLine from '@karrotmarket/lynx-monochrome-icon/IconPercentFlowerLine';
+import IconPercentLine from '@karrotmarket/lynx-monochrome-icon/IconPercentLine';
+import IconPerson2Fill from '@karrotmarket/lynx-monochrome-icon/IconPerson2Fill';
+import IconPerson2Line from '@karrotmarket/lynx-monochrome-icon/IconPerson2Line';
+import IconPerson2OpenarmsFill from '@karrotmarket/lynx-monochrome-icon/IconPerson2OpenarmsFill';
+import IconPerson2OpenarmsLine from '@karrotmarket/lynx-monochrome-icon/IconPerson2OpenarmsLine';
+import IconPersonCircleFill from '@karrotmarket/lynx-monochrome-icon/IconPersonCircleFill';
+import IconPersonCircleLine from '@karrotmarket/lynx-monochrome-icon/IconPersonCircleLine';
+import IconPersonFill from '@karrotmarket/lynx-monochrome-icon/IconPersonFill';
+import IconPersonFlowerFill from '@karrotmarket/lynx-monochrome-icon/IconPersonFlowerFill';
+import IconPersonFlowerLine from '@karrotmarket/lynx-monochrome-icon/IconPersonFlowerLine';
+import IconPersonLine from '@karrotmarket/lynx-monochrome-icon/IconPersonLine';
+import IconPersonMagnifyingglassFill from '@karrotmarket/lynx-monochrome-icon/IconPersonMagnifyingglassFill';
+import IconPersonMagnifyingglassLine from '@karrotmarket/lynx-monochrome-icon/IconPersonMagnifyingglassLine';
+import IconPersonPlusFill from '@karrotmarket/lynx-monochrome-icon/IconPersonPlusFill';
+import IconPersonPlusLine from '@karrotmarket/lynx-monochrome-icon/IconPersonPlusLine';
+import IconPersonShieldFill from '@karrotmarket/lynx-monochrome-icon/IconPersonShieldFill';
+import IconPersonShieldLine from '@karrotmarket/lynx-monochrome-icon/IconPersonShieldLine';
+import IconPhoneFill from '@karrotmarket/lynx-monochrome-icon/IconPhoneFill';
+import IconPhoneLine from '@karrotmarket/lynx-monochrome-icon/IconPhoneLine';
+import IconPhoneXmarkFill from '@karrotmarket/lynx-monochrome-icon/IconPhoneXmarkFill';
+import IconPhoneXmarkLine from '@karrotmarket/lynx-monochrome-icon/IconPhoneXmarkLine';
+import IconPicture2StackedFill from '@karrotmarket/lynx-monochrome-icon/IconPicture2StackedFill';
+import IconPicture2StackedLine from '@karrotmarket/lynx-monochrome-icon/IconPicture2StackedLine';
+import IconPictureFill from '@karrotmarket/lynx-monochrome-icon/IconPictureFill';
+import IconPictureLine from '@karrotmarket/lynx-monochrome-icon/IconPictureLine';
+import IconPlusCircleFill from '@karrotmarket/lynx-monochrome-icon/IconPlusCircleFill';
+import IconPlusCircleLine from '@karrotmarket/lynx-monochrome-icon/IconPlusCircleLine';
+import IconPlusFill from '@karrotmarket/lynx-monochrome-icon/IconPlusFill';
+import IconPlusLine from '@karrotmarket/lynx-monochrome-icon/IconPlusLine';
+import IconPlusSmallFill from '@karrotmarket/lynx-monochrome-icon/IconPlusSmallFill';
+import IconPlusSmallLine from '@karrotmarket/lynx-monochrome-icon/IconPlusSmallLine';
+import IconPlusSquareFill from '@karrotmarket/lynx-monochrome-icon/IconPlusSquareFill';
+import IconPlusSquareLine from '@karrotmarket/lynx-monochrome-icon/IconPlusSquareLine';
+import IconPostFill from '@karrotmarket/lynx-monochrome-icon/IconPostFill';
+import IconPostLine from '@karrotmarket/lynx-monochrome-icon/IconPostLine';
+import IconPUppercaseCircleFill from '@karrotmarket/lynx-monochrome-icon/IconPUppercaseCircleFill';
+import IconPUppercaseCircleLine from '@karrotmarket/lynx-monochrome-icon/IconPUppercaseCircleLine';
+import IconPushpinFill from '@karrotmarket/lynx-monochrome-icon/IconPushpinFill';
+import IconPushpinLine from '@karrotmarket/lynx-monochrome-icon/IconPushpinLine';
+import IconQUppercaseChatbubbleRightFill from '@karrotmarket/lynx-monochrome-icon/IconQUppercaseChatbubbleRightFill';
+import IconQUppercaseChatbubbleRightLine from '@karrotmarket/lynx-monochrome-icon/IconQUppercaseChatbubbleRightLine';
+import IconQuestionmarkCircleFill from '@karrotmarket/lynx-monochrome-icon/IconQuestionmarkCircleFill';
+import IconQuestionmarkCircleLine from '@karrotmarket/lynx-monochrome-icon/IconQuestionmarkCircleLine';
+import IconQuestionmarkSquareFill from '@karrotmarket/lynx-monochrome-icon/IconQuestionmarkSquareFill';
+import IconQuestionmarkSquareLine from '@karrotmarket/lynx-monochrome-icon/IconQuestionmarkSquareLine';
+import IconQuotationmark2LeftFill from '@karrotmarket/lynx-monochrome-icon/IconQuotationmark2LeftFill';
+import IconQuotationmark2LeftLine from '@karrotmarket/lynx-monochrome-icon/IconQuotationmark2LeftLine';
+import IconQuotationmark2RightFill from '@karrotmarket/lynx-monochrome-icon/IconQuotationmark2RightFill';
+import IconQuotationmark2RightLine from '@karrotmarket/lynx-monochrome-icon/IconQuotationmark2RightLine';
+import IconReceiptFill from '@karrotmarket/lynx-monochrome-icon/IconReceiptFill';
+import IconReceiptLine from '@karrotmarket/lynx-monochrome-icon/IconReceiptLine';
+import IconRectangleSplitedLineVerticalFill from '@karrotmarket/lynx-monochrome-icon/IconRectangleSplitedLineVerticalFill';
+import IconRectangleSplitedLineVerticalLine from '@karrotmarket/lynx-monochrome-icon/IconRectangleSplitedLineVerticalLine';
+import IconRoadlaneFill from '@karrotmarket/lynx-monochrome-icon/IconRoadlaneFill';
+import IconRoadlaneLine from '@karrotmarket/lynx-monochrome-icon/IconRoadlaneLine';
+import IconRocketFill from '@karrotmarket/lynx-monochrome-icon/IconRocketFill';
+import IconRocketLine from '@karrotmarket/lynx-monochrome-icon/IconRocketLine';
+import IconRooftoproomFill from '@karrotmarket/lynx-monochrome-icon/IconRooftoproomFill';
+import IconRooftoproomLine from '@karrotmarket/lynx-monochrome-icon/IconRooftoproomLine';
+import IconScissorsFill from '@karrotmarket/lynx-monochrome-icon/IconScissorsFill';
+import IconScissorsLine from '@karrotmarket/lynx-monochrome-icon/IconScissorsLine';
+import IconScribbleFill from '@karrotmarket/lynx-monochrome-icon/IconScribbleFill';
+import IconScribbleLine from '@karrotmarket/lynx-monochrome-icon/IconScribbleLine';
+import IconSeatLeftFanFill from '@karrotmarket/lynx-monochrome-icon/IconSeatLeftFanFill';
+import IconSeatLeftFanLine from '@karrotmarket/lynx-monochrome-icon/IconSeatLeftFanLine';
+import IconSeatLeftFill from '@karrotmarket/lynx-monochrome-icon/IconSeatLeftFill';
+import IconSeatLeftHeatwave2Fill from '@karrotmarket/lynx-monochrome-icon/IconSeatLeftHeatwave2Fill';
+import IconSeatLeftHeatwave2Line from '@karrotmarket/lynx-monochrome-icon/IconSeatLeftHeatwave2Line';
+import IconSeatLeftLine from '@karrotmarket/lynx-monochrome-icon/IconSeatLeftLine';
+import IconShoppingbag2StackedFill from '@karrotmarket/lynx-monochrome-icon/IconShoppingbag2StackedFill';
+import IconShoppingbag2StackedLine from '@karrotmarket/lynx-monochrome-icon/IconShoppingbag2StackedLine';
+import IconShoppingbagFill from '@karrotmarket/lynx-monochrome-icon/IconShoppingbagFill';
+import IconShoppingbagItemsFill from '@karrotmarket/lynx-monochrome-icon/IconShoppingbagItemsFill';
+import IconShoppingbagItemsLine from '@karrotmarket/lynx-monochrome-icon/IconShoppingbagItemsLine';
+import IconShoppingbagLine from '@karrotmarket/lynx-monochrome-icon/IconShoppingbagLine';
+import IconSidemirrorWaveFill from '@karrotmarket/lynx-monochrome-icon/IconSidemirrorWaveFill';
+import IconSidemirrorWaveLine from '@karrotmarket/lynx-monochrome-icon/IconSidemirrorWaveLine';
+import IconSignboardFill from '@karrotmarket/lynx-monochrome-icon/IconSignboardFill';
+import IconSignboardLine from '@karrotmarket/lynx-monochrome-icon/IconSignboardLine';
+import IconSlashCircleFill from '@karrotmarket/lynx-monochrome-icon/IconSlashCircleFill';
+import IconSlashCircleLine from '@karrotmarket/lynx-monochrome-icon/IconSlashCircleLine';
+import IconSlashSemicircle2Fill from '@karrotmarket/lynx-monochrome-icon/IconSlashSemicircle2Fill';
+import IconSlashSemicircle2Line from '@karrotmarket/lynx-monochrome-icon/IconSlashSemicircle2Line';
+import IconSlider2HorizontalFill from '@karrotmarket/lynx-monochrome-icon/IconSlider2HorizontalFill';
+import IconSlider2HorizontalLine from '@karrotmarket/lynx-monochrome-icon/IconSlider2HorizontalLine';
+import IconSmartkeyFill from '@karrotmarket/lynx-monochrome-icon/IconSmartkeyFill';
+import IconSmartkeyLine from '@karrotmarket/lynx-monochrome-icon/IconSmartkeyLine';
+import IconSneakerLiftedLeftsideFill from '@karrotmarket/lynx-monochrome-icon/IconSneakerLiftedLeftsideFill';
+import IconSneakerLiftedLeftsideLine from '@karrotmarket/lynx-monochrome-icon/IconSneakerLiftedLeftsideLine';
+import IconSofaFill from '@karrotmarket/lynx-monochrome-icon/IconSofaFill';
+import IconSofaLine from '@karrotmarket/lynx-monochrome-icon/IconSofaLine';
+import IconSparkle2Fill from '@karrotmarket/lynx-monochrome-icon/IconSparkle2Fill';
+import IconSparkle2Line from '@karrotmarket/lynx-monochrome-icon/IconSparkle2Line';
+import IconSparkleViewfinderFill from '@karrotmarket/lynx-monochrome-icon/IconSparkleViewfinderFill';
+import IconSparkleViewfinderLine from '@karrotmarket/lynx-monochrome-icon/IconSparkleViewfinderLine';
+import IconSpeakerWave2Fill from '@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2Fill';
+import IconSpeakerWave2Line from '@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2Line';
+import IconSpeakerWave2SlashFill from '@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2SlashFill';
+import IconSpeakerWave2SlashLine from '@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2SlashLine';
+import IconSpeedometer_1xFill from '@karrotmarket/lynx-monochrome-icon/IconSpeedometer_1xFill';
+import IconSpeedometer_1xLine from '@karrotmarket/lynx-monochrome-icon/IconSpeedometer_1xLine';
+import IconSpeedometer_2xFill from '@karrotmarket/lynx-monochrome-icon/IconSpeedometer_2xFill';
+import IconSpeedometer_2xLine from '@karrotmarket/lynx-monochrome-icon/IconSpeedometer_2xLine';
+import IconSpeedometer_3xFill from '@karrotmarket/lynx-monochrome-icon/IconSpeedometer_3xFill';
+import IconSpeedometer_3xLine from '@karrotmarket/lynx-monochrome-icon/IconSpeedometer_3xLine';
+import IconSpeedometerFill from '@karrotmarket/lynx-monochrome-icon/IconSpeedometerFill';
+import IconSpeedometerLine from '@karrotmarket/lynx-monochrome-icon/IconSpeedometerLine';
+import IconSplitedGridSquareFill from '@karrotmarket/lynx-monochrome-icon/IconSplitedGridSquareFill';
+import IconSplitedGridSquareLine from '@karrotmarket/lynx-monochrome-icon/IconSplitedGridSquareLine';
+import IconSpraybottleSpongeFill from '@karrotmarket/lynx-monochrome-icon/IconSpraybottleSpongeFill';
+import IconSpraybottleSpongeLine from '@karrotmarket/lynx-monochrome-icon/IconSpraybottleSpongeLine';
+import IconSquare2StackedFill from '@karrotmarket/lynx-monochrome-icon/IconSquare2StackedFill';
+import IconSquare2StackedLine from '@karrotmarket/lynx-monochrome-icon/IconSquare2StackedLine';
+import IconSquareline2VerticalFill from '@karrotmarket/lynx-monochrome-icon/IconSquareline2VerticalFill';
+import IconSquareline2VerticalLine from '@karrotmarket/lynx-monochrome-icon/IconSquareline2VerticalLine';
+import IconSquareSplitedVerticalLeftFill from '@karrotmarket/lynx-monochrome-icon/IconSquareSplitedVerticalLeftFill';
+import IconSquareSplitedVerticalLeftLine from '@karrotmarket/lynx-monochrome-icon/IconSquareSplitedVerticalLeftLine';
+import IconStarFill from '@karrotmarket/lynx-monochrome-icon/IconStarFill';
+import IconStarLine from '@karrotmarket/lynx-monochrome-icon/IconStarLine';
+import IconSteeringwheelHeatwave2Fill from '@karrotmarket/lynx-monochrome-icon/IconSteeringwheelHeatwave2Fill';
+import IconSteeringwheelHeatwave2Line from '@karrotmarket/lynx-monochrome-icon/IconSteeringwheelHeatwave2Line';
+import IconStepsFill from '@karrotmarket/lynx-monochrome-icon/IconStepsFill';
+import IconStepsLine from '@karrotmarket/lynx-monochrome-icon/IconStepsLine';
+import IconStoreCheckmarkFill from '@karrotmarket/lynx-monochrome-icon/IconStoreCheckmarkFill';
+import IconStoreCheckmarkLine from '@karrotmarket/lynx-monochrome-icon/IconStoreCheckmarkLine';
+import IconStoreFill from '@karrotmarket/lynx-monochrome-icon/IconStoreFill';
+import IconStoreLine from '@karrotmarket/lynx-monochrome-icon/IconStoreLine';
+import IconStorePenFill from '@karrotmarket/lynx-monochrome-icon/IconStorePenFill';
+import IconStorePenLine from '@karrotmarket/lynx-monochrome-icon/IconStorePenLine';
+import IconSUppercaseHorizlineCenterFill from '@karrotmarket/lynx-monochrome-icon/IconSUppercaseHorizlineCenterFill';
+import IconSUppercaseHorizlineCenterLine from '@karrotmarket/lynx-monochrome-icon/IconSUppercaseHorizlineCenterLine';
+import IconSunFill from '@karrotmarket/lynx-monochrome-icon/IconSunFill';
+import IconSunLine from '@karrotmarket/lynx-monochrome-icon/IconSunLine';
+import IconTagFill from '@karrotmarket/lynx-monochrome-icon/IconTagFill';
+import IconTagLine from '@karrotmarket/lynx-monochrome-icon/IconTagLine';
+import IconTextAligncenterFill from '@karrotmarket/lynx-monochrome-icon/IconTextAligncenterFill';
+import IconTextAligncenterLine from '@karrotmarket/lynx-monochrome-icon/IconTextAligncenterLine';
+import IconTextAlignleftFill from '@karrotmarket/lynx-monochrome-icon/IconTextAlignleftFill';
+import IconTextAlignleftLine from '@karrotmarket/lynx-monochrome-icon/IconTextAlignleftLine';
+import IconTextAlignrightFill from '@karrotmarket/lynx-monochrome-icon/IconTextAlignrightFill';
+import IconTextAlignrightLine from '@karrotmarket/lynx-monochrome-icon/IconTextAlignrightLine';
+import IconThumbDownFill from '@karrotmarket/lynx-monochrome-icon/IconThumbDownFill';
+import IconThumbDownLine from '@karrotmarket/lynx-monochrome-icon/IconThumbDownLine';
+import IconThumbUpFill from '@karrotmarket/lynx-monochrome-icon/IconThumbUpFill';
+import IconThumbUpLine from '@karrotmarket/lynx-monochrome-icon/IconThumbUpLine';
+import IconTimer_3Fill from '@karrotmarket/lynx-monochrome-icon/IconTimer_3Fill';
+import IconTimer_3Line from '@karrotmarket/lynx-monochrome-icon/IconTimer_3Line';
+import IconTimer_10Fill from '@karrotmarket/lynx-monochrome-icon/IconTimer_10Fill';
+import IconTimer_10Line from '@karrotmarket/lynx-monochrome-icon/IconTimer_10Line';
+import IconTimerFill from '@karrotmarket/lynx-monochrome-icon/IconTimerFill';
+import IconTimerLine from '@karrotmarket/lynx-monochrome-icon/IconTimerLine';
+import IconToolboxFill from '@karrotmarket/lynx-monochrome-icon/IconToolboxFill';
+import IconToolboxLine from '@karrotmarket/lynx-monochrome-icon/IconToolboxLine';
+import IconTranslationFill from '@karrotmarket/lynx-monochrome-icon/IconTranslationFill';
+import IconTranslationLine from '@karrotmarket/lynx-monochrome-icon/IconTranslationLine';
+import IconTrashcanFill from '@karrotmarket/lynx-monochrome-icon/IconTrashcanFill';
+import IconTrashcanLine from '@karrotmarket/lynx-monochrome-icon/IconTrashcanLine';
+import IconTriangleDownSmallFill from '@karrotmarket/lynx-monochrome-icon/IconTriangleDownSmallFill';
+import IconTriangleDownSmallLine from '@karrotmarket/lynx-monochrome-icon/IconTriangleDownSmallLine';
+import IconTriangleRightChatbubbleLeftFill from '@karrotmarket/lynx-monochrome-icon/IconTriangleRightChatbubbleLeftFill';
+import IconTriangleRightChatbubbleLeftLine from '@karrotmarket/lynx-monochrome-icon/IconTriangleRightChatbubbleLeftLine';
+import IconTriangleRightFill from '@karrotmarket/lynx-monochrome-icon/IconTriangleRightFill';
+import IconTriangleRightLine from '@karrotmarket/lynx-monochrome-icon/IconTriangleRightLine';
+import IconTriangleRightRectangleSplitedLineVerticalFill from '@karrotmarket/lynx-monochrome-icon/IconTriangleRightRectangleSplitedLineVerticalFill';
+import IconTriangleRightRectangleSplitedLineVerticalLine from '@karrotmarket/lynx-monochrome-icon/IconTriangleRightRectangleSplitedLineVerticalLine';
+import IconTriangleUpSmallFill from '@karrotmarket/lynx-monochrome-icon/IconTriangleUpSmallFill';
+import IconTriangleUpSmallLine from '@karrotmarket/lynx-monochrome-icon/IconTriangleUpSmallLine';
+import IconTrophyFill from '@karrotmarket/lynx-monochrome-icon/IconTrophyFill';
+import IconTrophyLine from '@karrotmarket/lynx-monochrome-icon/IconTrophyLine';
+import IconTruckFill from '@karrotmarket/lynx-monochrome-icon/IconTruckFill';
+import IconTruckLine from '@karrotmarket/lynx-monochrome-icon/IconTruckLine';
+import IconTshirtBubble2Fill from '@karrotmarket/lynx-monochrome-icon/IconTshirtBubble2Fill';
+import IconTshirtBubble2Line from '@karrotmarket/lynx-monochrome-icon/IconTshirtBubble2Line';
+import IconTUppercaseSerifFill from '@karrotmarket/lynx-monochrome-icon/IconTUppercaseSerifFill';
+import IconTUppercaseSerifLine from '@karrotmarket/lynx-monochrome-icon/IconTUppercaseSerifLine';
+import IconTUppercaseTLowercaseFill from '@karrotmarket/lynx-monochrome-icon/IconTUppercaseTLowercaseFill';
+import IconTUppercaseTLowercaseLine from '@karrotmarket/lynx-monochrome-icon/IconTUppercaseTLowercaseLine';
+import IconUUppercaseHorizlineFill from '@karrotmarket/lynx-monochrome-icon/IconUUppercaseHorizlineFill';
+import IconUUppercaseHorizlineLine from '@karrotmarket/lynx-monochrome-icon/IconUUppercaseHorizlineLine';
+import IconVertline3ViewfinderFill from '@karrotmarket/lynx-monochrome-icon/IconVertline3ViewfinderFill';
+import IconVertline3ViewfinderLine from '@karrotmarket/lynx-monochrome-icon/IconVertline3ViewfinderLine';
+import IconVertline4SparkleFill from '@karrotmarket/lynx-monochrome-icon/IconVertline4SparkleFill';
+import IconVertline4SparkleLine from '@karrotmarket/lynx-monochrome-icon/IconVertline4SparkleLine';
+import IconVertlineCouponFill from '@karrotmarket/lynx-monochrome-icon/IconVertlineCouponFill';
+import IconVertlineCouponLine from '@karrotmarket/lynx-monochrome-icon/IconVertlineCouponLine';
+import IconVertrectangle2HorizontalFill from '@karrotmarket/lynx-monochrome-icon/IconVertrectangle2HorizontalFill';
+import IconVertrectangle2HorizontalLine from '@karrotmarket/lynx-monochrome-icon/IconVertrectangle2HorizontalLine';
+import IconVertrectangleFoldedFill from '@karrotmarket/lynx-monochrome-icon/IconVertrectangleFoldedFill';
+import IconVertrectangleFoldedLine from '@karrotmarket/lynx-monochrome-icon/IconVertrectangleFoldedLine';
+import IconVotingstampFill from '@karrotmarket/lynx-monochrome-icon/IconVotingstampFill';
+import IconVotingstampLine from '@karrotmarket/lynx-monochrome-icon/IconVotingstampLine';
+import IconWandFill from '@karrotmarket/lynx-monochrome-icon/IconWandFill';
+import IconWandLine from '@karrotmarket/lynx-monochrome-icon/IconWandLine';
+import IconWandPlusCircleFill from '@karrotmarket/lynx-monochrome-icon/IconWandPlusCircleFill';
+import IconWandPlusCircleLine from '@karrotmarket/lynx-monochrome-icon/IconWandPlusCircleLine';
+import IconWashingmachineFill from '@karrotmarket/lynx-monochrome-icon/IconWashingmachineFill';
+import IconWashingmachineLine from '@karrotmarket/lynx-monochrome-icon/IconWashingmachineLine';
+import IconWindow2StoreFill from '@karrotmarket/lynx-monochrome-icon/IconWindow2StoreFill';
+import IconWindow2StoreLine from '@karrotmarket/lynx-monochrome-icon/IconWindow2StoreLine';
+import IconWindow4HouseFill from '@karrotmarket/lynx-monochrome-icon/IconWindow4HouseFill';
+import IconWindow4HouseLine from '@karrotmarket/lynx-monochrome-icon/IconWindow4HouseLine';
+import IconWonArrowClockwiseCircularFill from '@karrotmarket/lynx-monochrome-icon/IconWonArrowClockwiseCircularFill';
+import IconWonArrowClockwiseCircularLine from '@karrotmarket/lynx-monochrome-icon/IconWonArrowClockwiseCircularLine';
+import IconWonCircleArrowLeftFill from '@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowLeftFill';
+import IconWonCircleArrowLeftLine from '@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowLeftLine';
+import IconWonCircleArrowRightFill from '@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowRightFill';
+import IconWonCircleArrowRightLine from '@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowRightLine';
+import IconWonCircleFill from '@karrotmarket/lynx-monochrome-icon/IconWonCircleFill';
+import IconWonCircleLine from '@karrotmarket/lynx-monochrome-icon/IconWonCircleLine';
+import IconWonFill from '@karrotmarket/lynx-monochrome-icon/IconWonFill';
+import IconWonLine from '@karrotmarket/lynx-monochrome-icon/IconWonLine';
+import IconWonShieldFill from '@karrotmarket/lynx-monochrome-icon/IconWonShieldFill';
+import IconWonShieldLine from '@karrotmarket/lynx-monochrome-icon/IconWonShieldLine';
+import IconWrenchFill from '@karrotmarket/lynx-monochrome-icon/IconWrenchFill';
+import IconWrenchLine from '@karrotmarket/lynx-monochrome-icon/IconWrenchLine';
+import IconXmarkCircleFill from '@karrotmarket/lynx-monochrome-icon/IconXmarkCircleFill';
+import IconXmarkCircleLine from '@karrotmarket/lynx-monochrome-icon/IconXmarkCircleLine';
+import IconXmarkFill from '@karrotmarket/lynx-monochrome-icon/IconXmarkFill';
+import IconXmarkLine from '@karrotmarket/lynx-monochrome-icon/IconXmarkLine';
+import IconXmarkScaleFill from '@karrotmarket/lynx-monochrome-icon/IconXmarkScaleFill';
+import IconXmarkScaleLine from '@karrotmarket/lynx-monochrome-icon/IconXmarkScaleLine';
+import IconYenCircleArrowRightFill from '@karrotmarket/lynx-monochrome-icon/IconYenCircleArrowRightFill';
+import IconYenCircleArrowRightLine from '@karrotmarket/lynx-monochrome-icon/IconYenCircleArrowRightLine';
+import IconYenCircleFill from '@karrotmarket/lynx-monochrome-icon/IconYenCircleFill';
+import IconYenCircleLine from '@karrotmarket/lynx-monochrome-icon/IconYenCircleLine';
+import IconYenFill from '@karrotmarket/lynx-monochrome-icon/IconYenFill';
+import IconYenLine from '@karrotmarket/lynx-monochrome-icon/IconYenLine';
 
-import IconAUppercaseALowercaseFill from "@karrotmarket/lynx-monochrome-icon/IconAUppercaseALowercaseFill";
-import IconAUppercaseALowercaseLine from "@karrotmarket/lynx-monochrome-icon/IconAUppercaseALowercaseLine";
-import IconAUppercaseOutlineFill from "@karrotmarket/lynx-monochrome-icon/IconAUppercaseOutlineFill";
-import IconAUppercaseOutlineLine from "@karrotmarket/lynx-monochrome-icon/IconAUppercaseOutlineLine";
-import IconAUppercaseSquareFill from "@karrotmarket/lynx-monochrome-icon/IconAUppercaseSquareFill";
-import IconAUppercaseSquareLine from "@karrotmarket/lynx-monochrome-icon/IconAUppercaseSquareLine";
-import IconAndroidshareFill from "@karrotmarket/lynx-monochrome-icon/IconAndroidshareFill";
-import IconAndroidshareLine from "@karrotmarket/lynx-monochrome-icon/IconAndroidshareLine";
-import IconAppleFill from "@karrotmarket/lynx-monochrome-icon/IconAppleFill";
-import IconAppleLine from "@karrotmarket/lynx-monochrome-icon/IconAppleLine";
-import IconArrow2ClockwiseCircularFill from "@karrotmarket/lynx-monochrome-icon/IconArrow2ClockwiseCircularFill";
-import IconArrow2ClockwiseCircularLine from "@karrotmarket/lynx-monochrome-icon/IconArrow2ClockwiseCircularLine";
-import IconArrowClockwiseCircularFill from "@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseCircularFill";
-import IconArrowClockwiseCircularLine from "@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseCircularLine";
-import IconArrowClockwiseOvalFill from "@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseOvalFill";
-import IconArrowClockwiseOvalLine from "@karrotmarket/lynx-monochrome-icon/IconArrowClockwiseOvalLine";
-import IconArrowCounterclockwiseCircularFill from "@karrotmarket/lynx-monochrome-icon/IconArrowCounterclockwiseCircularFill";
-import IconArrowCounterclockwiseCircularLine from "@karrotmarket/lynx-monochrome-icon/IconArrowCounterclockwiseCircularLine";
-import IconArrowDownFill from "@karrotmarket/lynx-monochrome-icon/IconArrowDownFill";
-import IconArrowDownHorizlineFill from "@karrotmarket/lynx-monochrome-icon/IconArrowDownHorizlineFill";
-import IconArrowDownHorizlineLine from "@karrotmarket/lynx-monochrome-icon/IconArrowDownHorizlineLine";
-import IconArrowDownLine from "@karrotmarket/lynx-monochrome-icon/IconArrowDownLine";
-import IconArrowDownLineVerticalArrowUpSquareFill from "@karrotmarket/lynx-monochrome-icon/IconArrowDownLineVerticalArrowUpSquareFill";
-import IconArrowDownLineVerticalArrowUpSquareLine from "@karrotmarket/lynx-monochrome-icon/IconArrowDownLineVerticalArrowUpSquareLine";
-import IconArrowDownRightArrowUpLeftFill from "@karrotmarket/lynx-monochrome-icon/IconArrowDownRightArrowUpLeftFill";
-import IconArrowDownRightArrowUpLeftLine from "@karrotmarket/lynx-monochrome-icon/IconArrowDownRightArrowUpLeftLine";
-import IconArrowLeftBracketRightFill from "@karrotmarket/lynx-monochrome-icon/IconArrowLeftBracketRightFill";
-import IconArrowLeftBracketRightLine from "@karrotmarket/lynx-monochrome-icon/IconArrowLeftBracketRightLine";
-import IconArrowLeftFill from "@karrotmarket/lynx-monochrome-icon/IconArrowLeftFill";
-import IconArrowLeftLine from "@karrotmarket/lynx-monochrome-icon/IconArrowLeftLine";
-import IconArrowRightAngledFill from "@karrotmarket/lynx-monochrome-icon/IconArrowRightAngledFill";
-import IconArrowRightAngledLine from "@karrotmarket/lynx-monochrome-icon/IconArrowRightAngledLine";
-import IconArrowRightArrowLeftFill from "@karrotmarket/lynx-monochrome-icon/IconArrowRightArrowLeftFill";
-import IconArrowRightArrowLeftLine from "@karrotmarket/lynx-monochrome-icon/IconArrowRightArrowLeftLine";
-import IconArrowRightFill from "@karrotmarket/lynx-monochrome-icon/IconArrowRightFill";
-import IconArrowRightLine from "@karrotmarket/lynx-monochrome-icon/IconArrowRightLine";
-import IconArrowUpArrowDownFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUpArrowDownFill";
-import IconArrowUpArrowDownLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUpArrowDownLine";
-import IconArrowUpBracketDownFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUpBracketDownFill";
-import IconArrowUpBracketDownLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUpBracketDownLine";
-import IconArrowUpFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUpFill";
-import IconArrowUpLeftFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUpLeftFill";
-import IconArrowUpLeftLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUpLeftLine";
-import IconArrowUpLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUpLine";
-import IconArrowUpRightArrowDownLeftFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftFill";
-import IconArrowUpRightArrowDownLeftLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftLine";
-import IconArrowUpRightArrowDownLeftSquareFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftSquareFill";
-import IconArrowUpRightArrowDownLeftSquareLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUpRightArrowDownLeftSquareLine";
-import IconArrowUpRightFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUpRightFill";
-import IconArrowUpRightLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUpRightLine";
-import IconArrowUpRightShoppingbagTiltedFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUpRightShoppingbagTiltedFill";
-import IconArrowUpRightShoppingbagTiltedLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUpRightShoppingbagTiltedLine";
-import IconArrowUturnLeftFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUturnLeftFill";
-import IconArrowUturnLeftLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUturnLeftLine";
-import IconArrowUturnRightFill from "@karrotmarket/lynx-monochrome-icon/IconArrowUturnRightFill";
-import IconArrowUturnRightLine from "@karrotmarket/lynx-monochrome-icon/IconArrowUturnRightLine";
-import IconArticleFill from "@karrotmarket/lynx-monochrome-icon/IconArticleFill";
-import IconArticleLine from "@karrotmarket/lynx-monochrome-icon/IconArticleLine";
-import IconAsteriskHorizrectangleCoolwave3Fill from "@karrotmarket/lynx-monochrome-icon/IconAsteriskHorizrectangleCoolwave3Fill";
-import IconAsteriskHorizrectangleCoolwave3Line from "@karrotmarket/lynx-monochrome-icon/IconAsteriskHorizrectangleCoolwave3Line";
-import IconAtFill from "@karrotmarket/lynx-monochrome-icon/IconAtFill";
-import IconAtLine from "@karrotmarket/lynx-monochrome-icon/IconAtLine";
-import IconBUppercaseFill from "@karrotmarket/lynx-monochrome-icon/IconBUppercaseFill";
-import IconBUppercaseLine from "@karrotmarket/lynx-monochrome-icon/IconBUppercaseLine";
-import IconBackspacekeyFill from "@karrotmarket/lynx-monochrome-icon/IconBackspacekeyFill";
-import IconBackspacekeyLine from "@karrotmarket/lynx-monochrome-icon/IconBackspacekeyLine";
-import IconBarchartBoardFill from "@karrotmarket/lynx-monochrome-icon/IconBarchartBoardFill";
-import IconBarchartBoardLine from "@karrotmarket/lynx-monochrome-icon/IconBarchartBoardLine";
-import IconBarchartSquareFill from "@karrotmarket/lynx-monochrome-icon/IconBarchartSquareFill";
-import IconBarchartSquareLine from "@karrotmarket/lynx-monochrome-icon/IconBarchartSquareLine";
-import IconBedFrontsideFill from "@karrotmarket/lynx-monochrome-icon/IconBedFrontsideFill";
-import IconBedFrontsideLine from "@karrotmarket/lynx-monochrome-icon/IconBedFrontsideLine";
-import IconBellFill from "@karrotmarket/lynx-monochrome-icon/IconBellFill";
-import IconBellLine from "@karrotmarket/lynx-monochrome-icon/IconBellLine";
-import IconBellSlashFill from "@karrotmarket/lynx-monochrome-icon/IconBellSlashFill";
-import IconBellSlashLine from "@karrotmarket/lynx-monochrome-icon/IconBellSlashLine";
-import IconBookFill from "@karrotmarket/lynx-monochrome-icon/IconBookFill";
-import IconBookLine from "@karrotmarket/lynx-monochrome-icon/IconBookLine";
-import IconBookOpenFill from "@karrotmarket/lynx-monochrome-icon/IconBookOpenFill";
-import IconBookOpenLine from "@karrotmarket/lynx-monochrome-icon/IconBookOpenLine";
-import IconBookmarkFill from "@karrotmarket/lynx-monochrome-icon/IconBookmarkFill";
-import IconBookmarkLine from "@karrotmarket/lynx-monochrome-icon/IconBookmarkLine";
-import IconBoxFlapFill from "@karrotmarket/lynx-monochrome-icon/IconBoxFlapFill";
-import IconBoxFlapLine from "@karrotmarket/lynx-monochrome-icon/IconBoxFlapLine";
-import IconBracketLeftArrowRightFill from "@karrotmarket/lynx-monochrome-icon/IconBracketLeftArrowRightFill";
-import IconBracketLeftArrowRightLine from "@karrotmarket/lynx-monochrome-icon/IconBracketLeftArrowRightLine";
-import IconBuilding2Fill from "@karrotmarket/lynx-monochrome-icon/IconBuilding2Fill";
-import IconBuilding2Line from "@karrotmarket/lynx-monochrome-icon/IconBuilding2Line";
-import IconCalendarFill from "@karrotmarket/lynx-monochrome-icon/IconCalendarFill";
-import IconCalendarLine from "@karrotmarket/lynx-monochrome-icon/IconCalendarLine";
-import IconCamcorderFill from "@karrotmarket/lynx-monochrome-icon/IconCamcorderFill";
-import IconCamcorderLine from "@karrotmarket/lynx-monochrome-icon/IconCamcorderLine";
-import IconCameraFill from "@karrotmarket/lynx-monochrome-icon/IconCameraFill";
-import IconCameraLine from "@karrotmarket/lynx-monochrome-icon/IconCameraLine";
-import IconCarFill from "@karrotmarket/lynx-monochrome-icon/IconCarFill";
-import IconCarFrontUpsideWave2ReversedUpFill from "@karrotmarket/lynx-monochrome-icon/IconCarFrontUpsideWave2ReversedUpFill";
-import IconCarFrontUpsideWave2ReversedUpLine from "@karrotmarket/lynx-monochrome-icon/IconCarFrontUpsideWave2ReversedUpLine";
-import IconCarFrontsideFill from "@karrotmarket/lynx-monochrome-icon/IconCarFrontsideFill";
-import IconCarFrontsideLine from "@karrotmarket/lynx-monochrome-icon/IconCarFrontsideLine";
-import IconCarLine from "@karrotmarket/lynx-monochrome-icon/IconCarLine";
-import IconCarRearTrunkOpenLeftsideFill from "@karrotmarket/lynx-monochrome-icon/IconCarRearTrunkOpenLeftsideFill";
-import IconCarRearTrunkOpenLeftsideLine from "@karrotmarket/lynx-monochrome-icon/IconCarRearTrunkOpenLeftsideLine";
-import IconCarRearUpsideSectorDownFill from "@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideSectorDownFill";
-import IconCarRearUpsideSectorDownLine from "@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideSectorDownLine";
-import IconCarRearUpsideWave2ReversedDownFill from "@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownFill";
-import IconCarRearUpsideWave2ReversedDownLeftFill from "@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownLeftFill";
-import IconCarRearUpsideWave2ReversedDownLeftLine from "@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownLeftLine";
-import IconCarRearUpsideWave2ReversedDownLine from "@karrotmarket/lynx-monochrome-icon/IconCarRearUpsideWave2ReversedDownLine";
-import IconCardFill from "@karrotmarket/lynx-monochrome-icon/IconCardFill";
-import IconCardLine from "@karrotmarket/lynx-monochrome-icon/IconCardLine";
-import IconCarrotFill from "@karrotmarket/lynx-monochrome-icon/IconCarrotFill";
-import IconCarrotLine from "@karrotmarket/lynx-monochrome-icon/IconCarrotLine";
-import IconCartFill from "@karrotmarket/lynx-monochrome-icon/IconCartFill";
-import IconCartItemsFill from "@karrotmarket/lynx-monochrome-icon/IconCartItemsFill";
-import IconCartItemsLine from "@karrotmarket/lynx-monochrome-icon/IconCartItemsLine";
-import IconCartLine from "@karrotmarket/lynx-monochrome-icon/IconCartLine";
-import IconCartLoadFill from "@karrotmarket/lynx-monochrome-icon/IconCartLoadFill";
-import IconCartLoadLine from "@karrotmarket/lynx-monochrome-icon/IconCartLoadLine";
-import IconCheckmarkBadgeFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkBadgeFill";
-import IconCheckmarkBadgeLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkBadgeLine";
-import IconCheckmarkBallotboxFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkBallotboxFill";
-import IconCheckmarkBallotboxLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkBallotboxLine";
-import IconCheckmarkCalendarFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkCalendarFill";
-import IconCheckmarkCalendarLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkCalendarLine";
-import IconCheckmarkChatbubbleLeftFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkChatbubbleLeftFill";
-import IconCheckmarkChatbubbleLeftLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkChatbubbleLeftLine";
-import IconCheckmarkCircleFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkCircleFill";
-import IconCheckmarkCircleLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkCircleLine";
-import IconCheckmarkClipboardFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkClipboardFill";
-import IconCheckmarkClipboardLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkClipboardLine";
-import IconCheckmarkCouponFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkCouponFill";
-import IconCheckmarkCouponLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkCouponLine";
-import IconCheckmarkFatFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkFatFill";
-import IconCheckmarkFatLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkFatLine";
-import IconCheckmarkFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkFill";
-import IconCheckmarkFlowerFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkFlowerFill";
-import IconCheckmarkFlowerLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkFlowerLine";
-import IconCheckmarkHorizlineFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkHorizlineFill";
-import IconCheckmarkHorizlineLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkHorizlineLine";
-import IconCheckmarkLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkLine";
-import IconCheckmarkScaleFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkScaleFill";
-import IconCheckmarkScaleLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkScaleLine";
-import IconCheckmarkShieldFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkShieldFill";
-import IconCheckmarkShieldLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkShieldLine";
-import IconCheckmarkhorizline2VerticalFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkhorizline2VerticalFill";
-import IconCheckmarkhorizline2VerticalLine from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkhorizline2VerticalLine";
-import IconChevronDownFill from "@karrotmarket/lynx-monochrome-icon/IconChevronDownFill";
-import IconChevronDownLine from "@karrotmarket/lynx-monochrome-icon/IconChevronDownLine";
-import IconChevronDownSmallFill from "@karrotmarket/lynx-monochrome-icon/IconChevronDownSmallFill";
-import IconChevronDownSmallLine from "@karrotmarket/lynx-monochrome-icon/IconChevronDownSmallLine";
-import IconChevronLeftFill from "@karrotmarket/lynx-monochrome-icon/IconChevronLeftFill";
-import IconChevronLeftLine from "@karrotmarket/lynx-monochrome-icon/IconChevronLeftLine";
-import IconChevronLeftSmallFill from "@karrotmarket/lynx-monochrome-icon/IconChevronLeftSmallFill";
-import IconChevronLeftSmallLine from "@karrotmarket/lynx-monochrome-icon/IconChevronLeftSmallLine";
-import IconChevronRightFill from "@karrotmarket/lynx-monochrome-icon/IconChevronRightFill";
-import IconChevronRightLine from "@karrotmarket/lynx-monochrome-icon/IconChevronRightLine";
-import IconChevronRightSmallFill from "@karrotmarket/lynx-monochrome-icon/IconChevronRightSmallFill";
-import IconChevronRightSmallLine from "@karrotmarket/lynx-monochrome-icon/IconChevronRightSmallLine";
-import IconChevronUpFill from "@karrotmarket/lynx-monochrome-icon/IconChevronUpFill";
-import IconChevronUpLine from "@karrotmarket/lynx-monochrome-icon/IconChevronUpLine";
-import IconChevronUpSmallFill from "@karrotmarket/lynx-monochrome-icon/IconChevronUpSmallFill";
-import IconChevronUpSmallLine from "@karrotmarket/lynx-monochrome-icon/IconChevronUpSmallLine";
-import IconCircle4SquareFill from "@karrotmarket/lynx-monochrome-icon/IconCircle4SquareFill";
-import IconCircle4SquareLine from "@karrotmarket/lynx-monochrome-icon/IconCircle4SquareLine";
-import IconClockFill from "@karrotmarket/lynx-monochrome-icon/IconClockFill";
-import IconClockLine from "@karrotmarket/lynx-monochrome-icon/IconClockLine";
-import IconCompassFill from "@karrotmarket/lynx-monochrome-icon/IconCompassFill";
-import IconCompassLine from "@karrotmarket/lynx-monochrome-icon/IconCompassLine";
-import IconCorner4InwardFill from "@karrotmarket/lynx-monochrome-icon/IconCorner4InwardFill";
-import IconCorner4InwardLine from "@karrotmarket/lynx-monochrome-icon/IconCorner4InwardLine";
-import IconCorner4OutwardFill from "@karrotmarket/lynx-monochrome-icon/IconCorner4OutwardFill";
-import IconCorner4OutwardLine from "@karrotmarket/lynx-monochrome-icon/IconCorner4OutwardLine";
-import IconCornerDownLeftFill from "@karrotmarket/lynx-monochrome-icon/IconCornerDownLeftFill";
-import IconCornerDownLeftLine from "@karrotmarket/lynx-monochrome-icon/IconCornerDownLeftLine";
-import IconCouponFill from "@karrotmarket/lynx-monochrome-icon/IconCouponFill";
-import IconCouponLine from "@karrotmarket/lynx-monochrome-icon/IconCouponLine";
-import IconCropmarkFill from "@karrotmarket/lynx-monochrome-icon/IconCropmarkFill";
-import IconCropmarkLine from "@karrotmarket/lynx-monochrome-icon/IconCropmarkLine";
-import IconCrosshairFill from "@karrotmarket/lynx-monochrome-icon/IconCrosshairFill";
-import IconCrosshairLine from "@karrotmarket/lynx-monochrome-icon/IconCrosshairLine";
-import IconCrosshairQuestionmarkFill from "@karrotmarket/lynx-monochrome-icon/IconCrosshairQuestionmarkFill";
-import IconCrosshairQuestionmarkLine from "@karrotmarket/lynx-monochrome-icon/IconCrosshairQuestionmarkLine";
-import IconCrownFill from "@karrotmarket/lynx-monochrome-icon/IconCrownFill";
-import IconCrownLine from "@karrotmarket/lynx-monochrome-icon/IconCrownLine";
-import IconCupHeatwaveFill from "@karrotmarket/lynx-monochrome-icon/IconCupHeatwaveFill";
-import IconCupHeatwaveLine from "@karrotmarket/lynx-monochrome-icon/IconCupHeatwaveLine";
-import IconDiamondFill from "@karrotmarket/lynx-monochrome-icon/IconDiamondFill";
-import IconDiamondLine from "@karrotmarket/lynx-monochrome-icon/IconDiamondLine";
-import IconDocumentArrowLeftFill from "@karrotmarket/lynx-monochrome-icon/IconDocumentArrowLeftFill";
-import IconDocumentArrowLeftLine from "@karrotmarket/lynx-monochrome-icon/IconDocumentArrowLeftLine";
-import IconDocumentCheckmarkFill from "@karrotmarket/lynx-monochrome-icon/IconDocumentCheckmarkFill";
-import IconDocumentCheckmarkLine from "@karrotmarket/lynx-monochrome-icon/IconDocumentCheckmarkLine";
-import IconDocumentFill from "@karrotmarket/lynx-monochrome-icon/IconDocumentFill";
-import IconDocumentLine from "@karrotmarket/lynx-monochrome-icon/IconDocumentLine";
-import IconDocumentMagnifyingglassFill from "@karrotmarket/lynx-monochrome-icon/IconDocumentMagnifyingglassFill";
-import IconDocumentMagnifyingglassLine from "@karrotmarket/lynx-monochrome-icon/IconDocumentMagnifyingglassLine";
-import IconDocumentPenFill from "@karrotmarket/lynx-monochrome-icon/IconDocumentPenFill";
-import IconDocumentPenLine from "@karrotmarket/lynx-monochrome-icon/IconDocumentPenLine";
-import IconDocumentPlusFill from "@karrotmarket/lynx-monochrome-icon/IconDocumentPlusFill";
-import IconDocumentPlusLine from "@karrotmarket/lynx-monochrome-icon/IconDocumentPlusLine";
-import IconDollarCircleArrowRightFill from "@karrotmarket/lynx-monochrome-icon/IconDollarCircleArrowRightFill";
-import IconDollarCircleArrowRightLine from "@karrotmarket/lynx-monochrome-icon/IconDollarCircleArrowRightLine";
-import IconDollarCircleFill from "@karrotmarket/lynx-monochrome-icon/IconDollarCircleFill";
-import IconDollarCircleLine from "@karrotmarket/lynx-monochrome-icon/IconDollarCircleLine";
-import IconDollarFill from "@karrotmarket/lynx-monochrome-icon/IconDollarFill";
-import IconDollarLine from "@karrotmarket/lynx-monochrome-icon/IconDollarLine";
-import IconDot3CircleFill from "@karrotmarket/lynx-monochrome-icon/IconDot3CircleFill";
-import IconDot3CircleLine from "@karrotmarket/lynx-monochrome-icon/IconDot3CircleLine";
-import IconDot3HorizontalChatbubbleLeftFill from "@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftFill";
-import IconDot3HorizontalChatbubbleLeftLine from "@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftLine";
-import IconDot3HorizontalChatbubbleLeftSlashFill from "@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftSlashFill";
-import IconDot3HorizontalChatbubbleLeftSlashLine from "@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalChatbubbleLeftSlashLine";
-import IconDot3HorizontalFill from "@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalFill";
-import IconDot3HorizontalLine from "@karrotmarket/lynx-monochrome-icon/IconDot3HorizontalLine";
-import IconDot3VerticalFill from "@karrotmarket/lynx-monochrome-icon/IconDot3VerticalFill";
-import IconDot3VerticalLine from "@karrotmarket/lynx-monochrome-icon/IconDot3VerticalLine";
-import IconDothorizline3VerticalFill from "@karrotmarket/lynx-monochrome-icon/IconDothorizline3VerticalFill";
-import IconDothorizline3VerticalLine from "@karrotmarket/lynx-monochrome-icon/IconDothorizline3VerticalLine";
-import IconDumbbellFill from "@karrotmarket/lynx-monochrome-icon/IconDumbbellFill";
-import IconDumbbellLine from "@karrotmarket/lynx-monochrome-icon/IconDumbbellLine";
-import IconEarthFill from "@karrotmarket/lynx-monochrome-icon/IconEarthFill";
-import IconEarthLine from "@karrotmarket/lynx-monochrome-icon/IconEarthLine";
-import IconEnvelopeFill from "@karrotmarket/lynx-monochrome-icon/IconEnvelopeFill";
-import IconEnvelopeLine from "@karrotmarket/lynx-monochrome-icon/IconEnvelopeLine";
-import IconEpbFill from "@karrotmarket/lynx-monochrome-icon/IconEpbFill";
-import IconEpbLine from "@karrotmarket/lynx-monochrome-icon/IconEpbLine";
-import IconEraserHorizlineFill from "@karrotmarket/lynx-monochrome-icon/IconEraserHorizlineFill";
-import IconEraserHorizlineLine from "@karrotmarket/lynx-monochrome-icon/IconEraserHorizlineLine";
-import IconExclamationmarkChatbubbleRectangularCenterFill from "@karrotmarket/lynx-monochrome-icon/IconExclamationmarkChatbubbleRectangularCenterFill";
-import IconExclamationmarkChatbubbleRectangularCenterLine from "@karrotmarket/lynx-monochrome-icon/IconExclamationmarkChatbubbleRectangularCenterLine";
-import IconExclamationmarkCircleFill from "@karrotmarket/lynx-monochrome-icon/IconExclamationmarkCircleFill";
-import IconExclamationmarkCircleLine from "@karrotmarket/lynx-monochrome-icon/IconExclamationmarkCircleLine";
-import IconEyeFill from "@karrotmarket/lynx-monochrome-icon/IconEyeFill";
-import IconEyeLine from "@karrotmarket/lynx-monochrome-icon/IconEyeLine";
-import IconEyeSlashFill from "@karrotmarket/lynx-monochrome-icon/IconEyeSlashFill";
-import IconEyeSlashLine from "@karrotmarket/lynx-monochrome-icon/IconEyeSlashLine";
-import IconFaceFrustratedCircleFill from "@karrotmarket/lynx-monochrome-icon/IconFaceFrustratedCircleFill";
-import IconFaceFrustratedCircleLine from "@karrotmarket/lynx-monochrome-icon/IconFaceFrustratedCircleLine";
-import IconFaceSadCircleFill from "@karrotmarket/lynx-monochrome-icon/IconFaceSadCircleFill";
-import IconFaceSadCircleLine from "@karrotmarket/lynx-monochrome-icon/IconFaceSadCircleLine";
-import IconFaceSmileCircleFill from "@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleFill";
-import IconFaceSmileCircleFoldedFill from "@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleFoldedFill";
-import IconFaceSmileCircleFoldedLine from "@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleFoldedLine";
-import IconFaceSmileCircleLine from "@karrotmarket/lynx-monochrome-icon/IconFaceSmileCircleLine";
-import IconFaceSurprisedCircleFill from "@karrotmarket/lynx-monochrome-icon/IconFaceSurprisedCircleFill";
-import IconFaceSurprisedCircleLine from "@karrotmarket/lynx-monochrome-icon/IconFaceSurprisedCircleLine";
-import IconFaceViewfinderFill from "@karrotmarket/lynx-monochrome-icon/IconFaceViewfinderFill";
-import IconFaceViewfinderLine from "@karrotmarket/lynx-monochrome-icon/IconFaceViewfinderLine";
-import IconFigureBikeFill from "@karrotmarket/lynx-monochrome-icon/IconFigureBikeFill";
-import IconFigureBikeLine from "@karrotmarket/lynx-monochrome-icon/IconFigureBikeLine";
-import IconFigureOvalFill from "@karrotmarket/lynx-monochrome-icon/IconFigureOvalFill";
-import IconFigureOvalLine from "@karrotmarket/lynx-monochrome-icon/IconFigureOvalLine";
-import IconFigureRunFill from "@karrotmarket/lynx-monochrome-icon/IconFigureRunFill";
-import IconFigureRunLine from "@karrotmarket/lynx-monochrome-icon/IconFigureRunLine";
-import IconFigureWalkFill from "@karrotmarket/lynx-monochrome-icon/IconFigureWalkFill";
-import IconFigureWalkLine from "@karrotmarket/lynx-monochrome-icon/IconFigureWalkLine";
-import IconFigureWheelchairFill from "@karrotmarket/lynx-monochrome-icon/IconFigureWheelchairFill";
-import IconFigureWheelchairLine from "@karrotmarket/lynx-monochrome-icon/IconFigureWheelchairLine";
-import IconFingerprintFill from "@karrotmarket/lynx-monochrome-icon/IconFingerprintFill";
-import IconFingerprintLine from "@karrotmarket/lynx-monochrome-icon/IconFingerprintLine";
-import IconFireworkFill from "@karrotmarket/lynx-monochrome-icon/IconFireworkFill";
-import IconFireworkLine from "@karrotmarket/lynx-monochrome-icon/IconFireworkLine";
-import IconFishWave2Fill from "@karrotmarket/lynx-monochrome-icon/IconFishWave2Fill";
-import IconFishWave2Line from "@karrotmarket/lynx-monochrome-icon/IconFishWave2Line";
-import IconFlagFill from "@karrotmarket/lynx-monochrome-icon/IconFlagFill";
-import IconFlagHillFill from "@karrotmarket/lynx-monochrome-icon/IconFlagHillFill";
-import IconFlagHillLine from "@karrotmarket/lynx-monochrome-icon/IconFlagHillLine";
-import IconFlagLine from "@karrotmarket/lynx-monochrome-icon/IconFlagLine";
-import IconFlameFill from "@karrotmarket/lynx-monochrome-icon/IconFlameFill";
-import IconFlameLine from "@karrotmarket/lynx-monochrome-icon/IconFlameLine";
-import IconFlaskFill from "@karrotmarket/lynx-monochrome-icon/IconFlaskFill";
-import IconFlaskLine from "@karrotmarket/lynx-monochrome-icon/IconFlaskLine";
-import IconForkSpoonBagFill from "@karrotmarket/lynx-monochrome-icon/IconForkSpoonBagFill";
-import IconForkSpoonBagLine from "@karrotmarket/lynx-monochrome-icon/IconForkSpoonBagLine";
-import IconForkSpoonFill from "@karrotmarket/lynx-monochrome-icon/IconForkSpoonFill";
-import IconForkSpoonLine from "@karrotmarket/lynx-monochrome-icon/IconForkSpoonLine";
-import IconFridgeFill from "@karrotmarket/lynx-monochrome-icon/IconFridgeFill";
-import IconFridgeLine from "@karrotmarket/lynx-monochrome-icon/IconFridgeLine";
-import IconGearFill from "@karrotmarket/lynx-monochrome-icon/IconGearFill";
-import IconGearLine from "@karrotmarket/lynx-monochrome-icon/IconGearLine";
-import IconGiftFill from "@karrotmarket/lynx-monochrome-icon/IconGiftFill";
-import IconGiftLine from "@karrotmarket/lynx-monochrome-icon/IconGiftLine";
-import IconGlobeFill from "@karrotmarket/lynx-monochrome-icon/IconGlobeFill";
-import IconGlobeLine from "@karrotmarket/lynx-monochrome-icon/IconGlobeLine";
-import IconGraduationcapFill from "@karrotmarket/lynx-monochrome-icon/IconGraduationcapFill";
-import IconGraduationcapLine from "@karrotmarket/lynx-monochrome-icon/IconGraduationcapLine";
-import IconGridDot5Fill from "@karrotmarket/lynx-monochrome-icon/IconGridDot5Fill";
-import IconGridDot5Line from "@karrotmarket/lynx-monochrome-icon/IconGridDot5Line";
-import IconGridFill from "@karrotmarket/lynx-monochrome-icon/IconGridFill";
-import IconGridHeartFill from "@karrotmarket/lynx-monochrome-icon/IconGridHeartFill";
-import IconGridHeartLine from "@karrotmarket/lynx-monochrome-icon/IconGridHeartLine";
-import IconGridLine from "@karrotmarket/lynx-monochrome-icon/IconGridLine";
-import IconHandPointUpFill from "@karrotmarket/lynx-monochrome-icon/IconHandPointUpFill";
-import IconHandPointUpLine from "@karrotmarket/lynx-monochrome-icon/IconHandPointUpLine";
-import IconHandWaveFill from "@karrotmarket/lynx-monochrome-icon/IconHandWaveFill";
-import IconHandWaveLine from "@karrotmarket/lynx-monochrome-icon/IconHandWaveLine";
-import IconHashFill from "@karrotmarket/lynx-monochrome-icon/IconHashFill";
-import IconHashLine from "@karrotmarket/lynx-monochrome-icon/IconHashLine";
-import IconHeadsetFill from "@karrotmarket/lynx-monochrome-icon/IconHeadsetFill";
-import IconHeadsetLine from "@karrotmarket/lynx-monochrome-icon/IconHeadsetLine";
-import IconHeartFill from "@karrotmarket/lynx-monochrome-icon/IconHeartFill";
-import IconHeartLine from "@karrotmarket/lynx-monochrome-icon/IconHeartLine";
-import IconHorizline2VerticalChatbubbleRectangularRightFill from "@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightFill";
-import IconHorizline2VerticalChatbubbleRectangularRightLine from "@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightLine";
-import IconHorizline2VerticalChatbubbleRectangularRightSlashFill from "@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightSlashFill";
-import IconHorizline2VerticalChatbubbleRectangularRightSlashLine from "@karrotmarket/lynx-monochrome-icon/IconHorizline2VerticalChatbubbleRectangularRightSlashLine";
-import IconHorizline3VerticalCheckmarkFill from "@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalCheckmarkFill";
-import IconHorizline3VerticalCheckmarkLine from "@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalCheckmarkLine";
-import IconHorizline3VerticalFill from "@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalFill";
-import IconHorizline3VerticalLine from "@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalLine";
-import IconHorizline3VerticalStarFill from "@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalStarFill";
-import IconHorizline3VerticalStarLine from "@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalStarLine";
-import IconHorizline3VerticalTightFill from "@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalTightFill";
-import IconHorizline3VerticalTightLine from "@karrotmarket/lynx-monochrome-icon/IconHorizline3VerticalTightLine";
-import IconHorizlineViewfinderFill from "@karrotmarket/lynx-monochrome-icon/IconHorizlineViewfinderFill";
-import IconHorizlineViewfinderLine from "@karrotmarket/lynx-monochrome-icon/IconHorizlineViewfinderLine";
-import IconHorizrectangleHorizline2VerticalFill from "@karrotmarket/lynx-monochrome-icon/IconHorizrectangleHorizline2VerticalFill";
-import IconHorizrectangleHorizline2VerticalLine from "@karrotmarket/lynx-monochrome-icon/IconHorizrectangleHorizline2VerticalLine";
-import IconHospitalcrossBuildingFill from "@karrotmarket/lynx-monochrome-icon/IconHospitalcrossBuildingFill";
-import IconHospitalcrossBuildingLine from "@karrotmarket/lynx-monochrome-icon/IconHospitalcrossBuildingLine";
-import IconHospitalcrossSquareFill from "@karrotmarket/lynx-monochrome-icon/IconHospitalcrossSquareFill";
-import IconHospitalcrossSquareLine from "@karrotmarket/lynx-monochrome-icon/IconHospitalcrossSquareLine";
-import IconHouseFill from "@karrotmarket/lynx-monochrome-icon/IconHouseFill";
-import IconHouseLine from "@karrotmarket/lynx-monochrome-icon/IconHouseLine";
-import IconHousePlusFill from "@karrotmarket/lynx-monochrome-icon/IconHousePlusFill";
-import IconHousePlusLine from "@karrotmarket/lynx-monochrome-icon/IconHousePlusLine";
-import IconHouseSquareFill from "@karrotmarket/lynx-monochrome-icon/IconHouseSquareFill";
-import IconHouseSquareLine from "@karrotmarket/lynx-monochrome-icon/IconHouseSquareLine";
-import IconILowercaseSerifCircleFill from "@karrotmarket/lynx-monochrome-icon/IconILowercaseSerifCircleFill";
-import IconILowercaseSerifCircleLine from "@karrotmarket/lynx-monochrome-icon/IconILowercaseSerifCircleLine";
-import IconKeyboardChevronDownFill from "@karrotmarket/lynx-monochrome-icon/IconKeyboardChevronDownFill";
-import IconKeyboardChevronDownLine from "@karrotmarket/lynx-monochrome-icon/IconKeyboardChevronDownLine";
-import IconKeyholeShieldFill from "@karrotmarket/lynx-monochrome-icon/IconKeyholeShieldFill";
-import IconKeyholeShieldLine from "@karrotmarket/lynx-monochrome-icon/IconKeyholeShieldLine";
-import IconLaptopFill from "@karrotmarket/lynx-monochrome-icon/IconLaptopFill";
-import IconLaptopLine from "@karrotmarket/lynx-monochrome-icon/IconLaptopLine";
-import IconLeafFill from "@karrotmarket/lynx-monochrome-icon/IconLeafFill";
-import IconLeafLine from "@karrotmarket/lynx-monochrome-icon/IconLeafLine";
-import IconLightbulbDot5Fill from "@karrotmarket/lynx-monochrome-icon/IconLightbulbDot5Fill";
-import IconLightbulbDot5Line from "@karrotmarket/lynx-monochrome-icon/IconLightbulbDot5Line";
-import IconLightningFill from "@karrotmarket/lynx-monochrome-icon/IconLightningFill";
-import IconLightningLine from "@karrotmarket/lynx-monochrome-icon/IconLightningLine";
-import IconLightningSlashFill from "@karrotmarket/lynx-monochrome-icon/IconLightningSlashFill";
-import IconLightningSlashLine from "@karrotmarket/lynx-monochrome-icon/IconLightningSlashLine";
-import IconLinechartUpXaxisFill from "@karrotmarket/lynx-monochrome-icon/IconLinechartUpXaxisFill";
-import IconLinechartUpXaxisLine from "@karrotmarket/lynx-monochrome-icon/IconLinechartUpXaxisLine";
-import IconLocationpinFill from "@karrotmarket/lynx-monochrome-icon/IconLocationpinFill";
-import IconLocationpinLine from "@karrotmarket/lynx-monochrome-icon/IconLocationpinLine";
-import IconLockFill from "@karrotmarket/lynx-monochrome-icon/IconLockFill";
-import IconLockLine from "@karrotmarket/lynx-monochrome-icon/IconLockLine";
-import IconLockOpenedFill from "@karrotmarket/lynx-monochrome-icon/IconLockOpenedFill";
-import IconLockOpenedLine from "@karrotmarket/lynx-monochrome-icon/IconLockOpenedLine";
-import IconMagnifyingglassFill from "@karrotmarket/lynx-monochrome-icon/IconMagnifyingglassFill";
-import IconMagnifyingglassLine from "@karrotmarket/lynx-monochrome-icon/IconMagnifyingglassLine";
-import IconMalesymbolFemalesymbolFill from "@karrotmarket/lynx-monochrome-icon/IconMalesymbolFemalesymbolFill";
-import IconMalesymbolFemalesymbolLine from "@karrotmarket/lynx-monochrome-icon/IconMalesymbolFemalesymbolLine";
-import IconMapFill from "@karrotmarket/lynx-monochrome-icon/IconMapFill";
-import IconMapLine from "@karrotmarket/lynx-monochrome-icon/IconMapLine";
-import IconMapLocationpinFill from "@karrotmarket/lynx-monochrome-icon/IconMapLocationpinFill";
-import IconMapLocationpinLine from "@karrotmarket/lynx-monochrome-icon/IconMapLocationpinLine";
-import IconMegaphoneFill from "@karrotmarket/lynx-monochrome-icon/IconMegaphoneFill";
-import IconMegaphoneLine from "@karrotmarket/lynx-monochrome-icon/IconMegaphoneLine";
-import IconMegaphoneTiltedFill from "@karrotmarket/lynx-monochrome-icon/IconMegaphoneTiltedFill";
-import IconMegaphoneTiltedLine from "@karrotmarket/lynx-monochrome-icon/IconMegaphoneTiltedLine";
-import IconMetroFrontsideFill from "@karrotmarket/lynx-monochrome-icon/IconMetroFrontsideFill";
-import IconMetroFrontsideLine from "@karrotmarket/lynx-monochrome-icon/IconMetroFrontsideLine";
-import IconMicrophoneFill from "@karrotmarket/lynx-monochrome-icon/IconMicrophoneFill";
-import IconMicrophoneLine from "@karrotmarket/lynx-monochrome-icon/IconMicrophoneLine";
-import IconMicrophoneSlashFill from "@karrotmarket/lynx-monochrome-icon/IconMicrophoneSlashFill";
-import IconMicrophoneSlashLine from "@karrotmarket/lynx-monochrome-icon/IconMicrophoneSlashLine";
-import IconMicrowaveFill from "@karrotmarket/lynx-monochrome-icon/IconMicrowaveFill";
-import IconMicrowaveLine from "@karrotmarket/lynx-monochrome-icon/IconMicrowaveLine";
-import IconMidcutSquareFill from "@karrotmarket/lynx-monochrome-icon/IconMidcutSquareFill";
-import IconMidcutSquareLine from "@karrotmarket/lynx-monochrome-icon/IconMidcutSquareLine";
-import IconMinusCircleFill from "@karrotmarket/lynx-monochrome-icon/IconMinusCircleFill";
-import IconMinusCircleLine from "@karrotmarket/lynx-monochrome-icon/IconMinusCircleLine";
-import IconMinusFatFill from "@karrotmarket/lynx-monochrome-icon/IconMinusFatFill";
-import IconMinusFatLine from "@karrotmarket/lynx-monochrome-icon/IconMinusFatLine";
-import IconMinusFill from "@karrotmarket/lynx-monochrome-icon/IconMinusFill";
-import IconMinusLine from "@karrotmarket/lynx-monochrome-icon/IconMinusLine";
-import IconMobileFill from "@karrotmarket/lynx-monochrome-icon/IconMobileFill";
-import IconMobileLine from "@karrotmarket/lynx-monochrome-icon/IconMobileLine";
-import IconMoonFill from "@karrotmarket/lynx-monochrome-icon/IconMoonFill";
-import IconMoonLine from "@karrotmarket/lynx-monochrome-icon/IconMoonLine";
-import IconMusicalnoteDoubleFill from "@karrotmarket/lynx-monochrome-icon/IconMusicalnoteDoubleFill";
-import IconMusicalnoteDoubleLine from "@karrotmarket/lynx-monochrome-icon/IconMusicalnoteDoubleLine";
-import IconNUppercaseCircleFill from "@karrotmarket/lynx-monochrome-icon/IconNUppercaseCircleFill";
-import IconNUppercaseCircleLine from "@karrotmarket/lynx-monochrome-icon/IconNUppercaseCircleLine";
-import IconNailpolishFill from "@karrotmarket/lynx-monochrome-icon/IconNailpolishFill";
-import IconNailpolishLine from "@karrotmarket/lynx-monochrome-icon/IconNailpolishLine";
-import IconNeedleScaleFill from "@karrotmarket/lynx-monochrome-icon/IconNeedleScaleFill";
-import IconNeedleScaleLine from "@karrotmarket/lynx-monochrome-icon/IconNeedleScaleLine";
-import IconPUppercaseCircleFill from "@karrotmarket/lynx-monochrome-icon/IconPUppercaseCircleFill";
-import IconPUppercaseCircleLine from "@karrotmarket/lynx-monochrome-icon/IconPUppercaseCircleLine";
-import IconPaintrollerFill from "@karrotmarket/lynx-monochrome-icon/IconPaintrollerFill";
-import IconPaintrollerLine from "@karrotmarket/lynx-monochrome-icon/IconPaintrollerLine";
-import IconPaletteFill from "@karrotmarket/lynx-monochrome-icon/IconPaletteFill";
-import IconPaletteLine from "@karrotmarket/lynx-monochrome-icon/IconPaletteLine";
-import IconPaperclipFill from "@karrotmarket/lynx-monochrome-icon/IconPaperclipFill";
-import IconPaperclipLine from "@karrotmarket/lynx-monochrome-icon/IconPaperclipLine";
-import IconPaperplaneFill from "@karrotmarket/lynx-monochrome-icon/IconPaperplaneFill";
-import IconPaperplaneLine from "@karrotmarket/lynx-monochrome-icon/IconPaperplaneLine";
-import IconPaperplaneTiltedFill from "@karrotmarket/lynx-monochrome-icon/IconPaperplaneTiltedFill";
-import IconPaperplaneTiltedLine from "@karrotmarket/lynx-monochrome-icon/IconPaperplaneTiltedLine";
-import IconPawprintFill from "@karrotmarket/lynx-monochrome-icon/IconPawprintFill";
-import IconPawprintLine from "@karrotmarket/lynx-monochrome-icon/IconPawprintLine";
-import IconPenHorizlineFill from "@karrotmarket/lynx-monochrome-icon/IconPenHorizlineFill";
-import IconPenHorizlineLine from "@karrotmarket/lynx-monochrome-icon/IconPenHorizlineLine";
-import IconPencilFill from "@karrotmarket/lynx-monochrome-icon/IconPencilFill";
-import IconPencilLine from "@karrotmarket/lynx-monochrome-icon/IconPencilLine";
-import IconPeople3Fill from "@karrotmarket/lynx-monochrome-icon/IconPeople3Fill";
-import IconPeople3Line from "@karrotmarket/lynx-monochrome-icon/IconPeople3Line";
-import IconPercentFill from "@karrotmarket/lynx-monochrome-icon/IconPercentFill";
-import IconPercentFlowerFill from "@karrotmarket/lynx-monochrome-icon/IconPercentFlowerFill";
-import IconPercentFlowerLine from "@karrotmarket/lynx-monochrome-icon/IconPercentFlowerLine";
-import IconPercentLine from "@karrotmarket/lynx-monochrome-icon/IconPercentLine";
-import IconPerson2Fill from "@karrotmarket/lynx-monochrome-icon/IconPerson2Fill";
-import IconPerson2Line from "@karrotmarket/lynx-monochrome-icon/IconPerson2Line";
-import IconPerson2OpenarmsFill from "@karrotmarket/lynx-monochrome-icon/IconPerson2OpenarmsFill";
-import IconPerson2OpenarmsLine from "@karrotmarket/lynx-monochrome-icon/IconPerson2OpenarmsLine";
-import IconPersonCircleFill from "@karrotmarket/lynx-monochrome-icon/IconPersonCircleFill";
-import IconPersonCircleLine from "@karrotmarket/lynx-monochrome-icon/IconPersonCircleLine";
-import IconPersonFill from "@karrotmarket/lynx-monochrome-icon/IconPersonFill";
-import IconPersonFlowerFill from "@karrotmarket/lynx-monochrome-icon/IconPersonFlowerFill";
-import IconPersonFlowerLine from "@karrotmarket/lynx-monochrome-icon/IconPersonFlowerLine";
-import IconPersonLine from "@karrotmarket/lynx-monochrome-icon/IconPersonLine";
-import IconPersonMagnifyingglassFill from "@karrotmarket/lynx-monochrome-icon/IconPersonMagnifyingglassFill";
-import IconPersonMagnifyingglassLine from "@karrotmarket/lynx-monochrome-icon/IconPersonMagnifyingglassLine";
-import IconPersonPlusFill from "@karrotmarket/lynx-monochrome-icon/IconPersonPlusFill";
-import IconPersonPlusLine from "@karrotmarket/lynx-monochrome-icon/IconPersonPlusLine";
-import IconPersonShieldFill from "@karrotmarket/lynx-monochrome-icon/IconPersonShieldFill";
-import IconPersonShieldLine from "@karrotmarket/lynx-monochrome-icon/IconPersonShieldLine";
-import IconPhoneFill from "@karrotmarket/lynx-monochrome-icon/IconPhoneFill";
-import IconPhoneLine from "@karrotmarket/lynx-monochrome-icon/IconPhoneLine";
-import IconPhoneXmarkFill from "@karrotmarket/lynx-monochrome-icon/IconPhoneXmarkFill";
-import IconPhoneXmarkLine from "@karrotmarket/lynx-monochrome-icon/IconPhoneXmarkLine";
-import IconPicture2StackedFill from "@karrotmarket/lynx-monochrome-icon/IconPicture2StackedFill";
-import IconPicture2StackedLine from "@karrotmarket/lynx-monochrome-icon/IconPicture2StackedLine";
-import IconPictureFill from "@karrotmarket/lynx-monochrome-icon/IconPictureFill";
-import IconPictureLine from "@karrotmarket/lynx-monochrome-icon/IconPictureLine";
-import IconPlusCircleFill from "@karrotmarket/lynx-monochrome-icon/IconPlusCircleFill";
-import IconPlusCircleLine from "@karrotmarket/lynx-monochrome-icon/IconPlusCircleLine";
-import IconPlusFill from "@karrotmarket/lynx-monochrome-icon/IconPlusFill";
-import IconPlusLine from "@karrotmarket/lynx-monochrome-icon/IconPlusLine";
-import IconPlusSmallFill from "@karrotmarket/lynx-monochrome-icon/IconPlusSmallFill";
-import IconPlusSmallLine from "@karrotmarket/lynx-monochrome-icon/IconPlusSmallLine";
-import IconPlusSquareFill from "@karrotmarket/lynx-monochrome-icon/IconPlusSquareFill";
-import IconPlusSquareLine from "@karrotmarket/lynx-monochrome-icon/IconPlusSquareLine";
-import IconPostFill from "@karrotmarket/lynx-monochrome-icon/IconPostFill";
-import IconPostLine from "@karrotmarket/lynx-monochrome-icon/IconPostLine";
-import IconPushpinFill from "@karrotmarket/lynx-monochrome-icon/IconPushpinFill";
-import IconPushpinLine from "@karrotmarket/lynx-monochrome-icon/IconPushpinLine";
-import IconQUppercaseChatbubbleRightFill from "@karrotmarket/lynx-monochrome-icon/IconQUppercaseChatbubbleRightFill";
-import IconQUppercaseChatbubbleRightLine from "@karrotmarket/lynx-monochrome-icon/IconQUppercaseChatbubbleRightLine";
-import IconQuestionmarkCircleFill from "@karrotmarket/lynx-monochrome-icon/IconQuestionmarkCircleFill";
-import IconQuestionmarkCircleLine from "@karrotmarket/lynx-monochrome-icon/IconQuestionmarkCircleLine";
-import IconQuestionmarkSquareFill from "@karrotmarket/lynx-monochrome-icon/IconQuestionmarkSquareFill";
-import IconQuestionmarkSquareLine from "@karrotmarket/lynx-monochrome-icon/IconQuestionmarkSquareLine";
-import IconQuotationmark2LeftFill from "@karrotmarket/lynx-monochrome-icon/IconQuotationmark2LeftFill";
-import IconQuotationmark2LeftLine from "@karrotmarket/lynx-monochrome-icon/IconQuotationmark2LeftLine";
-import IconQuotationmark2RightFill from "@karrotmarket/lynx-monochrome-icon/IconQuotationmark2RightFill";
-import IconQuotationmark2RightLine from "@karrotmarket/lynx-monochrome-icon/IconQuotationmark2RightLine";
-import IconReceiptFill from "@karrotmarket/lynx-monochrome-icon/IconReceiptFill";
-import IconReceiptLine from "@karrotmarket/lynx-monochrome-icon/IconReceiptLine";
-import IconRectangleSplitedLineVerticalFill from "@karrotmarket/lynx-monochrome-icon/IconRectangleSplitedLineVerticalFill";
-import IconRectangleSplitedLineVerticalLine from "@karrotmarket/lynx-monochrome-icon/IconRectangleSplitedLineVerticalLine";
-import IconRoadlaneFill from "@karrotmarket/lynx-monochrome-icon/IconRoadlaneFill";
-import IconRoadlaneLine from "@karrotmarket/lynx-monochrome-icon/IconRoadlaneLine";
-import IconRocketFill from "@karrotmarket/lynx-monochrome-icon/IconRocketFill";
-import IconRocketLine from "@karrotmarket/lynx-monochrome-icon/IconRocketLine";
-import IconRooftoproomFill from "@karrotmarket/lynx-monochrome-icon/IconRooftoproomFill";
-import IconRooftoproomLine from "@karrotmarket/lynx-monochrome-icon/IconRooftoproomLine";
-import IconSUppercaseHorizlineCenterFill from "@karrotmarket/lynx-monochrome-icon/IconSUppercaseHorizlineCenterFill";
-import IconSUppercaseHorizlineCenterLine from "@karrotmarket/lynx-monochrome-icon/IconSUppercaseHorizlineCenterLine";
-import IconScissorsFill from "@karrotmarket/lynx-monochrome-icon/IconScissorsFill";
-import IconScissorsLine from "@karrotmarket/lynx-monochrome-icon/IconScissorsLine";
-import IconScribbleFill from "@karrotmarket/lynx-monochrome-icon/IconScribbleFill";
-import IconScribbleLine from "@karrotmarket/lynx-monochrome-icon/IconScribbleLine";
-import IconSeatLeftFanFill from "@karrotmarket/lynx-monochrome-icon/IconSeatLeftFanFill";
-import IconSeatLeftFanLine from "@karrotmarket/lynx-monochrome-icon/IconSeatLeftFanLine";
-import IconSeatLeftFill from "@karrotmarket/lynx-monochrome-icon/IconSeatLeftFill";
-import IconSeatLeftHeatwave2Fill from "@karrotmarket/lynx-monochrome-icon/IconSeatLeftHeatwave2Fill";
-import IconSeatLeftHeatwave2Line from "@karrotmarket/lynx-monochrome-icon/IconSeatLeftHeatwave2Line";
-import IconSeatLeftLine from "@karrotmarket/lynx-monochrome-icon/IconSeatLeftLine";
-import IconShoppingbag2StackedFill from "@karrotmarket/lynx-monochrome-icon/IconShoppingbag2StackedFill";
-import IconShoppingbag2StackedLine from "@karrotmarket/lynx-monochrome-icon/IconShoppingbag2StackedLine";
-import IconShoppingbagFill from "@karrotmarket/lynx-monochrome-icon/IconShoppingbagFill";
-import IconShoppingbagItemsFill from "@karrotmarket/lynx-monochrome-icon/IconShoppingbagItemsFill";
-import IconShoppingbagItemsLine from "@karrotmarket/lynx-monochrome-icon/IconShoppingbagItemsLine";
-import IconShoppingbagLine from "@karrotmarket/lynx-monochrome-icon/IconShoppingbagLine";
-import IconSidemirrorWaveFill from "@karrotmarket/lynx-monochrome-icon/IconSidemirrorWaveFill";
-import IconSidemirrorWaveLine from "@karrotmarket/lynx-monochrome-icon/IconSidemirrorWaveLine";
-import IconSignboardFill from "@karrotmarket/lynx-monochrome-icon/IconSignboardFill";
-import IconSignboardLine from "@karrotmarket/lynx-monochrome-icon/IconSignboardLine";
-import IconSlashCircleFill from "@karrotmarket/lynx-monochrome-icon/IconSlashCircleFill";
-import IconSlashCircleLine from "@karrotmarket/lynx-monochrome-icon/IconSlashCircleLine";
-import IconSlashSemicircle2Fill from "@karrotmarket/lynx-monochrome-icon/IconSlashSemicircle2Fill";
-import IconSlashSemicircle2Line from "@karrotmarket/lynx-monochrome-icon/IconSlashSemicircle2Line";
-import IconSlider2HorizontalFill from "@karrotmarket/lynx-monochrome-icon/IconSlider2HorizontalFill";
-import IconSlider2HorizontalLine from "@karrotmarket/lynx-monochrome-icon/IconSlider2HorizontalLine";
-import IconSmartkeyFill from "@karrotmarket/lynx-monochrome-icon/IconSmartkeyFill";
-import IconSmartkeyLine from "@karrotmarket/lynx-monochrome-icon/IconSmartkeyLine";
-import IconSneakerLiftedLeftsideFill from "@karrotmarket/lynx-monochrome-icon/IconSneakerLiftedLeftsideFill";
-import IconSneakerLiftedLeftsideLine from "@karrotmarket/lynx-monochrome-icon/IconSneakerLiftedLeftsideLine";
-import IconSofaFill from "@karrotmarket/lynx-monochrome-icon/IconSofaFill";
-import IconSofaLine from "@karrotmarket/lynx-monochrome-icon/IconSofaLine";
-import IconSparkle2Fill from "@karrotmarket/lynx-monochrome-icon/IconSparkle2Fill";
-import IconSparkle2Line from "@karrotmarket/lynx-monochrome-icon/IconSparkle2Line";
-import IconSparkleViewfinderFill from "@karrotmarket/lynx-monochrome-icon/IconSparkleViewfinderFill";
-import IconSparkleViewfinderLine from "@karrotmarket/lynx-monochrome-icon/IconSparkleViewfinderLine";
-import IconSpeakerWave2Fill from "@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2Fill";
-import IconSpeakerWave2Line from "@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2Line";
-import IconSpeakerWave2SlashFill from "@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2SlashFill";
-import IconSpeakerWave2SlashLine from "@karrotmarket/lynx-monochrome-icon/IconSpeakerWave2SlashLine";
-import IconSpeedometerFill from "@karrotmarket/lynx-monochrome-icon/IconSpeedometerFill";
-import IconSpeedometerLine from "@karrotmarket/lynx-monochrome-icon/IconSpeedometerLine";
-import IconSpeedometer_1xFill from "@karrotmarket/lynx-monochrome-icon/IconSpeedometer_1xFill";
-import IconSpeedometer_1xLine from "@karrotmarket/lynx-monochrome-icon/IconSpeedometer_1xLine";
-import IconSpeedometer_2xFill from "@karrotmarket/lynx-monochrome-icon/IconSpeedometer_2xFill";
-import IconSpeedometer_2xLine from "@karrotmarket/lynx-monochrome-icon/IconSpeedometer_2xLine";
-import IconSpeedometer_3xFill from "@karrotmarket/lynx-monochrome-icon/IconSpeedometer_3xFill";
-import IconSpeedometer_3xLine from "@karrotmarket/lynx-monochrome-icon/IconSpeedometer_3xLine";
-import IconSplitedGridSquareFill from "@karrotmarket/lynx-monochrome-icon/IconSplitedGridSquareFill";
-import IconSplitedGridSquareLine from "@karrotmarket/lynx-monochrome-icon/IconSplitedGridSquareLine";
-import IconSpraybottleSpongeFill from "@karrotmarket/lynx-monochrome-icon/IconSpraybottleSpongeFill";
-import IconSpraybottleSpongeLine from "@karrotmarket/lynx-monochrome-icon/IconSpraybottleSpongeLine";
-import IconSquare2StackedFill from "@karrotmarket/lynx-monochrome-icon/IconSquare2StackedFill";
-import IconSquare2StackedLine from "@karrotmarket/lynx-monochrome-icon/IconSquare2StackedLine";
-import IconSquareline2VerticalFill from "@karrotmarket/lynx-monochrome-icon/IconSquareline2VerticalFill";
-import IconSquareline2VerticalLine from "@karrotmarket/lynx-monochrome-icon/IconSquareline2VerticalLine";
-import IconStarFill from "@karrotmarket/lynx-monochrome-icon/IconStarFill";
-import IconStarLine from "@karrotmarket/lynx-monochrome-icon/IconStarLine";
-import IconSteeringwheelHeatwave2Fill from "@karrotmarket/lynx-monochrome-icon/IconSteeringwheelHeatwave2Fill";
-import IconSteeringwheelHeatwave2Line from "@karrotmarket/lynx-monochrome-icon/IconSteeringwheelHeatwave2Line";
-import IconStepsFill from "@karrotmarket/lynx-monochrome-icon/IconStepsFill";
-import IconStepsLine from "@karrotmarket/lynx-monochrome-icon/IconStepsLine";
-import IconStoreCheckmarkFill from "@karrotmarket/lynx-monochrome-icon/IconStoreCheckmarkFill";
-import IconStoreCheckmarkLine from "@karrotmarket/lynx-monochrome-icon/IconStoreCheckmarkLine";
-import IconStoreFill from "@karrotmarket/lynx-monochrome-icon/IconStoreFill";
-import IconStoreLine from "@karrotmarket/lynx-monochrome-icon/IconStoreLine";
-import IconStorePenFill from "@karrotmarket/lynx-monochrome-icon/IconStorePenFill";
-import IconStorePenLine from "@karrotmarket/lynx-monochrome-icon/IconStorePenLine";
-import IconSunFill from "@karrotmarket/lynx-monochrome-icon/IconSunFill";
-import IconSunLine from "@karrotmarket/lynx-monochrome-icon/IconSunLine";
-import IconTUppercaseSerifFill from "@karrotmarket/lynx-monochrome-icon/IconTUppercaseSerifFill";
-import IconTUppercaseSerifLine from "@karrotmarket/lynx-monochrome-icon/IconTUppercaseSerifLine";
-import IconTUppercaseTLowercaseFill from "@karrotmarket/lynx-monochrome-icon/IconTUppercaseTLowercaseFill";
-import IconTUppercaseTLowercaseLine from "@karrotmarket/lynx-monochrome-icon/IconTUppercaseTLowercaseLine";
-import IconTagFill from "@karrotmarket/lynx-monochrome-icon/IconTagFill";
-import IconTagLine from "@karrotmarket/lynx-monochrome-icon/IconTagLine";
-import IconTextAligncenterFill from "@karrotmarket/lynx-monochrome-icon/IconTextAligncenterFill";
-import IconTextAligncenterLine from "@karrotmarket/lynx-monochrome-icon/IconTextAligncenterLine";
-import IconTextAlignleftFill from "@karrotmarket/lynx-monochrome-icon/IconTextAlignleftFill";
-import IconTextAlignleftLine from "@karrotmarket/lynx-monochrome-icon/IconTextAlignleftLine";
-import IconTextAlignrightFill from "@karrotmarket/lynx-monochrome-icon/IconTextAlignrightFill";
-import IconTextAlignrightLine from "@karrotmarket/lynx-monochrome-icon/IconTextAlignrightLine";
-import IconThumbDownFill from "@karrotmarket/lynx-monochrome-icon/IconThumbDownFill";
-import IconThumbDownLine from "@karrotmarket/lynx-monochrome-icon/IconThumbDownLine";
-import IconThumbUpFill from "@karrotmarket/lynx-monochrome-icon/IconThumbUpFill";
-import IconThumbUpLine from "@karrotmarket/lynx-monochrome-icon/IconThumbUpLine";
-import IconTimerFill from "@karrotmarket/lynx-monochrome-icon/IconTimerFill";
-import IconTimerLine from "@karrotmarket/lynx-monochrome-icon/IconTimerLine";
-import IconTimer_10Fill from "@karrotmarket/lynx-monochrome-icon/IconTimer_10Fill";
-import IconTimer_10Line from "@karrotmarket/lynx-monochrome-icon/IconTimer_10Line";
-import IconTimer_3Fill from "@karrotmarket/lynx-monochrome-icon/IconTimer_3Fill";
-import IconTimer_3Line from "@karrotmarket/lynx-monochrome-icon/IconTimer_3Line";
-import IconToolboxFill from "@karrotmarket/lynx-monochrome-icon/IconToolboxFill";
-import IconToolboxLine from "@karrotmarket/lynx-monochrome-icon/IconToolboxLine";
-import IconTranslationFill from "@karrotmarket/lynx-monochrome-icon/IconTranslationFill";
-import IconTranslationLine from "@karrotmarket/lynx-monochrome-icon/IconTranslationLine";
-import IconTrashcanFill from "@karrotmarket/lynx-monochrome-icon/IconTrashcanFill";
-import IconTrashcanLine from "@karrotmarket/lynx-monochrome-icon/IconTrashcanLine";
-import IconTriangleDownSmallFill from "@karrotmarket/lynx-monochrome-icon/IconTriangleDownSmallFill";
-import IconTriangleDownSmallLine from "@karrotmarket/lynx-monochrome-icon/IconTriangleDownSmallLine";
-import IconTriangleRightChatbubbleLeftFill from "@karrotmarket/lynx-monochrome-icon/IconTriangleRightChatbubbleLeftFill";
-import IconTriangleRightChatbubbleLeftLine from "@karrotmarket/lynx-monochrome-icon/IconTriangleRightChatbubbleLeftLine";
-import IconTriangleRightFill from "@karrotmarket/lynx-monochrome-icon/IconTriangleRightFill";
-import IconTriangleRightLine from "@karrotmarket/lynx-monochrome-icon/IconTriangleRightLine";
-import IconTriangleRightRectangleSplitedLineVerticalFill from "@karrotmarket/lynx-monochrome-icon/IconTriangleRightRectangleSplitedLineVerticalFill";
-import IconTriangleRightRectangleSplitedLineVerticalLine from "@karrotmarket/lynx-monochrome-icon/IconTriangleRightRectangleSplitedLineVerticalLine";
-import IconTriangleUpSmallFill from "@karrotmarket/lynx-monochrome-icon/IconTriangleUpSmallFill";
-import IconTriangleUpSmallLine from "@karrotmarket/lynx-monochrome-icon/IconTriangleUpSmallLine";
-import IconTrophyFill from "@karrotmarket/lynx-monochrome-icon/IconTrophyFill";
-import IconTrophyLine from "@karrotmarket/lynx-monochrome-icon/IconTrophyLine";
-import IconTruckFill from "@karrotmarket/lynx-monochrome-icon/IconTruckFill";
-import IconTruckLine from "@karrotmarket/lynx-monochrome-icon/IconTruckLine";
-import IconTshirtBubble2Fill from "@karrotmarket/lynx-monochrome-icon/IconTshirtBubble2Fill";
-import IconTshirtBubble2Line from "@karrotmarket/lynx-monochrome-icon/IconTshirtBubble2Line";
-import IconUUppercaseHorizlineFill from "@karrotmarket/lynx-monochrome-icon/IconUUppercaseHorizlineFill";
-import IconUUppercaseHorizlineLine from "@karrotmarket/lynx-monochrome-icon/IconUUppercaseHorizlineLine";
-import IconVertline3ViewfinderFill from "@karrotmarket/lynx-monochrome-icon/IconVertline3ViewfinderFill";
-import IconVertline3ViewfinderLine from "@karrotmarket/lynx-monochrome-icon/IconVertline3ViewfinderLine";
-import IconVertline4SparkleFill from "@karrotmarket/lynx-monochrome-icon/IconVertline4SparkleFill";
-import IconVertline4SparkleLine from "@karrotmarket/lynx-monochrome-icon/IconVertline4SparkleLine";
-import IconVertlineCouponFill from "@karrotmarket/lynx-monochrome-icon/IconVertlineCouponFill";
-import IconVertlineCouponLine from "@karrotmarket/lynx-monochrome-icon/IconVertlineCouponLine";
-import IconVertrectangle2HorizontalFill from "@karrotmarket/lynx-monochrome-icon/IconVertrectangle2HorizontalFill";
-import IconVertrectangle2HorizontalLine from "@karrotmarket/lynx-monochrome-icon/IconVertrectangle2HorizontalLine";
-import IconVertrectangleFoldedFill from "@karrotmarket/lynx-monochrome-icon/IconVertrectangleFoldedFill";
-import IconVertrectangleFoldedLine from "@karrotmarket/lynx-monochrome-icon/IconVertrectangleFoldedLine";
-import IconVotingstampFill from "@karrotmarket/lynx-monochrome-icon/IconVotingstampFill";
-import IconVotingstampLine from "@karrotmarket/lynx-monochrome-icon/IconVotingstampLine";
-import IconWandFill from "@karrotmarket/lynx-monochrome-icon/IconWandFill";
-import IconWandLine from "@karrotmarket/lynx-monochrome-icon/IconWandLine";
-import IconWashingmachineFill from "@karrotmarket/lynx-monochrome-icon/IconWashingmachineFill";
-import IconWashingmachineLine from "@karrotmarket/lynx-monochrome-icon/IconWashingmachineLine";
-import IconWindow2StoreFill from "@karrotmarket/lynx-monochrome-icon/IconWindow2StoreFill";
-import IconWindow2StoreLine from "@karrotmarket/lynx-monochrome-icon/IconWindow2StoreLine";
-import IconWindow4HouseFill from "@karrotmarket/lynx-monochrome-icon/IconWindow4HouseFill";
-import IconWindow4HouseLine from "@karrotmarket/lynx-monochrome-icon/IconWindow4HouseLine";
-import IconWonArrowClockwiseCircularFill from "@karrotmarket/lynx-monochrome-icon/IconWonArrowClockwiseCircularFill";
-import IconWonArrowClockwiseCircularLine from "@karrotmarket/lynx-monochrome-icon/IconWonArrowClockwiseCircularLine";
-import IconWonCircleArrowLeftFill from "@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowLeftFill";
-import IconWonCircleArrowLeftLine from "@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowLeftLine";
-import IconWonCircleArrowRightFill from "@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowRightFill";
-import IconWonCircleArrowRightLine from "@karrotmarket/lynx-monochrome-icon/IconWonCircleArrowRightLine";
-import IconWonCircleFill from "@karrotmarket/lynx-monochrome-icon/IconWonCircleFill";
-import IconWonCircleLine from "@karrotmarket/lynx-monochrome-icon/IconWonCircleLine";
-import IconWonFill from "@karrotmarket/lynx-monochrome-icon/IconWonFill";
-import IconWonLine from "@karrotmarket/lynx-monochrome-icon/IconWonLine";
-import IconWonShieldFill from "@karrotmarket/lynx-monochrome-icon/IconWonShieldFill";
-import IconWonShieldLine from "@karrotmarket/lynx-monochrome-icon/IconWonShieldLine";
-import IconWrenchFill from "@karrotmarket/lynx-monochrome-icon/IconWrenchFill";
-import IconWrenchLine from "@karrotmarket/lynx-monochrome-icon/IconWrenchLine";
-import IconXmarkCircleFill from "@karrotmarket/lynx-monochrome-icon/IconXmarkCircleFill";
-import IconXmarkCircleLine from "@karrotmarket/lynx-monochrome-icon/IconXmarkCircleLine";
-import IconXmarkFill from "@karrotmarket/lynx-monochrome-icon/IconXmarkFill";
-import IconXmarkLine from "@karrotmarket/lynx-monochrome-icon/IconXmarkLine";
-import IconXmarkScaleFill from "@karrotmarket/lynx-monochrome-icon/IconXmarkScaleFill";
-import IconXmarkScaleLine from "@karrotmarket/lynx-monochrome-icon/IconXmarkScaleLine";
-import IconYenCircleArrowRightFill from "@karrotmarket/lynx-monochrome-icon/IconYenCircleArrowRightFill";
-import IconYenCircleArrowRightLine from "@karrotmarket/lynx-monochrome-icon/IconYenCircleArrowRightLine";
-import IconYenCircleFill from "@karrotmarket/lynx-monochrome-icon/IconYenCircleFill";
-import IconYenCircleLine from "@karrotmarket/lynx-monochrome-icon/IconYenCircleLine";
-import IconYenFill from "@karrotmarket/lynx-monochrome-icon/IconYenFill";
-import IconYenLine from "@karrotmarket/lynx-monochrome-icon/IconYenLine";
+import { vars } from '@seed-design/lynx-css/vars';
+import {
+  type IconEntry,
+  VirtualIconGrid,
+} from '../components/icon-virtual-grid.jsx';
 
 const { $color } = vars;
 
-interface IconEntry {
-  component: React.ComponentType<{ size?: number; color?: string; className?: string }>;
-  name: string;
-}
-
 const icons: IconEntry[] = [
-  { component: IconAUppercaseALowercaseFill, name: "AUppercaseALowercaseFill" },
-  { component: IconAUppercaseALowercaseLine, name: "AUppercaseALowercaseLine" },
-  { component: IconAUppercaseOutlineFill, name: "AUppercaseOutlineFill" },
-  { component: IconAUppercaseOutlineLine, name: "AUppercaseOutlineLine" },
-  { component: IconAUppercaseSquareFill, name: "AUppercaseSquareFill" },
-  { component: IconAUppercaseSquareLine, name: "AUppercaseSquareLine" },
-  { component: IconAndroidshareFill, name: "AndroidshareFill" },
-  { component: IconAndroidshareLine, name: "AndroidshareLine" },
-  { component: IconAppleFill, name: "AppleFill" },
-  { component: IconAppleLine, name: "AppleLine" },
+  {
+    component: IconAndroidshareFill,
+    name: 'AndroidshareFill',
+  },
+  {
+    component: IconAndroidshareLine,
+    name: 'AndroidshareLine',
+  },
+  {
+    component: IconAppleFill,
+    name: 'AppleFill',
+  },
+  {
+    component: IconAppleLine,
+    name: 'AppleLine',
+  },
   {
     component: IconArrow2ClockwiseCircularFill,
-    name: "Arrow2ClockwiseCircularFill",
+    name: 'Arrow2ClockwiseCircularFill',
   },
   {
     component: IconArrow2ClockwiseCircularLine,
-    name: "Arrow2ClockwiseCircularLine",
+    name: 'Arrow2ClockwiseCircularLine',
   },
   {
     component: IconArrowClockwiseCircularFill,
-    name: "ArrowClockwiseCircularFill",
+    name: 'ArrowClockwiseCircularFill',
   },
   {
     component: IconArrowClockwiseCircularLine,
-    name: "ArrowClockwiseCircularLine",
+    name: 'ArrowClockwiseCircularLine',
   },
-  { component: IconArrowClockwiseOvalFill, name: "ArrowClockwiseOvalFill" },
-  { component: IconArrowClockwiseOvalLine, name: "ArrowClockwiseOvalLine" },
+  {
+    component: IconArrowClockwiseOvalFill,
+    name: 'ArrowClockwiseOvalFill',
+  },
+  {
+    component: IconArrowClockwiseOvalLine,
+    name: 'ArrowClockwiseOvalLine',
+  },
   {
     component: IconArrowCounterclockwiseCircularFill,
-    name: "ArrowCounterclockwiseCircularFill",
+    name: 'ArrowCounterclockwiseCircularFill',
   },
   {
     component: IconArrowCounterclockwiseCircularLine,
-    name: "ArrowCounterclockwiseCircularLine",
+    name: 'ArrowCounterclockwiseCircularLine',
   },
-  { component: IconArrowDownFill, name: "ArrowDownFill" },
-  { component: IconArrowDownHorizlineFill, name: "ArrowDownHorizlineFill" },
-  { component: IconArrowDownHorizlineLine, name: "ArrowDownHorizlineLine" },
-  { component: IconArrowDownLine, name: "ArrowDownLine" },
+  {
+    component: IconArrowDownFill,
+    name: 'ArrowDownFill',
+  },
+  {
+    component: IconArrowDownHorizlineFill,
+    name: 'ArrowDownHorizlineFill',
+  },
+  {
+    component: IconArrowDownHorizlineLine,
+    name: 'ArrowDownHorizlineLine',
+  },
+  {
+    component: IconArrowDownLine,
+    name: 'ArrowDownLine',
+  },
   {
     component: IconArrowDownLineVerticalArrowUpSquareFill,
-    name: "ArrowDownLineVerticalArrowUpSquareFill",
+    name: 'ArrowDownLineVerticalArrowUpSquareFill',
   },
   {
     component: IconArrowDownLineVerticalArrowUpSquareLine,
-    name: "ArrowDownLineVerticalArrowUpSquareLine",
+    name: 'ArrowDownLineVerticalArrowUpSquareLine',
   },
   {
     component: IconArrowDownRightArrowUpLeftFill,
-    name: "ArrowDownRightArrowUpLeftFill",
+    name: 'ArrowDownRightArrowUpLeftFill',
   },
   {
     component: IconArrowDownRightArrowUpLeftLine,
-    name: "ArrowDownRightArrowUpLeftLine",
+    name: 'ArrowDownRightArrowUpLeftLine',
   },
   {
     component: IconArrowLeftBracketRightFill,
-    name: "ArrowLeftBracketRightFill",
+    name: 'ArrowLeftBracketRightFill',
   },
   {
     component: IconArrowLeftBracketRightLine,
-    name: "ArrowLeftBracketRightLine",
+    name: 'ArrowLeftBracketRightLine',
   },
-  { component: IconArrowLeftFill, name: "ArrowLeftFill" },
-  { component: IconArrowLeftLine, name: "ArrowLeftLine" },
-  { component: IconArrowRightAngledFill, name: "ArrowRightAngledFill" },
-  { component: IconArrowRightAngledLine, name: "ArrowRightAngledLine" },
-  { component: IconArrowRightArrowLeftFill, name: "ArrowRightArrowLeftFill" },
-  { component: IconArrowRightArrowLeftLine, name: "ArrowRightArrowLeftLine" },
-  { component: IconArrowRightFill, name: "ArrowRightFill" },
-  { component: IconArrowRightLine, name: "ArrowRightLine" },
-  { component: IconArrowUpArrowDownFill, name: "ArrowUpArrowDownFill" },
-  { component: IconArrowUpArrowDownLine, name: "ArrowUpArrowDownLine" },
-  { component: IconArrowUpBracketDownFill, name: "ArrowUpBracketDownFill" },
-  { component: IconArrowUpBracketDownLine, name: "ArrowUpBracketDownLine" },
-  { component: IconArrowUpFill, name: "ArrowUpFill" },
-  { component: IconArrowUpLeftFill, name: "ArrowUpLeftFill" },
-  { component: IconArrowUpLeftLine, name: "ArrowUpLeftLine" },
-  { component: IconArrowUpLine, name: "ArrowUpLine" },
+  {
+    component: IconArrowLeftFill,
+    name: 'ArrowLeftFill',
+  },
+  {
+    component: IconArrowLeftLine,
+    name: 'ArrowLeftLine',
+  },
+  {
+    component: IconArrowRightAngledFill,
+    name: 'ArrowRightAngledFill',
+  },
+  {
+    component: IconArrowRightAngledLine,
+    name: 'ArrowRightAngledLine',
+  },
+  {
+    component: IconArrowRightArrowLeftFill,
+    name: 'ArrowRightArrowLeftFill',
+  },
+  {
+    component: IconArrowRightArrowLeftLine,
+    name: 'ArrowRightArrowLeftLine',
+  },
+  {
+    component: IconArrowRightFill,
+    name: 'ArrowRightFill',
+  },
+  {
+    component: IconArrowRightLine,
+    name: 'ArrowRightLine',
+  },
+  {
+    component: IconArrowUpArrowDownFill,
+    name: 'ArrowUpArrowDownFill',
+  },
+  {
+    component: IconArrowUpArrowDownLine,
+    name: 'ArrowUpArrowDownLine',
+  },
+  {
+    component: IconArrowUpBracketDownFill,
+    name: 'ArrowUpBracketDownFill',
+  },
+  {
+    component: IconArrowUpBracketDownLine,
+    name: 'ArrowUpBracketDownLine',
+  },
+  {
+    component: IconArrowUpFill,
+    name: 'ArrowUpFill',
+  },
+  {
+    component: IconArrowUpLeftFill,
+    name: 'ArrowUpLeftFill',
+  },
+  {
+    component: IconArrowUpLeftLine,
+    name: 'ArrowUpLeftLine',
+  },
+  {
+    component: IconArrowUpLine,
+    name: 'ArrowUpLine',
+  },
   {
     component: IconArrowUpRightArrowDownLeftFill,
-    name: "ArrowUpRightArrowDownLeftFill",
+    name: 'ArrowUpRightArrowDownLeftFill',
   },
   {
     component: IconArrowUpRightArrowDownLeftLine,
-    name: "ArrowUpRightArrowDownLeftLine",
+    name: 'ArrowUpRightArrowDownLeftLine',
   },
   {
     component: IconArrowUpRightArrowDownLeftSquareFill,
-    name: "ArrowUpRightArrowDownLeftSquareFill",
+    name: 'ArrowUpRightArrowDownLeftSquareFill',
   },
   {
     component: IconArrowUpRightArrowDownLeftSquareLine,
-    name: "ArrowUpRightArrowDownLeftSquareLine",
+    name: 'ArrowUpRightArrowDownLeftSquareLine',
   },
-  { component: IconArrowUpRightFill, name: "ArrowUpRightFill" },
-  { component: IconArrowUpRightLine, name: "ArrowUpRightLine" },
+  {
+    component: IconArrowUpRightFill,
+    name: 'ArrowUpRightFill',
+  },
+  {
+    component: IconArrowUpRightLine,
+    name: 'ArrowUpRightLine',
+  },
   {
     component: IconArrowUpRightShoppingbagTiltedFill,
-    name: "ArrowUpRightShoppingbagTiltedFill",
+    name: 'ArrowUpRightShoppingbagTiltedFill',
   },
   {
     component: IconArrowUpRightShoppingbagTiltedLine,
-    name: "ArrowUpRightShoppingbagTiltedLine",
+    name: 'ArrowUpRightShoppingbagTiltedLine',
   },
-  { component: IconArrowUturnLeftFill, name: "ArrowUturnLeftFill" },
-  { component: IconArrowUturnLeftLine, name: "ArrowUturnLeftLine" },
-  { component: IconArrowUturnRightFill, name: "ArrowUturnRightFill" },
-  { component: IconArrowUturnRightLine, name: "ArrowUturnRightLine" },
-  { component: IconArticleFill, name: "ArticleFill" },
-  { component: IconArticleLine, name: "ArticleLine" },
+  {
+    component: IconArrowUturnLeftFill,
+    name: 'ArrowUturnLeftFill',
+  },
+  {
+    component: IconArrowUturnLeftLine,
+    name: 'ArrowUturnLeftLine',
+  },
+  {
+    component: IconArrowUturnRightFill,
+    name: 'ArrowUturnRightFill',
+  },
+  {
+    component: IconArrowUturnRightLine,
+    name: 'ArrowUturnRightLine',
+  },
+  {
+    component: IconArticleFill,
+    name: 'ArticleFill',
+  },
+  {
+    component: IconArticleLine,
+    name: 'ArticleLine',
+  },
   {
     component: IconAsteriskHorizrectangleCoolwave3Fill,
-    name: "AsteriskHorizrectangleCoolwave3Fill",
+    name: 'AsteriskHorizrectangleCoolwave3Fill',
   },
   {
     component: IconAsteriskHorizrectangleCoolwave3Line,
-    name: "AsteriskHorizrectangleCoolwave3Line",
+    name: 'AsteriskHorizrectangleCoolwave3Line',
   },
-  { component: IconAtFill, name: "AtFill" },
-  { component: IconAtLine, name: "AtLine" },
-  { component: IconBUppercaseFill, name: "BUppercaseFill" },
-  { component: IconBUppercaseLine, name: "BUppercaseLine" },
-  { component: IconBackspacekeyFill, name: "BackspacekeyFill" },
-  { component: IconBackspacekeyLine, name: "BackspacekeyLine" },
-  { component: IconBarchartBoardFill, name: "BarchartBoardFill" },
-  { component: IconBarchartBoardLine, name: "BarchartBoardLine" },
-  { component: IconBarchartSquareFill, name: "BarchartSquareFill" },
-  { component: IconBarchartSquareLine, name: "BarchartSquareLine" },
-  { component: IconBedFrontsideFill, name: "BedFrontsideFill" },
-  { component: IconBedFrontsideLine, name: "BedFrontsideLine" },
-  { component: IconBellFill, name: "BellFill" },
-  { component: IconBellLine, name: "BellLine" },
-  { component: IconBellSlashFill, name: "BellSlashFill" },
-  { component: IconBellSlashLine, name: "BellSlashLine" },
-  { component: IconBookFill, name: "BookFill" },
-  { component: IconBookLine, name: "BookLine" },
-  { component: IconBookOpenFill, name: "BookOpenFill" },
-  { component: IconBookOpenLine, name: "BookOpenLine" },
-  { component: IconBookmarkFill, name: "BookmarkFill" },
-  { component: IconBookmarkLine, name: "BookmarkLine" },
-  { component: IconBoxFlapFill, name: "BoxFlapFill" },
-  { component: IconBoxFlapLine, name: "BoxFlapLine" },
+  {
+    component: IconAtFill,
+    name: 'AtFill',
+  },
+  {
+    component: IconAtLine,
+    name: 'AtLine',
+  },
+  {
+    component: IconAUppercaseALowercaseFill,
+    name: 'AUppercaseALowercaseFill',
+  },
+  {
+    component: IconAUppercaseALowercaseLine,
+    name: 'AUppercaseALowercaseLine',
+  },
+  {
+    component: IconAUppercaseOutlineFill,
+    name: 'AUppercaseOutlineFill',
+  },
+  {
+    component: IconAUppercaseOutlineLine,
+    name: 'AUppercaseOutlineLine',
+  },
+  {
+    component: IconAUppercaseSquareFill,
+    name: 'AUppercaseSquareFill',
+  },
+  {
+    component: IconAUppercaseSquareLine,
+    name: 'AUppercaseSquareLine',
+  },
+  {
+    component: IconBackspacekeyFill,
+    name: 'BackspacekeyFill',
+  },
+  {
+    component: IconBackspacekeyLine,
+    name: 'BackspacekeyLine',
+  },
+  {
+    component: IconBarchartBoardFill,
+    name: 'BarchartBoardFill',
+  },
+  {
+    component: IconBarchartBoardLine,
+    name: 'BarchartBoardLine',
+  },
+  {
+    component: IconBarchartSquareFill,
+    name: 'BarchartSquareFill',
+  },
+  {
+    component: IconBarchartSquareLine,
+    name: 'BarchartSquareLine',
+  },
+  {
+    component: IconBedFrontsideFill,
+    name: 'BedFrontsideFill',
+  },
+  {
+    component: IconBedFrontsideLine,
+    name: 'BedFrontsideLine',
+  },
+  {
+    component: IconBellFill,
+    name: 'BellFill',
+  },
+  {
+    component: IconBellLine,
+    name: 'BellLine',
+  },
+  {
+    component: IconBellSlashFill,
+    name: 'BellSlashFill',
+  },
+  {
+    component: IconBellSlashLine,
+    name: 'BellSlashLine',
+  },
+  {
+    component: IconBluetoothFill,
+    name: 'BluetoothFill',
+  },
+  {
+    component: IconBluetoothLine,
+    name: 'BluetoothLine',
+  },
+  {
+    component: IconBookFill,
+    name: 'BookFill',
+  },
+  {
+    component: IconBookLine,
+    name: 'BookLine',
+  },
+  {
+    component: IconBookmarkFill,
+    name: 'BookmarkFill',
+  },
+  {
+    component: IconBookmarkLine,
+    name: 'BookmarkLine',
+  },
+  {
+    component: IconBookOpenFill,
+    name: 'BookOpenFill',
+  },
+  {
+    component: IconBookOpenLine,
+    name: 'BookOpenLine',
+  },
+  {
+    component: IconBoxFlapFill,
+    name: 'BoxFlapFill',
+  },
+  {
+    component: IconBoxFlapLine,
+    name: 'BoxFlapLine',
+  },
   {
     component: IconBracketLeftArrowRightFill,
-    name: "BracketLeftArrowRightFill",
+    name: 'BracketLeftArrowRightFill',
   },
   {
     component: IconBracketLeftArrowRightLine,
-    name: "BracketLeftArrowRightLine",
+    name: 'BracketLeftArrowRightLine',
   },
-  { component: IconBuilding2Fill, name: "Building2Fill" },
-  { component: IconBuilding2Line, name: "Building2Line" },
-  { component: IconCalendarFill, name: "CalendarFill" },
-  { component: IconCalendarLine, name: "CalendarLine" },
-  { component: IconCamcorderFill, name: "CamcorderFill" },
-  { component: IconCamcorderLine, name: "CamcorderLine" },
-  { component: IconCameraFill, name: "CameraFill" },
-  { component: IconCameraLine, name: "CameraLine" },
-  { component: IconCarFill, name: "CarFill" },
+  {
+    component: IconBUppercaseFill,
+    name: 'BUppercaseFill',
+  },
+  {
+    component: IconBUppercaseLine,
+    name: 'BUppercaseLine',
+  },
+  {
+    component: IconBuilding2Fill,
+    name: 'Building2Fill',
+  },
+  {
+    component: IconBuilding2Line,
+    name: 'Building2Line',
+  },
+  {
+    component: IconCalendarFill,
+    name: 'CalendarFill',
+  },
+  {
+    component: IconCalendarLine,
+    name: 'CalendarLine',
+  },
+  {
+    component: IconCamcorderFill,
+    name: 'CamcorderFill',
+  },
+  {
+    component: IconCamcorderLine,
+    name: 'CamcorderLine',
+  },
+  {
+    component: IconCameraFill,
+    name: 'CameraFill',
+  },
+  {
+    component: IconCameraLine,
+    name: 'CameraLine',
+  },
+  {
+    component: IconCardFill,
+    name: 'CardFill',
+  },
+  {
+    component: IconCardLine,
+    name: 'CardLine',
+  },
+  {
+    component: IconCarFill,
+    name: 'CarFill',
+  },
+  {
+    component: IconCarFrontsideFill,
+    name: 'CarFrontsideFill',
+  },
+  {
+    component: IconCarFrontsideLine,
+    name: 'CarFrontsideLine',
+  },
   {
     component: IconCarFrontUpsideWave2ReversedUpFill,
-    name: "CarFrontUpsideWave2ReversedUpFill",
+    name: 'CarFrontUpsideWave2ReversedUpFill',
   },
   {
     component: IconCarFrontUpsideWave2ReversedUpLine,
-    name: "CarFrontUpsideWave2ReversedUpLine",
+    name: 'CarFrontUpsideWave2ReversedUpLine',
   },
-  { component: IconCarFrontsideFill, name: "CarFrontsideFill" },
-  { component: IconCarFrontsideLine, name: "CarFrontsideLine" },
-  { component: IconCarLine, name: "CarLine" },
+  {
+    component: IconCarLine,
+    name: 'CarLine',
+  },
   {
     component: IconCarRearTrunkOpenLeftsideFill,
-    name: "CarRearTrunkOpenLeftsideFill",
+    name: 'CarRearTrunkOpenLeftsideFill',
   },
   {
     component: IconCarRearTrunkOpenLeftsideLine,
-    name: "CarRearTrunkOpenLeftsideLine",
+    name: 'CarRearTrunkOpenLeftsideLine',
   },
   {
     component: IconCarRearUpsideSectorDownFill,
-    name: "CarRearUpsideSectorDownFill",
+    name: 'CarRearUpsideSectorDownFill',
   },
   {
     component: IconCarRearUpsideSectorDownLine,
-    name: "CarRearUpsideSectorDownLine",
+    name: 'CarRearUpsideSectorDownLine',
   },
   {
     component: IconCarRearUpsideWave2ReversedDownFill,
-    name: "CarRearUpsideWave2ReversedDownFill",
+    name: 'CarRearUpsideWave2ReversedDownFill',
   },
   {
     component: IconCarRearUpsideWave2ReversedDownLeftFill,
-    name: "CarRearUpsideWave2ReversedDownLeftFill",
+    name: 'CarRearUpsideWave2ReversedDownLeftFill',
   },
   {
     component: IconCarRearUpsideWave2ReversedDownLeftLine,
-    name: "CarRearUpsideWave2ReversedDownLeftLine",
+    name: 'CarRearUpsideWave2ReversedDownLeftLine',
   },
   {
     component: IconCarRearUpsideWave2ReversedDownLine,
-    name: "CarRearUpsideWave2ReversedDownLine",
+    name: 'CarRearUpsideWave2ReversedDownLine',
   },
-  { component: IconCardFill, name: "CardFill" },
-  { component: IconCardLine, name: "CardLine" },
-  { component: IconCarrotFill, name: "CarrotFill" },
-  { component: IconCarrotLine, name: "CarrotLine" },
-  { component: IconCartFill, name: "CartFill" },
-  { component: IconCartItemsFill, name: "CartItemsFill" },
-  { component: IconCartItemsLine, name: "CartItemsLine" },
-  { component: IconCartLine, name: "CartLine" },
-  { component: IconCartLoadFill, name: "CartLoadFill" },
-  { component: IconCartLoadLine, name: "CartLoadLine" },
-  { component: IconCheckmarkBadgeFill, name: "CheckmarkBadgeFill" },
-  { component: IconCheckmarkBadgeLine, name: "CheckmarkBadgeLine" },
-  { component: IconCheckmarkBallotboxFill, name: "CheckmarkBallotboxFill" },
-  { component: IconCheckmarkBallotboxLine, name: "CheckmarkBallotboxLine" },
-  { component: IconCheckmarkCalendarFill, name: "CheckmarkCalendarFill" },
-  { component: IconCheckmarkCalendarLine, name: "CheckmarkCalendarLine" },
+  {
+    component: IconCarrotFill,
+    name: 'CarrotFill',
+  },
+  {
+    component: IconCarrotLine,
+    name: 'CarrotLine',
+  },
+  {
+    component: IconCartFill,
+    name: 'CartFill',
+  },
+  {
+    component: IconCartItemsFill,
+    name: 'CartItemsFill',
+  },
+  {
+    component: IconCartItemsLine,
+    name: 'CartItemsLine',
+  },
+  {
+    component: IconCartLine,
+    name: 'CartLine',
+  },
+  {
+    component: IconCartLoadFill,
+    name: 'CartLoadFill',
+  },
+  {
+    component: IconCartLoadLine,
+    name: 'CartLoadLine',
+  },
+  {
+    component: IconCheckmarkBadgeFill,
+    name: 'CheckmarkBadgeFill',
+  },
+  {
+    component: IconCheckmarkBadgeLine,
+    name: 'CheckmarkBadgeLine',
+  },
+  {
+    component: IconCheckmarkBallotboxFill,
+    name: 'CheckmarkBallotboxFill',
+  },
+  {
+    component: IconCheckmarkBallotboxLine,
+    name: 'CheckmarkBallotboxLine',
+  },
+  {
+    component: IconCheckmarkCalendarFill,
+    name: 'CheckmarkCalendarFill',
+  },
+  {
+    component: IconCheckmarkCalendarLine,
+    name: 'CheckmarkCalendarLine',
+  },
   {
     component: IconCheckmarkChatbubbleLeftFill,
-    name: "CheckmarkChatbubbleLeftFill",
+    name: 'CheckmarkChatbubbleLeftFill',
   },
   {
     component: IconCheckmarkChatbubbleLeftLine,
-    name: "CheckmarkChatbubbleLeftLine",
+    name: 'CheckmarkChatbubbleLeftLine',
   },
-  { component: IconCheckmarkCircleFill, name: "CheckmarkCircleFill" },
-  { component: IconCheckmarkCircleLine, name: "CheckmarkCircleLine" },
-  { component: IconCheckmarkClipboardFill, name: "CheckmarkClipboardFill" },
-  { component: IconCheckmarkClipboardLine, name: "CheckmarkClipboardLine" },
-  { component: IconCheckmarkCouponFill, name: "CheckmarkCouponFill" },
-  { component: IconCheckmarkCouponLine, name: "CheckmarkCouponLine" },
-  { component: IconCheckmarkFatFill, name: "CheckmarkFatFill" },
-  { component: IconCheckmarkFatLine, name: "CheckmarkFatLine" },
-  { component: IconCheckmarkFill, name: "CheckmarkFill" },
-  { component: IconCheckmarkFlowerFill, name: "CheckmarkFlowerFill" },
-  { component: IconCheckmarkFlowerLine, name: "CheckmarkFlowerLine" },
-  { component: IconCheckmarkHorizlineFill, name: "CheckmarkHorizlineFill" },
-  { component: IconCheckmarkHorizlineLine, name: "CheckmarkHorizlineLine" },
-  { component: IconCheckmarkLine, name: "CheckmarkLine" },
-  { component: IconCheckmarkScaleFill, name: "CheckmarkScaleFill" },
-  { component: IconCheckmarkScaleLine, name: "CheckmarkScaleLine" },
-  { component: IconCheckmarkShieldFill, name: "CheckmarkShieldFill" },
-  { component: IconCheckmarkShieldLine, name: "CheckmarkShieldLine" },
+  {
+    component: IconCheckmarkCircleFill,
+    name: 'CheckmarkCircleFill',
+  },
+  {
+    component: IconCheckmarkCircleLine,
+    name: 'CheckmarkCircleLine',
+  },
+  {
+    component: IconCheckmarkClipboardFill,
+    name: 'CheckmarkClipboardFill',
+  },
+  {
+    component: IconCheckmarkClipboardLine,
+    name: 'CheckmarkClipboardLine',
+  },
+  {
+    component: IconCheckmarkCouponFill,
+    name: 'CheckmarkCouponFill',
+  },
+  {
+    component: IconCheckmarkCouponLine,
+    name: 'CheckmarkCouponLine',
+  },
+  {
+    component: IconCheckmarkFatFill,
+    name: 'CheckmarkFatFill',
+  },
+  {
+    component: IconCheckmarkFatLine,
+    name: 'CheckmarkFatLine',
+  },
+  {
+    component: IconCheckmarkFill,
+    name: 'CheckmarkFill',
+  },
+  {
+    component: IconCheckmarkFlowerFill,
+    name: 'CheckmarkFlowerFill',
+  },
+  {
+    component: IconCheckmarkFlowerLine,
+    name: 'CheckmarkFlowerLine',
+  },
+  {
+    component: IconCheckmarkHorizlineFill,
+    name: 'CheckmarkHorizlineFill',
+  },
+  {
+    component: IconCheckmarkHorizlineLine,
+    name: 'CheckmarkHorizlineLine',
+  },
   {
     component: IconCheckmarkhorizline2VerticalFill,
-    name: "Checkmarkhorizline2VerticalFill",
+    name: 'Checkmarkhorizline2VerticalFill',
   },
   {
     component: IconCheckmarkhorizline2VerticalLine,
-    name: "Checkmarkhorizline2VerticalLine",
+    name: 'Checkmarkhorizline2VerticalLine',
   },
-  { component: IconChevronDownFill, name: "ChevronDownFill" },
-  { component: IconChevronDownLine, name: "ChevronDownLine" },
-  { component: IconChevronDownSmallFill, name: "ChevronDownSmallFill" },
-  { component: IconChevronDownSmallLine, name: "ChevronDownSmallLine" },
-  { component: IconChevronLeftFill, name: "ChevronLeftFill" },
-  { component: IconChevronLeftLine, name: "ChevronLeftLine" },
-  { component: IconChevronLeftSmallFill, name: "ChevronLeftSmallFill" },
-  { component: IconChevronLeftSmallLine, name: "ChevronLeftSmallLine" },
-  { component: IconChevronRightFill, name: "ChevronRightFill" },
-  { component: IconChevronRightLine, name: "ChevronRightLine" },
-  { component: IconChevronRightSmallFill, name: "ChevronRightSmallFill" },
-  { component: IconChevronRightSmallLine, name: "ChevronRightSmallLine" },
-  { component: IconChevronUpFill, name: "ChevronUpFill" },
-  { component: IconChevronUpLine, name: "ChevronUpLine" },
-  { component: IconChevronUpSmallFill, name: "ChevronUpSmallFill" },
-  { component: IconChevronUpSmallLine, name: "ChevronUpSmallLine" },
-  { component: IconCircle4SquareFill, name: "Circle4SquareFill" },
-  { component: IconCircle4SquareLine, name: "Circle4SquareLine" },
-  { component: IconClockFill, name: "ClockFill" },
-  { component: IconClockLine, name: "ClockLine" },
-  { component: IconCompassFill, name: "CompassFill" },
-  { component: IconCompassLine, name: "CompassLine" },
-  { component: IconCorner4InwardFill, name: "Corner4InwardFill" },
-  { component: IconCorner4InwardLine, name: "Corner4InwardLine" },
-  { component: IconCorner4OutwardFill, name: "Corner4OutwardFill" },
-  { component: IconCorner4OutwardLine, name: "Corner4OutwardLine" },
-  { component: IconCornerDownLeftFill, name: "CornerDownLeftFill" },
-  { component: IconCornerDownLeftLine, name: "CornerDownLeftLine" },
-  { component: IconCouponFill, name: "CouponFill" },
-  { component: IconCouponLine, name: "CouponLine" },
-  { component: IconCropmarkFill, name: "CropmarkFill" },
-  { component: IconCropmarkLine, name: "CropmarkLine" },
-  { component: IconCrosshairFill, name: "CrosshairFill" },
-  { component: IconCrosshairLine, name: "CrosshairLine" },
+  {
+    component: IconCheckmarkLine,
+    name: 'CheckmarkLine',
+  },
+  {
+    component: IconCheckmarkScaleFill,
+    name: 'CheckmarkScaleFill',
+  },
+  {
+    component: IconCheckmarkScaleLine,
+    name: 'CheckmarkScaleLine',
+  },
+  {
+    component: IconCheckmarkShieldFill,
+    name: 'CheckmarkShieldFill',
+  },
+  {
+    component: IconCheckmarkShieldLine,
+    name: 'CheckmarkShieldLine',
+  },
+  {
+    component: IconChevronDownFill,
+    name: 'ChevronDownFill',
+  },
+  {
+    component: IconChevronDownLine,
+    name: 'ChevronDownLine',
+  },
+  {
+    component: IconChevronDownSmallFill,
+    name: 'ChevronDownSmallFill',
+  },
+  {
+    component: IconChevronDownSmallLine,
+    name: 'ChevronDownSmallLine',
+  },
+  {
+    component: IconChevronLeftFill,
+    name: 'ChevronLeftFill',
+  },
+  {
+    component: IconChevronLeftLine,
+    name: 'ChevronLeftLine',
+  },
+  {
+    component: IconChevronLeftSmallFill,
+    name: 'ChevronLeftSmallFill',
+  },
+  {
+    component: IconChevronLeftSmallLine,
+    name: 'ChevronLeftSmallLine',
+  },
+  {
+    component: IconChevronRightFill,
+    name: 'ChevronRightFill',
+  },
+  {
+    component: IconChevronRightLine,
+    name: 'ChevronRightLine',
+  },
+  {
+    component: IconChevronRightSmallFill,
+    name: 'ChevronRightSmallFill',
+  },
+  {
+    component: IconChevronRightSmallLine,
+    name: 'ChevronRightSmallLine',
+  },
+  {
+    component: IconChevronUpFill,
+    name: 'ChevronUpFill',
+  },
+  {
+    component: IconChevronUpLine,
+    name: 'ChevronUpLine',
+  },
+  {
+    component: IconChevronUpSmallFill,
+    name: 'ChevronUpSmallFill',
+  },
+  {
+    component: IconChevronUpSmallLine,
+    name: 'ChevronUpSmallLine',
+  },
+  {
+    component: IconCircle4SquareFill,
+    name: 'Circle4SquareFill',
+  },
+  {
+    component: IconCircle4SquareLine,
+    name: 'Circle4SquareLine',
+  },
+  {
+    component: IconClockFill,
+    name: 'ClockFill',
+  },
+  {
+    component: IconClockLine,
+    name: 'ClockLine',
+  },
+  {
+    component: IconCompassFill,
+    name: 'CompassFill',
+  },
+  {
+    component: IconCompassLine,
+    name: 'CompassLine',
+  },
+  {
+    component: IconCorner4InwardFill,
+    name: 'Corner4InwardFill',
+  },
+  {
+    component: IconCorner4InwardLine,
+    name: 'Corner4InwardLine',
+  },
+  {
+    component: IconCorner4OutwardFill,
+    name: 'Corner4OutwardFill',
+  },
+  {
+    component: IconCorner4OutwardLine,
+    name: 'Corner4OutwardLine',
+  },
+  {
+    component: IconCornerDownLeftFill,
+    name: 'CornerDownLeftFill',
+  },
+  {
+    component: IconCornerDownLeftLine,
+    name: 'CornerDownLeftLine',
+  },
+  {
+    component: IconCouponFill,
+    name: 'CouponFill',
+  },
+  {
+    component: IconCouponLine,
+    name: 'CouponLine',
+  },
+  {
+    component: IconCropmarkFill,
+    name: 'CropmarkFill',
+  },
+  {
+    component: IconCropmarkLine,
+    name: 'CropmarkLine',
+  },
+  {
+    component: IconCrosshairFill,
+    name: 'CrosshairFill',
+  },
+  {
+    component: IconCrosshairLine,
+    name: 'CrosshairLine',
+  },
   {
     component: IconCrosshairQuestionmarkFill,
-    name: "CrosshairQuestionmarkFill",
+    name: 'CrosshairQuestionmarkFill',
   },
   {
     component: IconCrosshairQuestionmarkLine,
-    name: "CrosshairQuestionmarkLine",
+    name: 'CrosshairQuestionmarkLine',
   },
-  { component: IconCrownFill, name: "CrownFill" },
-  { component: IconCrownLine, name: "CrownLine" },
-  { component: IconCupHeatwaveFill, name: "CupHeatwaveFill" },
-  { component: IconCupHeatwaveLine, name: "CupHeatwaveLine" },
-  { component: IconDiamondFill, name: "DiamondFill" },
-  { component: IconDiamondLine, name: "DiamondLine" },
-  { component: IconDocumentArrowLeftFill, name: "DocumentArrowLeftFill" },
-  { component: IconDocumentArrowLeftLine, name: "DocumentArrowLeftLine" },
-  { component: IconDocumentCheckmarkFill, name: "DocumentCheckmarkFill" },
-  { component: IconDocumentCheckmarkLine, name: "DocumentCheckmarkLine" },
-  { component: IconDocumentFill, name: "DocumentFill" },
-  { component: IconDocumentLine, name: "DocumentLine" },
+  {
+    component: IconCrownFill,
+    name: 'CrownFill',
+  },
+  {
+    component: IconCrownLine,
+    name: 'CrownLine',
+  },
+  {
+    component: IconCupHeatwaveFill,
+    name: 'CupHeatwaveFill',
+  },
+  {
+    component: IconCupHeatwaveLine,
+    name: 'CupHeatwaveLine',
+  },
+  {
+    component: IconDiamondFill,
+    name: 'DiamondFill',
+  },
+  {
+    component: IconDiamondLine,
+    name: 'DiamondLine',
+  },
+  {
+    component: IconDocumentArrowLeftFill,
+    name: 'DocumentArrowLeftFill',
+  },
+  {
+    component: IconDocumentArrowLeftLine,
+    name: 'DocumentArrowLeftLine',
+  },
+  {
+    component: IconDocumentCheckmarkFill,
+    name: 'DocumentCheckmarkFill',
+  },
+  {
+    component: IconDocumentCheckmarkLine,
+    name: 'DocumentCheckmarkLine',
+  },
+  {
+    component: IconDocumentFill,
+    name: 'DocumentFill',
+  },
+  {
+    component: IconDocumentLine,
+    name: 'DocumentLine',
+  },
   {
     component: IconDocumentMagnifyingglassFill,
-    name: "DocumentMagnifyingglassFill",
+    name: 'DocumentMagnifyingglassFill',
   },
   {
     component: IconDocumentMagnifyingglassLine,
-    name: "DocumentMagnifyingglassLine",
+    name: 'DocumentMagnifyingglassLine',
   },
-  { component: IconDocumentPenFill, name: "DocumentPenFill" },
-  { component: IconDocumentPenLine, name: "DocumentPenLine" },
-  { component: IconDocumentPlusFill, name: "DocumentPlusFill" },
-  { component: IconDocumentPlusLine, name: "DocumentPlusLine" },
+  {
+    component: IconDocumentPenFill,
+    name: 'DocumentPenFill',
+  },
+  {
+    component: IconDocumentPenLine,
+    name: 'DocumentPenLine',
+  },
+  {
+    component: IconDocumentPlusFill,
+    name: 'DocumentPlusFill',
+  },
+  {
+    component: IconDocumentPlusLine,
+    name: 'DocumentPlusLine',
+  },
   {
     component: IconDollarCircleArrowRightFill,
-    name: "DollarCircleArrowRightFill",
+    name: 'DollarCircleArrowRightFill',
   },
   {
     component: IconDollarCircleArrowRightLine,
-    name: "DollarCircleArrowRightLine",
+    name: 'DollarCircleArrowRightLine',
   },
-  { component: IconDollarCircleFill, name: "DollarCircleFill" },
-  { component: IconDollarCircleLine, name: "DollarCircleLine" },
-  { component: IconDollarFill, name: "DollarFill" },
-  { component: IconDollarLine, name: "DollarLine" },
-  { component: IconDot3CircleFill, name: "Dot3CircleFill" },
-  { component: IconDot3CircleLine, name: "Dot3CircleLine" },
+  {
+    component: IconDollarCircleFill,
+    name: 'DollarCircleFill',
+  },
+  {
+    component: IconDollarCircleLine,
+    name: 'DollarCircleLine',
+  },
+  {
+    component: IconDollarFill,
+    name: 'DollarFill',
+  },
+  {
+    component: IconDollarLine,
+    name: 'DollarLine',
+  },
+  {
+    component: IconDot3CircleFill,
+    name: 'Dot3CircleFill',
+  },
+  {
+    component: IconDot3CircleLine,
+    name: 'Dot3CircleLine',
+  },
   {
     component: IconDot3HorizontalChatbubbleLeftFill,
-    name: "Dot3HorizontalChatbubbleLeftFill",
+    name: 'Dot3HorizontalChatbubbleLeftFill',
   },
   {
     component: IconDot3HorizontalChatbubbleLeftLine,
-    name: "Dot3HorizontalChatbubbleLeftLine",
+    name: 'Dot3HorizontalChatbubbleLeftLine',
   },
   {
     component: IconDot3HorizontalChatbubbleLeftSlashFill,
-    name: "Dot3HorizontalChatbubbleLeftSlashFill",
+    name: 'Dot3HorizontalChatbubbleLeftSlashFill',
   },
   {
     component: IconDot3HorizontalChatbubbleLeftSlashLine,
-    name: "Dot3HorizontalChatbubbleLeftSlashLine",
+    name: 'Dot3HorizontalChatbubbleLeftSlashLine',
   },
-  { component: IconDot3HorizontalFill, name: "Dot3HorizontalFill" },
-  { component: IconDot3HorizontalLine, name: "Dot3HorizontalLine" },
-  { component: IconDot3VerticalFill, name: "Dot3VerticalFill" },
-  { component: IconDot3VerticalLine, name: "Dot3VerticalLine" },
+  {
+    component: IconDot3HorizontalFill,
+    name: 'Dot3HorizontalFill',
+  },
+  {
+    component: IconDot3HorizontalLine,
+    name: 'Dot3HorizontalLine',
+  },
+  {
+    component: IconDot3VerticalFill,
+    name: 'Dot3VerticalFill',
+  },
+  {
+    component: IconDot3VerticalLine,
+    name: 'Dot3VerticalLine',
+  },
   {
     component: IconDothorizline3VerticalFill,
-    name: "Dothorizline3VerticalFill",
+    name: 'Dothorizline3VerticalFill',
   },
   {
     component: IconDothorizline3VerticalLine,
-    name: "Dothorizline3VerticalLine",
+    name: 'Dothorizline3VerticalLine',
   },
-  { component: IconDumbbellFill, name: "DumbbellFill" },
-  { component: IconDumbbellLine, name: "DumbbellLine" },
-  { component: IconEarthFill, name: "EarthFill" },
-  { component: IconEarthLine, name: "EarthLine" },
-  { component: IconEnvelopeFill, name: "EnvelopeFill" },
-  { component: IconEnvelopeLine, name: "EnvelopeLine" },
-  { component: IconEpbFill, name: "EpbFill" },
-  { component: IconEpbLine, name: "EpbLine" },
-  { component: IconEraserHorizlineFill, name: "EraserHorizlineFill" },
-  { component: IconEraserHorizlineLine, name: "EraserHorizlineLine" },
+  {
+    component: IconDumbbellFill,
+    name: 'DumbbellFill',
+  },
+  {
+    component: IconDumbbellLine,
+    name: 'DumbbellLine',
+  },
+  {
+    component: IconEarthFill,
+    name: 'EarthFill',
+  },
+  {
+    component: IconEarthLine,
+    name: 'EarthLine',
+  },
+  {
+    component: IconEnvelopeFill,
+    name: 'EnvelopeFill',
+  },
+  {
+    component: IconEnvelopeLine,
+    name: 'EnvelopeLine',
+  },
+  {
+    component: IconEpbFill,
+    name: 'EpbFill',
+  },
+  {
+    component: IconEpbLine,
+    name: 'EpbLine',
+  },
+  {
+    component: IconEraserHorizlineFill,
+    name: 'EraserHorizlineFill',
+  },
+  {
+    component: IconEraserHorizlineLine,
+    name: 'EraserHorizlineLine',
+  },
   {
     component: IconExclamationmarkChatbubbleRectangularCenterFill,
-    name: "ExclamationmarkChatbubbleRectangularCenterFill",
+    name: 'ExclamationmarkChatbubbleRectangularCenterFill',
   },
   {
     component: IconExclamationmarkChatbubbleRectangularCenterLine,
-    name: "ExclamationmarkChatbubbleRectangularCenterLine",
+    name: 'ExclamationmarkChatbubbleRectangularCenterLine',
   },
   {
     component: IconExclamationmarkCircleFill,
-    name: "ExclamationmarkCircleFill",
+    name: 'ExclamationmarkCircleFill',
   },
   {
     component: IconExclamationmarkCircleLine,
-    name: "ExclamationmarkCircleLine",
+    name: 'ExclamationmarkCircleLine',
   },
-  { component: IconEyeFill, name: "EyeFill" },
-  { component: IconEyeLine, name: "EyeLine" },
-  { component: IconEyeSlashFill, name: "EyeSlashFill" },
-  { component: IconEyeSlashLine, name: "EyeSlashLine" },
-  { component: IconFaceFrustratedCircleFill, name: "FaceFrustratedCircleFill" },
-  { component: IconFaceFrustratedCircleLine, name: "FaceFrustratedCircleLine" },
-  { component: IconFaceSadCircleFill, name: "FaceSadCircleFill" },
-  { component: IconFaceSadCircleLine, name: "FaceSadCircleLine" },
-  { component: IconFaceSmileCircleFill, name: "FaceSmileCircleFill" },
+  {
+    component: IconEyeFill,
+    name: 'EyeFill',
+  },
+  {
+    component: IconEyeLine,
+    name: 'EyeLine',
+  },
+  {
+    component: IconEyeSlashFill,
+    name: 'EyeSlashFill',
+  },
+  {
+    component: IconEyeSlashLine,
+    name: 'EyeSlashLine',
+  },
+  {
+    component: IconFaceFrustratedCircleFill,
+    name: 'FaceFrustratedCircleFill',
+  },
+  {
+    component: IconFaceFrustratedCircleLine,
+    name: 'FaceFrustratedCircleLine',
+  },
+  {
+    component: IconFaceSadCircleFill,
+    name: 'FaceSadCircleFill',
+  },
+  {
+    component: IconFaceSadCircleLine,
+    name: 'FaceSadCircleLine',
+  },
+  {
+    component: IconFaceSmileCircleFill,
+    name: 'FaceSmileCircleFill',
+  },
   {
     component: IconFaceSmileCircleFoldedFill,
-    name: "FaceSmileCircleFoldedFill",
+    name: 'FaceSmileCircleFoldedFill',
   },
   {
     component: IconFaceSmileCircleFoldedLine,
-    name: "FaceSmileCircleFoldedLine",
+    name: 'FaceSmileCircleFoldedLine',
   },
-  { component: IconFaceSmileCircleLine, name: "FaceSmileCircleLine" },
-  { component: IconFaceSurprisedCircleFill, name: "FaceSurprisedCircleFill" },
-  { component: IconFaceSurprisedCircleLine, name: "FaceSurprisedCircleLine" },
-  { component: IconFaceViewfinderFill, name: "FaceViewfinderFill" },
-  { component: IconFaceViewfinderLine, name: "FaceViewfinderLine" },
-  { component: IconFigureBikeFill, name: "FigureBikeFill" },
-  { component: IconFigureBikeLine, name: "FigureBikeLine" },
-  { component: IconFigureOvalFill, name: "FigureOvalFill" },
-  { component: IconFigureOvalLine, name: "FigureOvalLine" },
-  { component: IconFigureRunFill, name: "FigureRunFill" },
-  { component: IconFigureRunLine, name: "FigureRunLine" },
-  { component: IconFigureWalkFill, name: "FigureWalkFill" },
-  { component: IconFigureWalkLine, name: "FigureWalkLine" },
-  { component: IconFigureWheelchairFill, name: "FigureWheelchairFill" },
-  { component: IconFigureWheelchairLine, name: "FigureWheelchairLine" },
-  { component: IconFingerprintFill, name: "FingerprintFill" },
-  { component: IconFingerprintLine, name: "FingerprintLine" },
-  { component: IconFireworkFill, name: "FireworkFill" },
-  { component: IconFireworkLine, name: "FireworkLine" },
-  { component: IconFishWave2Fill, name: "FishWave2Fill" },
-  { component: IconFishWave2Line, name: "FishWave2Line" },
-  { component: IconFlagFill, name: "FlagFill" },
-  { component: IconFlagHillFill, name: "FlagHillFill" },
-  { component: IconFlagHillLine, name: "FlagHillLine" },
-  { component: IconFlagLine, name: "FlagLine" },
-  { component: IconFlameFill, name: "FlameFill" },
-  { component: IconFlameLine, name: "FlameLine" },
-  { component: IconFlaskFill, name: "FlaskFill" },
-  { component: IconFlaskLine, name: "FlaskLine" },
-  { component: IconForkSpoonBagFill, name: "ForkSpoonBagFill" },
-  { component: IconForkSpoonBagLine, name: "ForkSpoonBagLine" },
-  { component: IconForkSpoonFill, name: "ForkSpoonFill" },
-  { component: IconForkSpoonLine, name: "ForkSpoonLine" },
-  { component: IconFridgeFill, name: "FridgeFill" },
-  { component: IconFridgeLine, name: "FridgeLine" },
-  { component: IconGearFill, name: "GearFill" },
-  { component: IconGearLine, name: "GearLine" },
-  { component: IconGiftFill, name: "GiftFill" },
-  { component: IconGiftLine, name: "GiftLine" },
-  { component: IconGlobeFill, name: "GlobeFill" },
-  { component: IconGlobeLine, name: "GlobeLine" },
-  { component: IconGraduationcapFill, name: "GraduationcapFill" },
-  { component: IconGraduationcapLine, name: "GraduationcapLine" },
-  { component: IconGridDot5Fill, name: "GridDot5Fill" },
-  { component: IconGridDot5Line, name: "GridDot5Line" },
-  { component: IconGridFill, name: "GridFill" },
-  { component: IconGridHeartFill, name: "GridHeartFill" },
-  { component: IconGridHeartLine, name: "GridHeartLine" },
-  { component: IconGridLine, name: "GridLine" },
-  { component: IconHandPointUpFill, name: "HandPointUpFill" },
-  { component: IconHandPointUpLine, name: "HandPointUpLine" },
-  { component: IconHandWaveFill, name: "HandWaveFill" },
-  { component: IconHandWaveLine, name: "HandWaveLine" },
-  { component: IconHashFill, name: "HashFill" },
-  { component: IconHashLine, name: "HashLine" },
-  { component: IconHeadsetFill, name: "HeadsetFill" },
-  { component: IconHeadsetLine, name: "HeadsetLine" },
-  { component: IconHeartFill, name: "HeartFill" },
-  { component: IconHeartLine, name: "HeartLine" },
+  {
+    component: IconFaceSmileCircleLine,
+    name: 'FaceSmileCircleLine',
+  },
+  {
+    component: IconFaceSurprisedCircleFill,
+    name: 'FaceSurprisedCircleFill',
+  },
+  {
+    component: IconFaceSurprisedCircleLine,
+    name: 'FaceSurprisedCircleLine',
+  },
+  {
+    component: IconFaceViewfinderFill,
+    name: 'FaceViewfinderFill',
+  },
+  {
+    component: IconFaceViewfinderLine,
+    name: 'FaceViewfinderLine',
+  },
+  {
+    component: IconFigureBikeFill,
+    name: 'FigureBikeFill',
+  },
+  {
+    component: IconFigureBikeLine,
+    name: 'FigureBikeLine',
+  },
+  {
+    component: IconFigureOvalFill,
+    name: 'FigureOvalFill',
+  },
+  {
+    component: IconFigureOvalLine,
+    name: 'FigureOvalLine',
+  },
+  {
+    component: IconFigureRunFill,
+    name: 'FigureRunFill',
+  },
+  {
+    component: IconFigureRunLine,
+    name: 'FigureRunLine',
+  },
+  {
+    component: IconFigureWalkFill,
+    name: 'FigureWalkFill',
+  },
+  {
+    component: IconFigureWalkLine,
+    name: 'FigureWalkLine',
+  },
+  {
+    component: IconFigureWheelchairFill,
+    name: 'FigureWheelchairFill',
+  },
+  {
+    component: IconFigureWheelchairLine,
+    name: 'FigureWheelchairLine',
+  },
+  {
+    component: IconFingerprintFill,
+    name: 'FingerprintFill',
+  },
+  {
+    component: IconFingerprintLine,
+    name: 'FingerprintLine',
+  },
+  {
+    component: IconFireworkFill,
+    name: 'FireworkFill',
+  },
+  {
+    component: IconFireworkLine,
+    name: 'FireworkLine',
+  },
+  {
+    component: IconFishWave2Fill,
+    name: 'FishWave2Fill',
+  },
+  {
+    component: IconFishWave2Line,
+    name: 'FishWave2Line',
+  },
+  {
+    component: IconFlagFill,
+    name: 'FlagFill',
+  },
+  {
+    component: IconFlagHillFill,
+    name: 'FlagHillFill',
+  },
+  {
+    component: IconFlagHillLine,
+    name: 'FlagHillLine',
+  },
+  {
+    component: IconFlagLine,
+    name: 'FlagLine',
+  },
+  {
+    component: IconFlameFill,
+    name: 'FlameFill',
+  },
+  {
+    component: IconFlameLine,
+    name: 'FlameLine',
+  },
+  {
+    component: IconFlaskFill,
+    name: 'FlaskFill',
+  },
+  {
+    component: IconFlaskLine,
+    name: 'FlaskLine',
+  },
+  {
+    component: IconForkSpoonBagFill,
+    name: 'ForkSpoonBagFill',
+  },
+  {
+    component: IconForkSpoonBagLine,
+    name: 'ForkSpoonBagLine',
+  },
+  {
+    component: IconForkSpoonFill,
+    name: 'ForkSpoonFill',
+  },
+  {
+    component: IconForkSpoonLine,
+    name: 'ForkSpoonLine',
+  },
+  {
+    component: IconFridgeFill,
+    name: 'FridgeFill',
+  },
+  {
+    component: IconFridgeLine,
+    name: 'FridgeLine',
+  },
+  {
+    component: IconGearFill,
+    name: 'GearFill',
+  },
+  {
+    component: IconGearLine,
+    name: 'GearLine',
+  },
+  {
+    component: IconGiftFill,
+    name: 'GiftFill',
+  },
+  {
+    component: IconGiftLine,
+    name: 'GiftLine',
+  },
+  {
+    component: IconGlobeFill,
+    name: 'GlobeFill',
+  },
+  {
+    component: IconGlobeLine,
+    name: 'GlobeLine',
+  },
+  {
+    component: IconGraduationcapFill,
+    name: 'GraduationcapFill',
+  },
+  {
+    component: IconGraduationcapLine,
+    name: 'GraduationcapLine',
+  },
+  {
+    component: IconGridDot5Fill,
+    name: 'GridDot5Fill',
+  },
+  {
+    component: IconGridDot5Line,
+    name: 'GridDot5Line',
+  },
+  {
+    component: IconGridFill,
+    name: 'GridFill',
+  },
+  {
+    component: IconGridHeartFill,
+    name: 'GridHeartFill',
+  },
+  {
+    component: IconGridHeartLine,
+    name: 'GridHeartLine',
+  },
+  {
+    component: IconGridLine,
+    name: 'GridLine',
+  },
+  {
+    component: IconHandPointUpFill,
+    name: 'HandPointUpFill',
+  },
+  {
+    component: IconHandPointUpLine,
+    name: 'HandPointUpLine',
+  },
+  {
+    component: IconHandWaveFill,
+    name: 'HandWaveFill',
+  },
+  {
+    component: IconHandWaveLine,
+    name: 'HandWaveLine',
+  },
+  {
+    component: IconHashFill,
+    name: 'HashFill',
+  },
+  {
+    component: IconHashLine,
+    name: 'HashLine',
+  },
+  {
+    component: IconHeadphoneFill,
+    name: 'HeadphoneFill',
+  },
+  {
+    component: IconHeadphoneLine,
+    name: 'HeadphoneLine',
+  },
+  {
+    component: IconHeadsetFill,
+    name: 'HeadsetFill',
+  },
+  {
+    component: IconHeadsetLine,
+    name: 'HeadsetLine',
+  },
+  {
+    component: IconHeartFill,
+    name: 'HeartFill',
+  },
+  {
+    component: IconHeartLine,
+    name: 'HeartLine',
+  },
   {
     component: IconHorizline2VerticalChatbubbleRectangularRightFill,
-    name: "Horizline2VerticalChatbubbleRectangularRightFill",
+    name: 'Horizline2VerticalChatbubbleRectangularRightFill',
   },
   {
     component: IconHorizline2VerticalChatbubbleRectangularRightLine,
-    name: "Horizline2VerticalChatbubbleRectangularRightLine",
+    name: 'Horizline2VerticalChatbubbleRectangularRightLine',
   },
   {
     component: IconHorizline2VerticalChatbubbleRectangularRightSlashFill,
-    name: "Horizline2VerticalChatbubbleRectangularRightSlashFill",
+    name: 'Horizline2VerticalChatbubbleRectangularRightSlashFill',
   },
   {
     component: IconHorizline2VerticalChatbubbleRectangularRightSlashLine,
-    name: "Horizline2VerticalChatbubbleRectangularRightSlashLine",
+    name: 'Horizline2VerticalChatbubbleRectangularRightSlashLine',
   },
   {
     component: IconHorizline3VerticalCheckmarkFill,
-    name: "Horizline3VerticalCheckmarkFill",
+    name: 'Horizline3VerticalCheckmarkFill',
   },
   {
     component: IconHorizline3VerticalCheckmarkLine,
-    name: "Horizline3VerticalCheckmarkLine",
+    name: 'Horizline3VerticalCheckmarkLine',
   },
-  { component: IconHorizline3VerticalFill, name: "Horizline3VerticalFill" },
-  { component: IconHorizline3VerticalLine, name: "Horizline3VerticalLine" },
+  {
+    component: IconHorizline3VerticalFill,
+    name: 'Horizline3VerticalFill',
+  },
+  {
+    component: IconHorizline3VerticalLine,
+    name: 'Horizline3VerticalLine',
+  },
   {
     component: IconHorizline3VerticalStarFill,
-    name: "Horizline3VerticalStarFill",
+    name: 'Horizline3VerticalStarFill',
   },
   {
     component: IconHorizline3VerticalStarLine,
-    name: "Horizline3VerticalStarLine",
+    name: 'Horizline3VerticalStarLine',
   },
   {
     component: IconHorizline3VerticalTightFill,
-    name: "Horizline3VerticalTightFill",
+    name: 'Horizline3VerticalTightFill',
   },
   {
     component: IconHorizline3VerticalTightLine,
-    name: "Horizline3VerticalTightLine",
+    name: 'Horizline3VerticalTightLine',
   },
-  { component: IconHorizlineViewfinderFill, name: "HorizlineViewfinderFill" },
-  { component: IconHorizlineViewfinderLine, name: "HorizlineViewfinderLine" },
+  {
+    component: IconHorizlineViewfinderFill,
+    name: 'HorizlineViewfinderFill',
+  },
+  {
+    component: IconHorizlineViewfinderLine,
+    name: 'HorizlineViewfinderLine',
+  },
   {
     component: IconHorizrectangleHorizline2VerticalFill,
-    name: "HorizrectangleHorizline2VerticalFill",
+    name: 'HorizrectangleHorizline2VerticalFill',
   },
   {
     component: IconHorizrectangleHorizline2VerticalLine,
-    name: "HorizrectangleHorizline2VerticalLine",
+    name: 'HorizrectangleHorizline2VerticalLine',
   },
   {
     component: IconHospitalcrossBuildingFill,
-    name: "HospitalcrossBuildingFill",
+    name: 'HospitalcrossBuildingFill',
   },
   {
     component: IconHospitalcrossBuildingLine,
-    name: "HospitalcrossBuildingLine",
+    name: 'HospitalcrossBuildingLine',
   },
-  { component: IconHospitalcrossSquareFill, name: "HospitalcrossSquareFill" },
-  { component: IconHospitalcrossSquareLine, name: "HospitalcrossSquareLine" },
-  { component: IconHouseFill, name: "HouseFill" },
-  { component: IconHouseLine, name: "HouseLine" },
-  { component: IconHousePlusFill, name: "HousePlusFill" },
-  { component: IconHousePlusLine, name: "HousePlusLine" },
-  { component: IconHouseSquareFill, name: "HouseSquareFill" },
-  { component: IconHouseSquareLine, name: "HouseSquareLine" },
+  {
+    component: IconHospitalcrossSquareFill,
+    name: 'HospitalcrossSquareFill',
+  },
+  {
+    component: IconHospitalcrossSquareLine,
+    name: 'HospitalcrossSquareLine',
+  },
+  {
+    component: IconHouseCardFill,
+    name: 'HouseCardFill',
+  },
+  {
+    component: IconHouseCardLine,
+    name: 'HouseCardLine',
+  },
+  {
+    component: IconHouseFill,
+    name: 'HouseFill',
+  },
+  {
+    component: IconHouseLine,
+    name: 'HouseLine',
+  },
+  {
+    component: IconHousePlusFill,
+    name: 'HousePlusFill',
+  },
+  {
+    component: IconHousePlusLine,
+    name: 'HousePlusLine',
+  },
+  {
+    component: IconHouseSquareFill,
+    name: 'HouseSquareFill',
+  },
+  {
+    component: IconHouseSquareLine,
+    name: 'HouseSquareLine',
+  },
   {
     component: IconILowercaseSerifCircleFill,
-    name: "ILowercaseSerifCircleFill",
+    name: 'ILowercaseSerifCircleFill',
   },
   {
     component: IconILowercaseSerifCircleLine,
-    name: "ILowercaseSerifCircleLine",
+    name: 'ILowercaseSerifCircleLine',
   },
-  { component: IconKeyboardChevronDownFill, name: "KeyboardChevronDownFill" },
-  { component: IconKeyboardChevronDownLine, name: "KeyboardChevronDownLine" },
-  { component: IconKeyholeShieldFill, name: "KeyholeShieldFill" },
-  { component: IconKeyholeShieldLine, name: "KeyholeShieldLine" },
-  { component: IconLaptopFill, name: "LaptopFill" },
-  { component: IconLaptopLine, name: "LaptopLine" },
-  { component: IconLeafFill, name: "LeafFill" },
-  { component: IconLeafLine, name: "LeafLine" },
-  { component: IconLightbulbDot5Fill, name: "LightbulbDot5Fill" },
-  { component: IconLightbulbDot5Line, name: "LightbulbDot5Line" },
-  { component: IconLightningFill, name: "LightningFill" },
-  { component: IconLightningLine, name: "LightningLine" },
-  { component: IconLightningSlashFill, name: "LightningSlashFill" },
-  { component: IconLightningSlashLine, name: "LightningSlashLine" },
-  { component: IconLinechartUpXaxisFill, name: "LinechartUpXaxisFill" },
-  { component: IconLinechartUpXaxisLine, name: "LinechartUpXaxisLine" },
-  { component: IconLocationpinFill, name: "LocationpinFill" },
-  { component: IconLocationpinLine, name: "LocationpinLine" },
-  { component: IconLockFill, name: "LockFill" },
-  { component: IconLockLine, name: "LockLine" },
-  { component: IconLockOpenedFill, name: "LockOpenedFill" },
-  { component: IconLockOpenedLine, name: "LockOpenedLine" },
-  { component: IconMagnifyingglassFill, name: "MagnifyingglassFill" },
-  { component: IconMagnifyingglassLine, name: "MagnifyingglassLine" },
+  {
+    component: IconKeyboardChevronDownFill,
+    name: 'KeyboardChevronDownFill',
+  },
+  {
+    component: IconKeyboardChevronDownLine,
+    name: 'KeyboardChevronDownLine',
+  },
+  {
+    component: IconKeyholeShieldFill,
+    name: 'KeyholeShieldFill',
+  },
+  {
+    component: IconKeyholeShieldLine,
+    name: 'KeyholeShieldLine',
+  },
+  {
+    component: IconLaptopFill,
+    name: 'LaptopFill',
+  },
+  {
+    component: IconLaptopLine,
+    name: 'LaptopLine',
+  },
+  {
+    component: IconLeafFill,
+    name: 'LeafFill',
+  },
+  {
+    component: IconLeafLine,
+    name: 'LeafLine',
+  },
+  {
+    component: IconLightbulbDot5Fill,
+    name: 'LightbulbDot5Fill',
+  },
+  {
+    component: IconLightbulbDot5Line,
+    name: 'LightbulbDot5Line',
+  },
+  {
+    component: IconLightningFill,
+    name: 'LightningFill',
+  },
+  {
+    component: IconLightningLine,
+    name: 'LightningLine',
+  },
+  {
+    component: IconLightningSlashFill,
+    name: 'LightningSlashFill',
+  },
+  {
+    component: IconLightningSlashLine,
+    name: 'LightningSlashLine',
+  },
+  {
+    component: IconLinechartUpXaxisFill,
+    name: 'LinechartUpXaxisFill',
+  },
+  {
+    component: IconLinechartUpXaxisLine,
+    name: 'LinechartUpXaxisLine',
+  },
+  {
+    component: IconLocationpinFill,
+    name: 'LocationpinFill',
+  },
+  {
+    component: IconLocationpinLine,
+    name: 'LocationpinLine',
+  },
+  {
+    component: IconLockFill,
+    name: 'LockFill',
+  },
+  {
+    component: IconLockLine,
+    name: 'LockLine',
+  },
+  {
+    component: IconLockOpenedFill,
+    name: 'LockOpenedFill',
+  },
+  {
+    component: IconLockOpenedLine,
+    name: 'LockOpenedLine',
+  },
+  {
+    component: IconMagnifyingglassFill,
+    name: 'MagnifyingglassFill',
+  },
+  {
+    component: IconMagnifyingglassLine,
+    name: 'MagnifyingglassLine',
+  },
   {
     component: IconMalesymbolFemalesymbolFill,
-    name: "MalesymbolFemalesymbolFill",
+    name: 'MalesymbolFemalesymbolFill',
   },
   {
     component: IconMalesymbolFemalesymbolLine,
-    name: "MalesymbolFemalesymbolLine",
+    name: 'MalesymbolFemalesymbolLine',
   },
-  { component: IconMapFill, name: "MapFill" },
-  { component: IconMapLine, name: "MapLine" },
-  { component: IconMapLocationpinFill, name: "MapLocationpinFill" },
-  { component: IconMapLocationpinLine, name: "MapLocationpinLine" },
-  { component: IconMegaphoneFill, name: "MegaphoneFill" },
-  { component: IconMegaphoneLine, name: "MegaphoneLine" },
-  { component: IconMegaphoneTiltedFill, name: "MegaphoneTiltedFill" },
-  { component: IconMegaphoneTiltedLine, name: "MegaphoneTiltedLine" },
-  { component: IconMetroFrontsideFill, name: "MetroFrontsideFill" },
-  { component: IconMetroFrontsideLine, name: "MetroFrontsideLine" },
-  { component: IconMicrophoneFill, name: "MicrophoneFill" },
-  { component: IconMicrophoneLine, name: "MicrophoneLine" },
-  { component: IconMicrophoneSlashFill, name: "MicrophoneSlashFill" },
-  { component: IconMicrophoneSlashLine, name: "MicrophoneSlashLine" },
-  { component: IconMicrowaveFill, name: "MicrowaveFill" },
-  { component: IconMicrowaveLine, name: "MicrowaveLine" },
-  { component: IconMidcutSquareFill, name: "MidcutSquareFill" },
-  { component: IconMidcutSquareLine, name: "MidcutSquareLine" },
-  { component: IconMinusCircleFill, name: "MinusCircleFill" },
-  { component: IconMinusCircleLine, name: "MinusCircleLine" },
-  { component: IconMinusFatFill, name: "MinusFatFill" },
-  { component: IconMinusFatLine, name: "MinusFatLine" },
-  { component: IconMinusFill, name: "MinusFill" },
-  { component: IconMinusLine, name: "MinusLine" },
-  { component: IconMobileFill, name: "MobileFill" },
-  { component: IconMobileLine, name: "MobileLine" },
-  { component: IconMoonFill, name: "MoonFill" },
-  { component: IconMoonLine, name: "MoonLine" },
-  { component: IconMusicalnoteDoubleFill, name: "MusicalnoteDoubleFill" },
-  { component: IconMusicalnoteDoubleLine, name: "MusicalnoteDoubleLine" },
-  { component: IconNUppercaseCircleFill, name: "NUppercaseCircleFill" },
-  { component: IconNUppercaseCircleLine, name: "NUppercaseCircleLine" },
-  { component: IconNailpolishFill, name: "NailpolishFill" },
-  { component: IconNailpolishLine, name: "NailpolishLine" },
-  { component: IconNeedleScaleFill, name: "NeedleScaleFill" },
-  { component: IconNeedleScaleLine, name: "NeedleScaleLine" },
-  { component: IconPUppercaseCircleFill, name: "PUppercaseCircleFill" },
-  { component: IconPUppercaseCircleLine, name: "PUppercaseCircleLine" },
-  { component: IconPaintrollerFill, name: "PaintrollerFill" },
-  { component: IconPaintrollerLine, name: "PaintrollerLine" },
-  { component: IconPaletteFill, name: "PaletteFill" },
-  { component: IconPaletteLine, name: "PaletteLine" },
-  { component: IconPaperclipFill, name: "PaperclipFill" },
-  { component: IconPaperclipLine, name: "PaperclipLine" },
-  { component: IconPaperplaneFill, name: "PaperplaneFill" },
-  { component: IconPaperplaneLine, name: "PaperplaneLine" },
-  { component: IconPaperplaneTiltedFill, name: "PaperplaneTiltedFill" },
-  { component: IconPaperplaneTiltedLine, name: "PaperplaneTiltedLine" },
-  { component: IconPawprintFill, name: "PawprintFill" },
-  { component: IconPawprintLine, name: "PawprintLine" },
-  { component: IconPenHorizlineFill, name: "PenHorizlineFill" },
-  { component: IconPenHorizlineLine, name: "PenHorizlineLine" },
-  { component: IconPencilFill, name: "PencilFill" },
-  { component: IconPencilLine, name: "PencilLine" },
-  { component: IconPeople3Fill, name: "People3Fill" },
-  { component: IconPeople3Line, name: "People3Line" },
-  { component: IconPercentFill, name: "PercentFill" },
-  { component: IconPercentFlowerFill, name: "PercentFlowerFill" },
-  { component: IconPercentFlowerLine, name: "PercentFlowerLine" },
-  { component: IconPercentLine, name: "PercentLine" },
-  { component: IconPerson2Fill, name: "Person2Fill" },
-  { component: IconPerson2Line, name: "Person2Line" },
-  { component: IconPerson2OpenarmsFill, name: "Person2OpenarmsFill" },
-  { component: IconPerson2OpenarmsLine, name: "Person2OpenarmsLine" },
-  { component: IconPersonCircleFill, name: "PersonCircleFill" },
-  { component: IconPersonCircleLine, name: "PersonCircleLine" },
-  { component: IconPersonFill, name: "PersonFill" },
-  { component: IconPersonFlowerFill, name: "PersonFlowerFill" },
-  { component: IconPersonFlowerLine, name: "PersonFlowerLine" },
-  { component: IconPersonLine, name: "PersonLine" },
+  {
+    component: IconMapFill,
+    name: 'MapFill',
+  },
+  {
+    component: IconMapLine,
+    name: 'MapLine',
+  },
+  {
+    component: IconMapLocationpinFill,
+    name: 'MapLocationpinFill',
+  },
+  {
+    component: IconMapLocationpinLine,
+    name: 'MapLocationpinLine',
+  },
+  {
+    component: IconMegaphoneFill,
+    name: 'MegaphoneFill',
+  },
+  {
+    component: IconMegaphoneLine,
+    name: 'MegaphoneLine',
+  },
+  {
+    component: IconMegaphoneTiltedFill,
+    name: 'MegaphoneTiltedFill',
+  },
+  {
+    component: IconMegaphoneTiltedLine,
+    name: 'MegaphoneTiltedLine',
+  },
+  {
+    component: IconMetroFrontsideFill,
+    name: 'MetroFrontsideFill',
+  },
+  {
+    component: IconMetroFrontsideLine,
+    name: 'MetroFrontsideLine',
+  },
+  {
+    component: IconMicrophoneFill,
+    name: 'MicrophoneFill',
+  },
+  {
+    component: IconMicrophoneLine,
+    name: 'MicrophoneLine',
+  },
+  {
+    component: IconMicrophoneSlashFill,
+    name: 'MicrophoneSlashFill',
+  },
+  {
+    component: IconMicrophoneSlashLine,
+    name: 'MicrophoneSlashLine',
+  },
+  {
+    component: IconMicrowaveFill,
+    name: 'MicrowaveFill',
+  },
+  {
+    component: IconMicrowaveLine,
+    name: 'MicrowaveLine',
+  },
+  {
+    component: IconMidcutSquareFill,
+    name: 'MidcutSquareFill',
+  },
+  {
+    component: IconMidcutSquareLine,
+    name: 'MidcutSquareLine',
+  },
+  {
+    component: IconMinusCircleFill,
+    name: 'MinusCircleFill',
+  },
+  {
+    component: IconMinusCircleLine,
+    name: 'MinusCircleLine',
+  },
+  {
+    component: IconMinusFatFill,
+    name: 'MinusFatFill',
+  },
+  {
+    component: IconMinusFatLine,
+    name: 'MinusFatLine',
+  },
+  {
+    component: IconMinusFill,
+    name: 'MinusFill',
+  },
+  {
+    component: IconMinusLine,
+    name: 'MinusLine',
+  },
+  {
+    component: IconMobileFill,
+    name: 'MobileFill',
+  },
+  {
+    component: IconMobileLine,
+    name: 'MobileLine',
+  },
+  {
+    component: IconMoonFill,
+    name: 'MoonFill',
+  },
+  {
+    component: IconMoonLine,
+    name: 'MoonLine',
+  },
+  {
+    component: IconMusicalnoteDoubleFill,
+    name: 'MusicalnoteDoubleFill',
+  },
+  {
+    component: IconMusicalnoteDoubleLine,
+    name: 'MusicalnoteDoubleLine',
+  },
+  {
+    component: IconNailpolishFill,
+    name: 'NailpolishFill',
+  },
+  {
+    component: IconNailpolishLine,
+    name: 'NailpolishLine',
+  },
+  {
+    component: IconNeedleScaleFill,
+    name: 'NeedleScaleFill',
+  },
+  {
+    component: IconNeedleScaleLine,
+    name: 'NeedleScaleLine',
+  },
+  {
+    component: IconNUppercaseCircleFill,
+    name: 'NUppercaseCircleFill',
+  },
+  {
+    component: IconNUppercaseCircleLine,
+    name: 'NUppercaseCircleLine',
+  },
+  {
+    component: IconPaintrollerFill,
+    name: 'PaintrollerFill',
+  },
+  {
+    component: IconPaintrollerLine,
+    name: 'PaintrollerLine',
+  },
+  {
+    component: IconPaletteFill,
+    name: 'PaletteFill',
+  },
+  {
+    component: IconPaletteLine,
+    name: 'PaletteLine',
+  },
+  {
+    component: IconPaperclipFill,
+    name: 'PaperclipFill',
+  },
+  {
+    component: IconPaperclipLine,
+    name: 'PaperclipLine',
+  },
+  {
+    component: IconPaperplaneFill,
+    name: 'PaperplaneFill',
+  },
+  {
+    component: IconPaperplaneLine,
+    name: 'PaperplaneLine',
+  },
+  {
+    component: IconPaperplaneTiltedFill,
+    name: 'PaperplaneTiltedFill',
+  },
+  {
+    component: IconPaperplaneTiltedLine,
+    name: 'PaperplaneTiltedLine',
+  },
+  {
+    component: IconPawprintFill,
+    name: 'PawprintFill',
+  },
+  {
+    component: IconPawprintLine,
+    name: 'PawprintLine',
+  },
+  {
+    component: IconPencilFill,
+    name: 'PencilFill',
+  },
+  {
+    component: IconPencilLine,
+    name: 'PencilLine',
+  },
+  {
+    component: IconPenHorizlineFill,
+    name: 'PenHorizlineFill',
+  },
+  {
+    component: IconPenHorizlineLine,
+    name: 'PenHorizlineLine',
+  },
+  {
+    component: IconPeople3Fill,
+    name: 'People3Fill',
+  },
+  {
+    component: IconPeople3Line,
+    name: 'People3Line',
+  },
+  {
+    component: IconPercentFill,
+    name: 'PercentFill',
+  },
+  {
+    component: IconPercentFlowerFill,
+    name: 'PercentFlowerFill',
+  },
+  {
+    component: IconPercentFlowerLine,
+    name: 'PercentFlowerLine',
+  },
+  {
+    component: IconPercentLine,
+    name: 'PercentLine',
+  },
+  {
+    component: IconPerson2Fill,
+    name: 'Person2Fill',
+  },
+  {
+    component: IconPerson2Line,
+    name: 'Person2Line',
+  },
+  {
+    component: IconPerson2OpenarmsFill,
+    name: 'Person2OpenarmsFill',
+  },
+  {
+    component: IconPerson2OpenarmsLine,
+    name: 'Person2OpenarmsLine',
+  },
+  {
+    component: IconPersonCircleFill,
+    name: 'PersonCircleFill',
+  },
+  {
+    component: IconPersonCircleLine,
+    name: 'PersonCircleLine',
+  },
+  {
+    component: IconPersonFill,
+    name: 'PersonFill',
+  },
+  {
+    component: IconPersonFlowerFill,
+    name: 'PersonFlowerFill',
+  },
+  {
+    component: IconPersonFlowerLine,
+    name: 'PersonFlowerLine',
+  },
+  {
+    component: IconPersonLine,
+    name: 'PersonLine',
+  },
   {
     component: IconPersonMagnifyingglassFill,
-    name: "PersonMagnifyingglassFill",
+    name: 'PersonMagnifyingglassFill',
   },
   {
     component: IconPersonMagnifyingglassLine,
-    name: "PersonMagnifyingglassLine",
+    name: 'PersonMagnifyingglassLine',
   },
-  { component: IconPersonPlusFill, name: "PersonPlusFill" },
-  { component: IconPersonPlusLine, name: "PersonPlusLine" },
-  { component: IconPersonShieldFill, name: "PersonShieldFill" },
-  { component: IconPersonShieldLine, name: "PersonShieldLine" },
-  { component: IconPhoneFill, name: "PhoneFill" },
-  { component: IconPhoneLine, name: "PhoneLine" },
-  { component: IconPhoneXmarkFill, name: "PhoneXmarkFill" },
-  { component: IconPhoneXmarkLine, name: "PhoneXmarkLine" },
-  { component: IconPicture2StackedFill, name: "Picture2StackedFill" },
-  { component: IconPicture2StackedLine, name: "Picture2StackedLine" },
-  { component: IconPictureFill, name: "PictureFill" },
-  { component: IconPictureLine, name: "PictureLine" },
-  { component: IconPlusCircleFill, name: "PlusCircleFill" },
-  { component: IconPlusCircleLine, name: "PlusCircleLine" },
-  { component: IconPlusFill, name: "PlusFill" },
-  { component: IconPlusLine, name: "PlusLine" },
-  { component: IconPlusSmallFill, name: "PlusSmallFill" },
-  { component: IconPlusSmallLine, name: "PlusSmallLine" },
-  { component: IconPlusSquareFill, name: "PlusSquareFill" },
-  { component: IconPlusSquareLine, name: "PlusSquareLine" },
-  { component: IconPostFill, name: "PostFill" },
-  { component: IconPostLine, name: "PostLine" },
-  { component: IconPushpinFill, name: "PushpinFill" },
-  { component: IconPushpinLine, name: "PushpinLine" },
+  {
+    component: IconPersonPlusFill,
+    name: 'PersonPlusFill',
+  },
+  {
+    component: IconPersonPlusLine,
+    name: 'PersonPlusLine',
+  },
+  {
+    component: IconPersonShieldFill,
+    name: 'PersonShieldFill',
+  },
+  {
+    component: IconPersonShieldLine,
+    name: 'PersonShieldLine',
+  },
+  {
+    component: IconPhoneFill,
+    name: 'PhoneFill',
+  },
+  {
+    component: IconPhoneLine,
+    name: 'PhoneLine',
+  },
+  {
+    component: IconPhoneXmarkFill,
+    name: 'PhoneXmarkFill',
+  },
+  {
+    component: IconPhoneXmarkLine,
+    name: 'PhoneXmarkLine',
+  },
+  {
+    component: IconPicture2StackedFill,
+    name: 'Picture2StackedFill',
+  },
+  {
+    component: IconPicture2StackedLine,
+    name: 'Picture2StackedLine',
+  },
+  {
+    component: IconPictureFill,
+    name: 'PictureFill',
+  },
+  {
+    component: IconPictureLine,
+    name: 'PictureLine',
+  },
+  {
+    component: IconPlusCircleFill,
+    name: 'PlusCircleFill',
+  },
+  {
+    component: IconPlusCircleLine,
+    name: 'PlusCircleLine',
+  },
+  {
+    component: IconPlusFill,
+    name: 'PlusFill',
+  },
+  {
+    component: IconPlusLine,
+    name: 'PlusLine',
+  },
+  {
+    component: IconPlusSmallFill,
+    name: 'PlusSmallFill',
+  },
+  {
+    component: IconPlusSmallLine,
+    name: 'PlusSmallLine',
+  },
+  {
+    component: IconPlusSquareFill,
+    name: 'PlusSquareFill',
+  },
+  {
+    component: IconPlusSquareLine,
+    name: 'PlusSquareLine',
+  },
+  {
+    component: IconPostFill,
+    name: 'PostFill',
+  },
+  {
+    component: IconPostLine,
+    name: 'PostLine',
+  },
+  {
+    component: IconPUppercaseCircleFill,
+    name: 'PUppercaseCircleFill',
+  },
+  {
+    component: IconPUppercaseCircleLine,
+    name: 'PUppercaseCircleLine',
+  },
+  {
+    component: IconPushpinFill,
+    name: 'PushpinFill',
+  },
+  {
+    component: IconPushpinLine,
+    name: 'PushpinLine',
+  },
   {
     component: IconQUppercaseChatbubbleRightFill,
-    name: "QUppercaseChatbubbleRightFill",
+    name: 'QUppercaseChatbubbleRightFill',
   },
   {
     component: IconQUppercaseChatbubbleRightLine,
-    name: "QUppercaseChatbubbleRightLine",
+    name: 'QUppercaseChatbubbleRightLine',
   },
-  { component: IconQuestionmarkCircleFill, name: "QuestionmarkCircleFill" },
-  { component: IconQuestionmarkCircleLine, name: "QuestionmarkCircleLine" },
-  { component: IconQuestionmarkSquareFill, name: "QuestionmarkSquareFill" },
-  { component: IconQuestionmarkSquareLine, name: "QuestionmarkSquareLine" },
-  { component: IconQuotationmark2LeftFill, name: "Quotationmark2LeftFill" },
-  { component: IconQuotationmark2LeftLine, name: "Quotationmark2LeftLine" },
-  { component: IconQuotationmark2RightFill, name: "Quotationmark2RightFill" },
-  { component: IconQuotationmark2RightLine, name: "Quotationmark2RightLine" },
-  { component: IconReceiptFill, name: "ReceiptFill" },
-  { component: IconReceiptLine, name: "ReceiptLine" },
+  {
+    component: IconQuestionmarkCircleFill,
+    name: 'QuestionmarkCircleFill',
+  },
+  {
+    component: IconQuestionmarkCircleLine,
+    name: 'QuestionmarkCircleLine',
+  },
+  {
+    component: IconQuestionmarkSquareFill,
+    name: 'QuestionmarkSquareFill',
+  },
+  {
+    component: IconQuestionmarkSquareLine,
+    name: 'QuestionmarkSquareLine',
+  },
+  {
+    component: IconQuotationmark2LeftFill,
+    name: 'Quotationmark2LeftFill',
+  },
+  {
+    component: IconQuotationmark2LeftLine,
+    name: 'Quotationmark2LeftLine',
+  },
+  {
+    component: IconQuotationmark2RightFill,
+    name: 'Quotationmark2RightFill',
+  },
+  {
+    component: IconQuotationmark2RightLine,
+    name: 'Quotationmark2RightLine',
+  },
+  {
+    component: IconReceiptFill,
+    name: 'ReceiptFill',
+  },
+  {
+    component: IconReceiptLine,
+    name: 'ReceiptLine',
+  },
   {
     component: IconRectangleSplitedLineVerticalFill,
-    name: "RectangleSplitedLineVerticalFill",
+    name: 'RectangleSplitedLineVerticalFill',
   },
   {
     component: IconRectangleSplitedLineVerticalLine,
-    name: "RectangleSplitedLineVerticalLine",
-  },
-  { component: IconRoadlaneFill, name: "RoadlaneFill" },
-  { component: IconRoadlaneLine, name: "RoadlaneLine" },
-  { component: IconRocketFill, name: "RocketFill" },
-  { component: IconRocketLine, name: "RocketLine" },
-  { component: IconRooftoproomFill, name: "RooftoproomFill" },
-  { component: IconRooftoproomLine, name: "RooftoproomLine" },
-  {
-    component: IconSUppercaseHorizlineCenterFill,
-    name: "SUppercaseHorizlineCenterFill",
+    name: 'RectangleSplitedLineVerticalLine',
   },
   {
-    component: IconSUppercaseHorizlineCenterLine,
-    name: "SUppercaseHorizlineCenterLine",
+    component: IconRoadlaneFill,
+    name: 'RoadlaneFill',
   },
-  { component: IconScissorsFill, name: "ScissorsFill" },
-  { component: IconScissorsLine, name: "ScissorsLine" },
-  { component: IconScribbleFill, name: "ScribbleFill" },
-  { component: IconScribbleLine, name: "ScribbleLine" },
-  { component: IconSeatLeftFanFill, name: "SeatLeftFanFill" },
-  { component: IconSeatLeftFanLine, name: "SeatLeftFanLine" },
-  { component: IconSeatLeftFill, name: "SeatLeftFill" },
-  { component: IconSeatLeftHeatwave2Fill, name: "SeatLeftHeatwave2Fill" },
-  { component: IconSeatLeftHeatwave2Line, name: "SeatLeftHeatwave2Line" },
-  { component: IconSeatLeftLine, name: "SeatLeftLine" },
-  { component: IconShoppingbag2StackedFill, name: "Shoppingbag2StackedFill" },
-  { component: IconShoppingbag2StackedLine, name: "Shoppingbag2StackedLine" },
-  { component: IconShoppingbagFill, name: "ShoppingbagFill" },
-  { component: IconShoppingbagItemsFill, name: "ShoppingbagItemsFill" },
-  { component: IconShoppingbagItemsLine, name: "ShoppingbagItemsLine" },
-  { component: IconShoppingbagLine, name: "ShoppingbagLine" },
-  { component: IconSidemirrorWaveFill, name: "SidemirrorWaveFill" },
-  { component: IconSidemirrorWaveLine, name: "SidemirrorWaveLine" },
-  { component: IconSignboardFill, name: "SignboardFill" },
-  { component: IconSignboardLine, name: "SignboardLine" },
-  { component: IconSlashCircleFill, name: "SlashCircleFill" },
-  { component: IconSlashCircleLine, name: "SlashCircleLine" },
-  { component: IconSlashSemicircle2Fill, name: "SlashSemicircle2Fill" },
-  { component: IconSlashSemicircle2Line, name: "SlashSemicircle2Line" },
-  { component: IconSlider2HorizontalFill, name: "Slider2HorizontalFill" },
-  { component: IconSlider2HorizontalLine, name: "Slider2HorizontalLine" },
-  { component: IconSmartkeyFill, name: "SmartkeyFill" },
-  { component: IconSmartkeyLine, name: "SmartkeyLine" },
+  {
+    component: IconRoadlaneLine,
+    name: 'RoadlaneLine',
+  },
+  {
+    component: IconRocketFill,
+    name: 'RocketFill',
+  },
+  {
+    component: IconRocketLine,
+    name: 'RocketLine',
+  },
+  {
+    component: IconRooftoproomFill,
+    name: 'RooftoproomFill',
+  },
+  {
+    component: IconRooftoproomLine,
+    name: 'RooftoproomLine',
+  },
+  {
+    component: IconScissorsFill,
+    name: 'ScissorsFill',
+  },
+  {
+    component: IconScissorsLine,
+    name: 'ScissorsLine',
+  },
+  {
+    component: IconScribbleFill,
+    name: 'ScribbleFill',
+  },
+  {
+    component: IconScribbleLine,
+    name: 'ScribbleLine',
+  },
+  {
+    component: IconSeatLeftFanFill,
+    name: 'SeatLeftFanFill',
+  },
+  {
+    component: IconSeatLeftFanLine,
+    name: 'SeatLeftFanLine',
+  },
+  {
+    component: IconSeatLeftFill,
+    name: 'SeatLeftFill',
+  },
+  {
+    component: IconSeatLeftHeatwave2Fill,
+    name: 'SeatLeftHeatwave2Fill',
+  },
+  {
+    component: IconSeatLeftHeatwave2Line,
+    name: 'SeatLeftHeatwave2Line',
+  },
+  {
+    component: IconSeatLeftLine,
+    name: 'SeatLeftLine',
+  },
+  {
+    component: IconShoppingbag2StackedFill,
+    name: 'Shoppingbag2StackedFill',
+  },
+  {
+    component: IconShoppingbag2StackedLine,
+    name: 'Shoppingbag2StackedLine',
+  },
+  {
+    component: IconShoppingbagFill,
+    name: 'ShoppingbagFill',
+  },
+  {
+    component: IconShoppingbagItemsFill,
+    name: 'ShoppingbagItemsFill',
+  },
+  {
+    component: IconShoppingbagItemsLine,
+    name: 'ShoppingbagItemsLine',
+  },
+  {
+    component: IconShoppingbagLine,
+    name: 'ShoppingbagLine',
+  },
+  {
+    component: IconSidemirrorWaveFill,
+    name: 'SidemirrorWaveFill',
+  },
+  {
+    component: IconSidemirrorWaveLine,
+    name: 'SidemirrorWaveLine',
+  },
+  {
+    component: IconSignboardFill,
+    name: 'SignboardFill',
+  },
+  {
+    component: IconSignboardLine,
+    name: 'SignboardLine',
+  },
+  {
+    component: IconSlashCircleFill,
+    name: 'SlashCircleFill',
+  },
+  {
+    component: IconSlashCircleLine,
+    name: 'SlashCircleLine',
+  },
+  {
+    component: IconSlashSemicircle2Fill,
+    name: 'SlashSemicircle2Fill',
+  },
+  {
+    component: IconSlashSemicircle2Line,
+    name: 'SlashSemicircle2Line',
+  },
+  {
+    component: IconSlider2HorizontalFill,
+    name: 'Slider2HorizontalFill',
+  },
+  {
+    component: IconSlider2HorizontalLine,
+    name: 'Slider2HorizontalLine',
+  },
+  {
+    component: IconSmartkeyFill,
+    name: 'SmartkeyFill',
+  },
+  {
+    component: IconSmartkeyLine,
+    name: 'SmartkeyLine',
+  },
   {
     component: IconSneakerLiftedLeftsideFill,
-    name: "SneakerLiftedLeftsideFill",
+    name: 'SneakerLiftedLeftsideFill',
   },
   {
     component: IconSneakerLiftedLeftsideLine,
-    name: "SneakerLiftedLeftsideLine",
+    name: 'SneakerLiftedLeftsideLine',
   },
-  { component: IconSofaFill, name: "SofaFill" },
-  { component: IconSofaLine, name: "SofaLine" },
-  { component: IconSparkle2Fill, name: "Sparkle2Fill" },
-  { component: IconSparkle2Line, name: "Sparkle2Line" },
-  { component: IconSparkleViewfinderFill, name: "SparkleViewfinderFill" },
-  { component: IconSparkleViewfinderLine, name: "SparkleViewfinderLine" },
-  { component: IconSpeakerWave2Fill, name: "SpeakerWave2Fill" },
-  { component: IconSpeakerWave2Line, name: "SpeakerWave2Line" },
-  { component: IconSpeakerWave2SlashFill, name: "SpeakerWave2SlashFill" },
-  { component: IconSpeakerWave2SlashLine, name: "SpeakerWave2SlashLine" },
-  { component: IconSpeedometerFill, name: "SpeedometerFill" },
-  { component: IconSpeedometerLine, name: "SpeedometerLine" },
-  { component: IconSpeedometer_1xFill, name: "Speedometer_1xFill" },
-  { component: IconSpeedometer_1xLine, name: "Speedometer_1xLine" },
-  { component: IconSpeedometer_2xFill, name: "Speedometer_2xFill" },
-  { component: IconSpeedometer_2xLine, name: "Speedometer_2xLine" },
-  { component: IconSpeedometer_3xFill, name: "Speedometer_3xFill" },
-  { component: IconSpeedometer_3xLine, name: "Speedometer_3xLine" },
-  { component: IconSplitedGridSquareFill, name: "SplitedGridSquareFill" },
-  { component: IconSplitedGridSquareLine, name: "SplitedGridSquareLine" },
-  { component: IconSpraybottleSpongeFill, name: "SpraybottleSpongeFill" },
-  { component: IconSpraybottleSpongeLine, name: "SpraybottleSpongeLine" },
-  { component: IconSquare2StackedFill, name: "Square2StackedFill" },
-  { component: IconSquare2StackedLine, name: "Square2StackedLine" },
-  { component: IconSquareline2VerticalFill, name: "Squareline2VerticalFill" },
-  { component: IconSquareline2VerticalLine, name: "Squareline2VerticalLine" },
-  { component: IconStarFill, name: "StarFill" },
-  { component: IconStarLine, name: "StarLine" },
+  {
+    component: IconSofaFill,
+    name: 'SofaFill',
+  },
+  {
+    component: IconSofaLine,
+    name: 'SofaLine',
+  },
+  {
+    component: IconSparkle2Fill,
+    name: 'Sparkle2Fill',
+  },
+  {
+    component: IconSparkle2Line,
+    name: 'Sparkle2Line',
+  },
+  {
+    component: IconSparkleViewfinderFill,
+    name: 'SparkleViewfinderFill',
+  },
+  {
+    component: IconSparkleViewfinderLine,
+    name: 'SparkleViewfinderLine',
+  },
+  {
+    component: IconSpeakerWave2Fill,
+    name: 'SpeakerWave2Fill',
+  },
+  {
+    component: IconSpeakerWave2Line,
+    name: 'SpeakerWave2Line',
+  },
+  {
+    component: IconSpeakerWave2SlashFill,
+    name: 'SpeakerWave2SlashFill',
+  },
+  {
+    component: IconSpeakerWave2SlashLine,
+    name: 'SpeakerWave2SlashLine',
+  },
+  {
+    component: IconSpeedometer_1xFill,
+    name: 'Speedometer_1xFill',
+  },
+  {
+    component: IconSpeedometer_1xLine,
+    name: 'Speedometer_1xLine',
+  },
+  {
+    component: IconSpeedometer_2xFill,
+    name: 'Speedometer_2xFill',
+  },
+  {
+    component: IconSpeedometer_2xLine,
+    name: 'Speedometer_2xLine',
+  },
+  {
+    component: IconSpeedometer_3xFill,
+    name: 'Speedometer_3xFill',
+  },
+  {
+    component: IconSpeedometer_3xLine,
+    name: 'Speedometer_3xLine',
+  },
+  {
+    component: IconSpeedometerFill,
+    name: 'SpeedometerFill',
+  },
+  {
+    component: IconSpeedometerLine,
+    name: 'SpeedometerLine',
+  },
+  {
+    component: IconSplitedGridSquareFill,
+    name: 'SplitedGridSquareFill',
+  },
+  {
+    component: IconSplitedGridSquareLine,
+    name: 'SplitedGridSquareLine',
+  },
+  {
+    component: IconSpraybottleSpongeFill,
+    name: 'SpraybottleSpongeFill',
+  },
+  {
+    component: IconSpraybottleSpongeLine,
+    name: 'SpraybottleSpongeLine',
+  },
+  {
+    component: IconSquare2StackedFill,
+    name: 'Square2StackedFill',
+  },
+  {
+    component: IconSquare2StackedLine,
+    name: 'Square2StackedLine',
+  },
+  {
+    component: IconSquareline2VerticalFill,
+    name: 'Squareline2VerticalFill',
+  },
+  {
+    component: IconSquareline2VerticalLine,
+    name: 'Squareline2VerticalLine',
+  },
+  {
+    component: IconSquareSplitedVerticalLeftFill,
+    name: 'SquareSplitedVerticalLeftFill',
+  },
+  {
+    component: IconSquareSplitedVerticalLeftLine,
+    name: 'SquareSplitedVerticalLeftLine',
+  },
+  {
+    component: IconStarFill,
+    name: 'StarFill',
+  },
+  {
+    component: IconStarLine,
+    name: 'StarLine',
+  },
   {
     component: IconSteeringwheelHeatwave2Fill,
-    name: "SteeringwheelHeatwave2Fill",
+    name: 'SteeringwheelHeatwave2Fill',
   },
   {
     component: IconSteeringwheelHeatwave2Line,
-    name: "SteeringwheelHeatwave2Line",
+    name: 'SteeringwheelHeatwave2Line',
   },
-  { component: IconStepsFill, name: "StepsFill" },
-  { component: IconStepsLine, name: "StepsLine" },
-  { component: IconStoreCheckmarkFill, name: "StoreCheckmarkFill" },
-  { component: IconStoreCheckmarkLine, name: "StoreCheckmarkLine" },
-  { component: IconStoreFill, name: "StoreFill" },
-  { component: IconStoreLine, name: "StoreLine" },
-  { component: IconStorePenFill, name: "StorePenFill" },
-  { component: IconStorePenLine, name: "StorePenLine" },
-  { component: IconSunFill, name: "SunFill" },
-  { component: IconSunLine, name: "SunLine" },
-  { component: IconTUppercaseSerifFill, name: "TUppercaseSerifFill" },
-  { component: IconTUppercaseSerifLine, name: "TUppercaseSerifLine" },
-  { component: IconTUppercaseTLowercaseFill, name: "TUppercaseTLowercaseFill" },
-  { component: IconTUppercaseTLowercaseLine, name: "TUppercaseTLowercaseLine" },
-  { component: IconTagFill, name: "TagFill" },
-  { component: IconTagLine, name: "TagLine" },
-  { component: IconTextAligncenterFill, name: "TextAligncenterFill" },
-  { component: IconTextAligncenterLine, name: "TextAligncenterLine" },
-  { component: IconTextAlignleftFill, name: "TextAlignleftFill" },
-  { component: IconTextAlignleftLine, name: "TextAlignleftLine" },
-  { component: IconTextAlignrightFill, name: "TextAlignrightFill" },
-  { component: IconTextAlignrightLine, name: "TextAlignrightLine" },
-  { component: IconThumbDownFill, name: "ThumbDownFill" },
-  { component: IconThumbDownLine, name: "ThumbDownLine" },
-  { component: IconThumbUpFill, name: "ThumbUpFill" },
-  { component: IconThumbUpLine, name: "ThumbUpLine" },
-  { component: IconTimerFill, name: "TimerFill" },
-  { component: IconTimerLine, name: "TimerLine" },
-  { component: IconTimer_10Fill, name: "Timer_10Fill" },
-  { component: IconTimer_10Line, name: "Timer_10Line" },
-  { component: IconTimer_3Fill, name: "Timer_3Fill" },
-  { component: IconTimer_3Line, name: "Timer_3Line" },
-  { component: IconToolboxFill, name: "ToolboxFill" },
-  { component: IconToolboxLine, name: "ToolboxLine" },
-  { component: IconTranslationFill, name: "TranslationFill" },
-  { component: IconTranslationLine, name: "TranslationLine" },
-  { component: IconTrashcanFill, name: "TrashcanFill" },
-  { component: IconTrashcanLine, name: "TrashcanLine" },
-  { component: IconTriangleDownSmallFill, name: "TriangleDownSmallFill" },
-  { component: IconTriangleDownSmallLine, name: "TriangleDownSmallLine" },
+  {
+    component: IconStepsFill,
+    name: 'StepsFill',
+  },
+  {
+    component: IconStepsLine,
+    name: 'StepsLine',
+  },
+  {
+    component: IconStoreCheckmarkFill,
+    name: 'StoreCheckmarkFill',
+  },
+  {
+    component: IconStoreCheckmarkLine,
+    name: 'StoreCheckmarkLine',
+  },
+  {
+    component: IconStoreFill,
+    name: 'StoreFill',
+  },
+  {
+    component: IconStoreLine,
+    name: 'StoreLine',
+  },
+  {
+    component: IconStorePenFill,
+    name: 'StorePenFill',
+  },
+  {
+    component: IconStorePenLine,
+    name: 'StorePenLine',
+  },
+  {
+    component: IconSUppercaseHorizlineCenterFill,
+    name: 'SUppercaseHorizlineCenterFill',
+  },
+  {
+    component: IconSUppercaseHorizlineCenterLine,
+    name: 'SUppercaseHorizlineCenterLine',
+  },
+  {
+    component: IconSunFill,
+    name: 'SunFill',
+  },
+  {
+    component: IconSunLine,
+    name: 'SunLine',
+  },
+  {
+    component: IconTagFill,
+    name: 'TagFill',
+  },
+  {
+    component: IconTagLine,
+    name: 'TagLine',
+  },
+  {
+    component: IconTextAligncenterFill,
+    name: 'TextAligncenterFill',
+  },
+  {
+    component: IconTextAligncenterLine,
+    name: 'TextAligncenterLine',
+  },
+  {
+    component: IconTextAlignleftFill,
+    name: 'TextAlignleftFill',
+  },
+  {
+    component: IconTextAlignleftLine,
+    name: 'TextAlignleftLine',
+  },
+  {
+    component: IconTextAlignrightFill,
+    name: 'TextAlignrightFill',
+  },
+  {
+    component: IconTextAlignrightLine,
+    name: 'TextAlignrightLine',
+  },
+  {
+    component: IconThumbDownFill,
+    name: 'ThumbDownFill',
+  },
+  {
+    component: IconThumbDownLine,
+    name: 'ThumbDownLine',
+  },
+  {
+    component: IconThumbUpFill,
+    name: 'ThumbUpFill',
+  },
+  {
+    component: IconThumbUpLine,
+    name: 'ThumbUpLine',
+  },
+  {
+    component: IconTimer_3Fill,
+    name: 'Timer_3Fill',
+  },
+  {
+    component: IconTimer_3Line,
+    name: 'Timer_3Line',
+  },
+  {
+    component: IconTimer_10Fill,
+    name: 'Timer_10Fill',
+  },
+  {
+    component: IconTimer_10Line,
+    name: 'Timer_10Line',
+  },
+  {
+    component: IconTimerFill,
+    name: 'TimerFill',
+  },
+  {
+    component: IconTimerLine,
+    name: 'TimerLine',
+  },
+  {
+    component: IconToolboxFill,
+    name: 'ToolboxFill',
+  },
+  {
+    component: IconToolboxLine,
+    name: 'ToolboxLine',
+  },
+  {
+    component: IconTranslationFill,
+    name: 'TranslationFill',
+  },
+  {
+    component: IconTranslationLine,
+    name: 'TranslationLine',
+  },
+  {
+    component: IconTrashcanFill,
+    name: 'TrashcanFill',
+  },
+  {
+    component: IconTrashcanLine,
+    name: 'TrashcanLine',
+  },
+  {
+    component: IconTriangleDownSmallFill,
+    name: 'TriangleDownSmallFill',
+  },
+  {
+    component: IconTriangleDownSmallLine,
+    name: 'TriangleDownSmallLine',
+  },
   {
     component: IconTriangleRightChatbubbleLeftFill,
-    name: "TriangleRightChatbubbleLeftFill",
+    name: 'TriangleRightChatbubbleLeftFill',
   },
   {
     component: IconTriangleRightChatbubbleLeftLine,
-    name: "TriangleRightChatbubbleLeftLine",
+    name: 'TriangleRightChatbubbleLeftLine',
   },
-  { component: IconTriangleRightFill, name: "TriangleRightFill" },
-  { component: IconTriangleRightLine, name: "TriangleRightLine" },
+  {
+    component: IconTriangleRightFill,
+    name: 'TriangleRightFill',
+  },
+  {
+    component: IconTriangleRightLine,
+    name: 'TriangleRightLine',
+  },
   {
     component: IconTriangleRightRectangleSplitedLineVerticalFill,
-    name: "TriangleRightRectangleSplitedLineVerticalFill",
+    name: 'TriangleRightRectangleSplitedLineVerticalFill',
   },
   {
     component: IconTriangleRightRectangleSplitedLineVerticalLine,
-    name: "TriangleRightRectangleSplitedLineVerticalLine",
+    name: 'TriangleRightRectangleSplitedLineVerticalLine',
   },
-  { component: IconTriangleUpSmallFill, name: "TriangleUpSmallFill" },
-  { component: IconTriangleUpSmallLine, name: "TriangleUpSmallLine" },
-  { component: IconTrophyFill, name: "TrophyFill" },
-  { component: IconTrophyLine, name: "TrophyLine" },
-  { component: IconTruckFill, name: "TruckFill" },
-  { component: IconTruckLine, name: "TruckLine" },
-  { component: IconTshirtBubble2Fill, name: "TshirtBubble2Fill" },
-  { component: IconTshirtBubble2Line, name: "TshirtBubble2Line" },
-  { component: IconUUppercaseHorizlineFill, name: "UUppercaseHorizlineFill" },
-  { component: IconUUppercaseHorizlineLine, name: "UUppercaseHorizlineLine" },
-  { component: IconVertline3ViewfinderFill, name: "Vertline3ViewfinderFill" },
-  { component: IconVertline3ViewfinderLine, name: "Vertline3ViewfinderLine" },
-  { component: IconVertline4SparkleFill, name: "Vertline4SparkleFill" },
-  { component: IconVertline4SparkleLine, name: "Vertline4SparkleLine" },
-  { component: IconVertlineCouponFill, name: "VertlineCouponFill" },
-  { component: IconVertlineCouponLine, name: "VertlineCouponLine" },
+  {
+    component: IconTriangleUpSmallFill,
+    name: 'TriangleUpSmallFill',
+  },
+  {
+    component: IconTriangleUpSmallLine,
+    name: 'TriangleUpSmallLine',
+  },
+  {
+    component: IconTrophyFill,
+    name: 'TrophyFill',
+  },
+  {
+    component: IconTrophyLine,
+    name: 'TrophyLine',
+  },
+  {
+    component: IconTruckFill,
+    name: 'TruckFill',
+  },
+  {
+    component: IconTruckLine,
+    name: 'TruckLine',
+  },
+  {
+    component: IconTshirtBubble2Fill,
+    name: 'TshirtBubble2Fill',
+  },
+  {
+    component: IconTshirtBubble2Line,
+    name: 'TshirtBubble2Line',
+  },
+  {
+    component: IconTUppercaseSerifFill,
+    name: 'TUppercaseSerifFill',
+  },
+  {
+    component: IconTUppercaseSerifLine,
+    name: 'TUppercaseSerifLine',
+  },
+  {
+    component: IconTUppercaseTLowercaseFill,
+    name: 'TUppercaseTLowercaseFill',
+  },
+  {
+    component: IconTUppercaseTLowercaseLine,
+    name: 'TUppercaseTLowercaseLine',
+  },
+  {
+    component: IconUUppercaseHorizlineFill,
+    name: 'UUppercaseHorizlineFill',
+  },
+  {
+    component: IconUUppercaseHorizlineLine,
+    name: 'UUppercaseHorizlineLine',
+  },
+  {
+    component: IconVertline3ViewfinderFill,
+    name: 'Vertline3ViewfinderFill',
+  },
+  {
+    component: IconVertline3ViewfinderLine,
+    name: 'Vertline3ViewfinderLine',
+  },
+  {
+    component: IconVertline4SparkleFill,
+    name: 'Vertline4SparkleFill',
+  },
+  {
+    component: IconVertline4SparkleLine,
+    name: 'Vertline4SparkleLine',
+  },
+  {
+    component: IconVertlineCouponFill,
+    name: 'VertlineCouponFill',
+  },
+  {
+    component: IconVertlineCouponLine,
+    name: 'VertlineCouponLine',
+  },
   {
     component: IconVertrectangle2HorizontalFill,
-    name: "Vertrectangle2HorizontalFill",
+    name: 'Vertrectangle2HorizontalFill',
   },
   {
     component: IconVertrectangle2HorizontalLine,
-    name: "Vertrectangle2HorizontalLine",
+    name: 'Vertrectangle2HorizontalLine',
   },
-  { component: IconVertrectangleFoldedFill, name: "VertrectangleFoldedFill" },
-  { component: IconVertrectangleFoldedLine, name: "VertrectangleFoldedLine" },
-  { component: IconVotingstampFill, name: "VotingstampFill" },
-  { component: IconVotingstampLine, name: "VotingstampLine" },
-  { component: IconWandFill, name: "WandFill" },
-  { component: IconWandLine, name: "WandLine" },
-  { component: IconWashingmachineFill, name: "WashingmachineFill" },
-  { component: IconWashingmachineLine, name: "WashingmachineLine" },
-  { component: IconWindow2StoreFill, name: "Window2StoreFill" },
-  { component: IconWindow2StoreLine, name: "Window2StoreLine" },
-  { component: IconWindow4HouseFill, name: "Window4HouseFill" },
-  { component: IconWindow4HouseLine, name: "Window4HouseLine" },
+  {
+    component: IconVertrectangleFoldedFill,
+    name: 'VertrectangleFoldedFill',
+  },
+  {
+    component: IconVertrectangleFoldedLine,
+    name: 'VertrectangleFoldedLine',
+  },
+  {
+    component: IconVotingstampFill,
+    name: 'VotingstampFill',
+  },
+  {
+    component: IconVotingstampLine,
+    name: 'VotingstampLine',
+  },
+  {
+    component: IconWandFill,
+    name: 'WandFill',
+  },
+  {
+    component: IconWandLine,
+    name: 'WandLine',
+  },
+  {
+    component: IconWandPlusCircleFill,
+    name: 'WandPlusCircleFill',
+  },
+  {
+    component: IconWandPlusCircleLine,
+    name: 'WandPlusCircleLine',
+  },
+  {
+    component: IconWashingmachineFill,
+    name: 'WashingmachineFill',
+  },
+  {
+    component: IconWashingmachineLine,
+    name: 'WashingmachineLine',
+  },
+  {
+    component: IconWindow2StoreFill,
+    name: 'Window2StoreFill',
+  },
+  {
+    component: IconWindow2StoreLine,
+    name: 'Window2StoreLine',
+  },
+  {
+    component: IconWindow4HouseFill,
+    name: 'Window4HouseFill',
+  },
+  {
+    component: IconWindow4HouseLine,
+    name: 'Window4HouseLine',
+  },
   {
     component: IconWonArrowClockwiseCircularFill,
-    name: "WonArrowClockwiseCircularFill",
+    name: 'WonArrowClockwiseCircularFill',
   },
   {
     component: IconWonArrowClockwiseCircularLine,
-    name: "WonArrowClockwiseCircularLine",
+    name: 'WonArrowClockwiseCircularLine',
   },
-  { component: IconWonCircleArrowLeftFill, name: "WonCircleArrowLeftFill" },
-  { component: IconWonCircleArrowLeftLine, name: "WonCircleArrowLeftLine" },
-  { component: IconWonCircleArrowRightFill, name: "WonCircleArrowRightFill" },
-  { component: IconWonCircleArrowRightLine, name: "WonCircleArrowRightLine" },
-  { component: IconWonCircleFill, name: "WonCircleFill" },
-  { component: IconWonCircleLine, name: "WonCircleLine" },
-  { component: IconWonFill, name: "WonFill" },
-  { component: IconWonLine, name: "WonLine" },
-  { component: IconWonShieldFill, name: "WonShieldFill" },
-  { component: IconWonShieldLine, name: "WonShieldLine" },
-  { component: IconWrenchFill, name: "WrenchFill" },
-  { component: IconWrenchLine, name: "WrenchLine" },
-  { component: IconXmarkCircleFill, name: "XmarkCircleFill" },
-  { component: IconXmarkCircleLine, name: "XmarkCircleLine" },
-  { component: IconXmarkFill, name: "XmarkFill" },
-  { component: IconXmarkLine, name: "XmarkLine" },
-  { component: IconXmarkScaleFill, name: "XmarkScaleFill" },
-  { component: IconXmarkScaleLine, name: "XmarkScaleLine" },
-  { component: IconYenCircleArrowRightFill, name: "YenCircleArrowRightFill" },
-  { component: IconYenCircleArrowRightLine, name: "YenCircleArrowRightLine" },
-  { component: IconYenCircleFill, name: "YenCircleFill" },
-  { component: IconYenCircleLine, name: "YenCircleLine" },
-  { component: IconYenFill, name: "YenFill" },
-  { component: IconYenLine, name: "YenLine" },
+  {
+    component: IconWonCircleArrowLeftFill,
+    name: 'WonCircleArrowLeftFill',
+  },
+  {
+    component: IconWonCircleArrowLeftLine,
+    name: 'WonCircleArrowLeftLine',
+  },
+  {
+    component: IconWonCircleArrowRightFill,
+    name: 'WonCircleArrowRightFill',
+  },
+  {
+    component: IconWonCircleArrowRightLine,
+    name: 'WonCircleArrowRightLine',
+  },
+  {
+    component: IconWonCircleFill,
+    name: 'WonCircleFill',
+  },
+  {
+    component: IconWonCircleLine,
+    name: 'WonCircleLine',
+  },
+  {
+    component: IconWonFill,
+    name: 'WonFill',
+  },
+  {
+    component: IconWonLine,
+    name: 'WonLine',
+  },
+  {
+    component: IconWonShieldFill,
+    name: 'WonShieldFill',
+  },
+  {
+    component: IconWonShieldLine,
+    name: 'WonShieldLine',
+  },
+  {
+    component: IconWrenchFill,
+    name: 'WrenchFill',
+  },
+  {
+    component: IconWrenchLine,
+    name: 'WrenchLine',
+  },
+  {
+    component: IconXmarkCircleFill,
+    name: 'XmarkCircleFill',
+  },
+  {
+    component: IconXmarkCircleLine,
+    name: 'XmarkCircleLine',
+  },
+  {
+    component: IconXmarkFill,
+    name: 'XmarkFill',
+  },
+  {
+    component: IconXmarkLine,
+    name: 'XmarkLine',
+  },
+  {
+    component: IconXmarkScaleFill,
+    name: 'XmarkScaleFill',
+  },
+  {
+    component: IconXmarkScaleLine,
+    name: 'XmarkScaleLine',
+  },
+  {
+    component: IconYenCircleArrowRightFill,
+    name: 'YenCircleArrowRightFill',
+  },
+  {
+    component: IconYenCircleArrowRightLine,
+    name: 'YenCircleArrowRightLine',
+  },
+  {
+    component: IconYenCircleFill,
+    name: 'YenCircleFill',
+  },
+  {
+    component: IconYenCircleLine,
+    name: 'YenCircleLine',
+  },
+  {
+    component: IconYenFill,
+    name: 'YenFill',
+  },
+  {
+    component: IconYenLine,
+    name: 'YenLine',
+  },
 ];
 
 export function FoundationMonochromeIconPage() {
   return (
-    <scroll-view scroll-y style={{ display: "flex", flexDirection: "column", flex: 1 }}>
-      <text style={{ fontSize: "20px", fontWeight: "bold" }}>Monochrome Icon</text>
-      <text
-        style={{
-          fontSize: "13px",
-          color: $color.fg.neutralSubtle,
-          marginBottom: "8px",
-        }}
-      >
-        @karrotmarket/lynx-monochrome-icon — {icons.length} icons
-      </text>
-
-      <view
-        style={{
-          display: "flex",
-          flexDirection: "row",
-          flexWrap: "wrap",
-        }}
-      >
-        {icons.map(({ component: IconComp, name }) => (
-          <view
-            key={name}
-            style={{
-              width: "25%",
-              padding: "8px 4px",
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              gap: "4px",
-            }}
-          >
-            <IconComp size={24} color={$color.fg.neutral} />
-            <text
-              style={{
-                fontSize: "9px",
-                color: $color.fg.neutralMuted,
-                textAlign: "center",
-                wordBreak: "break-all",
-              }}
-            >
-              {name}
-            </text>
-          </view>
-        ))}
-      </view>
-    </scroll-view>
+    <VirtualIconGrid
+      title="Monochrome Icon"
+      packageName="@karrotmarket/lynx-monochrome-icon"
+      icons={icons}
+      iconColor={$color.fg.neutral}
+    />
   );
 }

--- a/examples/lynx-spa/src/pages/FoundationMulticolorIconPage.tsx
+++ b/examples/lynx-spa/src/pages/FoundationMulticolorIconPage.tsx
@@ -1,217 +1,413 @@
-import { vars } from "@seed-design/lynx-css/vars";
+import IconAnimalFace from '@karrotmarket/lynx-multicolor-icon/IconAnimalFace';
+import IconApple from '@karrotmarket/lynx-multicolor-icon/IconApple';
+import IconArrowUpRightShoppingbagTilted from '@karrotmarket/lynx-multicolor-icon/IconArrowUpRightShoppingbagTilted';
+import IconAsteriskHorizrectangleCoolwave3 from '@karrotmarket/lynx-multicolor-icon/IconAsteriskHorizrectangleCoolwave3';
+import IconBoxFlap from '@karrotmarket/lynx-multicolor-icon/IconBoxFlap';
+import IconBuilding2 from '@karrotmarket/lynx-multicolor-icon/IconBuilding2';
+import IconBuilding2Twosize from '@karrotmarket/lynx-multicolor-icon/IconBuilding2Twosize';
+import IconCamera from '@karrotmarket/lynx-multicolor-icon/IconCamera';
+import IconCard from '@karrotmarket/lynx-multicolor-icon/IconCard';
+import IconCarFrontside from '@karrotmarket/lynx-multicolor-icon/IconCarFrontside';
+import IconCarFrontsideBubble from '@karrotmarket/lynx-multicolor-icon/IconCarFrontsideBubble';
+import IconCart from '@karrotmarket/lynx-multicolor-icon/IconCart';
+import IconCartItems from '@karrotmarket/lynx-multicolor-icon/IconCartItems';
+import IconCartLoad from '@karrotmarket/lynx-multicolor-icon/IconCartLoad';
+import IconCheckmarkCalendar from '@karrotmarket/lynx-multicolor-icon/IconCheckmarkCalendar';
+import IconClover4 from '@karrotmarket/lynx-multicolor-icon/IconClover4';
+import IconCupcake from '@karrotmarket/lynx-multicolor-icon/IconCupcake';
+import IconCupHeatwave from '@karrotmarket/lynx-multicolor-icon/IconCupHeatwave';
+import IconCupTakeout from '@karrotmarket/lynx-multicolor-icon/IconCupTakeout';
+import IconDiamond from '@karrotmarket/lynx-multicolor-icon/IconDiamond';
+import IconDocumentSeal from '@karrotmarket/lynx-multicolor-icon/IconDocumentSeal';
+import IconDomePillar3 from '@karrotmarket/lynx-multicolor-icon/IconDomePillar3';
+import IconDonut from '@karrotmarket/lynx-multicolor-icon/IconDonut';
+import IconDuckLeftside from '@karrotmarket/lynx-multicolor-icon/IconDuckLeftside';
+import IconDumbbell from '@karrotmarket/lynx-multicolor-icon/IconDumbbell';
+import IconEnvelope from '@karrotmarket/lynx-multicolor-icon/IconEnvelope';
+import IconEyebrow from '@karrotmarket/lynx-multicolor-icon/IconEyebrow';
+import IconFaceSmileCircle from '@karrotmarket/lynx-multicolor-icon/IconFaceSmileCircle';
+import IconFigureWalk from '@karrotmarket/lynx-multicolor-icon/IconFigureWalk';
+import IconFishWave2 from '@karrotmarket/lynx-multicolor-icon/IconFishWave2';
+import IconForkSpoon from '@karrotmarket/lynx-multicolor-icon/IconForkSpoon';
+import IconForkSpoonBag from '@karrotmarket/lynx-multicolor-icon/IconForkSpoonBag';
+import IconFraction_1NUppercase from '@karrotmarket/lynx-multicolor-icon/IconFraction_1NUppercase';
+import IconGamepad from '@karrotmarket/lynx-multicolor-icon/IconGamepad';
+import IconGift from '@karrotmarket/lynx-multicolor-icon/IconGift';
+import IconGridDot5 from '@karrotmarket/lynx-multicolor-icon/IconGridDot5';
+import IconHandDrop from '@karrotmarket/lynx-multicolor-icon/IconHandDrop';
+import IconHorizlineViewfinder from '@karrotmarket/lynx-multicolor-icon/IconHorizlineViewfinder';
+import IconHospital from '@karrotmarket/lynx-multicolor-icon/IconHospital';
+import IconHouseCard from '@karrotmarket/lynx-multicolor-icon/IconHouseCard';
+import IconIcecreamcone from '@karrotmarket/lynx-multicolor-icon/IconIcecreamcone';
+import IconLinechartUpXaxis from '@karrotmarket/lynx-multicolor-icon/IconLinechartUpXaxis';
+import IconMagnifyingglass from '@karrotmarket/lynx-multicolor-icon/IconMagnifyingglass';
+import IconMask2SmileStacked from '@karrotmarket/lynx-multicolor-icon/IconMask2SmileStacked';
+import IconMegaphoneTilted from '@karrotmarket/lynx-multicolor-icon/IconMegaphoneTilted';
+import IconMonitor from '@karrotmarket/lynx-multicolor-icon/IconMonitor';
+import IconNailpolish from '@karrotmarket/lynx-multicolor-icon/IconNailpolish';
+import IconPaintroller from '@karrotmarket/lynx-multicolor-icon/IconPaintroller';
+import IconPalette from '@karrotmarket/lynx-multicolor-icon/IconPalette';
+import IconPencil from '@karrotmarket/lynx-multicolor-icon/IconPencil';
+import IconPercentArrowshapeDown from '@karrotmarket/lynx-multicolor-icon/IconPercentArrowshapeDown';
+import IconPerson2Openarms from '@karrotmarket/lynx-multicolor-icon/IconPerson2Openarms';
+import IconPersonMagnifyingglass from '@karrotmarket/lynx-multicolor-icon/IconPersonMagnifyingglass';
+import IconPizzaSlice from '@karrotmarket/lynx-multicolor-icon/IconPizzaSlice';
+import IconPlateCovered from '@karrotmarket/lynx-multicolor-icon/IconPlateCovered';
+import IconPost from '@karrotmarket/lynx-multicolor-icon/IconPost';
+import IconRocket from '@karrotmarket/lynx-multicolor-icon/IconRocket';
+import IconRoundmeatBottombone from '@karrotmarket/lynx-multicolor-icon/IconRoundmeatBottombone';
+import IconScissors from '@karrotmarket/lynx-multicolor-icon/IconScissors';
+import IconShoppingbag2Stacked from '@karrotmarket/lynx-multicolor-icon/IconShoppingbag2Stacked';
+import IconShoppingbagItems from '@karrotmarket/lynx-multicolor-icon/IconShoppingbagItems';
+import IconSneakerLiftedLeftside from '@karrotmarket/lynx-multicolor-icon/IconSneakerLiftedLeftside';
+import IconSofa from '@karrotmarket/lynx-multicolor-icon/IconSofa';
+import IconSparkle2 from '@karrotmarket/lynx-multicolor-icon/IconSparkle2';
+import IconSpraybottleSponge from '@karrotmarket/lynx-multicolor-icon/IconSpraybottleSponge';
+import IconTree from '@karrotmarket/lynx-multicolor-icon/IconTree';
+import IconTriangleRightChatbubbleLeft from '@karrotmarket/lynx-multicolor-icon/IconTriangleRightChatbubbleLeft';
+import IconTruck from '@karrotmarket/lynx-multicolor-icon/IconTruck';
+import IconTshirtBubble2 from '@karrotmarket/lynx-multicolor-icon/IconTshirtBubble2';
+import IconVertrectangleTiltedstacked from '@karrotmarket/lynx-multicolor-icon/IconVertrectangleTiltedstacked';
+import IconVestHorizstripe from '@karrotmarket/lynx-multicolor-icon/IconVestHorizstripe';
+import IconWandPlusCircle from '@karrotmarket/lynx-multicolor-icon/IconWandPlusCircle';
+import IconWarninglight from '@karrotmarket/lynx-multicolor-icon/IconWarninglight';
+import IconWindow2Store from '@karrotmarket/lynx-multicolor-icon/IconWindow2Store';
+import IconWindow2StoreDoubleband from '@karrotmarket/lynx-multicolor-icon/IconWindow2StoreDoubleband';
+import IconWindow4House from '@karrotmarket/lynx-multicolor-icon/IconWindow4House';
+import IconWonCircle from '@karrotmarket/lynx-multicolor-icon/IconWonCircle';
+import IconWonShield from '@karrotmarket/lynx-multicolor-icon/IconWonShield';
+import IconWrench from '@karrotmarket/lynx-multicolor-icon/IconWrench';
 
-import IconAnimalFace from "@karrotmarket/lynx-multicolor-icon/IconAnimalFace";
-import IconApple from "@karrotmarket/lynx-multicolor-icon/IconApple";
-import IconArrowUpRightShoppingbagTilted from "@karrotmarket/lynx-multicolor-icon/IconArrowUpRightShoppingbagTilted";
-import IconAsteriskHorizrectangleCoolwave3 from "@karrotmarket/lynx-multicolor-icon/IconAsteriskHorizrectangleCoolwave3";
-import IconBoxFlap from "@karrotmarket/lynx-multicolor-icon/IconBoxFlap";
-import IconBuilding2 from "@karrotmarket/lynx-multicolor-icon/IconBuilding2";
-import IconBuilding2Twosize from "@karrotmarket/lynx-multicolor-icon/IconBuilding2Twosize";
-import IconCamera from "@karrotmarket/lynx-multicolor-icon/IconCamera";
-import IconCarFrontside from "@karrotmarket/lynx-multicolor-icon/IconCarFrontside";
-import IconCarFrontsideBubble from "@karrotmarket/lynx-multicolor-icon/IconCarFrontsideBubble";
-import IconCard from "@karrotmarket/lynx-multicolor-icon/IconCard";
-import IconCart from "@karrotmarket/lynx-multicolor-icon/IconCart";
-import IconCartItems from "@karrotmarket/lynx-multicolor-icon/IconCartItems";
-import IconCartLoad from "@karrotmarket/lynx-multicolor-icon/IconCartLoad";
-import IconCheckmarkCalendar from "@karrotmarket/lynx-multicolor-icon/IconCheckmarkCalendar";
-import IconClover4 from "@karrotmarket/lynx-multicolor-icon/IconClover4";
-import IconCupHeatwave from "@karrotmarket/lynx-multicolor-icon/IconCupHeatwave";
-import IconDiamond from "@karrotmarket/lynx-multicolor-icon/IconDiamond";
-import IconDomePillar3 from "@karrotmarket/lynx-multicolor-icon/IconDomePillar3";
-import IconDonut from "@karrotmarket/lynx-multicolor-icon/IconDonut";
-import IconDuckLeftside from "@karrotmarket/lynx-multicolor-icon/IconDuckLeftside";
-import IconDumbbell from "@karrotmarket/lynx-multicolor-icon/IconDumbbell";
-import IconEnvelope from "@karrotmarket/lynx-multicolor-icon/IconEnvelope";
-import IconFaceSmileCircle from "@karrotmarket/lynx-multicolor-icon/IconFaceSmileCircle";
-import IconFigureWalk from "@karrotmarket/lynx-multicolor-icon/IconFigureWalk";
-import IconFishWave2 from "@karrotmarket/lynx-multicolor-icon/IconFishWave2";
-import IconForkSpoon from "@karrotmarket/lynx-multicolor-icon/IconForkSpoon";
-import IconForkSpoonBag from "@karrotmarket/lynx-multicolor-icon/IconForkSpoonBag";
-import IconFraction_1NUppercase from "@karrotmarket/lynx-multicolor-icon/IconFraction_1NUppercase";
-import IconGamepad from "@karrotmarket/lynx-multicolor-icon/IconGamepad";
-import IconGift from "@karrotmarket/lynx-multicolor-icon/IconGift";
-import IconGridDot5 from "@karrotmarket/lynx-multicolor-icon/IconGridDot5";
-import IconHorizlineViewfinder from "@karrotmarket/lynx-multicolor-icon/IconHorizlineViewfinder";
-import IconHospital from "@karrotmarket/lynx-multicolor-icon/IconHospital";
-import IconIcecreamcone from "@karrotmarket/lynx-multicolor-icon/IconIcecreamcone";
-import IconLinechartUpXaxis from "@karrotmarket/lynx-multicolor-icon/IconLinechartUpXaxis";
-import IconMagnifyingglass from "@karrotmarket/lynx-multicolor-icon/IconMagnifyingglass";
-import IconMask2SmileStacked from "@karrotmarket/lynx-multicolor-icon/IconMask2SmileStacked";
-import IconMegaphoneTilted from "@karrotmarket/lynx-multicolor-icon/IconMegaphoneTilted";
-import IconMonitor from "@karrotmarket/lynx-multicolor-icon/IconMonitor";
-import IconNailpolish from "@karrotmarket/lynx-multicolor-icon/IconNailpolish";
-import IconPaintroller from "@karrotmarket/lynx-multicolor-icon/IconPaintroller";
-import IconPalette from "@karrotmarket/lynx-multicolor-icon/IconPalette";
-import IconPencil from "@karrotmarket/lynx-multicolor-icon/IconPencil";
-import IconPerson2Openarms from "@karrotmarket/lynx-multicolor-icon/IconPerson2Openarms";
-import IconPersonMagnifyingglass from "@karrotmarket/lynx-multicolor-icon/IconPersonMagnifyingglass";
-import IconPizzaSlice from "@karrotmarket/lynx-multicolor-icon/IconPizzaSlice";
-import IconPlateCovered from "@karrotmarket/lynx-multicolor-icon/IconPlateCovered";
-import IconPost from "@karrotmarket/lynx-multicolor-icon/IconPost";
-import IconRocket from "@karrotmarket/lynx-multicolor-icon/IconRocket";
-import IconRoundmeatBottombone from "@karrotmarket/lynx-multicolor-icon/IconRoundmeatBottombone";
-import IconScissors from "@karrotmarket/lynx-multicolor-icon/IconScissors";
-import IconShoppingbag2Stacked from "@karrotmarket/lynx-multicolor-icon/IconShoppingbag2Stacked";
-import IconShoppingbagItems from "@karrotmarket/lynx-multicolor-icon/IconShoppingbagItems";
-import IconSneakerLiftedLeftside from "@karrotmarket/lynx-multicolor-icon/IconSneakerLiftedLeftside";
-import IconSofa from "@karrotmarket/lynx-multicolor-icon/IconSofa";
-import IconSparkle2 from "@karrotmarket/lynx-multicolor-icon/IconSparkle2";
-import IconSpraybottleSponge from "@karrotmarket/lynx-multicolor-icon/IconSpraybottleSponge";
-import IconTree from "@karrotmarket/lynx-multicolor-icon/IconTree";
-import IconTriangleRightChatbubbleLeft from "@karrotmarket/lynx-multicolor-icon/IconTriangleRightChatbubbleLeft";
-import IconTruck from "@karrotmarket/lynx-multicolor-icon/IconTruck";
-import IconTshirtBubble2 from "@karrotmarket/lynx-multicolor-icon/IconTshirtBubble2";
-import IconVertrectangleTiltedstacked from "@karrotmarket/lynx-multicolor-icon/IconVertrectangleTiltedstacked";
-import IconVestHorizstripe from "@karrotmarket/lynx-multicolor-icon/IconVestHorizstripe";
-import IconWarninglight from "@karrotmarket/lynx-multicolor-icon/IconWarninglight";
-import IconWindow2Store from "@karrotmarket/lynx-multicolor-icon/IconWindow2Store";
-import IconWindow2StoreDoubleband from "@karrotmarket/lynx-multicolor-icon/IconWindow2StoreDoubleband";
-import IconWindow4House from "@karrotmarket/lynx-multicolor-icon/IconWindow4House";
-import IconWonCircle from "@karrotmarket/lynx-multicolor-icon/IconWonCircle";
-import IconWonShield from "@karrotmarket/lynx-multicolor-icon/IconWonShield";
-import IconWrench from "@karrotmarket/lynx-multicolor-icon/IconWrench";
-
-const { $color } = vars;
-
-interface IconEntry {
-  component: React.ComponentType<{ size?: number; className?: string }>;
-  name: string;
-}
+import {
+  type IconEntry,
+  VirtualIconGrid,
+} from '../components/icon-virtual-grid.jsx';
 
 const icons: IconEntry[] = [
-  { component: IconAnimalFace, name: "AnimalFace" },
-  { component: IconApple, name: "Apple" },
+  {
+    component: IconAnimalFace,
+    name: 'AnimalFace',
+  },
+  {
+    component: IconApple,
+    name: 'Apple',
+  },
   {
     component: IconArrowUpRightShoppingbagTilted,
-    name: "ArrowUpRightShoppingbagTilted",
+    name: 'ArrowUpRightShoppingbagTilted',
   },
   {
     component: IconAsteriskHorizrectangleCoolwave3,
-    name: "AsteriskHorizrectangleCoolwave3",
+    name: 'AsteriskHorizrectangleCoolwave3',
   },
-  { component: IconBoxFlap, name: "BoxFlap" },
-  { component: IconBuilding2, name: "Building2" },
-  { component: IconBuilding2Twosize, name: "Building2Twosize" },
-  { component: IconCamera, name: "Camera" },
-  { component: IconCarFrontside, name: "CarFrontside" },
-  { component: IconCarFrontsideBubble, name: "CarFrontsideBubble" },
-  { component: IconCard, name: "Card" },
-  { component: IconCart, name: "Cart" },
-  { component: IconCartItems, name: "CartItems" },
-  { component: IconCartLoad, name: "CartLoad" },
-  { component: IconCheckmarkCalendar, name: "CheckmarkCalendar" },
-  { component: IconClover4, name: "Clover4" },
-  { component: IconCupHeatwave, name: "CupHeatwave" },
-  { component: IconDiamond, name: "Diamond" },
-  { component: IconDomePillar3, name: "DomePillar3" },
-  { component: IconDonut, name: "Donut" },
-  { component: IconDuckLeftside, name: "DuckLeftside" },
-  { component: IconDumbbell, name: "Dumbbell" },
-  { component: IconEnvelope, name: "Envelope" },
-  { component: IconFaceSmileCircle, name: "FaceSmileCircle" },
-  { component: IconFigureWalk, name: "FigureWalk" },
-  { component: IconFishWave2, name: "FishWave2" },
-  { component: IconForkSpoon, name: "ForkSpoon" },
-  { component: IconForkSpoonBag, name: "ForkSpoonBag" },
-  { component: IconFraction_1NUppercase, name: "Fraction_1NUppercase" },
-  { component: IconGamepad, name: "Gamepad" },
-  { component: IconGift, name: "Gift" },
-  { component: IconGridDot5, name: "GridDot5" },
-  { component: IconHorizlineViewfinder, name: "HorizlineViewfinder" },
-  { component: IconHospital, name: "Hospital" },
-  { component: IconIcecreamcone, name: "Icecreamcone" },
-  { component: IconLinechartUpXaxis, name: "LinechartUpXaxis" },
-  { component: IconMagnifyingglass, name: "Magnifyingglass" },
-  { component: IconMask2SmileStacked, name: "Mask2SmileStacked" },
-  { component: IconMegaphoneTilted, name: "MegaphoneTilted" },
-  { component: IconMonitor, name: "Monitor" },
-  { component: IconNailpolish, name: "Nailpolish" },
-  { component: IconPaintroller, name: "Paintroller" },
-  { component: IconPalette, name: "Palette" },
-  { component: IconPencil, name: "Pencil" },
-  { component: IconPerson2Openarms, name: "Person2Openarms" },
-  { component: IconPersonMagnifyingglass, name: "PersonMagnifyingglass" },
-  { component: IconPizzaSlice, name: "PizzaSlice" },
-  { component: IconPlateCovered, name: "PlateCovered" },
-  { component: IconPost, name: "Post" },
-  { component: IconRocket, name: "Rocket" },
-  { component: IconRoundmeatBottombone, name: "RoundmeatBottombone" },
-  { component: IconScissors, name: "Scissors" },
-  { component: IconShoppingbag2Stacked, name: "Shoppingbag2Stacked" },
-  { component: IconShoppingbagItems, name: "ShoppingbagItems" },
-  { component: IconSneakerLiftedLeftside, name: "SneakerLiftedLeftside" },
-  { component: IconSofa, name: "Sofa" },
-  { component: IconSparkle2, name: "Sparkle2" },
-  { component: IconSpraybottleSponge, name: "SpraybottleSponge" },
-  { component: IconTree, name: "Tree" },
+  {
+    component: IconBoxFlap,
+    name: 'BoxFlap',
+  },
+  {
+    component: IconBuilding2,
+    name: 'Building2',
+  },
+  {
+    component: IconBuilding2Twosize,
+    name: 'Building2Twosize',
+  },
+  {
+    component: IconCamera,
+    name: 'Camera',
+  },
+  {
+    component: IconCard,
+    name: 'Card',
+  },
+  {
+    component: IconCarFrontside,
+    name: 'CarFrontside',
+  },
+  {
+    component: IconCarFrontsideBubble,
+    name: 'CarFrontsideBubble',
+  },
+  {
+    component: IconCart,
+    name: 'Cart',
+  },
+  {
+    component: IconCartItems,
+    name: 'CartItems',
+  },
+  {
+    component: IconCartLoad,
+    name: 'CartLoad',
+  },
+  {
+    component: IconCheckmarkCalendar,
+    name: 'CheckmarkCalendar',
+  },
+  {
+    component: IconClover4,
+    name: 'Clover4',
+  },
+  {
+    component: IconCupcake,
+    name: 'Cupcake',
+  },
+  {
+    component: IconCupHeatwave,
+    name: 'CupHeatwave',
+  },
+  {
+    component: IconCupTakeout,
+    name: 'CupTakeout',
+  },
+  {
+    component: IconDiamond,
+    name: 'Diamond',
+  },
+  {
+    component: IconDocumentSeal,
+    name: 'DocumentSeal',
+  },
+  {
+    component: IconDomePillar3,
+    name: 'DomePillar3',
+  },
+  {
+    component: IconDonut,
+    name: 'Donut',
+  },
+  {
+    component: IconDuckLeftside,
+    name: 'DuckLeftside',
+  },
+  {
+    component: IconDumbbell,
+    name: 'Dumbbell',
+  },
+  {
+    component: IconEnvelope,
+    name: 'Envelope',
+  },
+  {
+    component: IconEyebrow,
+    name: 'Eyebrow',
+  },
+  {
+    component: IconFaceSmileCircle,
+    name: 'FaceSmileCircle',
+  },
+  {
+    component: IconFigureWalk,
+    name: 'FigureWalk',
+  },
+  {
+    component: IconFishWave2,
+    name: 'FishWave2',
+  },
+  {
+    component: IconForkSpoon,
+    name: 'ForkSpoon',
+  },
+  {
+    component: IconForkSpoonBag,
+    name: 'ForkSpoonBag',
+  },
+  {
+    component: IconFraction_1NUppercase,
+    name: 'Fraction_1NUppercase',
+  },
+  {
+    component: IconGamepad,
+    name: 'Gamepad',
+  },
+  {
+    component: IconGift,
+    name: 'Gift',
+  },
+  {
+    component: IconGridDot5,
+    name: 'GridDot5',
+  },
+  {
+    component: IconHandDrop,
+    name: 'HandDrop',
+  },
+  {
+    component: IconHorizlineViewfinder,
+    name: 'HorizlineViewfinder',
+  },
+  {
+    component: IconHospital,
+    name: 'Hospital',
+  },
+  {
+    component: IconHouseCard,
+    name: 'HouseCard',
+  },
+  {
+    component: IconIcecreamcone,
+    name: 'Icecreamcone',
+  },
+  {
+    component: IconLinechartUpXaxis,
+    name: 'LinechartUpXaxis',
+  },
+  {
+    component: IconMagnifyingglass,
+    name: 'Magnifyingglass',
+  },
+  {
+    component: IconMask2SmileStacked,
+    name: 'Mask2SmileStacked',
+  },
+  {
+    component: IconMegaphoneTilted,
+    name: 'MegaphoneTilted',
+  },
+  {
+    component: IconMonitor,
+    name: 'Monitor',
+  },
+  {
+    component: IconNailpolish,
+    name: 'Nailpolish',
+  },
+  {
+    component: IconPaintroller,
+    name: 'Paintroller',
+  },
+  {
+    component: IconPalette,
+    name: 'Palette',
+  },
+  {
+    component: IconPencil,
+    name: 'Pencil',
+  },
+  {
+    component: IconPercentArrowshapeDown,
+    name: 'PercentArrowshapeDown',
+  },
+  {
+    component: IconPerson2Openarms,
+    name: 'Person2Openarms',
+  },
+  {
+    component: IconPersonMagnifyingglass,
+    name: 'PersonMagnifyingglass',
+  },
+  {
+    component: IconPizzaSlice,
+    name: 'PizzaSlice',
+  },
+  {
+    component: IconPlateCovered,
+    name: 'PlateCovered',
+  },
+  {
+    component: IconPost,
+    name: 'Post',
+  },
+  {
+    component: IconRocket,
+    name: 'Rocket',
+  },
+  {
+    component: IconRoundmeatBottombone,
+    name: 'RoundmeatBottombone',
+  },
+  {
+    component: IconScissors,
+    name: 'Scissors',
+  },
+  {
+    component: IconShoppingbag2Stacked,
+    name: 'Shoppingbag2Stacked',
+  },
+  {
+    component: IconShoppingbagItems,
+    name: 'ShoppingbagItems',
+  },
+  {
+    component: IconSneakerLiftedLeftside,
+    name: 'SneakerLiftedLeftside',
+  },
+  {
+    component: IconSofa,
+    name: 'Sofa',
+  },
+  {
+    component: IconSparkle2,
+    name: 'Sparkle2',
+  },
+  {
+    component: IconSpraybottleSponge,
+    name: 'SpraybottleSponge',
+  },
+  {
+    component: IconTree,
+    name: 'Tree',
+  },
   {
     component: IconTriangleRightChatbubbleLeft,
-    name: "TriangleRightChatbubbleLeft",
+    name: 'TriangleRightChatbubbleLeft',
   },
-  { component: IconTruck, name: "Truck" },
-  { component: IconTshirtBubble2, name: "TshirtBubble2" },
+  {
+    component: IconTruck,
+    name: 'Truck',
+  },
+  {
+    component: IconTshirtBubble2,
+    name: 'TshirtBubble2',
+  },
   {
     component: IconVertrectangleTiltedstacked,
-    name: "VertrectangleTiltedstacked",
+    name: 'VertrectangleTiltedstacked',
   },
-  { component: IconVestHorizstripe, name: "VestHorizstripe" },
-  { component: IconWarninglight, name: "Warninglight" },
-  { component: IconWindow2Store, name: "Window2Store" },
-  { component: IconWindow2StoreDoubleband, name: "Window2StoreDoubleband" },
-  { component: IconWindow4House, name: "Window4House" },
-  { component: IconWonCircle, name: "WonCircle" },
-  { component: IconWonShield, name: "WonShield" },
-  { component: IconWrench, name: "Wrench" },
+  {
+    component: IconVestHorizstripe,
+    name: 'VestHorizstripe',
+  },
+  {
+    component: IconWandPlusCircle,
+    name: 'WandPlusCircle',
+  },
+  {
+    component: IconWarninglight,
+    name: 'Warninglight',
+  },
+  {
+    component: IconWindow2Store,
+    name: 'Window2Store',
+  },
+  {
+    component: IconWindow2StoreDoubleband,
+    name: 'Window2StoreDoubleband',
+  },
+  {
+    component: IconWindow4House,
+    name: 'Window4House',
+  },
+  {
+    component: IconWonCircle,
+    name: 'WonCircle',
+  },
+  {
+    component: IconWonShield,
+    name: 'WonShield',
+  },
+  {
+    component: IconWrench,
+    name: 'Wrench',
+  },
 ];
 
 export function FoundationMulticolorIconPage() {
   return (
-    <scroll-view scroll-y style={{ display: "flex", flexDirection: "column", flex: 1 }}>
-      <text style={{ fontSize: "20px", fontWeight: "bold" }}>Multicolor Icon</text>
-      <text
-        style={{
-          fontSize: "13px",
-          color: $color.fg.neutralSubtle,
-          marginBottom: "8px",
-        }}
-      >
-        @karrotmarket/lynx-multicolor-icon — {icons.length} icons
-      </text>
-
-      <view
-        style={{
-          display: "flex",
-          flexDirection: "row",
-          flexWrap: "wrap",
-        }}
-      >
-        {icons.map(({ component: IconComp, name }) => (
-          <view
-            key={name}
-            style={{
-              width: "25%",
-              padding: "8px 4px",
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              gap: "4px",
-            }}
-          >
-            <IconComp size={24} />
-            <text
-              style={{
-                fontSize: "9px",
-                color: $color.fg.neutralMuted,
-                textAlign: "center",
-                wordBreak: "break-all",
-              }}
-            >
-              {name}
-            </text>
-          </view>
-        ))}
-      </view>
-    </scroll-view>
+    <VirtualIconGrid
+      title="Multicolor Icon"
+      packageName="@karrotmarket/lynx-multicolor-icon"
+      icons={icons}
+    />
   );
 }


### PR DESCRIPTION
## Summary

- Apply Lynx `<list>` / `<list-item>` virtualization to the Monochrome Icon and Multicolor Icon pages in `examples/lynx-spa`
- Lazy-load the two heavy icon catalog pages from `App.tsx` and let them own their fullscreen scroll area
- Update `generate-icon-pages.js` so regenerated icon catalog pages use the shared virtual grid

## Validation

- Pass: `bun --filter lynx-spa generate:icons`
- Pass: `../../node_modules/.bin/biome check scripts/generate-icon-pages.js src/App.tsx src/components/icon-virtual-grid.tsx src/pages/FoundationMonochromeIconPage.tsx src/pages/FoundationMulticolorIconPage.tsx`
- Pass: `git diff --check`
- Failed: `bun generate:all` failed at `@seed-design/lynx-css qvism:generate` because `@seed-design/postcss-lynx-compat/lib/index.js` was missing from `packages/qvism-preset/node_modules`
- Failed: `bun --filter lynx-spa test` failed while collecting tests with `SyntaxError: Unexpected token '<'` from raw JSX in installed Lynx icon package output
- Failed: `bun --filter lynx-spa build` failed on existing `@seed-design/lynx-react` module resolution and `TagGroup*` export issues

## Notes

- Generated icon page counts after refresh: monochrome 646 icons, multicolor 79 icons.
