### PR TITLE
fix(changeset): remove stale lynx primitive metadata

### DIFF
--- a/.changeset/lynx-alpha-release.md
+++ b/.changeset/lynx-alpha-release.md
@@ -1,11 +1,9 @@
 ---
-"@seed-design/lynx-primitive": patch
 "@seed-design/lynx-css": patch
 "@seed-design/lynx-react": patch
 ---
 
 feat(lynx): initial alpha release
 
-- `@seed-design/lynx-primitive`: Slot, composeRefs
 - `@seed-design/lynx-css`: 디자인 토큰, CSS 레시피
 - `@seed-design/lynx-react`: ActionButton, ProgressCircle

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -20,7 +20,6 @@
     "@seed-design/docs-mcp": "0.5.1",
     "@seed-design/figma": "1.3.9",
     "@seed-design/lynx-css": "0.1.0",
-    "@seed-design/lynx-primitive": "0.1.0",
     "@seed-design/lynx-react": "0.1.0",
     "@seed-design/mcp": "1.3.9",
     "@seed-design/migration-index": "1.0.0",


### PR DESCRIPTION
## 요약
- 삭제된 `@seed-design/lynx-primitive`가 `.changeset/lynx-alpha-release.md`에 release 대상 패키지로 남아 있던 문제를 정리했습니다.
- prerelease 상태 파일인 `.changeset/pre.json`의 `initialVersions`에서도 `@seed-design/lynx-primitive` 항목을 제거했습니다.
- `lynx-alpha-release` changeset 이력은 `lynx-css`, `lynx-react`에 여전히 필요하므로 유지했습니다.

## 원인
`changeset version`은 prerelease 모드에서도 changeset frontmatter의 패키지가 현재 workspace에 존재하는지 먼저 검증합니다. 삭제된 `@seed-design/lynx-primitive`가 release 대상에 남아 있어 CI에서 `Found changeset lynx-alpha-release for package @seed-design/lynx-primitive which is not in the workspace` 에러가 발생했습니다.

## 테스트
- `.changeset/*.md` frontmatter의 모든 패키지가 workspace에 존재하는지 스캔
- `.changeset` 안에 `@seed-design/lynx-primitive` 참조가 남아 있지 않은지 확인
- `git diff --check HEAD~1..HEAD`
- `/tmp` 복사본에서 `bun install --no-immutable` 후 `bun run version` 통과
