### PR TITLE
fix(lynx-react): stabilize icon tint color

### DIFF
--- a/examples/lynx-spa/vitest.config.ts
+++ b/examples/lynx-spa/vitest.config.ts
@@ -1,10 +1,117 @@
 import { defineConfig, mergeConfig } from 'vitest/config';
 import { createVitestConfig } from '@lynx-js/react/testing-library/vitest-config';
+import { transformReactLynxSync } from '@lynx-js/react/transform';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const defaultConfig = await createVitestConfig();
+const configRoot = fileURLToPath(new URL('.', import.meta.url));
+const reactPackageUrl = import.meta.resolve('@lynx-js/react/package.json');
+const reactPackageRootUrl = new URL('.', reactPackageUrl);
+const preactRoot = fileURLToPath(new URL('../../preact', reactPackageRootUrl));
+const preactAliases = [
+  { find: 'preact', replacement: preactRoot },
+  { find: 'preact/hooks', replacement: `${preactRoot}/hooks` },
+  { find: 'preact/compat', replacement: `${preactRoot}/compat` },
+  { find: 'preact/test-utils', replacement: `${preactRoot}/test-utils` },
+  { find: 'preact/jsx-runtime', replacement: `${preactRoot}/jsx-runtime` },
+  { find: 'preact/jsx-dev-runtime', replacement: `${preactRoot}/jsx-dev-runtime` },
+];
+const inlineLynxTestDeps = [
+  '@lynx-js/motion',
+  '@karrotmarket/lynx-monochrome-icon',
+  '@karrotmarket/lynx-multicolor-icon',
+  '@karrotmarket/assets-monochrome',
+  '@karrotmarket/assets-multicolor',
+];
+
+function normalizeSlashes(file: string) {
+  return file.replaceAll(path.win32.sep, '/');
+}
+
 const config = defineConfig({
+  plugins: [
+    {
+      name: 'transform-lynx-icon-jsx',
+      enforce: 'pre',
+      transform(code, id) {
+        if (
+          /@karrotmarket[+/]lynx-(monochrome|multicolor)-icon/.test(id) &&
+          id.endsWith('.js')
+        ) {
+          const relativePath = normalizeSlashes(path.relative(configRoot, id));
+          const result = transformReactLynxSync(code, {
+            mode: 'test',
+            pluginName: '',
+            filename: path.basename(id),
+            sourcemap: true,
+            snapshot: {
+              preserveJsx: false,
+              runtimePkg: '@lynx-js/react/internal',
+              jsxImportSource: '@lynx-js/react',
+              filename: relativePath,
+              target: 'MIXED',
+            },
+            engineVersion: '',
+            dynamicImport: {
+              injectLazyBundle: false,
+              layer: 'test',
+              runtimePkg: '@lynx-js/react/internal',
+            },
+            directiveDCE: false,
+            defineDCE: false,
+            shake: false,
+            compat: false,
+            worklet: {
+              filename: relativePath,
+              runtimePkg: '@lynx-js/react/internal',
+              target: 'MIXED',
+            },
+            refresh: false,
+            cssScope: false,
+          });
+
+          if (result.errors.length > 0) {
+            result.errors.forEach((error) => {
+              this.error(error.text ?? 'Lynx icon transform failed.');
+            });
+          }
+
+          if (result.warnings.length > 0) {
+            result.warnings.forEach((warning) => {
+              this.warn(warning.text ?? 'Lynx icon transform warning.');
+            });
+          }
+
+          return {
+            code: result.code,
+            map: result.map,
+          };
+        }
+      },
+    },
+  ],
+  resolve: {
+    alias: preactAliases,
+  },
   test: {
     include: ['src/**/*.test.{ts,tsx}', 'src/**/*.vitest.{ts,tsx}'],
+    server: {
+      deps: {
+        inline: inlineLynxTestDeps,
+      },
+    },
+  },
+  optimizeDeps: {
+    exclude: ['@lynx-js/react', 'preact', 'preact/hooks', 'preact/compat'],
+  },
+  ssr: {
+    noExternal: [
+      '@lynx-js/react',
+      'preact',
+      '@lynx-js/internal-preact',
+      ...inlineLynxTestDeps,
+    ],
   },
 });
 

--- a/packages/lynx-react/src/hooks/__tests__/use-press-tap.test.ts
+++ b/packages/lynx-react/src/hooks/__tests__/use-press-tap.test.ts
@@ -60,6 +60,21 @@ describe("usePressTap", () => {
       expect(onTap).toHaveBeenCalledTimes(1);
     });
 
