### PR TITLE
fix(lynx-react): restart progress circle animation on size change

### DIFF
--- a/.changeset/gentle-rings-spin.md
+++ b/.changeset/gentle-rings-spin.md
@@ -1,0 +1,7 @@
+---
+"@seed-design/lynx-react": patch
+---
+
+Lynx `ProgressCircle`에서 `size` 변경이 애니메이션에 즉시 반영되도록 수정합니다.
+
+- 같은 `ProgressCircle` 인스턴스에서 `size`가 변경될 때 이전 크기의 애니메이션 geometry가 남지 않도록 개선합니다.

--- a/packages/lynx-react/src/components/ProgressCircle/ProgressCircle.tsx
+++ b/packages/lynx-react/src/components/ProgressCircle/ProgressCircle.tsx
@@ -1,4 +1,4 @@
-import * as React from "@lynx-js/react";
+import type * as React from "@lynx-js/react";
 import {
   createContext,
   runOnMainThread,
@@ -261,7 +261,7 @@ function DeterminateRange({
     return () => {
       runOnMainThread(cancelAnimation)();
     };
-  }, [progress]);
+  }, [progress, numSize]);
 
   return (
     <>
@@ -357,7 +357,7 @@ function IndeterminateRange({ numSize, classes }: { numSize: number; classes: Cl
     return () => {
       runOnMainThread(stopLoop)();
     };
-  }, []);
+  }, [numSize]);
 
   const initialClipPath = 'path("M 0 0 Z")';
 

--- a/packages/lynx-react/src/components/__tests__/ProgressCircle.test.ts
+++ b/packages/lynx-react/src/components/__tests__/ProgressCircle.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const progressCircleSource = readFileSync(
+  join(currentDir, "..", "ProgressCircle", "ProgressCircle.tsx"),
+  "utf8",
+);
+
+function readEffectDependencies(marker: string): string {
+  const markerIndex = progressCircleSource.indexOf(marker);
+  expect(markerIndex).toBeGreaterThanOrEqual(0);
+
+  const dependencyStart = progressCircleSource.indexOf("}, [", markerIndex);
+  expect(dependencyStart).toBeGreaterThanOrEqual(0);
+
+  const dependencyEnd = progressCircleSource.indexOf("]);", dependencyStart);
+  expect(dependencyEnd).toBeGreaterThanOrEqual(0);
+
+  return progressCircleSource.slice(dependencyStart, dependencyEnd);
+}
+
+describe("ProgressCircle", () => {
+  it("restarts indeterminate animation when size changes", () => {
+    expect(readEffectDependencies("runOnMainThread(startLoop)")).toContain("numSize");
+  });
+
+  it("restarts determinate transition when size changes", () => {
+    expect(readEffectDependencies("runOnMainThread(startAnimation)")).toContain("numSize");
+  });
+});


### PR DESCRIPTION
## Summary
- Restart ProgressCircle main-thread effects when the size prop changes.
- Keep the public ProgressCircle API unchanged.
- Add regression coverage for determinate and indeterminate size dependency handling.

## Root Cause
The Lynx ProgressCircle animation effects captured geometry from the previous numSize. When the same component instance changed size, the RAF loop or transition could keep using stale geometry unless the component remounted.

## Validation
- bun biome check packages/lynx-react/src/components/ProgressCircle/ProgressCircle.tsx packages/lynx-react/src/components/__tests__/ProgressCircle.test.ts
- bun --filter @seed-design/lynx-react test
- bun --filter lynx-spa build
- bun ecosystem:build
- bun packages:build
- bun generate:all

## Notes
- bun --filter lynx-spa test was blocked before test collection by a missing preact package from @lynx-js/internal-preact.
- bun test:all still fails from an existing broader workspace test issue outside this change.