### PR TITLE
feat(lynx-spa): show preview state overlay

### DIFF
--- a/examples/lynx-spa/src/components/variant-catalog.tsx
+++ b/examples/lynx-spa/src/components/variant-catalog.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useState } from '@lynx-js/react';
 
 import {
+  getPreviewStateDefaultValues,
   type SetVariantValue,
   VariantPlayground,
   type VariantPlaygroundProps,
@@ -9,6 +10,7 @@ import {
 import { VariantTable } from './variant-table.jsx';
 
 export type {
+  PreviewState,
   PrimitiveValue,
   SetVariantValue,
   VariantAxis,
@@ -31,7 +33,7 @@ export interface VariantCatalogProps extends VariantPlaygroundProps {
  * 두 모드 모두 같은 `children` render function 을 공유한다.
  */
 export function VariantCatalog(props: VariantCatalogProps) {
-  const { children, variants, examples } = props;
+  const { children, variants, previewStates, examples } = props;
   const [mode, setMode] = useState<Mode>('playground');
   const tabs: Mode[] =
     examples == null
@@ -70,10 +72,12 @@ export function VariantCatalog(props: VariantCatalogProps) {
         ))}
       </view>
       {mode === 'playground' ? (
-        <VariantPlayground variants={variants}>{children}</VariantPlayground>
+        <VariantPlayground variants={variants} previewStates={previewStates}>
+          {children}
+        </VariantPlayground>
       ) : mode === 'table' ? (
         <VariantTable variants={variants}>
-          {(values) => renderForTable(children, values)}
+          {(values) => renderForTable(children, values, previewStates)}
         </VariantTable>
       ) : (
         <view style={{ flex: 1, minHeight: 0 }}>{examples}</view>
@@ -86,8 +90,12 @@ const noopSetValue: SetVariantValue = () => {};
 function renderForTable(
   children: VariantPlaygroundProps['children'],
   values: VariantValues,
+  previewStates: VariantPlaygroundProps['previewStates'],
 ): ReactNode {
-  return children(values, noopSetValue);
+  return children(
+    { ...getPreviewStateDefaultValues(previewStates), ...values },
+    noopSetValue,
+  );
 }
 
 function toTabLabel(mode: Mode) {

--- a/examples/lynx-spa/src/components/variant-playground.tsx
+++ b/examples/lynx-spa/src/components/variant-playground.tsx
@@ -11,12 +11,23 @@ export interface VariantAxis {
   defaultValue: PrimitiveValue;
 }
 
+export interface PreviewState {
+  key: string;
+  label?: string;
+  defaultValue: PrimitiveValue;
+}
+
 export interface VariantPlaygroundProps {
   /**
    * Public하게 조작 가능한 variant 축만 넘긴다. recipe에는 있어도 컴포넌트 prop으로
    * 고정할 수 없는 상태(예: pressed)는 포함하지 않는다.
    */
   variants: readonly VariantAxis[];
+  /**
+   * Preview 오른쪽 아래에 표시할 controlled state 값.
+   * variant control에는 없어도 preview에서 setValue로 갱신할 수 있다.
+   */
+  previewStates?: readonly PreviewState[];
   /**
    * preview 영역. 현재 값 스냅샷과 setter 를 받아 실제 컴포넌트를 렌더한다.
    * setter 는 controlled state (예: `checked`) 를 playground 로 되돌릴 때 사용.
@@ -42,15 +53,50 @@ export function getVariantDefaultValues(
   return result;
 }
 
+export function getPreviewStateDefaultValues(
+  previewStates: readonly PreviewState[] = [],
+): VariantValues {
+  const result: VariantValues = {};
+  for (const state of previewStates) {
+    result[state.key] = state.defaultValue;
+  }
+  return result;
+}
+
+function getDefaultValues(
+  variants: readonly VariantAxis[],
+  previewStates: readonly PreviewState[] = [],
+): VariantValues {
+  return {
+    ...getVariantDefaultValues(variants),
+    ...getPreviewStateDefaultValues(previewStates),
+  };
+}
+
+function getPreviewStateText(
+  previewStates: readonly PreviewState[] = [],
+  values: VariantValues,
+) {
+  if (previewStates.length === 0) return null;
+
+  return previewStates
+    .map((state) => {
+      const value = values[state.key] ?? state.defaultValue;
+      return `${state.label ?? state.key}=${toLabel(value)}`;
+    })
+    .join(' · ');
+}
+
 export function VariantPlayground(props: VariantPlaygroundProps) {
-  const { variants, children } = props;
+  const { variants, previewStates, children } = props;
 
   const defaultValues = useMemo(
-    () => getVariantDefaultValues(variants),
-    [variants],
+    () => getDefaultValues(variants, previewStates),
+    [variants, previewStates],
   );
 
   const [values, setValues] = useState<VariantValues>(() => defaultValues);
+  const previewStateText = getPreviewStateText(previewStates, values);
 
   const setValue = (key: string, value: PrimitiveValue) => {
     setValues((prev) =>
@@ -76,9 +122,29 @@ export function VariantPlayground(props: VariantPlaygroundProps) {
           justifyContent: 'center',
           padding: '16px',
           overflow: 'hidden',
+          position: 'relative',
         }}
       >
         {children(values, setValue)}
+        {previewStateText != null && (
+          <view
+            style={{
+              position: 'absolute',
+              right: '8px',
+              bottom: '8px',
+            }}
+          >
+            <text
+              style={{
+                fontSize: '10px',
+                lineHeight: '12px',
+                color: '#888',
+              }}
+            >
+              {previewStateText}
+            </text>
+          </view>
+        )}
       </view>
 
       {/* Controls: fixed to the bottom with its own scroll area. */}

--- a/examples/lynx-spa/src/components/variant-playground.vitest.tsx
+++ b/examples/lynx-spa/src/components/variant-playground.vitest.tsx
@@ -1,0 +1,62 @@
+/** @jsxImportSource @lynx-js/react */
+import '@testing-library/jest-dom';
+import { fireEvent, render } from '@lynx-js/react/testing-library';
+import { expect, test } from 'vitest';
+
+import {
+  VariantPlayground,
+  type PreviewState,
+  type VariantAxis,
+} from './variant-playground.jsx';
+
+const booleanVariants: readonly VariantAxis[] = [
+  {
+    key: 'checked',
+    options: [false, true],
+    defaultValue: false,
+  },
+];
+
+test('VariantPlayground renders preview state text', async () => {
+  const previewStates: readonly PreviewState[] = [
+    { key: 'checked', defaultValue: false },
+    { key: 'open', defaultValue: false },
+  ];
+
+  const { findByText } = render(
+    <VariantPlayground variants={booleanVariants} previewStates={previewStates}>
+      {(values) => <text>{String(values.checked)}</text>}
+    </VariantPlayground>,
+  );
+
+  expect(await findByText('checked=false · open=false')).toBeInTheDocument();
+});
+
+test('VariantPlayground updates hidden preview state from child render function', async () => {
+  const previewStates: readonly PreviewState[] = [
+    { key: 'open', defaultValue: false },
+  ];
+
+  const { findByText } = render(
+    <VariantPlayground variants={[]} previewStates={previewStates}>
+      {(_values, setValue) => (
+        <view bindtap={() => setValue('open', true)}>
+          <text>Toggle open</text>
+        </view>
+      )}
+    </VariantPlayground>,
+  );
+
+  expect(await findByText('open=false')).toBeInTheDocument();
+
+  const triggerText = (await findByText('Toggle open')) as HTMLElement;
+  if (triggerText.parentElement == null) {
+    throw new Error(
+      'Expected trigger text to be rendered inside a tappable view.',
+    );
+  }
+
+  fireEvent.tap(triggerText.parentElement);
+
+  expect(await findByText('open=true')).toBeInTheDocument();
+});

--- a/examples/lynx-spa/src/pages/ActionButtonPage.tsx
+++ b/examples/lynx-spa/src/pages/ActionButtonPage.tsx
@@ -8,6 +8,7 @@ import {
   CatalogSectionTitle,
 } from '../components/catalog-examples.jsx';
 import {
+  type PreviewState,
   type VariantAxis,
   VariantCatalog,
   type VariantValues,
@@ -43,6 +44,11 @@ const variants: readonly VariantAxis[] = [
     options: actionButtonVariantMap.loading,
     defaultValue: false,
   },
+];
+
+const previewStates: readonly PreviewState[] = [
+  { key: 'disabled', defaultValue: false },
+  { key: 'loading', defaultValue: false },
 ];
 
 function renderActionButton(values: VariantValues) {
@@ -245,7 +251,11 @@ function ActionButtonExamples() {
 
 export function ActionButtonPage() {
   return (
-    <VariantCatalog variants={variants} examples={<ActionButtonExamples />}>
+    <VariantCatalog
+      variants={variants}
+      previewStates={previewStates}
+      examples={<ActionButtonExamples />}
+    >
       {(values) => renderActionButton(values)}
     </VariantCatalog>
   );

--- a/examples/lynx-spa/src/pages/BottomSheetPage.tsx
+++ b/examples/lynx-spa/src/pages/BottomSheetPage.tsx
@@ -7,6 +7,8 @@ import {
   CatalogSectionTitle,
 } from '../components/catalog-examples.jsx';
 import {
+  type PreviewState,
+  type SetVariantValue,
   type VariantAxis,
   VariantCatalog,
   type VariantValues,
@@ -38,17 +40,27 @@ const variants: readonly VariantAxis[] = [
   },
 ];
 
-function renderBottomSheet(values: VariantValues) {
+const previewStates: readonly PreviewState[] = [
+  { key: 'open', defaultValue: false },
+];
+
+function renderBottomSheet(values: VariantValues, setValue: SetVariantValue) {
   const headerAlign = values.headerAlign as BottomSheetHeaderAlign;
   const skipAnimation = Boolean(values.skipAnimation);
+  const open = Boolean(values.open);
 
   return (
     <BottomSheetRoot
       headerAlign={headerAlign}
       skipAnimation={skipAnimation}
+      open={open}
+      onOpenChange={(next) => setValue('open', next)}
       snapPoints={SNAP_POINTS_FIT_80}
     >
-      <BottomSheetTrigger style={{ alignSelf: 'flex-start' }}>
+      <BottomSheetTrigger
+        style={{ alignSelf: 'flex-start' }}
+        bindtap={() => setValue('open', true)}
+      >
         <ActionButton variant="brandSolid">Open sheet</ActionButton>
       </BottomSheetTrigger>
       <BottomSheetContent
@@ -147,8 +159,12 @@ function BottomSheetExamples() {
 
 export function BottomSheetPage() {
   return (
-    <VariantCatalog variants={variants} examples={<BottomSheetExamples />}>
-      {(values) => renderBottomSheet(values)}
+    <VariantCatalog
+      variants={variants}
+      previewStates={previewStates}
+      examples={<BottomSheetExamples />}
+    >
+      {(values, setValue) => renderBottomSheet(values, setValue)}
     </VariantCatalog>
   );
 }

--- a/examples/lynx-spa/src/pages/CheckboxPage.tsx
+++ b/examples/lynx-spa/src/pages/CheckboxPage.tsx
@@ -2,6 +2,7 @@ import { checkboxVariantMap } from '@seed-design/lynx-css/recipes/checkbox';
 import { checkmarkVariantMap } from '@seed-design/lynx-css/recipes/checkmark';
 
 import {
+  type PreviewState,
   VariantCatalog,
   type SetVariantValue,
   type VariantAxis,
@@ -52,6 +53,12 @@ const variants: readonly VariantAxis[] = [
   },
 ];
 
+const previewStates: readonly PreviewState[] = [
+  { key: 'checked', defaultValue: false },
+  { key: 'indeterminate', defaultValue: false },
+  { key: 'disabled', defaultValue: false },
+];
+
 function renderCheckbox(values: VariantValues, setValue: SetVariantValue) {
   return (
     <Checkbox
@@ -70,7 +77,7 @@ function renderCheckbox(values: VariantValues, setValue: SetVariantValue) {
 
 export function CheckboxPage() {
   return (
-    <VariantCatalog variants={variants}>
+    <VariantCatalog variants={variants} previewStates={previewStates}>
       {(values, setValue) => renderCheckbox(values, setValue)}
     </VariantCatalog>
   );

--- a/examples/lynx-spa/src/pages/ProgressCirclePage.tsx
+++ b/examples/lynx-spa/src/pages/ProgressCirclePage.tsx
@@ -7,6 +7,7 @@ import {
 } from '../components/catalog-examples.jsx';
 import {
   VariantCatalog,
+  type PreviewState,
   type VariantAxis,
   type VariantValues,
 } from '../components/variant-catalog.jsx';
@@ -46,6 +47,10 @@ const variants: readonly VariantAxis[] = [
     options: ['indeterminate', '25%', '50%', '75%', '100%'],
     defaultValue: 'indeterminate',
   },
+];
+
+const previewStates: readonly PreviewState[] = [
+  { key: 'progressState', label: 'value', defaultValue: 'indeterminate' },
 ];
 
 function renderProgressCircle(values: VariantValues) {
@@ -260,7 +265,11 @@ function ProgressCircleExamples() {
 
 export function ProgressCirclePage() {
   return (
-    <VariantCatalog variants={variants} examples={<ProgressCircleExamples />}>
+    <VariantCatalog
+      variants={variants}
+      previewStates={previewStates}
+      examples={<ProgressCircleExamples />}
+    >
       {(values) => renderProgressCircle(values)}
     </VariantCatalog>
   );

--- a/examples/lynx-spa/src/pages/RadioGroupPage.tsx
+++ b/examples/lynx-spa/src/pages/RadioGroupPage.tsx
@@ -2,6 +2,8 @@ import { radioVariantMap } from '@seed-design/lynx-css/recipes/radio';
 import { radiomarkVariantMap } from '@seed-design/lynx-css/recipes/radiomark';
 
 import {
+  type PreviewState,
+  type SetVariantValue,
   VariantCatalog,
   type VariantAxis,
   type VariantValues,
@@ -39,14 +41,21 @@ const variants: readonly VariantAxis[] = [
   },
 ];
 
-function renderRadioGroup(values: VariantValues) {
+const previewStates: readonly PreviewState[] = [
+  { key: 'value', defaultValue: 'option1' },
+];
+
+function renderRadioGroup(values: VariantValues, setValue: SetVariantValue) {
+  const selectedValue = values.value as string;
+
   return (
     <RadioGroup
       weight={values.weight as RadioWeight}
       size={values.size as RadioSize}
       tone={values.tone as RadioTone}
       disabled={Boolean(values.disabled)}
-      defaultValue="option1"
+      value={selectedValue}
+      onValueChange={(next) => setValue('value', next)}
     >
       {['option1', 'option2', 'option3'].map((value) => (
         <Radio
@@ -61,8 +70,8 @@ function renderRadioGroup(values: VariantValues) {
 
 export function RadioGroupPage() {
   return (
-    <VariantCatalog variants={variants}>
-      {(values) => renderRadioGroup(values)}
+    <VariantCatalog variants={variants} previewStates={previewStates}>
+      {(values, setValue) => renderRadioGroup(values, setValue)}
     </VariantCatalog>
   );
 }

--- a/examples/lynx-spa/src/pages/SwitchPage.tsx
+++ b/examples/lynx-spa/src/pages/SwitchPage.tsx
@@ -14,6 +14,7 @@ import {
 } from '../components/catalog-examples.jsx';
 import {
   VariantCatalog,
+  type PreviewState,
   type SetVariantValue,
   type VariantAxis,
   type VariantValues,
@@ -44,6 +45,11 @@ const variants: readonly VariantAxis[] = [
     options: switchVariantMap.disabled,
     defaultValue: false,
   },
+];
+
+const previewStates: readonly PreviewState[] = [
+  { key: 'checked', defaultValue: false },
+  { key: 'disabled', defaultValue: false },
 ];
 
 function renderSwitch(values: VariantValues, setValue: SetVariantValue) {
@@ -155,7 +161,11 @@ function SwitchExamples() {
 
 export function SwitchPage() {
   return (
-    <VariantCatalog variants={variants} examples={<SwitchExamples />}>
+    <VariantCatalog
+      variants={variants}
+      previewStates={previewStates}
+      examples={<SwitchExamples />}
+    >
       {(values, setValue) => renderSwitch(values, setValue)}
     </VariantCatalog>
   );

--- a/examples/lynx-spa/vitest.config.ts
+++ b/examples/lynx-spa/vitest.config.ts
@@ -3,7 +3,9 @@ import { createVitestConfig } from '@lynx-js/react/testing-library/vitest-config
 
 const defaultConfig = await createVitestConfig();
 const config = defineConfig({
-  test: {},
+  test: {
+    include: ['src/**/*.test.{ts,tsx}', 'src/**/*.vitest.{ts,tsx}'],
+  },
 });
 
 export default mergeConfig(defaultConfig, config);


### PR DESCRIPTION
## Summary
- Add a small gray preview-state overlay to the Lynx SPA Playground preview area.
- Track hidden preview state values such as RadioGroup `value` and BottomSheet `open` through the existing render function setter.
- Wire controllable state labels for ActionButton, Checkbox, Switch, RadioGroup, BottomSheet, and ProgressCircle while leaving TagGroup without an overlay.

## Validation
- PASS: `bun --filter lynx-spa build`
- PASS: `bun --filter lynx-spa test src/components/variant-playground.vitest.tsx`
- FAIL: `bun --filter lynx-spa test` fails in existing `src/__tests__/index.test.tsx` with `SyntaxError: Unexpected token '<'`
- FAIL: `bun generate:all` fails in qvism step with `@seed-design/css qvism:generate: error: Script not found "qvism"`
- FAIL: `bun test:all` fails on existing repo-wide module resolution issues such as `react/jsx-dev-runtime` and `@seed-design/dom-utils`

## Manual Check
- Ran the Lynx SPA dev server locally and confirmed the overlay works in the Lynx preview.