+    it("clears pressed when bindtap fires", () => {
+      const { result } = renderHook(() => usePressTap());
+
+      act(() => {
+        result.current.bindtouchstart(fakeEvent);
+      });
+      expect(result.current.pressed).toBe(true);
+
+      act(() => {
+        result.current.bindtap(fakeEvent);
+      });
+
+      expect(result.current.pressed).toBe(false);
+    });
+
     it("can be omitted without error", () => {
       const { result } = renderHook(() => usePressTap());
 
@@ -91,6 +106,22 @@ describe("usePressTap", () => {
       });
 
       expect(onTap).not.toHaveBeenCalled();
+    });
+
+    it("clears pressed when disabled changes to true", () => {
+      const { result, rerender } = renderHook(
+        ({ disabled }) => usePressTap({ disabled }),
+        { initialProps: { disabled: false } },
+      );
+
+      act(() => {
+        result.current.bindtouchstart(fakeEvent);
+      });
+      expect(result.current.pressed).toBe(true);
+
+      rerender({ disabled: true });
+
+      expect(result.current.pressed).toBe(false);
     });
   });
 

--- a/packages/lynx-react/src/hooks/use-press-tap.ts
+++ b/packages/lynx-react/src/hooks/use-press-tap.ts
@@ -1,4 +1,4 @@
-import { useState } from "@lynx-js/react";
+import { useEffect, useState } from "@lynx-js/react";
 import type { TouchEvent } from "@lynx-js/types";
 import { useMemoizedFn } from "@lynx-js/lynx-ui-common";
 
@@ -39,9 +39,16 @@ export function usePressTap(options: UsePressTapOptions = {}): UsePressTapReturn
   });
 
   const handleTap = useMemoizedFn(() => {
+    setPressed(false);
     if (disabled) return;
     onTap?.();
   });
+
+  useEffect(() => {
+    if (disabled) {
+      setPressed(false);
+    }
+  }, [disabled]);
 
   return {
     pressed,


### PR DESCRIPTION
## Summary

- `@seed-design/lynx-react`에서 Lynx icon tint를 CSS computed color에만 의존하지 않도록 보강했습니다.
- ActionButton, Checkbox, RadioGroup indicator icon에 recipe color token을 concrete hex tint로 해석해 `color` prop으로 직접 주입합니다.
- concrete tint가 있는 경우에는 `useIconColor` fallback ref를 연결하지 않고, unresolved token일 때만 fallback sync를 유지합니다.
- Lynx `<image tint-color>`가 stale로 남는 경우를 줄이기 위해 icon class/color/size가 바뀔 때 icon element key도 함께 갱신합니다.
- Lynx Vitest 환경에서 `@lynx-js/react`가 번들로 들고 있는 `preact`를 `import.meta.resolve` 기반 alias로 연결했고, `lynx-spa` 테스트에서 Lynx icon package JSX를 테스트 전용 transform으로 처리합니다.

## Root Cause

Variant 변경 시 className은 갱신되지만, 실제 Lynx `<image tint-color>`는 CSS variable/computed color 동기화 타이밍과 image attribute 갱신 타이밍에 민감했습니다. Simulator에서 확인해보니 next-frame computed color sync만으로는 충분하지 않았고, recipe token을 concrete tint 값으로 해석해 icon package의 `color` prop에 직접 넣어야 안정적으로 반영됐습니다.

## Diff Review

- catalog-only key/remount workaround는 추가하지 않았습니다.
- public API/type surface는 변경하지 않았습니다.
- `useIconColor`는 fallback hook으로 유지하되, 직접 concrete tint를 주입하는 공용 컴포넌트 경로가 기본이 되도록 했습니다.
- RadioGroup도 같은 indicator icon tint 경로를 공유하므로 함께 regression coverage를 추가했습니다.

## Test Plan

- [x] `bun generate:all`
- [x] `bun --filter @seed-design/lynx-react test`
- [x] `bun --filter @seed-design/lynx-react build`
- [x] `bun --cwd examples/lynx-spa test`
- [x] `bun --cwd examples/lynx-spa build`
- [x] `git diff --check`
- [x] Manual simulator smoke with `serve-sim` + booted `iPhone 17 Pro Max` + `com.lynx.LynxExplorer`
  - ActionButton Playground: `variant=brandSolid`, `layout=iconOnly` plus icon is white after reload/re-entry.
  - Checkbox Playground: `checked=true`, `variant=square -> ghost` check icon remains visible in brand color after reload/re-entry.
  - Evidence screenshots captured locally under `/tmp/lynx-icon-tint-evidence/07-action-button-icononly-after-refguard.png` and `/tmp/lynx-icon-tint-evidence/08-checkbox-ghost-checked-after-refguard.png`.
- [ ] `bun test:all` - `origin/lynx`와 동일하게 root Bun test runner가 `examples/lynx-spa/src/__tests__/index.test.tsx`를 직접 집어 실행하면서 `react/jsx-dev-runtime`을 찾지 못해 실패합니다. `lynx-spa`의 Vitest config를 사용하는 `bun --cwd examples/lynx-spa test`는 통과합니다.

## Notes

ActionButton Table의 `layout=iconOnly` row는 Simulator automation에서 table scroll이 안정적으로 먹지 않아 Playground의 동일 render path로 수동 검증했습니다. Component regression test는 `layout="iconOnly"`, `variant="brandSolid"`에서 `tint-color="#ffffff"`를 직접 확인합니다.
