### PR TITLE
fix(rsbuild-plugin): allow @rsbuild/core v1.1 and v2 in peer range

### DIFF
--- a/.changeset/wide-rangers-allow.md
+++ b/.changeset/wide-rangers-allow.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/rsbuild-plugin": patch
+---
+
+`@rsbuild/core` peerDependency 범위를 확장하여 rsbuild v1.1과 v2를 모두 지원합니다.

--- a/bun.lock
+++ b/bun.lock
@@ -981,7 +981,7 @@
         "@seed-design/css": "^1.1.0",
       },
       "peerDependencies": {
-        "@rsbuild/core": "^2.0.0",
+        "@rsbuild/core": "^1.1.0 || ^2.0.0",
         "@seed-design/css": "^1.1.0",
       },
     },

--- a/packages/rsbuild-plugin/package.json
+++ b/packages/rsbuild-plugin/package.json
@@ -39,7 +39,7 @@
     "@seed-design/css": "^1.1.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "^2.0.0",
+    "@rsbuild/core": "^1.1.0 || ^2.0.0",
     "@seed-design/css": "^1.1.0"
   },
   "publishConfig": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * `@seed-design/rsbuild-plugin`의 호환성을 확장하여 rsbuild v1.1과 v2를 모두 지원하도록 업데이트했습니다. 사용자들은 더 넓은 범위의 rsbuild 버전과 호환되는 플러그인을 사용할 수 있습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daangn/seed-design/pull/1574)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->