### PR TITLE
fix(stackflow-spa): use closeOnInteractOutside in step overlay activity

### DIFF
--- a/examples/stackflow-spa/src/activities/ActivityBottomSheetWithAlertDialogStep.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityBottomSheetWithAlertDialogStep.tsx
@@ -55,7 +55,13 @@ const ActivityBottomSheetWithAlertDialogStep: StaticActivityComponentType<
               description="useStepOverlay로 BottomSheet step과 AlertDialog step을 한 Activity 안에서 동시에 사용합니다. BottomSheet 위에 AlertDialog를 얹은 상태에서 AlertDialog의 Backdrop이나 Content 빈 영역을 클릭해 동작을 관찰해보세요."
             />
           </Box>
-          <BottomSheetRoot {...bottomSheet.overlayProps}>
+          <BottomSheetRoot
+            {...bottomSheet.overlayProps}
+            // AlertDialog가 떠있는 동안 BottomSheet의 outside-press는 무시한다.
+            // AlertDialog는 closeOnInteractOutside=true이므로 자체적으로 닫히고,
+            // BottomSheet는 외부 클릭으로 닫히지 않도록 비활성화한다.
+            closeOnInteractOutside={!alertDialog.open}
+          >
             <BottomSheetTrigger asChild>
               <ActionButton variant="neutralSolid" flexGrow>
                 Open BottomSheet
@@ -67,14 +73,6 @@ const ActivityBottomSheetWithAlertDialogStep: StaticActivityComponentType<
                 title="BottomSheet (step)"
                 description="이 BottomSheet 위에 AlertDialog를 얹어볼 수 있어요."
                 layerIndex={useActivityZIndexBase({ activityOffset: 1 })}
-                onPointerDownOutside={(e) => {
-                  // AlertDialog가 떠있는 동안 BottomSheet의 outside 발화는 무시한다.
-                  // AlertDialog는 closeOnInteractOutside=true이므로 자체적으로 닫히고,
-                  // BottomSheet만 닫히지 않도록 preventDefault.
-                  if (alertDialog.open) {
-                    e.preventDefault();
-                  }
-                }}
               >
                 <BottomSheetBody>
                   <AlertDialogRoot {...alertDialog.overlayProps} closeOnInteractOutside>


### PR DESCRIPTION
## Summary

`ActivityBottomSheetWithAlertDialogStep`이 `BottomSheetContent`에 더 이상 존재하지 않는 `onPointerDownOutside` prop을 사용해 `deploy-seed-design-stackflow-spa-alpha-pages` 빌드가 [2026-05-12부터 빨간색](https://github.com/daangn/seed-design/actions/workflows/deploy-seed-design-stackflow-spa-alpha-pages.yml?query=branch%3Aalpha)이었음.

\`onPointerDownOutside\` 같은 콜백은 Menu refactor PR(#1410, #1455)에서 \`Drawer.ContentProps\`에서 제거되어 \`useDismissibleLayer\` 기반의 \`onOpenChange(open, details)\`로 대체됨. 이번 activity는 그 refactor 머지된 직후에 들어왔는데 새 API로 마이그레이션되지 못해 alpha의 \`vite build\`가 \`TS2322\` / \`TS7006\` 두 에러로 실패하고 있었음.

"AlertDialog가 떠있는 동안 BottomSheet의 outside-press를 무시한다"는 의도는 헤드리스 drawer가 그대로 노출하는 \`closeOnInteractOutside\`로 \`BottomSheetRoot\`에서 토글하면 그대로 보존됨.

## Test plan

- [x] \`cd examples/stackflow-spa && bun run build\` 성공 (\`✓ built in 4.58s\`, alpha base에서)
- [ ] alpha 머지 후 \`deploy-seed-design-stackflow-spa-alpha-pages\` 워크플로우 그린 확인
- [ ] /bottom-sheet-with-alert-dialog-step 라우트에서 BottomSheet 위 AlertDialog 띄운 채 AlertDialog Backdrop 클릭 시 BottomSheet은 닫히지 않고 AlertDialog만 닫히는 동작 시각 확인