### PR TITLE
feat(lynx-react): align React interface patterns

### DIFF
--- a/docs/content/lynx/components/action-button.mdx
+++ b/docs/content/lynx/components/action-button.mdx
@@ -18,7 +18,7 @@ Lynx `ActionButton`은 별도 `ui:action-button` snippet 없이 `@seed-design/ly
 ```tsx
 import IconChevronRightLine from "@karrotmarket/lynx-monochrome-icon/IconChevronRightLine";
 import IconPlusFill from "@karrotmarket/lynx-monochrome-icon/IconPlusFill";
-import { ActionButton } from "@seed-design/lynx-react";
+import { ActionButton, Icon, PrefixIcon } from "@seed-design/lynx-react";
 
 export function App() {
   return (
@@ -26,21 +26,22 @@ export function App() {
       <ActionButton
         variant="brandSolid"
         size="medium"
-        prefixIcon={<IconPlusFill />}
         bindtap={() => {
           "background only";
           console.log("tapped");
         }}
       >
+        <PrefixIcon icon={<IconPlusFill />} />
         버튼
       </ActionButton>
 
       <ActionButton
         layout="iconOnly"
         variant="neutralSolid"
-        icon={<IconChevronRightLine />}
         aria-label="다음"
-      />
+      >
+        <Icon icon={<IconChevronRightLine />} />
+      </ActionButton>
     </view>
   );
 }
@@ -58,7 +59,8 @@ Lynx `ActionButton`은 React `ActionButton`과 다음과 같은 차이가 있습
 - **이벤트 핸들링**: `onClick` 대신 `bindtap`을 사용합니다.
 - **렌더링 요소**: HTML `<button>` 대신 네이티브 `<view>`/`<text>` 요소를 렌더링합니다.
 - **ref forwarding**: `React.forwardRef`로 ref를 전달할 수 있습니다.
-- **아이콘 전달 방식**: 웹의 slot 컴포넌트 대신 `prefixIcon` / `suffixIcon` / `icon` prop으로 아이콘 element를 전달합니다.
+- **아이콘 렌더링 방식**: 웹의 SVG `currentColor` 대신 Lynx `<image>`의 `tint-color`를 사용합니다. `Icon` / `PrefixIcon` / `SuffixIcon`이 recipe color를 native tint로 동기화합니다.
+- **호환 아이콘 prop**: 기존 `prefixIcon` / `suffixIcon` / `icon` prop도 계속 지원하지만, 기본 예시는 child slot API를 사용합니다.
 - **Loading 상태**: 웹과 동일하게 spinner를 absolute로 얹고 기존 content를 숨겨 원래 버튼 폭을 유지합니다.
 </Callout>
 

--- a/docs/content/lynx/components/checkbox.mdx
+++ b/docs/content/lynx/components/checkbox.mdx
@@ -134,6 +134,7 @@ Lynx `Checkbox`는 React `Checkbox`와 다음과 같은 차이가 있습니다.
 
 - **아이콘 주입 방식**: snippet의 `Checkbox`와 `Checkmark`는 `@karrotmarket/lynx-monochrome-icon`의 check / minus icon을 자동으로 주입합니다. compound component를 직접 조합할 때는 `Checkbox.Indicator`에 Lynx monochrome icon을 전달해야 합니다. raw `<svg>` 주입은 Lynx 범위 밖입니다.
 - **이벤트 핸들링**: `onChange` 대신 `onCheckedChange`만 노출합니다. tap 핸들러는 Root 내부에서 소유합니다.
+- **Pressed 상태**: 웹의 `data-active` 대신 내부 press state를 `checkmark` recipe의 `pressed` boolean variant로 전달합니다.
 - **렌더링 요소**: HTML `<label>` / `<input>` 대신 네이티브 `<view>` / `<text>` 요소를 렌더링합니다.
 - **Compound 구조**: `Checkbox.Root` → `Checkbox.Control` → `Checkbox.Indicator` + `Checkbox.Label` 구성과 Context로 상태/variant를 공유하는 흐름은 동일합니다.
 - **ref forwarding**: `Checkbox`, `Checkmark`, `CheckboxGroup`은 Root view로 ref를 전달합니다. 웹 snippet처럼 hidden input ref를 제공하지 않습니다.
@@ -153,9 +154,3 @@ Lynx `Checkbox`는 React `Checkbox`와 다음과 같은 차이가 있습니다.
 | `focus` / `focusVisible` | 키보드 포커스 | Lynx에 키보드 포커스 개념 없음 |
 | `onChange` (raw DOM event) | `React.ChangeEvent` | 의미 없음. `onCheckedChange`로 대체 |
 | `weight="default"` / `"stronger"` | deprecated 호환 매핑 | Lynx 신규 컴포넌트이므로 처음부터 `"regular"` / `"bold"` 만 노출 |
-
-### 추후 CSS 지원 시 추가 예정
-
-| 기능 | 웹 대응 | 설명 |
-|------|---------|------|
-| `active` (pressed) 모디파이어 | `data-active` | `checkmark` recipe CSS에 pressed 상태가 정의되면 활성화 |

--- a/docs/content/lynx/components/radio-group.mdx
+++ b/docs/content/lynx/components/radio-group.mdx
@@ -13,7 +13,7 @@ npx @seed-design/cli add ui:radio-group
 
 ## Usage
 
-설치한 snippet은 기본 사용 경로인 `RadioGroup`과 `RadioGroupItem`, 커스텀 레이아웃에서 마크만 조합할 때 쓰는 `Radiomark`를 함께 export 합니다.
+설치한 snippet은 기본 사용 경로인 `RadioGroup`과 `RadioGroupItem`, 커스텀 레이아웃에서 item context 안의 마크만 조합할 때 쓰는 `Radiomark`를 함께 export 합니다.
 
 ```tsx
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
@@ -107,8 +107,9 @@ Lynx `RadioGroup`은 React `RadioGroup`과 다음과 같은 차이가 있습니�
 - **Field wrapper 없음**: React snippet의 `label`, `description`, `errorMessage`, `indicator`, `showRequiredIndicator` 같은 field 관련 prop은 Lynx snippet에서 제공하지 않습니다.
 - **아이콘 렌더링 방식**: 기본 `RadioGroup.ItemIndicator`는 `<view>` dot으로 렌더됩니다. custom icon을 전달할 때는 `@karrotmarket/lynx-monochrome-icon`의 monochrome icon 컴포넌트를 사용해야 하며 raw `<svg>` 주입은 Lynx 범위 밖입니다.
 - **이벤트 핸들링**: `onChange` 대신 `onValueChange(value: string)`만 노출합니다. tap 핸들러는 item 내부에서 소유합니다.
+- **Pressed 상태**: 웹의 `data-active` 대신 내부 press state를 `radiomark` recipe의 `pressed` boolean variant로 전달합니다.
 - **렌더링 요소**: HTML `<label>` / `<input type="radio">` 대신 네이티브 `<view>` / `<text>` 요소를 렌더링합니다.
-- **Strict containment**: `RadioGroupItem`, `Radiomark`, `RadioGroup.ItemControl`, `RadioGroup.ItemIndicator`, `RadioGroup.ItemLabel`은 반드시 `RadioGroup.Root`와 `RadioGroup.Item`의 적절한 context 안에서 사용해야 합니다.
+- **Strict containment**: `RadioGroupItem`, `Radiomark`, `RadioGroup.ItemControl`, `RadioGroup.ItemIndicator`, `RadioGroup.ItemLabel`은 반드시 `RadioGroup.Root`와 `RadioGroup.Item`의 적절한 context 안에서 사용해야 합니다. `Radiomark`는 standalone primitive가 아니라 item context 안에서 `ItemControl`과 `ItemIndicator`를 묶는 snippet helper입니다.
 </Callout>
 
 ## Lynx 미지원 기능
@@ -125,9 +126,3 @@ Lynx `RadioGroup`은 React `RadioGroup`과 다음과 같은 차이가 있습니�
 | `label` / `description` / `errorMessage` on `RadioGroup` | field wrapper props | Lynx에 대응 field wrapper snippet을 제공하지 않음 |
 | `focus` / `focusVisible` | 키보드 포커스 | Lynx에 키보드 포커스 개념 없음 |
 | `onChange` (raw DOM event) | `React.ChangeEvent` | 의미 없음. `onValueChange`로 대체 |
-
-### 추후 CSS 지원 시 추가 예정
-
-| 기능 | 웹 대응 | 설명 |
-|------|---------|------|
-| `active` (pressed) 모디파이어 | `data-active` | `radiomark` recipe CSS에 pressed 상태가 정의되면 활성화 |

--- a/docs/content/lynx/components/tag-group.mdx
+++ b/docs/content/lynx/components/tag-group.mdx
@@ -31,6 +31,8 @@ export function App() {
 
 `TagGroupRoot`의 `size`·`weight`·`tone`은 Context로 하위 `TagGroupItem`에 전파되며, 개별 `TagGroupItem`에서 prop으로 덮어쓸 수 있습니다. 구분자는 기본 `" · "`이고 `separator` prop으로 바꿀 수 있습니다.
 
+`TagGroupItem`은 `flexShrink`를 지원합니다. 긴 태그가 있는 레이아웃에서 item의 축소 우선순위를 조정해야 할 때 사용하세요.
+
 ### Tone / Separator
 
 `TagGroupRoot`의 `tone`, `weight`, `separator`는 그룹 기본값으로 전달되고, 개별 `TagGroupItem`에서 필요한 값만 덮어쓸 수 있습니다.
@@ -89,7 +91,6 @@ Lynx TagGroup은 Lynx view 엔진(Yoga 기반 flex)의 제약으로 React 웹 �
 | prop | 웹 동작 | Lynx 미지원 사유 |
 |------|---------|------------------|
 | `truncate` (Root) | 한 줄 유지 + 모든 item label의 말줄임 | Lynx flex 모델에서는 label이 item 너비에 맞춰지지 않아 웹 수준의 inline ellipsis가 동작하지 않음. 모든 item에 말줄임을 일괄 적용하는 경험이 자연스럽지 않아 제거됨 |
-| `flexShrink` (Item) | Item 축소 우선순위 제어 | CSS variable 동적 주입 제한 |
 | `asChild` (Root/Item) | Slot 기반 다형 렌더 | Lynx에서 Primitive Slot 패턴 미제공 |
 | `prefixIcon` / `suffixIcon` (Item) | 아이콘 + 라벨 | Lynx 3.7 SVG 지원 이후 Tier B에서 재검토 |
 

--- a/docs/content/lynx/foundation/iconography.mdx
+++ b/docs/content/lynx/foundation/iconography.mdx
@@ -166,3 +166,31 @@ export function App() {
   );
 }
 ```
+
+## SEED Component Slots
+
+일반 화면에서 아이콘만 직접 렌더할 때는 위 예시처럼 `@karrotmarket/lynx-*-icon` 컴포넌트를 그대로 사용합니다.
+
+SEED 컴포넌트의 monochrome icon slot 안에서는 `@seed-design/lynx-react`의 `Icon`, `PrefixIcon`, `SuffixIcon` wrapper를 사용하세요. wrapper가 recipe className에서 계산된 color를 Lynx `<image>`의 `tint-color`로 동기화하고, slot size를 icon image에 전달합니다.
+
+```tsx
+import IconChevronDownFill from "@karrotmarket/lynx-monochrome-icon/IconChevronDownFill";
+import IconPlusFill from "@karrotmarket/lynx-monochrome-icon/IconPlusFill";
+import { ActionButton, Icon, PrefixIcon, SuffixIcon } from "@seed-design/lynx-react";
+
+export function App() {
+  return (
+    <view>
+      <ActionButton>
+        <PrefixIcon icon={<IconPlusFill />} />
+        추가
+        <SuffixIcon icon={<IconChevronDownFill />} />
+      </ActionButton>
+
+      <ActionButton layout="iconOnly" aria-label="추가">
+        <Icon icon={<IconPlusFill />} />
+      </ActionButton>
+    </view>
+  );
+}
+```

--- a/docs/content/lynx/hooks/use-icon-color.mdx
+++ b/docs/content/lynx/hooks/use-icon-color.mdx
@@ -17,6 +17,7 @@ import { useIconColor } from "@seed-design/lynx-react";
 
 ```tsx
 import { cloneElement, isValidElement, type ReactElement } from "react";
+import { useMainThreadRef } from "@lynx-js/react";
 import { useIconColor } from "@seed-design/lynx-react";
 
 function IconSlot({ icon, variant, disabled }: {
@@ -24,18 +25,23 @@ function IconSlot({ icon, variant, disabled }: {
   variant: string;
   disabled: boolean;
 }) {
-  const iconColorProps = useIconColor([variant, disabled]);
+  const wrapperRef = useMainThreadRef(null);
+  const iconColorProps = useIconColor([variant, disabled], { sourceRef: wrapperRef });
 
   if (!isValidElement(icon)) return null;
 
-  return cloneElement(icon, {
-    ...iconColorProps,
-    className: "my-icon-slot",
-  });
+  return (
+    <view main-thread:ref={wrapperRef} className="my-icon-slot">
+      {cloneElement(icon, {
+        ...iconColorProps,
+        style: { width: "100%", height: "100%" },
+      })}
+    </view>
+  );
 }
 ```
 
-`useIconColor`가 반환하는 객체는 icon element에 그대로 주입할 수 있는 props입니다. 기존처럼 `{ ref }`만 구조 분해해서 사용할 수도 있지만, Lynx `list`처럼 UI 노드가 늦게 appear 되는 컨테이너까지 안정적으로 지원하려면 반환 객체 전체를 icon에 넘기는 방식을 권장합니다.
+`useIconColor`가 반환하는 객체는 icon element에 그대로 주입할 수 있는 props입니다. `sourceRef`를 전달하면 wrapper의 computed `color`를 읽어 icon `<image>`의 `tint-color`에 반영합니다. 기존처럼 `sourceRef` 없이 쓰면 icon element 자신의 computed `color`를 읽습니다.
 
 ### 상태 의존성
 
@@ -95,6 +101,7 @@ Lynx의 monochrome icon은 내부적으로 `<image>`를 렌더링하고, 실제 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `deps` | `DependencyList` | icon의 CSS `color`에 영향을 주는 의존성 목록입니다. 값이 바뀌면 main thread에서 tint color를 다시 동기화합니다. |
+| `options.sourceRef` | `RefObject<MainThread.Element>` | optional. icon 자체가 아니라 wrapper element의 computed `color`를 source로 사용할 때 전달합니다. |
 
 ### Return
 

--- a/examples/lynx-spa/src/components/variant-catalog.tsx
+++ b/examples/lynx-spa/src/components/variant-catalog.tsx
@@ -3,23 +3,35 @@ import { type ReactNode, useState } from '@lynx-js/react';
 import {
   getPreviewStateDefaultValues,
   type SetVariantValue,
+  type PreviewState,
+  type VariantAxis,
+  type VariantCatalogValues,
   VariantPlayground,
   type VariantPlaygroundProps,
   type VariantValues,
 } from './variant-playground.jsx';
 import { VariantTable } from './variant-table.jsx';
 
+export {
+  definePreviewStates,
+  defineVariantAxes,
+} from './variant-playground.jsx';
+
 export type {
   PreviewState,
   PrimitiveValue,
   SetVariantValue,
   VariantAxis,
+  VariantCatalogValues,
   VariantValues,
 } from './variant-playground.jsx';
 
 type Mode = 'playground' | 'table' | 'examples';
 
-export interface VariantCatalogProps extends VariantPlaygroundProps {
+export interface VariantCatalogProps<
+  Variants extends readonly VariantAxis[] = readonly VariantAxis[],
+  PreviewStates extends readonly PreviewState[] = readonly PreviewState[],
+> extends VariantPlaygroundProps<Variants, PreviewStates> {
   examples?: ReactNode;
 }
 
@@ -32,7 +44,10 @@ export interface VariantCatalogProps extends VariantPlaygroundProps {
  *
  * 두 모드 모두 같은 `children` render function 을 공유한다.
  */
-export function VariantCatalog(props: VariantCatalogProps) {
+export function VariantCatalog<
+  const Variants extends readonly VariantAxis[],
+  const PreviewStates extends readonly PreviewState[] = readonly [],
+>(props: VariantCatalogProps<Variants, PreviewStates>) {
   const { children, variants, previewStates, examples } = props;
   const [mode, setMode] = useState<Mode>('playground');
   const tabs: Mode[] =
@@ -72,11 +87,14 @@ export function VariantCatalog(props: VariantCatalogProps) {
         ))}
       </view>
       {mode === 'playground' ? (
-        <VariantPlayground variants={variants} previewStates={previewStates}>
+        <VariantPlayground<Variants, PreviewStates>
+          variants={variants}
+          previewStates={previewStates}
+        >
           {children}
         </VariantPlayground>
       ) : mode === 'table' ? (
-        <VariantTable variants={variants}>
+        <VariantTable<Variants> variants={variants}>
           {(values) => renderForTable(children, values, previewStates)}
         </VariantTable>
       ) : (
@@ -87,14 +105,25 @@ export function VariantCatalog(props: VariantCatalogProps) {
 }
 
 const noopSetValue: SetVariantValue = () => {};
-function renderForTable(
-  children: VariantPlaygroundProps['children'],
+function renderForTable<
+  Variants extends readonly VariantAxis[],
+  PreviewStates extends readonly PreviewState[],
+>(
+  children: VariantPlaygroundProps<Variants, PreviewStates>['children'],
   values: VariantValues,
-  previewStates: VariantPlaygroundProps['previewStates'],
+  previewStates: VariantPlaygroundProps<
+    Variants,
+    PreviewStates
+  >['previewStates'],
 ): ReactNode {
   return children(
-    { ...getPreviewStateDefaultValues(previewStates), ...values },
-    noopSetValue,
+    {
+      ...getPreviewStateDefaultValues(previewStates),
+      ...values,
+    } as VariantCatalogValues<Variants, PreviewStates>,
+    noopSetValue as SetVariantValue<
+      VariantCatalogValues<Variants, PreviewStates>
+    >,
   );
 }
 

--- a/examples/lynx-spa/src/components/variant-playground.tsx
+++ b/examples/lynx-spa/src/components/variant-playground.tsx
@@ -2,37 +2,99 @@ import { type ReactNode, useMemo, useState } from '@lynx-js/react';
 
 export type PrimitiveValue = string | number | boolean;
 export type VariantValues = Record<string, PrimitiveValue>;
-export type SetVariantValue = (key: string, value: PrimitiveValue) => void;
+export type SetVariantValue<Values extends VariantValues = VariantValues> = <
+  Key extends keyof Values & string,
+>(
+  key: Key,
+  value: Values[Key],
+) => void;
 
-export interface VariantAxis {
-  key: string;
+export interface VariantAxis<
+  Key extends string = string,
+  Value extends PrimitiveValue = PrimitiveValue,
+> {
+  key: Key;
   label?: string;
-  options: readonly PrimitiveValue[];
-  defaultValue: PrimitiveValue;
+  options: readonly Value[];
+  defaultValue: Value;
 }
 
-export interface PreviewState {
-  key: string;
+export interface PreviewState<
+  Key extends string = string,
+  Value extends PrimitiveValue = PrimitiveValue,
+> {
+  key: Key;
   label?: string;
-  defaultValue: PrimitiveValue;
+  defaultValue: Value;
 }
 
-export interface VariantPlaygroundProps {
+type WidenPrimitive<Value> = Value extends string
+  ? string
+  : Value extends number
+    ? number
+    : Value extends boolean
+      ? boolean
+      : Value;
+
+type VariantAxisValues<Variants extends readonly VariantAxis[]> = {
+  [Axis in Variants[number] as Axis['key']]: Axis extends VariantAxis<
+    string,
+    infer Value
+  >
+    ? Value
+    : never;
+};
+
+type PreviewStateValues<PreviewStates extends readonly PreviewState[]> = {
+  [State in PreviewStates[number] as State['key']]: State extends PreviewState<
+    string,
+    infer Value
+  >
+    ? WidenPrimitive<Value>
+    : never;
+};
+
+export type VariantCatalogValues<
+  Variants extends readonly VariantAxis[] = readonly VariantAxis[],
+  PreviewStates extends readonly PreviewState[] = readonly PreviewState[],
+> = VariantValues &
+  VariantAxisValues<Variants> &
+  PreviewStateValues<PreviewStates>;
+
+export function defineVariantAxes<
+  const Variants extends readonly VariantAxis[],
+>(variants: Variants): Variants {
+  return variants;
+}
+
+export function definePreviewStates<
+  const PreviewStates extends readonly PreviewState[],
+>(previewStates: PreviewStates): PreviewStates {
+  return previewStates;
+}
+
+export interface VariantPlaygroundProps<
+  Variants extends readonly VariantAxis[] = readonly VariantAxis[],
+  PreviewStates extends readonly PreviewState[] = readonly PreviewState[],
+> {
   /**
    * Public하게 조작 가능한 variant 축만 넘긴다. recipe에는 있어도 컴포넌트 prop으로
    * 고정할 수 없는 상태(예: pressed)는 포함하지 않는다.
    */
-  variants: readonly VariantAxis[];
+  variants: Variants;
   /**
    * Preview 오른쪽 아래에 표시할 controlled state 값.
    * variant control에는 없어도 preview에서 setValue로 갱신할 수 있다.
    */
-  previewStates?: readonly PreviewState[];
+  previewStates?: PreviewStates;
   /**
    * preview 영역. 현재 값 스냅샷과 setter 를 받아 실제 컴포넌트를 렌더한다.
    * setter 는 controlled state (예: `checked`) 를 playground 로 되돌릴 때 사용.
    */
-  children: (values: VariantValues, setValue: SetVariantValue) => ReactNode;
+  children: (
+    values: VariantCatalogValues<Variants, PreviewStates>,
+    setValue: SetVariantValue<VariantCatalogValues<Variants, PreviewStates>>,
+  ) => ReactNode;
 }
 
 function isBooleanOptions(
@@ -87,7 +149,10 @@ function getPreviewStateText(
     .join(' · ');
 }
 
-export function VariantPlayground(props: VariantPlaygroundProps) {
+export function VariantPlayground<
+  const Variants extends readonly VariantAxis[],
+  const PreviewStates extends readonly PreviewState[] = readonly [],
+>(props: VariantPlaygroundProps<Variants, PreviewStates>) {
   const { variants, previewStates, children } = props;
 
   const defaultValues = useMemo(
@@ -98,11 +163,14 @@ export function VariantPlayground(props: VariantPlaygroundProps) {
   const [values, setValues] = useState<VariantValues>(() => defaultValues);
   const previewStateText = getPreviewStateText(previewStates, values);
 
-  const setValue = (key: string, value: PrimitiveValue) => {
+  const setPrimitiveValue = (key: string, value: PrimitiveValue) => {
     setValues((prev) =>
       prev[key] === value ? prev : { ...prev, [key]: value },
     );
   };
+  const setValue: SetVariantValue<
+    VariantCatalogValues<Variants, PreviewStates>
+  > = (key, value) => setPrimitiveValue(key, value);
 
   return (
     <view
@@ -125,7 +193,10 @@ export function VariantPlayground(props: VariantPlaygroundProps) {
           position: 'relative',
         }}
       >
-        {children(values, setValue)}
+        {children(
+          values as VariantCatalogValues<Variants, PreviewStates>,
+          setValue,
+        )}
         {previewStateText != null && (
           <view
             style={{
@@ -173,7 +244,7 @@ export function VariantPlayground(props: VariantPlaygroundProps) {
                   key={variant.key}
                   name={variant.label ?? variant.key}
                   current={!!values[variant.key]}
-                  onChange={(next) => setValue(variant.key, next)}
+                  onChange={(next) => setPrimitiveValue(variant.key, next)}
                 />
               ) : (
                 <VariantRow
@@ -181,7 +252,7 @@ export function VariantPlayground(props: VariantPlaygroundProps) {
                   name={variant.label ?? variant.key}
                   options={variant.options}
                   current={values[variant.key]}
-                  onChange={(next) => setValue(variant.key, next)}
+                  onChange={(next) => setPrimitiveValue(variant.key, next)}
                 />
               ),
             )}

--- a/examples/lynx-spa/src/components/variant-table.tsx
+++ b/examples/lynx-spa/src/components/variant-table.tsx
@@ -4,12 +4,15 @@ import {
   getVariantDefaultValues,
   type PrimitiveValue,
   type VariantAxis,
+  type VariantCatalogValues,
   type VariantValues,
 } from './variant-playground.jsx';
 
-export interface VariantTableProps {
-  variants: readonly VariantAxis[];
-  children: (values: VariantValues) => ReactNode;
+export interface VariantTableProps<
+  Variants extends readonly VariantAxis[] = readonly VariantAxis[],
+> {
+  variants: Variants;
+  children: (values: VariantCatalogValues<Variants>) => ReactNode;
 }
 
 type TableEntry =
@@ -22,7 +25,9 @@ type TableEntry =
       values: VariantValues;
     };
 
-export function VariantTable(props: VariantTableProps) {
+export function VariantTable<const Variants extends readonly VariantAxis[]>(
+  props: VariantTableProps<Variants>,
+) {
   const { variants, children } = props;
 
   const entries = useMemo<TableEntry[]>(() => {
@@ -59,7 +64,7 @@ export function VariantTable(props: VariantTableProps) {
               axis={entry.axis}
               option={entry.option}
               values={entry.values}
-              renderComponent={children}
+              renderComponent={children as (values: VariantValues) => ReactNode}
             />
           )}
         </list-item>

--- a/examples/lynx-spa/src/pages/ActionButtonPage.tsx
+++ b/examples/lynx-spa/src/pages/ActionButtonPage.tsx
@@ -1,7 +1,13 @@
 import IconChevronDownFill from '@karrotmarket/lynx-monochrome-icon/IconChevronDownFill';
 import IconPlusFill from '@karrotmarket/lynx-monochrome-icon/IconPlusFill';
 import { actionButtonVariantMap } from '@seed-design/lynx-css/recipes/action-button';
-import { ActionButton, type ActionButtonProps } from '@seed-design/lynx-react';
+import {
+  ActionButton,
+  Icon,
+  PrefixIcon,
+  SuffixIcon,
+  type ActionButtonProps,
+} from '@seed-design/lynx-react';
 
 import {
   CatalogExamples,
@@ -66,9 +72,10 @@ function renderActionButton(values: VariantValues) {
         size={size}
         disabled={disabled}
         loading={loading}
-        icon={<IconPlusFill />}
         aria-label="Add"
-      />
+      >
+        <Icon icon={<IconPlusFill />} />
+      </ActionButton>
     );
   }
 
@@ -147,27 +154,21 @@ function ActionButtonExamples() {
           gap: '8px',
         }}
       >
-        <ActionButton variant="brandSolid" prefixIcon={<IconPlusFill />}>
+        <ActionButton variant="brandSolid">
+          <PrefixIcon icon={<IconPlusFill />} />
           Prefix Icon
         </ActionButton>
-        <ActionButton
-          variant="neutralSolid"
-          suffixIcon={<IconChevronDownFill />}
-        >
+        <ActionButton variant="neutralSolid">
           Suffix Icon
+          <SuffixIcon icon={<IconChevronDownFill />} />
         </ActionButton>
-        <ActionButton
-          variant="brandOutline"
-          prefixIcon={<IconPlusFill />}
-          suffixIcon={<IconChevronDownFill />}
-        >
+        <ActionButton variant="brandOutline">
+          <PrefixIcon icon={<IconPlusFill />} />
           Both
+          <SuffixIcon icon={<IconChevronDownFill />} />
         </ActionButton>
-        <ActionButton
-          variant="brandSolid"
-          disabled
-          prefixIcon={<IconPlusFill />}
-        >
+        <ActionButton variant="brandSolid" disabled>
+          <PrefixIcon icon={<IconPlusFill />} />
           Disabled
         </ActionButton>
       </view>
@@ -185,27 +186,22 @@ function ActionButtonExamples() {
         <ActionButton variant="brandSolid" loading>
           Loading
         </ActionButton>
-        <ActionButton
-          variant="neutralSolid"
-          prefixIcon={<IconPlusFill />}
-          loading
-        >
+        <ActionButton variant="neutralSolid" loading>
+          <PrefixIcon icon={<IconPlusFill />} />
           Prefix Icon
         </ActionButton>
-        <ActionButton
-          variant="brandOutline"
-          suffixIcon={<IconChevronDownFill />}
-          loading
-        >
+        <ActionButton variant="brandOutline" loading>
           Suffix Icon
+          <SuffixIcon icon={<IconChevronDownFill />} />
         </ActionButton>
         <ActionButton
           layout="iconOnly"
           variant="brandSolid"
-          icon={<IconPlusFill />}
           loading
           aria-label="Loading"
-        />
+        >
+          <Icon icon={<IconPlusFill />} />
+        </ActionButton>
       </view>
 
       <CatalogSectionTitle>Icon Only</CatalogSectionTitle>
@@ -218,32 +214,28 @@ function ActionButtonExamples() {
           alignItems: 'center',
         }}
       >
-        <ActionButton
-          layout="iconOnly"
-          variant="brandSolid"
-          icon={<IconPlusFill />}
-          aria-label="Add"
-        />
+        <ActionButton layout="iconOnly" variant="brandSolid" aria-label="Add">
+          <Icon icon={<IconPlusFill />} />
+        </ActionButton>
         <ActionButton
           layout="iconOnly"
           variant="neutralSolid"
           size="small"
-          icon={<IconPlusFill />}
           aria-label="Add"
-        />
-        <ActionButton
-          layout="iconOnly"
-          variant="brandOutline"
-          icon={<IconPlusFill />}
-          aria-label="Add"
-        />
+        >
+          <Icon icon={<IconPlusFill />} />
+        </ActionButton>
+        <ActionButton layout="iconOnly" variant="brandOutline" aria-label="Add">
+          <Icon icon={<IconPlusFill />} />
+        </ActionButton>
         <ActionButton
           layout="iconOnly"
           variant="brandSolid"
           disabled
-          icon={<IconPlusFill />}
           aria-label="Disabled"
-        />
+        >
+          <Icon icon={<IconPlusFill />} />
+        </ActionButton>
       </view>
     </CatalogExamples>
   );

--- a/examples/lynx-spa/src/pages/ActionButtonPage.tsx
+++ b/examples/lynx-spa/src/pages/ActionButtonPage.tsx
@@ -6,7 +6,6 @@ import {
   Icon,
   PrefixIcon,
   SuffixIcon,
-  type ActionButtonProps,
 } from '@seed-design/lynx-react';
 
 import {
@@ -14,17 +13,13 @@ import {
   CatalogSectionTitle,
 } from '../components/catalog-examples.jsx';
 import {
-  type PreviewState,
-  type VariantAxis,
+  definePreviewStates,
+  defineVariantAxes,
   VariantCatalog,
-  type VariantValues,
+  type VariantCatalogValues,
 } from '../components/variant-catalog.jsx';
 
-type ActionButtonVariant = NonNullable<ActionButtonProps['variant']>;
-type ActionButtonSize = NonNullable<ActionButtonProps['size']>;
-type ActionButtonLayout = NonNullable<ActionButtonProps['layout']>;
-
-const variants: readonly VariantAxis[] = [
+const variants = defineVariantAxes([
   {
     key: 'variant',
     options: actionButtonVariantMap.variant,
@@ -50,17 +45,20 @@ const variants: readonly VariantAxis[] = [
     options: actionButtonVariantMap.loading,
     defaultValue: false,
   },
-];
+]);
 
-const previewStates: readonly PreviewState[] = [
+const previewStates = definePreviewStates([
   { key: 'disabled', defaultValue: false },
   { key: 'loading', defaultValue: false },
-];
+]);
 
-function renderActionButton(values: VariantValues) {
-  const layout = values.layout as ActionButtonLayout;
-  const size = values.size as ActionButtonSize;
-  const variant = values.variant as ActionButtonVariant;
+type ActionButtonValues = VariantCatalogValues<
+  typeof variants,
+  typeof previewStates
+>;
+
+function renderActionButton(values: ActionButtonValues) {
+  const { layout, size, variant } = values;
   const disabled = Boolean(values.disabled);
   const loading = Boolean(values.loading);
 

--- a/examples/lynx-spa/src/pages/BottomSheetPage.tsx
+++ b/examples/lynx-spa/src/pages/BottomSheetPage.tsx
@@ -7,11 +7,11 @@ import {
   CatalogSectionTitle,
 } from '../components/catalog-examples.jsx';
 import {
-  type PreviewState,
+  definePreviewStates,
+  defineVariantAxes,
   type SetVariantValue,
-  type VariantAxis,
   VariantCatalog,
-  type VariantValues,
+  type VariantCatalogValues,
 } from '../components/variant-catalog.jsx';
 import {
   BottomSheetBody,
@@ -19,16 +19,13 @@ import {
   BottomSheetFooter,
   BottomSheetRoot,
   type BottomSheetRootRef,
-  type BottomSheetRootProps,
   BottomSheetTrigger,
 } from '../seed-design/ui/bottom-sheet';
 
 const SNAP_POINTS_FIT_80: Array<number | string> = ['fit', '80%'];
 const SNAP_POINTS_FIT: Array<number | string> = ['fit'];
 
-type BottomSheetHeaderAlign = NonNullable<BottomSheetRootProps['headerAlign']>;
-
-const variants: readonly VariantAxis[] = [
+const variants = defineVariantAxes([
   {
     key: 'headerAlign',
     options: bottomSheetVariantMap.headerAlign,
@@ -39,14 +36,22 @@ const variants: readonly VariantAxis[] = [
     options: bottomSheetVariantMap.skipAnimation,
     defaultValue: false,
   },
-];
+]);
 
-const previewStates: readonly PreviewState[] = [
+const previewStates = definePreviewStates([
   { key: 'open', defaultValue: false },
-];
+]);
 
-function renderBottomSheet(values: VariantValues, setValue: SetVariantValue) {
-  const headerAlign = values.headerAlign as BottomSheetHeaderAlign;
+type BottomSheetValues = VariantCatalogValues<
+  typeof variants,
+  typeof previewStates
+>;
+
+function renderBottomSheet(
+  values: BottomSheetValues,
+  setValue: SetVariantValue<BottomSheetValues>,
+) {
+  const { headerAlign } = values;
   const skipAnimation = Boolean(values.skipAnimation);
   const open = Boolean(values.open);
 

--- a/examples/lynx-spa/src/pages/CheckboxPage.tsx
+++ b/examples/lynx-spa/src/pages/CheckboxPage.tsx
@@ -7,25 +7,15 @@ import {
   CatalogSectionTitle,
 } from '../components/catalog-examples.jsx';
 import {
-  type PreviewState,
+  definePreviewStates,
+  defineVariantAxes,
   VariantCatalog,
   type SetVariantValue,
-  type VariantAxis,
-  type VariantValues,
+  type VariantCatalogValues,
 } from '../components/variant-catalog.jsx';
-import {
-  Checkbox,
-  CheckboxGroup,
-  Checkmark,
-  type CheckboxProps,
-} from '../seed-design/ui/checkbox';
+import { Checkbox, CheckboxGroup, Checkmark } from '../seed-design/ui/checkbox';
 
-type CheckboxWeight = NonNullable<CheckboxProps['weight']>;
-type CheckboxSize = NonNullable<CheckboxProps['size']>;
-type CheckboxTone = NonNullable<CheckboxProps['tone']>;
-type CheckboxVariant = NonNullable<CheckboxProps['variant']>;
-
-const variants: readonly VariantAxis[] = [
+const variants = defineVariantAxes([
   {
     key: 'weight',
     options: checkboxVariantMap.weight,
@@ -61,22 +51,30 @@ const variants: readonly VariantAxis[] = [
     options: checkmarkVariantMap.indeterminate,
     defaultValue: false,
   },
-];
+]);
 
-const previewStates: readonly PreviewState[] = [
+const previewStates = definePreviewStates([
   { key: 'checked', defaultValue: false },
   { key: 'indeterminate', defaultValue: false },
   { key: 'disabled', defaultValue: false },
-];
+]);
 
-function renderCheckbox(values: VariantValues, setValue: SetVariantValue) {
+type CheckboxValues = VariantCatalogValues<
+  typeof variants,
+  typeof previewStates
+>;
+
+function renderCheckbox(
+  values: CheckboxValues,
+  setValue: SetVariantValue<CheckboxValues>,
+) {
   return (
     <Checkbox
       label="Checkbox"
-      weight={values.weight as CheckboxWeight}
-      size={values.size as CheckboxSize}
-      tone={values.tone as CheckboxTone}
-      variant={values.variant as CheckboxVariant}
+      weight={values.weight}
+      size={values.size}
+      tone={values.tone}
+      variant={values.variant}
       checked={Boolean(values.checked)}
       indeterminate={Boolean(values.indeterminate)}
       disabled={Boolean(values.disabled)}

--- a/examples/lynx-spa/src/pages/ProgressCirclePage.tsx
+++ b/examples/lynx-spa/src/pages/ProgressCirclePage.tsx
@@ -7,17 +7,12 @@ import {
 } from '../components/catalog-examples.jsx';
 import {
   VariantCatalog,
-  type PreviewState,
-  type VariantAxis,
-  type VariantValues,
+  definePreviewStates,
+  defineVariantAxes,
+  type VariantCatalogValues,
 } from '../components/variant-catalog.jsx';
-import {
-  ProgressCircle,
-  type ProgressCircleProps,
-} from '../seed-design/ui/progress-circle';
+import { ProgressCircle } from '../seed-design/ui/progress-circle';
 
-type ProgressCircleTone = NonNullable<ProgressCircleProps['tone']>;
-type ProgressCircleSize = NonNullable<ProgressCircleProps['size']>;
 type ProgressState = 'indeterminate' | '25%' | '50%' | '75%' | '100%';
 
 const progressValueMap: Record<
@@ -30,7 +25,7 @@ const progressValueMap: Record<
   '100%': 1,
 };
 
-const variants: readonly VariantAxis[] = [
+const variants = defineVariantAxes([
   {
     key: 'tone',
     options: progressCircleVariantMap.tone,
@@ -47,16 +42,20 @@ const variants: readonly VariantAxis[] = [
     options: ['indeterminate', '25%', '50%', '75%', '100%'],
     defaultValue: 'indeterminate',
   },
-];
+]);
 
-const previewStates: readonly PreviewState[] = [
+const previewStates = definePreviewStates([
   { key: 'progressState', label: 'value', defaultValue: 'indeterminate' },
-];
+]);
 
-function renderProgressCircle(values: VariantValues) {
-  const tone = values.tone as ProgressCircleTone;
-  const size = values.size as ProgressCircleSize;
-  const progressState = values.progressState as ProgressState;
+type ProgressCircleValues = VariantCatalogValues<
+  typeof variants,
+  typeof previewStates
+>;
+
+function renderProgressCircle(values: ProgressCircleValues) {
+  const { tone, size } = values;
+  const progressState: ProgressState = values.progressState;
   const progressValue =
     progressState === 'indeterminate'
       ? undefined

--- a/examples/lynx-spa/src/pages/RadioGroupPage.tsx
+++ b/examples/lynx-spa/src/pages/RadioGroupPage.tsx
@@ -2,23 +2,15 @@ import { radioVariantMap } from '@seed-design/lynx-css/recipes/radio';
 import { radiomarkVariantMap } from '@seed-design/lynx-css/recipes/radiomark';
 
 import {
-  type PreviewState,
+  definePreviewStates,
+  defineVariantAxes,
   type SetVariantValue,
-  type VariantAxis,
   VariantCatalog,
-  type VariantValues,
+  type VariantCatalogValues,
 } from '../components/variant-catalog.jsx';
-import {
-  RadioGroup,
-  RadioGroupItem,
-  type RadioGroupProps,
-} from '../seed-design/ui/radio-group';
+import { RadioGroup, RadioGroupItem } from '../seed-design/ui/radio-group';
 
-type RadioWeight = NonNullable<RadioGroupProps['weight']>;
-type RadioSize = NonNullable<RadioGroupProps['size']>;
-type RadioTone = NonNullable<RadioGroupProps['tone']>;
-
-const variants: readonly VariantAxis[] = [
+const variants = defineVariantAxes([
   {
     key: 'weight',
     options: radioVariantMap.weight,
@@ -39,22 +31,28 @@ const variants: readonly VariantAxis[] = [
     options: radioVariantMap.disabled,
     defaultValue: false,
   },
-];
+]);
 
-const previewStates: readonly PreviewState[] = [
+const previewStates = definePreviewStates([
   { key: 'value', defaultValue: 'option1' },
-];
+]);
 
-function renderRadioGroup(values: VariantValues, setValue: SetVariantValue) {
-  const selectedValue = values.value as string;
+type RadioGroupValues = VariantCatalogValues<
+  typeof variants,
+  typeof previewStates
+>;
 
+function renderRadioGroup(
+  values: RadioGroupValues,
+  setValue: SetVariantValue<RadioGroupValues>,
+) {
   return (
     <RadioGroup
-      weight={values.weight as RadioWeight}
-      size={values.size as RadioSize}
-      tone={values.tone as RadioTone}
+      weight={values.weight}
+      size={values.size}
+      tone={values.tone}
       disabled={Boolean(values.disabled)}
-      value={selectedValue}
+      value={values.value}
       onValueChange={(next) => setValue('value', next)}
     >
       {['option1', 'option2', 'option3'].map((value) => (

--- a/examples/lynx-spa/src/pages/SwitchPage.tsx
+++ b/examples/lynx-spa/src/pages/SwitchPage.tsx
@@ -14,17 +14,14 @@ import {
 } from '../components/catalog-examples.jsx';
 import {
   VariantCatalog,
-  type PreviewState,
+  definePreviewStates,
+  defineVariantAxes,
   type SetVariantValue,
-  type VariantAxis,
-  type VariantValues,
+  type VariantCatalogValues,
 } from '../components/variant-catalog.jsx';
-import { Switch, Switchmark, type SwitchProps } from '../seed-design/ui/switch';
+import { Switch, Switchmark } from '../seed-design/ui/switch';
 
-type SwitchSize = NonNullable<SwitchProps['size']>;
-type SwitchTone = NonNullable<SwitchProps['tone']>;
-
-const variants: readonly VariantAxis[] = [
+const variants = defineVariantAxes([
   {
     key: 'size',
     options: switchVariantMap.size,
@@ -45,20 +42,25 @@ const variants: readonly VariantAxis[] = [
     options: switchVariantMap.disabled,
     defaultValue: false,
   },
-];
+]);
 
-const previewStates: readonly PreviewState[] = [
+const previewStates = definePreviewStates([
   { key: 'checked', defaultValue: false },
   { key: 'disabled', defaultValue: false },
-];
+]);
 
-function renderSwitch(values: VariantValues, setValue: SetVariantValue) {
+type SwitchValues = VariantCatalogValues<typeof variants, typeof previewStates>;
+
+function renderSwitch(
+  values: SwitchValues,
+  setValue: SetVariantValue<SwitchValues>,
+) {
   const checked = Boolean(values.checked);
   return (
     <Switch
       label={checked ? 'On' : 'Off'}
-      size={values.size as SwitchSize}
-      tone={values.tone as SwitchTone}
+      size={values.size}
+      tone={values.tone}
       checked={checked}
       disabled={Boolean(values.disabled)}
       onCheckedChange={(next) => setValue('checked', next)}

--- a/examples/lynx-spa/src/pages/TagGroupPage.tsx
+++ b/examples/lynx-spa/src/pages/TagGroupPage.tsx
@@ -7,20 +7,12 @@ import {
 } from '../components/catalog-examples.jsx';
 import {
   VariantCatalog,
-  type VariantAxis,
-  type VariantValues,
+  defineVariantAxes,
+  type VariantCatalogValues,
 } from '../components/variant-catalog.jsx';
-import {
-  TagGroupItem,
-  TagGroupRoot,
-  type TagGroupRootProps,
-} from '../seed-design/ui/tag-group';
+import { TagGroupItem, TagGroupRoot } from '../seed-design/ui/tag-group';
 
-type TagGroupSize = NonNullable<TagGroupRootProps['size']>;
-type TagGroupWeight = NonNullable<TagGroupRootProps['weight']>;
-type TagGroupTone = NonNullable<TagGroupRootProps['tone']>;
-
-const variants: readonly VariantAxis[] = [
+const variants = defineVariantAxes([
   {
     key: 'size',
     options: tagGroupVariantMap.size,
@@ -36,15 +28,13 @@ const variants: readonly VariantAxis[] = [
     options: tagGroupItemVariantMap.tone,
     defaultValue: 'neutralSubtle',
   },
-];
+]);
 
-function renderTagGroup(values: VariantValues) {
+type TagGroupValues = VariantCatalogValues<typeof variants>;
+
+function renderTagGroup(values: TagGroupValues) {
   return (
-    <TagGroupRoot
-      size={values.size as TagGroupSize}
-      weight={values.weight as TagGroupWeight}
-      tone={values.tone as TagGroupTone}
-    >
+    <TagGroupRoot size={values.size} weight={values.weight} tone={values.tone}>
       <TagGroupItem label="동네 인증" />
       <TagGroupItem label="매너 온도 42.0°C" />
       <TagGroupItem label="재거래 희망률 89%" />

--- a/packages/lynx-react/src/components/ActionButton/ActionButton.tsx
+++ b/packages/lynx-react/src/components/ActionButton/ActionButton.tsx
@@ -1,13 +1,19 @@
 import { actionButton } from "@seed-design/lynx-css/recipes/action-button";
 import type { ActionButtonVariantProps } from "@seed-design/lynx-css/recipes/action-button";
+import { progressCircleVariantMap } from "@seed-design/lynx-css/recipes/progress-circle";
 import { actionButton as actionButtonVars } from "@seed-design/lynx-css/vars/component";
-import type { MainThread } from "@lynx-js/types";
 import clsx from "clsx";
 import * as React from "react";
-import { cloneElement, isValidElement, useMemo, type ReactElement } from "react";
+import { isValidElement, useMemo } from "react";
 
-import { useIconColor } from "../../hooks/useIconColor";
-import { usePressTap, type UsePressTapReturn } from "../../hooks/usePressTap";
+import { usePressTap } from "../../hooks/usePressTap";
+import type {
+  LynxElementProps,
+  LynxPressableProps,
+  LynxStyledElementProps,
+  LynxTouchProps,
+} from "../../types";
+import type { StyleProps } from "../../utils/styled";
 import { createSlotRecipeContext } from "../../utils/create-slot-recipe-context";
 import { capitalize, resolveRecipeToken } from "../../utils/resolve-recipe-token";
 import {
@@ -15,54 +21,57 @@ import {
   ProgressCircleRoot,
   type ProgressCircleRootProps,
 } from "../ProgressCircle";
+import {
+  Icon,
+  IconRequired,
+  IconSlotProvider,
+  PrefixIcon,
+  SuffixIcon,
+  getIconSlotName,
+  type IconProps,
+  type PrefixIconProps,
+  type SuffixIconProps,
+} from "../Icon/Icon";
 
 // Root/TextSlot 은 `withProvider("view", ...)` / `withContext("text", ...)` 를 쓰지 않는다.
 // intrinsic string 인자는 `React.createElement("view", ...)` 로 컴파일되어 Lynx 컴파일러의
 // 리터럴 JSX 정적 분석을 우회하고 `BackgroundSnapshot not found: view` 런타임 에러를 유발한다.
 // (자세한 내용: `packages/lynx-react/AGENTS.md` 의 "Native tag literal JSX constraint" 섹션)
-const { ClassNamesProvider, useClassNames, PropsProvider, useProps } =
-  createSlotRecipeContext(actionButton);
+const { ClassNamesProvider, useClassNames, PropsProvider } = createSlotRecipeContext(actionButton);
 
-type IconSlotKey = "prefixIcon" | "suffixIcon" | "icon";
-type ActionButtonSize = NonNullable<ActionButtonVariantProps["size"]>;
-
-type IconElementProps = {
-  className?: string;
-  style?: React.CSSProperties;
-  ref?: React.Ref<MainThread.Element>;
-  "main-thread:binduiappear"?: () => void;
-};
-
-type ActionButtonContentProps = {
-  children?: React.ReactNode;
+interface ActionButtonContentProps extends LynxElementProps {
   isIconOnly: boolean;
-  icon?: ReactElement<IconElementProps>;
-  prefixIcon?: ReactElement<IconElementProps>;
-  suffixIcon?: ReactElement<IconElementProps>;
-};
+  icon?: IconProps["icon"];
+  prefixIcon?: PrefixIconProps["icon"];
+  suffixIcon?: SuffixIconProps["icon"];
+}
 
-type ActionButtonRootOwnProps = {
-  className?: string;
-  style?: React.CSSProperties;
-  children?: React.ReactNode;
-  bindtouchstart?: UsePressTapReturn["bindtouchstart"];
-  bindtouchend?: UsePressTapReturn["bindtouchend"];
-  bindtouchcancel?: UsePressTapReturn["bindtouchcancel"];
-  bindtap?: UsePressTapReturn["bindtap"];
-  "main-thread:bindtap"?: UsePressTapReturn["main-thread:bindtap"];
-};
+interface ActionButtonRootOwnProps extends LynxStyledElementProps, LynxTouchProps {}
 
-const progressCircleSizeMap = {
-  xsmall: "14",
-  small: "14",
-  medium: "16",
-  large: "18",
-} as const satisfies Record<ActionButtonSize, NonNullable<ProgressCircleRootProps["size"]>>;
+interface ActionButtonRootProps extends ActionButtonVariantProps, ActionButtonRootOwnProps {}
 
-const ActionButtonRoot = React.forwardRef<
-  unknown,
-  ActionButtonVariantProps & ActionButtonRootOwnProps
->((innerProps, ref) => {
+function resolveProgressCircleSize(
+  actionButtonSize: ActionButtonVariantProps["size"],
+): ProgressCircleRootProps["size"] {
+  const size = actionButtonSize ?? "medium";
+  const token = resolveRecipeToken(actionButtonVars, [
+    `size${capitalize(size)}`,
+    "enabled",
+    "progressCircle",
+    "size",
+  ]);
+  const normalized = token?.endsWith("px") ? token.slice(0, -2) : token;
+
+  return progressCircleVariantMap.size.find((size) => size === normalized) ?? "16";
+}
+
+function resolveFlexGrow(flexGrow: StyleProps["flexGrow"]) {
+  if (flexGrow === true) return 1;
+  if (flexGrow === false) return 0;
+  return flexGrow;
+}
+
+const ActionButtonRoot = React.forwardRef<unknown, ActionButtonRootProps>((innerProps, ref) => {
   const props = { layout: "withText" as const, ...innerProps };
   const [variantProps, otherProps] = actionButton.splitVariantProps(props);
   const classNames = actionButton(variantProps);
@@ -82,26 +91,51 @@ const ActionButtonRoot = React.forwardRef<
       variantProps.loading,
     ],
   );
+  const iconSlotContextValue = useMemo(
+    () => ({
+      classNames: {
+        icon: classNames.icon,
+        prefixIcon: classNames.prefixIcon,
+        suffixIcon: classNames.suffixIcon,
+      },
+      deps: [
+        variantProps.variant ?? null,
+        variantProps.disabled ?? false,
+        variantProps.loading ?? false,
+        variantProps.pressed ?? false,
+      ],
+    }),
+    [
+      classNames.icon,
+      classNames.prefixIcon,
+      classNames.suffixIcon,
+      variantProps.variant,
+      variantProps.disabled,
+      variantProps.loading,
+      variantProps.pressed,
+    ],
+  );
   return (
     <ClassNamesProvider value={classNames}>
       <PropsProvider value={propsForContext}>
-        <view
-          {...(ref ? { ref: ref as React.Ref<SVGViewElement> } : {})}
-          {...rest}
-          className={clsx(classNames.root, userClassName)}
-        >
-          {children as React.ReactNode}
-        </view>
+        <IconSlotProvider value={iconSlotContextValue}>
+          <view
+            {...(ref ? { ref: ref as React.Ref<SVGViewElement> } : {})}
+            {...rest}
+            className={clsx(classNames.root, userClassName)}
+          >
+            {children as React.ReactNode}
+          </view>
+        </IconSlotProvider>
       </PropsProvider>
     </ClassNamesProvider>
   );
 });
 ActionButtonRoot.displayName = "ActionButtonRoot";
 
-const ActionButtonTextSlot = React.forwardRef<
-  unknown,
-  { children?: React.ReactNode; className?: string }
->((props, ref) => {
+interface ActionButtonTextSlotProps extends LynxElementProps {}
+
+const ActionButtonTextSlot = React.forwardRef<unknown, ActionButtonTextSlotProps>((props, ref) => {
   const { children, className: userClassName, ...rest } = props;
   const classNames = useClassNames();
   return (
@@ -116,56 +150,6 @@ const ActionButtonTextSlot = React.forwardRef<
 });
 ActionButtonTextSlot.displayName = "ActionButtonTextSlot";
 
-/**
- * rootage vars 에서 현재 variant/size/layout 조합의 slot `size` 토큰
- * (예: `"var(--seed-dimension-x4)"`) 을 꺼낸다. 아이콘 컴포넌트가 inline
- * `style={{ width, height }}` 를 박기 때문에 style prop 으로 덮어 씌워야 recipe 사이즈가 적용된다.
- */
-function resolveIconSize(
-  variantProps: ActionButtonVariantProps | null,
-  slot: IconSlotKey,
-): string | undefined {
-  const size = variantProps?.size ?? "medium";
-  // `icon` slot is only rendered under `layout="iconOnly"` and keyed at
-  // `sizeXxxLayoutIconOnly.enabled.icon.size`. prefixIcon/suffixIcon follow
-  // the current `layout` (`withText` by default) path.
-  const layout = slot === "icon" ? "iconOnly" : (variantProps?.layout ?? "withText");
-  return resolveRecipeToken(actionButtonVars, [
-    `size${capitalize(size)}Layout${capitalize(layout)}`,
-    "enabled",
-    slot,
-    "size",
-  ]);
-}
-
-/**
- * `prefixIcon` / `suffixIcon` prop 으로 전달된 아이콘 element 에 slot className +
- * size(style) + main-thread tint-color ref 를 주입한다.
- */
-function ActionButtonIconSlot({
-  icon,
-  slot,
-}: {
-  icon: ReactElement<IconElementProps>;
-  slot: IconSlotKey;
-}) {
-  const classNames = useClassNames();
-  const variantProps = useProps() as ActionButtonVariantProps | null;
-  const iconColor = useIconColor([
-    variantProps?.variant ?? null,
-    variantProps?.disabled ?? false,
-    variantProps?.loading ?? false,
-  ]);
-  const sizeVar = resolveIconSize(variantProps, slot);
-  const childProps = icon.props;
-  return cloneElement(icon, {
-    ...iconColor,
-    className: clsx(classNames[slot], childProps.className),
-    style:
-      sizeVar != null ? { width: sizeVar, height: sizeVar, ...childProps.style } : childProps.style,
-  });
-}
-
 function ActionButtonContent({
   children,
   isIconOnly,
@@ -173,21 +157,43 @@ function ActionButtonContent({
   prefixIcon,
   suffixIcon,
 }: ActionButtonContentProps) {
+  const childArray = React.Children.toArray(children);
+  const prefixIconChildren: React.ReactNode[] = [];
+  const suffixIconChildren: React.ReactNode[] = [];
+  const iconChildren: React.ReactNode[] = [];
+  const textChildren: React.ReactNode[] = [];
+
+  for (const child of childArray) {
+    const slotName = getIconSlotName(child);
+
+    if (slotName === "prefixIcon") {
+      prefixIconChildren.push(child);
+      continue;
+    }
+    if (slotName === "suffixIcon") {
+      suffixIconChildren.push(child);
+      continue;
+    }
+    if (slotName === "icon") {
+      iconChildren.push(child);
+      continue;
+    }
+
+    textChildren.push(child);
+  }
+
   if (isIconOnly) {
-    return icon != null && isValidElement(icon) ? (
-      <ActionButtonIconSlot icon={icon} slot="icon" />
-    ) : null;
+    if (icon != null && isValidElement(icon)) return <Icon icon={icon} />;
+    return iconChildren.length > 0 ? <>{iconChildren}</> : null;
   }
 
   return (
     <>
-      {prefixIcon != null && isValidElement(prefixIcon) ? (
-        <ActionButtonIconSlot icon={prefixIcon} slot="prefixIcon" />
-      ) : null}
-      <ActionButtonTextSlot>{children}</ActionButtonTextSlot>
-      {suffixIcon != null && isValidElement(suffixIcon) ? (
-        <ActionButtonIconSlot icon={suffixIcon} slot="suffixIcon" />
-      ) : null}
+      {prefixIcon != null && isValidElement(prefixIcon) ? <PrefixIcon icon={prefixIcon} /> : null}
+      {prefixIconChildren}
+      {textChildren.length > 0 ? <ActionButtonTextSlot>{textChildren}</ActionButtonTextSlot> : null}
+      {suffixIconChildren}
+      {suffixIcon != null && isValidElement(suffixIcon) ? <SuffixIcon icon={suffixIcon} /> : null}
     </>
   );
 }
@@ -202,12 +208,13 @@ function ActionButtonLoadingContent(props: ActionButtonContentProps) {
   );
 }
 
-function ActionButtonLoadingIndicator({ size }: { size: ActionButtonSize }) {
+function ActionButtonLoadingIndicator({ size }: { size: ActionButtonVariantProps["size"] }) {
   const classNames = useClassNames();
+  const progressCircleSize = resolveProgressCircleSize(size);
 
   return (
     <view className={classNames.loadingIndicator}>
-      <ProgressCircleRoot size={progressCircleSizeMap[size]} tone="inherit">
+      <ProgressCircleRoot size={progressCircleSize} tone="inherit">
         <ProgressCircleRange />
       </ProgressCircleRoot>
     </view>
@@ -218,44 +225,42 @@ function ActionButtonLoadingIndicator({ size }: { size: ActionButtonSize }) {
  * @platform Lynx
  *
  * 웹 대비 차이:
- * - 아이콘 전달 방식: 웹의 `<ActionButton.PrefixIcon svg={...} />` 가 아니라 `prefixIcon` /
- *   `suffixIcon` / `icon` prop 으로 ReactElement 를 직접 넘긴다. Lynx `<text>` 가 flex
- *   컨테이너가 아니라 children 전체를 text 로 감싸면 아이콘이 flex item 이 안 되기 때문.
+ * - 아이콘 렌더링: 웹의 SVG `currentColor` 대신 Lynx `<image>` 의 `tint-color` 를
+ *   `Icon` / `PrefixIcon` / `SuffixIcon` wrapper 가 동기화한다.
+ * - 호환 API: 기존 `prefixIcon` / `suffixIcon` / `icon` prop 도 유지한다.
  * - 미지원 prop: `color`, `fontWeight`, `bleedX`, `bleedY` (CSS variable 동적 주입 제한)
  *
  * ```tsx
  * import IconPlusFill from "@karrotmarket/lynx-monochrome-icon/IconPlusFill";
  * import IconChevronDownFill from "@karrotmarket/lynx-monochrome-icon/IconChevronDownFill";
+ * import { Icon, PrefixIcon, SuffixIcon } from "@seed-design/lynx-react";
  *
  * // withText (기본)
- * <ActionButton
- *   variant="brandSolid"
- *   prefixIcon={<IconPlusFill />}
- *   suffixIcon={<IconChevronDownFill />}
- * >
+ * <ActionButton variant="brandSolid">
+ *   <PrefixIcon icon={<IconPlusFill />} />
  *   라벨
+ *   <SuffixIcon icon={<IconChevronDownFill />} />
  * </ActionButton>
  *
- * // iconOnly — `icon` prop 과 `aria-label` 필수
+ * // iconOnly — `<Icon />` child 와 `aria-label` 필수
  * <ActionButton
  *   layout="iconOnly"
  *   variant="neutralSolid"
- *   icon={<IconPlusFill />}
  *   aria-label="추가"
- * />
+ * >
+ *   <Icon icon={<IconPlusFill />} />
+ * </ActionButton>
  * ```
  */
-export interface ActionButtonProps extends Omit<ActionButtonVariantProps, "layout" | "pressed"> {
-  children?: React.ReactNode;
-  className?: string;
-  flexGrow?: number;
-  layout?: "withText" | "iconOnly";
-  icon?: ReactElement<IconElementProps>;
-  prefixIcon?: ReactElement<IconElementProps>;
-  suffixIcon?: ReactElement<IconElementProps>;
+export interface ActionButtonProps
+  extends Omit<ActionButtonVariantProps, "pressed">,
+    Pick<StyleProps, "flexGrow">,
+    LynxElementProps,
+    LynxPressableProps {
+  icon?: IconProps["icon"];
+  prefixIcon?: PrefixIconProps["icon"];
+  suffixIcon?: SuffixIconProps["icon"];
   "aria-label"?: string;
-  bindtap?: () => void;
-  "main-thread:bindtap"?: () => void;
 }
 
 export const ActionButton = React.forwardRef<unknown, ActionButtonProps>((props, ref) => {
@@ -273,7 +278,7 @@ export const ActionButton = React.forwardRef<unknown, ActionButtonProps>((props,
   const { disabled = false, loading = false } = variantAndRest;
   const isInteractive = !disabled && !loading;
   const isIconOnly = layout === "iconOnly";
-  const size = variantAndRest.size ?? "medium";
+  const size = variantAndRest.size;
 
   if (process.env.NODE_ENV !== "production" && isIconOnly && !props["aria-label"]) {
     console.warn('ActionButton: `layout="iconOnly"` requires `aria-label` for accessibility.');
@@ -286,37 +291,39 @@ export const ActionButton = React.forwardRef<unknown, ActionButtonProps>((props,
   });
 
   return (
-    <ActionButtonRoot
-      {...variantAndRest}
-      layout={layout}
-      pressed={pressed}
-      ref={ref}
-      style={flexGrow != null ? { flexGrow } : undefined}
-      {...pressTapHandlers}
-    >
-      {loading ? (
-        <>
-          <ActionButtonLoadingIndicator size={size} />
-          <ActionButtonLoadingContent
+    <IconRequired enabled={isIconOnly}>
+      <ActionButtonRoot
+        {...variantAndRest}
+        layout={layout}
+        pressed={pressed}
+        ref={ref}
+        style={flexGrow != null ? { flexGrow: resolveFlexGrow(flexGrow) } : undefined}
+        {...pressTapHandlers}
+      >
+        {loading ? (
+          <>
+            <ActionButtonLoadingIndicator size={size} />
+            <ActionButtonLoadingContent
+              isIconOnly={isIconOnly}
+              icon={icon}
+              prefixIcon={prefixIcon}
+              suffixIcon={suffixIcon}
+            >
+              {children}
+            </ActionButtonLoadingContent>
+          </>
+        ) : (
+          <ActionButtonContent
             isIconOnly={isIconOnly}
             icon={icon}
             prefixIcon={prefixIcon}
             suffixIcon={suffixIcon}
           >
             {children}
-          </ActionButtonLoadingContent>
-        </>
-      ) : (
-        <ActionButtonContent
-          isIconOnly={isIconOnly}
-          icon={icon}
-          prefixIcon={prefixIcon}
-          suffixIcon={suffixIcon}
-        >
-          {children}
-        </ActionButtonContent>
-      )}
-    </ActionButtonRoot>
+          </ActionButtonContent>
+        )}
+      </ActionButtonRoot>
+    </IconRequired>
   );
 });
 ActionButton.displayName = "ActionButton";

--- a/packages/lynx-react/src/components/ActionButton/ActionButton.tsx
+++ b/packages/lynx-react/src/components/ActionButton/ActionButton.tsx
@@ -13,9 +13,9 @@ import type {
   LynxStyledElementProps,
   LynxTouchProps,
 } from "../../types";
-import type { StyleProps } from "../../utils/styled";
 import { createSlotRecipeContext } from "../../utils/create-slot-recipe-context";
 import { capitalize, resolveRecipeToken } from "../../utils/resolve-recipe-token";
+import { resolveFlexValue, type StyleProps } from "../../utils/styled";
 import {
   ProgressCircleRange,
   ProgressCircleRoot,
@@ -38,6 +38,8 @@ import {
 // 리터럴 JSX 정적 분석을 우회하고 `BackgroundSnapshot not found: view` 런타임 에러를 유발한다.
 // (자세한 내용: `packages/lynx-react/AGENTS.md` 의 "Native tag literal JSX constraint" 섹션)
 const { ClassNamesProvider, useClassNames, PropsProvider } = createSlotRecipeContext(actionButton);
+
+////////////////////////////////////////////////////////////////////////////////////
 
 interface ActionButtonContentProps extends LynxElementProps {
   isIconOnly: boolean;
@@ -65,11 +67,7 @@ function resolveProgressCircleSize(
   return progressCircleVariantMap.size.find((size) => size === normalized) ?? "16";
 }
 
-function resolveFlexGrow(flexGrow: StyleProps["flexGrow"]) {
-  if (flexGrow === true) return 1;
-  if (flexGrow === false) return 0;
-  return flexGrow;
-}
+////////////////////////////////////////////////////////////////////////////////////
 
 const ActionButtonRoot = React.forwardRef<unknown, ActionButtonRootProps>((innerProps, ref) => {
   const props = { layout: "withText" as const, ...innerProps };
@@ -133,6 +131,8 @@ const ActionButtonRoot = React.forwardRef<unknown, ActionButtonRootProps>((inner
 });
 ActionButtonRoot.displayName = "ActionButtonRoot";
 
+////////////////////////////////////////////////////////////////////////////////////
+
 interface ActionButtonTextSlotProps extends LynxElementProps {}
 
 const ActionButtonTextSlot = React.forwardRef<unknown, ActionButtonTextSlotProps>((props, ref) => {
@@ -149,6 +149,8 @@ const ActionButtonTextSlot = React.forwardRef<unknown, ActionButtonTextSlotProps
   );
 });
 ActionButtonTextSlot.displayName = "ActionButtonTextSlot";
+
+////////////////////////////////////////////////////////////////////////////////////
 
 function ActionButtonContent({
   children,
@@ -198,6 +200,8 @@ function ActionButtonContent({
   );
 }
 
+////////////////////////////////////////////////////////////////////////////////////
+
 function ActionButtonLoadingContent(props: ActionButtonContentProps) {
   const classNames = useClassNames();
 
@@ -207,6 +211,8 @@ function ActionButtonLoadingContent(props: ActionButtonContentProps) {
     </view>
   );
 }
+
+////////////////////////////////////////////////////////////////////////////////////
 
 function ActionButtonLoadingIndicator({ size }: { size: ActionButtonVariantProps["size"] }) {
   const classNames = useClassNames();
@@ -220,6 +226,8 @@ function ActionButtonLoadingIndicator({ size }: { size: ActionButtonVariantProps
     </view>
   );
 }
+
+////////////////////////////////////////////////////////////////////////////////////
 
 /**
  * @platform Lynx
@@ -297,7 +305,7 @@ export const ActionButton = React.forwardRef<unknown, ActionButtonProps>((props,
         layout={layout}
         pressed={pressed}
         ref={ref}
-        style={flexGrow != null ? { flexGrow: resolveFlexGrow(flexGrow) } : undefined}
+        style={flexGrow != null ? { flexGrow: resolveFlexValue(flexGrow) } : undefined}
         {...pressTapHandlers}
       >
         {loading ? (

--- a/packages/lynx-react/src/components/ActionButton/__tests__/ActionButton.test.tsx
+++ b/packages/lynx-react/src/components/ActionButton/__tests__/ActionButton.test.tsx
@@ -1,8 +1,20 @@
 import "@testing-library/jest-dom";
 import { getQueriesForElement, render } from "@lynx-js/react/testing-library";
-import { describe, expect, it } from "vitest";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
 
+import type { LynxIconElementProps } from "../../../types";
+import { Icon, PrefixIcon, SuffixIcon } from "../../Icon";
 import { ActionButton } from "../ActionButton";
+
+vi.mock("@lynx-js/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lynx-js/react")>();
+
+  return {
+    ...actual,
+    runOnMainThread: () => () => undefined,
+  };
+});
 
 function getRenderedQueries() {
   return getQueriesForElement(getRenderedRoot());
@@ -18,6 +30,20 @@ function getRenderedRoot() {
   return root;
 }
 
+const MockIcon = React.forwardRef<unknown, LynxIconElementProps>((props, ref) => {
+  const { className, style, ...rest } = props;
+
+  return (
+    <image
+      {...rest}
+      {...(ref ? { "main-thread:ref": ref as React.Ref<unknown> } : {})}
+      className={className}
+      style={style}
+    />
+  );
+});
+MockIcon.displayName = "MockIcon";
+
 describe("ActionButton", () => {
   it("keeps the original label in the text slot while loading", () => {
     render(<ActionButton loading>Submit</ActionButton>);
@@ -31,5 +57,80 @@ describe("ActionButton", () => {
     expect(root.querySelector(".seed-action-button__content")).toBeInTheDocument();
     expect(root.querySelector(".seed-action-button__loadingIndicator")).toBeInTheDocument();
     expect(root.querySelector(".seed-progress-circle__root")).toBeInTheDocument();
+  });
+
+  it("applies action button slot classes to child icon slots", () => {
+    render(
+      <ActionButton variant="brandSolid">
+        <PrefixIcon icon={<MockIcon />} />
+        Submit
+        <SuffixIcon icon={<MockIcon />} />
+      </ActionButton>,
+    );
+
+    const { getByText } = getRenderedQueries();
+    const root = getRenderedRoot();
+
+    expect(root.querySelector(".seed-prefix-icon")).toHaveClass("seed-action-button__prefixIcon");
+    expect(root.querySelector(".seed-suffix-icon")).toHaveClass("seed-action-button__suffixIcon");
+    expect(root.querySelector(".seed-prefix-icon image")).toHaveStyle({
+      width: "100%",
+      height: "100%",
+    });
+    expect(getByText("Submit")).toHaveClass("seed-action-button__text");
+  });
+
+  it("keeps existing icon props compatible with the new slot wrapper", () => {
+    render(
+      <ActionButton prefixIcon={<MockIcon />} suffixIcon={<MockIcon />}>
+        Submit
+      </ActionButton>,
+    );
+
+    const root = getRenderedRoot();
+
+    expect(root.querySelector(".seed-prefix-icon")).toHaveClass("seed-action-button__prefixIcon");
+    expect(root.querySelector(".seed-suffix-icon")).toHaveClass("seed-action-button__suffixIcon");
+  });
+
+  it("supports icon-only child slot", () => {
+    render(
+      <ActionButton layout="iconOnly" aria-label="Add">
+        <Icon icon={<MockIcon />} />
+      </ActionButton>,
+    );
+
+    const root = getRenderedRoot();
+
+    expect(root.querySelector(".seed-icon")).toHaveClass("seed-action-button__icon");
+  });
+
+  it("keeps existing icon prop compatible with icon-only validation", () => {
+    render(<ActionButton layout="iconOnly" aria-label="Add" icon={<MockIcon />} />);
+
+    const root = getRenderedRoot();
+
+    expect(root.querySelector(".seed-icon")).toHaveClass("seed-action-button__icon");
+  });
+
+  it("throws in development when icon-only layout has no Icon child", () => {
+    expect(() => {
+      render(
+        <ActionButton layout="iconOnly" aria-label="Add">
+          Add
+        </ActionButton>,
+      );
+    }).toThrow(/must render <Icon \/> as a child/);
+  });
+
+  it("throws in development when icon-only layout has multiple Icon children", () => {
+    expect(() => {
+      render(
+        <ActionButton layout="iconOnly" aria-label="Add">
+          <Icon icon={<MockIcon />} />
+          <Icon icon={<MockIcon />} />
+        </ActionButton>,
+      );
+    }).toThrow(/must render only one <Icon \/>/);
   });
 });

--- a/packages/lynx-react/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/lynx-react/src/components/BottomSheet/BottomSheet.tsx
@@ -24,13 +24,12 @@ import {
   useContext,
   useMemo,
   useRef,
-  type ReactNode,
   type Ref,
   type RefObject,
 } from "@lynx-js/react";
-import type { CSSProperties } from "react";
 import clsx from "clsx";
 
+import type { LynxPressableProps, LynxStyledElementProps } from "../../types";
 import { createSlotRecipeContext } from "../../utils/create-slot-recipe-context";
 
 type BottomSheetClassNames = ReturnType<typeof bottomSheet>;
@@ -194,12 +193,9 @@ BottomSheetRoot.displayName = "BottomSheetRoot";
 // Trigger
 ////////////////////////////////////////////////////////////////////////////////////
 
-export interface BottomSheetTriggerProps {
-  children?: ReactNode;
-  className?: string;
-  style?: CSSProperties;
-  bindtap?: () => void;
-}
+export interface BottomSheetTriggerProps
+  extends LynxStyledElementProps,
+    Pick<LynxPressableProps, "bindtap"> {}
 
 export const BottomSheetTrigger = forwardRef<unknown, BottomSheetTriggerProps>((props, ref) => {
   const { children, className, style, bindtap: userBindtap } = props;
@@ -323,11 +319,7 @@ BottomSheetHandle.displayName = "BottomSheetHandle";
 // (lynx-ui-sheet 같은 외부 컴포넌트 감싸기엔 withContext를 그대로 사용해도 안전.)
 ////////////////////////////////////////////////////////////////////////////////////
 
-export interface BottomSheetSlotProps {
-  children?: ReactNode;
-  className?: string;
-  style?: CSSProperties;
-}
+export interface BottomSheetSlotProps extends LynxStyledElementProps {}
 
 function createViewSlot(slotName: keyof BottomSheetClassNames) {
   const Slot = forwardRef<unknown, BottomSheetSlotProps>((props, ref) => {

--- a/packages/lynx-react/src/components/Box/Box.tsx
+++ b/packages/lynx-react/src/components/Box/Box.tsx
@@ -1,17 +1,13 @@
 import clsx from "clsx";
 import * as React from "react";
 
+import type { LynxPressableProps, LynxStyledElementProps } from "../../types";
 import { useStyleProps, type StyleProps } from "../../utils/styled";
 
-export interface BoxProps extends StyleProps {
-  className?: string;
-  style?: React.CSSProperties;
-  children?: React.ReactNode;
-  bindtap?: () => void;
+export interface BoxProps extends StyleProps, LynxStyledElementProps, LynxPressableProps {
   bindtouchstart?: () => void;
   bindtouchend?: () => void;
   bindtouchcancel?: () => void;
-  "main-thread:bindtap"?: () => void;
 }
 
 export const Box = React.forwardRef<unknown, BoxProps>((props, ref) => {

--- a/packages/lynx-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/lynx-react/src/components/Checkbox/Checkbox.tsx
@@ -1,20 +1,18 @@
 import * as React from "react";
-import { cloneElement, isValidElement, type CSSProperties, type ReactElement } from "react";
+import { isValidElement, type ReactElement } from "react";
 import clsx from "clsx";
-import type { MainThread } from "@lynx-js/types";
 
 import { checkbox } from "@seed-design/lynx-css/recipes/checkbox";
 import type { CheckboxVariantProps } from "@seed-design/lynx-css/recipes/checkbox";
 import { checkmark } from "@seed-design/lynx-css/recipes/checkmark";
 import type { CheckmarkVariantProps } from "@seed-design/lynx-css/recipes/checkmark";
 import { checkboxGroup } from "@seed-design/lynx-css/recipes/checkbox-group";
-import { vars as checkmarkVars } from "@seed-design/lynx-css/vars/component/checkmark";
 
 import { useControllableState } from "../../hooks/useControllableState";
-import { useIconColor } from "../../hooks/useIconColor";
 import { usePressTap } from "../../hooks/usePressTap";
-import { capitalize, resolveRecipeToken } from "../../utils/resolve-recipe-token";
+import type { LynxIconElementProps, LynxStyledElementProps } from "../../types";
 import { splitMultipleVariantsProps } from "../../utils/split-multiple-variants-props";
+import { InternalIcon } from "../Icon/Icon";
 
 /**
  * @platform Lynx
@@ -30,25 +28,19 @@ import { splitMultipleVariantsProps } from "../../utils/split-multiple-variants-
  * recipe 의 `color` 토큰을 `tint-color` 로 동기화한다. raw SVG 주입은 Lynx 범위 밖.
  */
 
-type CheckboxSize = NonNullable<CheckboxVariantProps["size"]>;
-type CheckboxWeight = NonNullable<CheckboxVariantProps["weight"]>;
-type CheckmarkTone = NonNullable<CheckmarkVariantProps["tone"]>;
-type CheckmarkVariant = NonNullable<CheckmarkVariantProps["variant"]>;
-
-interface CheckboxContextValue {
+interface CheckboxApi {
   checked: boolean;
   indeterminate: boolean;
   disabled: boolean;
   pressed: boolean;
-  size: CheckboxSize;
-  weight: CheckboxWeight;
-  tone: CheckmarkTone;
-  variant: CheckmarkVariant;
+  checkboxVariantProps: CheckboxVariantProps;
+  checkmarkVariantProps: CheckmarkVariantProps;
+  toggle: () => void;
 }
 
-const CheckboxContext = React.createContext<CheckboxContextValue | null>(null);
+const CheckboxContext = React.createContext<CheckboxApi | null>(null);
 
-function useCheckboxContext(consumer: string): CheckboxContextValue {
+function useCheckboxContext(consumer: string): CheckboxApi {
   const ctx = React.useContext(CheckboxContext);
   if (!ctx) {
     throw new Error(`<${consumer}/> must be rendered inside <CheckboxRoot/>.`);
@@ -56,10 +48,15 @@ function useCheckboxContext(consumer: string): CheckboxContextValue {
   return ctx;
 }
 
-const CheckmarkIconClassContext = React.createContext<string | null>(null);
+interface CheckmarkControlContextValue {
+  iconClassName: string;
+  checkmarkVariantProps: CheckmarkVariantProps;
+}
 
-function useCheckmarkIconClass(consumer: string): string {
-  const ctx = React.useContext(CheckmarkIconClassContext);
+const CheckmarkControlContext = React.createContext<CheckmarkControlContextValue | null>(null);
+
+function useCheckmarkControlContext(consumer: string): CheckmarkControlContextValue {
+  const ctx = React.useContext(CheckmarkControlContext);
   if (!ctx) {
     throw new Error(`<${consumer}/> must be rendered inside <CheckboxControl/>.`);
   }
@@ -70,9 +67,8 @@ function useCheckmarkIconClass(consumer: string): string {
 
 export interface CheckboxRootProps
   extends CheckboxVariantProps,
-    Omit<CheckmarkVariantProps, "size" | "checked" | "disabled" | "indeterminate"> {
-  children?: React.ReactNode;
-  className?: string;
+    Omit<CheckmarkVariantProps, "size" | "checked" | "disabled" | "indeterminate">,
+    LynxStyledElementProps {
   checked?: boolean;
   defaultChecked?: boolean;
   indeterminate?: boolean;
@@ -93,10 +89,6 @@ export const CheckboxRoot = React.forwardRef<unknown, CheckboxRootProps>((props,
   } = props;
   const [{ checkbox: checkboxVariantProps, checkmark: checkmarkVariantProps }, nativeProps] =
     splitMultipleVariantsProps(restProps, { checkbox, checkmark });
-  const weight: CheckboxWeight = checkboxVariantProps.weight ?? "regular";
-  const size: CheckboxSize = checkboxVariantProps.size ?? "medium";
-  const tone: CheckmarkTone = checkmarkVariantProps.tone ?? "brand";
-  const variant: CheckmarkVariant = checkmarkVariantProps.variant ?? "square";
 
   const [checked, setChecked] = useControllableState({
     value: checkedProp,
@@ -104,20 +96,38 @@ export const CheckboxRoot = React.forwardRef<unknown, CheckboxRootProps>((props,
     onChange: onCheckedChange,
   });
 
+  const toggle = React.useCallback(() => setChecked(!checked), [checked, setChecked]);
+
   const { pressed, ...pressHandlers } = usePressTap({
     disabled,
-    onTap: () => setChecked(!checked),
+    onTap: toggle,
   });
 
-  const rootClassName = checkbox({ weight, size, disabled }).root;
+  const rootClassName = checkbox({ ...checkboxVariantProps, disabled }).root;
 
-  const ctx = React.useMemo<CheckboxContextValue>(
-    () => ({ checked, indeterminate, disabled, pressed, size, weight, tone, variant }),
-    [checked, indeterminate, disabled, pressed, size, weight, tone, variant],
+  const api = React.useMemo<CheckboxApi>(
+    () => ({
+      checked,
+      indeterminate,
+      disabled,
+      pressed,
+      checkboxVariantProps,
+      checkmarkVariantProps,
+      toggle,
+    }),
+    [
+      checked,
+      indeterminate,
+      disabled,
+      pressed,
+      checkboxVariantProps,
+      checkmarkVariantProps,
+      toggle,
+    ],
   );
 
   return (
-    <CheckboxContext.Provider value={ctx}>
+    <CheckboxContext.Provider value={api}>
       <view
         {...(ref ? { ref: ref as React.Ref<SVGViewElement> } : {})}
         className={clsx(rootClassName, className)}
@@ -134,35 +144,27 @@ CheckboxRoot.displayName = "CheckboxRoot";
 ////////////////////////////////////////////////////////////////////////////////////
 
 export interface CheckboxControlProps
-  extends Pick<CheckmarkVariantProps, "tone" | "variant" | "size"> {
-  children?: React.ReactNode;
-  className?: string;
-}
+  extends Pick<CheckmarkVariantProps, "tone" | "variant" | "size">,
+    LynxStyledElementProps {}
 
 export const CheckboxControl = React.forwardRef<unknown, CheckboxControlProps>((props, ref) => {
   const [variantProps, restProps] = checkmark.splitVariantProps(props);
   const { children, className, ...nativeProps } = restProps;
-  const {
-    checked,
-    indeterminate,
-    disabled,
-    pressed,
-    tone: ctxTone,
-    variant: ctxVariant,
-    size: ctxSize,
-  } = useCheckboxContext("CheckboxControl");
-
-  const tone: CheckmarkTone = variantProps.tone ?? ctxTone;
-  const variant: CheckmarkVariant = variantProps.variant ?? ctxVariant;
-  const size: CheckboxSize = (variantProps.size as CheckboxSize | undefined) ?? ctxSize;
-
-  const classes = React.useMemo(
-    () => checkmark({ variant, tone, size, checked, disabled, indeterminate, pressed }),
-    [variant, tone, size, checked, disabled, indeterminate, pressed],
-  );
+  const api = useCheckboxContext("CheckboxControl");
+  const checkmarkVariantProps: CheckmarkVariantProps = {
+    ...api.checkmarkVariantProps,
+    ...variantProps,
+    checked: api.checked,
+    disabled: api.disabled,
+    indeterminate: api.indeterminate,
+    pressed: api.pressed,
+  };
+  const classes = checkmark(checkmarkVariantProps);
 
   return (
-    <CheckmarkIconClassContext.Provider value={classes.icon}>
+    <CheckmarkControlContext.Provider
+      value={{ iconClassName: classes.icon, checkmarkVariantProps }}
+    >
       <view
         {...(ref ? { ref: ref as React.Ref<SVGViewElement> } : {})}
         className={clsx(classes.root, className)}
@@ -170,29 +172,21 @@ export const CheckboxControl = React.forwardRef<unknown, CheckboxControlProps>((
       >
         {children}
       </view>
-    </CheckmarkIconClassContext.Provider>
+    </CheckmarkControlContext.Provider>
   );
 });
 CheckboxControl.displayName = "CheckboxControl";
 
 ////////////////////////////////////////////////////////////////////////////////////
 
-type IconElementProps = {
-  className?: string;
-  style?: CSSProperties;
-  ref?: React.Ref<MainThread.Element>;
-  "main-thread:binduiappear"?: () => void;
-};
-
-export interface CheckboxIndicatorProps {
+export interface CheckboxIndicatorProps
+  extends Pick<LynxStyledElementProps, "className" | "style"> {
   /** Icon rendered when neither checked nor indeterminate. Optional. */
-  unchecked?: ReactElement<IconElementProps>;
+  unchecked?: ReactElement<LynxIconElementProps>;
   /** Icon rendered when `checked=true` and `indeterminate=false`. */
-  checked: ReactElement<IconElementProps>;
+  checked: ReactElement<LynxIconElementProps>;
   /** Icon rendered when `indeterminate=true`. */
-  indeterminate?: ReactElement<IconElementProps>;
-  className?: string;
-  style?: CSSProperties;
+  indeterminate?: ReactElement<LynxIconElementProps>;
 }
 
 export function CheckboxIndicator(props: CheckboxIndicatorProps) {
@@ -203,58 +197,45 @@ export function CheckboxIndicator(props: CheckboxIndicatorProps) {
     className,
     style,
   } = props;
-  const { checked, indeterminate, disabled, pressed, tone, variant, size } =
-    useCheckboxContext("CheckboxIndicator");
-  const iconClassName = useCheckmarkIconClass("CheckboxIndicator");
-  const iconColor = useIconColor([
-    checked,
-    indeterminate,
-    disabled,
-    pressed,
-    tone,
-    variant,
-    size,
-  ]);
+  const api = useCheckboxContext("CheckboxIndicator");
+  const { iconClassName, checkmarkVariantProps } = useCheckmarkControlContext("CheckboxIndicator");
 
-  if (process.env.NODE_ENV !== "production" && indeterminate && !indeterminateIcon) {
+  if (process.env.NODE_ENV !== "production" && api.indeterminate && !indeterminateIcon) {
     console.warn(
       "[seed-design] CheckboxIndicator: `indeterminate` prop must be provided when the checkbox is in an indeterminate state.",
     );
   }
 
-  const icon = indeterminate ? indeterminateIcon : checked ? checkedIcon : unchecked;
-  if (!icon || !isValidElement<IconElementProps>(icon)) return null;
+  const icon = api.indeterminate ? indeterminateIcon : api.checked ? checkedIcon : unchecked;
+  if (!icon || !isValidElement<LynxIconElementProps>(icon)) return null;
 
-  // lynx-monochrome-icon 이 `<image style={{ width, height, ...style }}>` 로 자체 default size 를 박으므로
-  // recipe 토큰에서 꺼낸 사이즈를 inline 으로 주입해 덮는다.
-  const iconSize = resolveRecipeToken(checkmarkVars, [
-    `variant${capitalize(variant)}Size${capitalize(size)}`,
-    "enabled",
-    "icon",
-    "size",
-  ]);
-
-  return cloneElement(icon, {
-    ...iconColor,
-    className: clsx(iconClassName, icon.props.className, className),
-    style: iconSize
-      ? { width: iconSize, height: iconSize, ...icon.props.style, ...style }
-      : { ...icon.props.style, ...style },
-  });
+  return (
+    <InternalIcon
+      icon={icon}
+      className={clsx(iconClassName, className)}
+      style={style}
+      deps={[
+        api.checked,
+        api.indeterminate,
+        api.disabled,
+        api.pressed,
+        checkmarkVariantProps.tone,
+        checkmarkVariantProps.variant,
+        checkmarkVariantProps.size,
+      ]}
+    />
+  );
 }
 CheckboxIndicator.displayName = "CheckboxIndicator";
 
 ////////////////////////////////////////////////////////////////////////////////////
 
-export interface CheckboxLabelProps {
-  children?: React.ReactNode;
-  className?: string;
-}
+export interface CheckboxLabelProps extends LynxStyledElementProps {}
 
 export const CheckboxLabel = React.forwardRef<unknown, CheckboxLabelProps>((props, ref) => {
   const { children, className, ...nativeProps } = props;
-  const { disabled, weight, size } = useCheckboxContext("CheckboxLabel");
-  const labelClassName = checkbox({ weight, size, disabled }).label;
+  const api = useCheckboxContext("CheckboxLabel");
+  const labelClassName = checkbox({ ...api.checkboxVariantProps, disabled: api.disabled }).label;
 
   return (
     <text
@@ -270,10 +251,7 @@ CheckboxLabel.displayName = "CheckboxLabel";
 
 ////////////////////////////////////////////////////////////////////////////////////
 
-export interface CheckboxGroupProps {
-  children?: React.ReactNode;
-  className?: string;
-}
+export interface CheckboxGroupProps extends LynxStyledElementProps {}
 
 export const CheckboxGroup = React.forwardRef<unknown, CheckboxGroupProps>((props, ref) => {
   const { children, className, ...nativeProps } = props;

--- a/packages/lynx-react/src/components/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/lynx-react/src/components/Checkbox/__tests__/Checkbox.test.tsx
@@ -1,0 +1,83 @@
+import "@testing-library/jest-dom";
+import { getQueriesForElement, render } from "@lynx-js/react/testing-library";
+import { checkbox } from "@seed-design/lynx-css/recipes/checkbox";
+import { checkmark } from "@seed-design/lynx-css/recipes/checkmark";
+import * as React from "react";
+import { describe, expect, it } from "vitest";
+
+import type { LynxIconElementProps } from "../../../types";
+import { CheckboxControl, CheckboxIndicator, CheckboxLabel, CheckboxRoot } from "../Checkbox";
+
+function getRenderedQueries() {
+  return getQueriesForElement(getRenderedRoot());
+}
+
+function getRenderedRoot() {
+  const root = elementTree.root;
+
+  if (!root) {
+    throw new Error("Expected Lynx render root to exist.");
+  }
+
+  return root;
+}
+
+const MockIcon = React.forwardRef<unknown, LynxIconElementProps>((props, ref) => {
+  const { className, style, ...rest } = props;
+
+  return (
+    <image
+      {...rest}
+      {...(ref ? { "main-thread:ref": ref as React.Ref<unknown> } : {})}
+      className={className}
+      style={style}
+    />
+  );
+});
+MockIcon.displayName = "MockIcon";
+
+describe("Checkbox", () => {
+  it("merges parent and local variant props through context", () => {
+    render(
+      <CheckboxRoot defaultChecked size="large" weight="bold" tone="brand">
+        <CheckboxControl tone="neutral" variant="ghost" />
+        <CheckboxLabel>동의</CheckboxLabel>
+      </CheckboxRoot>,
+    );
+
+    const root = getRenderedRoot();
+    const { getByText } = getRenderedQueries();
+
+    expect(root.querySelector(".seed-checkmark__root")).toHaveClass(
+      checkmark({
+        variant: "ghost",
+        tone: "neutral",
+        size: "large",
+        checked: true,
+        disabled: false,
+        indeterminate: false,
+        pressed: false,
+      }).root,
+    );
+    expect(getByText("동의")).toHaveClass(
+      checkbox({ size: "large", weight: "bold", disabled: false }).label,
+    );
+  });
+
+  it("wraps a custom indicator icon with the final checkmark icon class", () => {
+    render(
+      <CheckboxRoot defaultChecked>
+        <CheckboxControl>
+          <CheckboxIndicator checked={<MockIcon />} />
+        </CheckboxControl>
+      </CheckboxRoot>,
+    );
+
+    const root = getRenderedRoot();
+    const iconWrapper = root.querySelector(".seed-checkmark__icon");
+    const image = iconWrapper?.querySelector("image");
+
+    expect(iconWrapper).toBeInTheDocument();
+    expect(image).toHaveStyle({ width: "100%", height: "100%" });
+  });
+});

--- a/packages/lynx-react/src/components/Icon/Icon.tsx
+++ b/packages/lynx-react/src/components/Icon/Icon.tsx
@@ -133,6 +133,10 @@ function mergeWrapperStyle({
   };
 }
 
+function getStyleColor(style: React.CSSProperties | undefined): React.CSSProperties["color"] {
+  return style?.color;
+}
+
 const IconSlotBase = React.forwardRef<unknown, IconSlotBaseProps>((props, ref) => {
   const {
     icon,
@@ -149,8 +153,9 @@ const IconSlotBase = React.forwardRef<unknown, IconSlotBaseProps>((props, ref) =
   const iconRequiredContext = React.useContext(IconRequiredContext);
   const sourceRef = useMainThreadRef<MainThread.Element>(null);
   const slotClassName = slot != null ? context?.classNames?.[slot] : undefined;
+  const styleColor = getStyleColor(style);
   const iconColor = useIconColor(
-    [baseClassName, slotClassName, className, size, color, ...(context?.deps ?? [])],
+    [baseClassName, slotClassName, className, size, color, styleColor, ...(context?.deps ?? [])],
     { sourceRef },
   );
   const hasValidIcon = isValidElement<LynxIconElementProps>(icon);
@@ -227,7 +232,8 @@ export interface InternalIconProps extends LynxStyledElementProps {
 export const InternalIcon = React.forwardRef<unknown, InternalIconProps>((props, ref) => {
   const { icon, deps = [], className, style, children: _children, ...nativeProps } = props;
   const sourceRef = useMainThreadRef<MainThread.Element>(null);
-  const iconColor = useIconColor([className, ...(deps ?? [])], { sourceRef });
+  const styleColor = getStyleColor(style);
+  const iconColor = useIconColor([className, styleColor, ...(deps ?? [])], { sourceRef });
 
   if (!isValidElement<LynxIconElementProps>(icon)) return null;
 

--- a/packages/lynx-react/src/components/Icon/Icon.tsx
+++ b/packages/lynx-react/src/components/Icon/Icon.tsx
@@ -1,0 +1,247 @@
+import { useMainThreadRef } from "@lynx-js/react";
+import type { MainThread } from "@lynx-js/types";
+import clsx from "clsx";
+import * as React from "react";
+import { cloneElement, isValidElement, type DependencyList, type ReactElement } from "react";
+
+import { useIconColor } from "../../hooks/useIconColor";
+import type { LynxIconElementProps, LynxStyledElementProps } from "../../types";
+
+export type IconSlotName = "icon" | "prefixIcon" | "suffixIcon";
+
+interface IconSlotContextValue {
+  classNames?: Partial<Record<IconSlotName, string>>;
+  deps?: DependencyList;
+}
+
+const IconSlotContext = React.createContext<IconSlotContextValue | null>(null);
+
+interface IconRequiredContextValue {
+  register: () => void;
+  unregister: () => void;
+}
+
+const IconRequiredContext = React.createContext<IconRequiredContextValue | null>(null);
+
+export function IconRequired({
+  children,
+  enabled,
+}: {
+  children: React.ReactNode;
+  enabled: boolean;
+}) {
+  const registeredCountRef = React.useRef(0);
+  const parentContext = React.useContext(IconRequiredContext);
+
+  const register = React.useCallback(() => {
+    registeredCountRef.current += 1;
+
+    if (process.env.NODE_ENV !== "production" && registeredCountRef.current > 1) {
+      throw new Error(
+        "Icon-only Component must render only one <Icon /> under children. Check if you are rendering multiple <Icon />.",
+      );
+    }
+  }, []);
+
+  const unregister = React.useCallback(() => {
+    registeredCountRef.current = Math.max(0, registeredCountRef.current - 1);
+  }, []);
+
+  React.useLayoutEffect(() => {
+    if (!enabled) return;
+
+    if (process.env.NODE_ENV !== "production") {
+      if (parentContext) {
+        throw new Error(
+          "Icon-only Component must not be nested within another Icon-Only. Check if you are using Icon-Only inside another Icon-Only.",
+        );
+      }
+      if (registeredCountRef.current === 0) {
+        throw new Error(
+          "Icon-only Component must render <Icon /> as a child. Check if you are using raw icon element instead of <Icon icon={} />.",
+        );
+      }
+    }
+  }, [enabled, parentContext]);
+
+  const value = React.useMemo<IconRequiredContextValue | null>(() => {
+    if (!enabled) return parentContext ?? null;
+    return { register, unregister };
+  }, [enabled, parentContext, register, unregister]);
+
+  return <IconRequiredContext.Provider value={value}>{children}</IconRequiredContext.Provider>;
+}
+
+export function IconSlotProvider({
+  value,
+  children,
+}: {
+  value: IconSlotContextValue;
+  children: React.ReactNode;
+}) {
+  return <IconSlotContext.Provider value={value}>{children}</IconSlotContext.Provider>;
+}
+
+const iconSlotMarker = Symbol.for("@seed-design/lynx-react/icon-slot");
+
+interface IconSlotComponent {
+  [iconSlotMarker]?: IconSlotName;
+}
+
+export function getIconSlotName(node: React.ReactNode): IconSlotName | null {
+  if (!isValidElement(node)) return null;
+
+  return ((node.type as IconSlotComponent)[iconSlotMarker] ?? null) as IconSlotName | null;
+}
+
+export interface IconProps extends LynxStyledElementProps {
+  icon: ReactElement<LynxIconElementProps>;
+  size?: number | string;
+  color?: string;
+}
+
+export interface PrefixIconProps extends IconProps {}
+
+export interface SuffixIconProps extends IconProps {}
+
+interface IconSlotBaseProps extends IconProps {
+  slot: IconSlotName | null;
+  baseClassName?: string;
+}
+
+function toDimension(value: number | string | undefined): string | undefined {
+  if (typeof value === "number") return `${value}px`;
+  return value;
+}
+
+function mergeWrapperStyle({
+  size,
+  color,
+  style,
+}: Pick<IconProps, "size" | "color" | "style">): React.CSSProperties | undefined {
+  const dimension = toDimension(size);
+
+  if (dimension == null && color == null) return style;
+
+  return {
+    ...(dimension != null ? { width: dimension, height: dimension } : {}),
+    ...(color != null ? { color } : {}),
+    ...style,
+  };
+}
+
+const IconSlotBase = React.forwardRef<unknown, IconSlotBaseProps>((props, ref) => {
+  const {
+    icon,
+    slot,
+    baseClassName,
+    className,
+    style,
+    size,
+    color,
+    children: _children,
+    ...nativeProps
+  } = props;
+  const context = React.useContext(IconSlotContext);
+  const iconRequiredContext = React.useContext(IconRequiredContext);
+  const sourceRef = useMainThreadRef<MainThread.Element>(null);
+  const slotClassName = slot != null ? context?.classNames?.[slot] : undefined;
+  const iconColor = useIconColor(
+    [baseClassName, slotClassName, className, size, color, ...(context?.deps ?? [])],
+    { sourceRef },
+  );
+  const hasValidIcon = isValidElement<LynxIconElementProps>(icon);
+
+  React.useLayoutEffect(() => {
+    if (slot !== "icon" || !hasValidIcon) return;
+
+    iconRequiredContext?.register();
+    return () => {
+      iconRequiredContext?.unregister();
+    };
+  }, [hasValidIcon, iconRequiredContext, slot]);
+
+  if (!hasValidIcon) return null;
+
+  return (
+    <view
+      {...(ref ? { ref: ref as React.Ref<SVGViewElement> } : {})}
+      {...nativeProps}
+      main-thread:ref={sourceRef}
+      className={clsx(baseClassName, slotClassName, className)}
+      style={mergeWrapperStyle({ size, color, style })}
+    >
+      {cloneElement(icon, {
+        ...iconColor,
+        className: icon.props.className,
+        style: {
+          ...icon.props.style,
+          width: "100%",
+          height: "100%",
+        },
+      })}
+    </view>
+  );
+});
+IconSlotBase.displayName = "IconSlotBase";
+
+function createIconComponent<Props extends IconProps>(
+  displayName: string,
+  slot: IconSlotName,
+  baseClassName: string,
+) {
+  const Component = React.forwardRef<unknown, Props>((props, ref) => {
+    return <IconSlotBase ref={ref} slot={slot} baseClassName={baseClassName} {...props} />;
+  });
+
+  Component.displayName = displayName;
+  (Component as IconSlotComponent)[iconSlotMarker] = slot;
+
+  return Component;
+}
+
+export const Icon = createIconComponent<IconProps>("Icon", "icon", "seed-icon");
+export const PrefixIcon = createIconComponent<PrefixIconProps>(
+  "PrefixIcon",
+  "prefixIcon",
+  "seed-prefix-icon",
+);
+export const SuffixIcon = createIconComponent<SuffixIconProps>(
+  "SuffixIcon",
+  "suffixIcon",
+  "seed-suffix-icon",
+);
+
+export interface InternalIconProps extends LynxStyledElementProps {
+  icon: ReactElement<LynxIconElementProps>;
+  deps?: DependencyList;
+}
+
+export const InternalIcon = React.forwardRef<unknown, InternalIconProps>((props, ref) => {
+  const { icon, deps = [], className, style, children: _children, ...nativeProps } = props;
+  const sourceRef = useMainThreadRef<MainThread.Element>(null);
+  const iconColor = useIconColor([className, ...(deps ?? [])], { sourceRef });
+
+  if (!isValidElement<LynxIconElementProps>(icon)) return null;
+
+  return (
+    <view
+      {...(ref ? { ref: ref as React.Ref<SVGViewElement> } : {})}
+      {...nativeProps}
+      main-thread:ref={sourceRef}
+      className={className}
+      style={style}
+    >
+      {cloneElement(icon, {
+        ...iconColor,
+        className: icon.props.className,
+        style: {
+          ...icon.props.style,
+          width: "100%",
+          height: "100%",
+        },
+      })}
+    </view>
+  );
+});
+InternalIcon.displayName = "InternalIcon";

--- a/packages/lynx-react/src/components/Icon/Icon.tsx
+++ b/packages/lynx-react/src/components/Icon/Icon.tsx
@@ -6,8 +6,11 @@ import { cloneElement, isValidElement, type DependencyList, type ReactElement } 
 
 import { useIconColor } from "../../hooks/useIconColor";
 import type { LynxIconElementProps, LynxStyledElementProps } from "../../types";
+import { handleColor, handleDimension, type StyleProps } from "../../utils/styled";
 
 export type IconSlotName = "icon" | "prefixIcon" | "suffixIcon";
+
+////////////////////////////////////////////////////////////////////////////////////
 
 interface IconSlotContextValue {
   classNames?: Partial<Record<IconSlotName, string>>;
@@ -82,6 +85,8 @@ export function IconSlotProvider({
   return <IconSlotContext.Provider value={value}>{children}</IconSlotContext.Provider>;
 }
 
+////////////////////////////////////////////////////////////////////////////////////
+
 const iconSlotMarker = Symbol.for("@seed-design/lynx-react/icon-slot");
 
 interface IconSlotComponent {
@@ -94,10 +99,12 @@ export function getIconSlotName(node: React.ReactNode): IconSlotName | null {
   return ((node.type as IconSlotComponent)[iconSlotMarker] ?? null) as IconSlotName | null;
 }
 
+////////////////////////////////////////////////////////////////////////////////////
+
 export interface IconProps extends LynxStyledElementProps {
   icon: ReactElement<LynxIconElementProps>;
-  size?: number | string;
-  color?: string;
+  size?: StyleProps["height"] | number;
+  color?: StyleProps["color"];
 }
 
 export interface PrefixIconProps extends IconProps {}
@@ -109,23 +116,19 @@ interface IconSlotBaseProps extends IconProps {
   baseClassName?: string;
 }
 
-function toDimension(value: number | string | undefined): string | undefined {
-  if (typeof value === "number") return `${value}px`;
-  return value;
-}
-
 function mergeWrapperStyle({
   size,
   color,
   style,
 }: Pick<IconProps, "size" | "color" | "style">): React.CSSProperties | undefined {
-  const dimension = toDimension(size);
+  const dimension = handleDimension(size);
+  const resolvedColor = handleColor(color);
 
-  if (dimension == null && color == null) return style;
+  if (dimension == null && resolvedColor == null) return style;
 
   return {
     ...(dimension != null ? { width: dimension, height: dimension } : {}),
-    ...(color != null ? { color } : {}),
+    ...(resolvedColor != null ? { color: resolvedColor } : {}),
     ...style,
   };
 }
@@ -185,6 +188,8 @@ const IconSlotBase = React.forwardRef<unknown, IconSlotBaseProps>((props, ref) =
 });
 IconSlotBase.displayName = "IconSlotBase";
 
+////////////////////////////////////////////////////////////////////////////////////
+
 function createIconComponent<Props extends IconProps>(
   displayName: string,
   slot: IconSlotName,
@@ -211,6 +216,8 @@ export const SuffixIcon = createIconComponent<SuffixIconProps>(
   "suffixIcon",
   "seed-suffix-icon",
 );
+
+////////////////////////////////////////////////////////////////////////////////////
 
 export interface InternalIconProps extends LynxStyledElementProps {
   icon: ReactElement<LynxIconElementProps>;

--- a/packages/lynx-react/src/components/Icon/__tests__/Icon.test.tsx
+++ b/packages/lynx-react/src/components/Icon/__tests__/Icon.test.tsx
@@ -62,6 +62,15 @@ describe("Icon", () => {
     expect(image).toHaveStyle({ width: "100%", height: "100%" });
   });
 
+  it("lets wrapper style color override the color prop", () => {
+    render(<Icon icon={<MockIcon />} color="fg.brand" style={{ color: "#123456" }} />);
+
+    const root = getRenderedRoot();
+    const wrapper = root.querySelector(".seed-icon");
+
+    expect(wrapper).toHaveStyle({ color: "#123456" });
+  });
+
   it("renders prefix and suffix wrappers with global slot classes", () => {
     render(
       <view>

--- a/packages/lynx-react/src/components/Icon/__tests__/Icon.test.tsx
+++ b/packages/lynx-react/src/components/Icon/__tests__/Icon.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom";
 import { render } from "@lynx-js/react/testing-library";
+import { vars } from "@seed-design/lynx-css/vars";
 import * as React from "react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -41,7 +42,14 @@ MockIcon.displayName = "MockIcon";
 
 describe("Icon", () => {
   it("renders a wrapped icon image that fills the wrapper", () => {
-    render(<Icon icon={<MockIcon className="child-icon" />} className="custom-icon" size={20} />);
+    render(
+      <Icon
+        icon={<MockIcon className="child-icon" />}
+        className="custom-icon"
+        size={20}
+        color="fg.brand"
+      />,
+    );
 
     const root = getRenderedRoot();
     const wrapper = root.querySelector(".seed-icon");
@@ -49,6 +57,7 @@ describe("Icon", () => {
 
     expect(wrapper).toHaveClass("custom-icon");
     expect(wrapper).toHaveStyle({ width: "20px", height: "20px" });
+    expect((wrapper as HTMLElement).style.getPropertyValue("color")).toBe(vars.$color.fg.brand);
     expect(image).toHaveClass("child-icon");
     expect(image).toHaveStyle({ width: "100%", height: "100%" });
   });

--- a/packages/lynx-react/src/components/Icon/__tests__/Icon.test.tsx
+++ b/packages/lynx-react/src/components/Icon/__tests__/Icon.test.tsx
@@ -1,0 +1,69 @@
+import "@testing-library/jest-dom";
+import { render } from "@lynx-js/react/testing-library";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { LynxIconElementProps } from "../../../types";
+import { Icon, PrefixIcon, SuffixIcon } from "../Icon";
+
+vi.mock("@lynx-js/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lynx-js/react")>();
+
+  return {
+    ...actual,
+    runOnMainThread: () => () => undefined,
+  };
+});
+
+function getRenderedRoot() {
+  const root = elementTree.root;
+
+  if (!root) {
+    throw new Error("Expected Lynx render root to exist.");
+  }
+
+  return root;
+}
+
+const MockIcon = React.forwardRef<unknown, LynxIconElementProps>((props, ref) => {
+  const { className, style, ...rest } = props;
+
+  return (
+    <image
+      {...rest}
+      {...(ref ? { "main-thread:ref": ref as React.Ref<unknown> } : {})}
+      className={className}
+      style={style}
+    />
+  );
+});
+MockIcon.displayName = "MockIcon";
+
+describe("Icon", () => {
+  it("renders a wrapped icon image that fills the wrapper", () => {
+    render(<Icon icon={<MockIcon className="child-icon" />} className="custom-icon" size={20} />);
+
+    const root = getRenderedRoot();
+    const wrapper = root.querySelector(".seed-icon");
+    const image = wrapper?.querySelector("image");
+
+    expect(wrapper).toHaveClass("custom-icon");
+    expect(wrapper).toHaveStyle({ width: "20px", height: "20px" });
+    expect(image).toHaveClass("child-icon");
+    expect(image).toHaveStyle({ width: "100%", height: "100%" });
+  });
+
+  it("renders prefix and suffix wrappers with global slot classes", () => {
+    render(
+      <view>
+        <PrefixIcon icon={<MockIcon />} />
+        <SuffixIcon icon={<MockIcon />} />
+      </view>,
+    );
+
+    const root = getRenderedRoot();
+
+    expect(root.querySelector(".seed-prefix-icon")).toBeInTheDocument();
+    expect(root.querySelector(".seed-suffix-icon")).toBeInTheDocument();
+  });
+});

--- a/packages/lynx-react/src/components/Icon/index.ts
+++ b/packages/lynx-react/src/components/Icon/index.ts
@@ -1,0 +1,8 @@
+export {
+  Icon,
+  PrefixIcon,
+  SuffixIcon,
+  type IconProps,
+  type PrefixIconProps,
+  type SuffixIconProps,
+} from "./Icon";

--- a/packages/lynx-react/src/components/ProgressCircle/ProgressCircle.tsx
+++ b/packages/lynx-react/src/components/ProgressCircle/ProgressCircle.tsx
@@ -13,6 +13,8 @@ import { progressCircle } from "@seed-design/lynx-css/recipes/progress-circle";
 import type { ProgressCircleVariantProps } from "@seed-design/lynx-css/recipes/progress-circle";
 import type { LynxElementProps } from "../../types";
 
+////////////////////////////////////////////////////////////////////////////////////
+
 interface ProgressCircleContextValue {
   numSize: number;
   isDeterminate: boolean;
@@ -29,6 +31,8 @@ function useProgressCircleCtx() {
   }
   return ctx;
 }
+
+////////////////////////////////////////////////////////////////////////////////////
 
 // --- Background-thread-only utilities (for initial render) ---
 
@@ -51,6 +55,8 @@ function bgPieClipPath(size: number, angleDeg: number): string | undefined {
   const largeArc = angleDeg > 180 ? 1 : 0;
   return `path("M ${c} ${c} L ${c} ${c - r} A ${r} ${r} 0 ${largeArc} 1 ${endX} ${endY} Z")`;
 }
+
+////////////////////////////////////////////////////////////////////////////////////
 
 // --- Main-thread-only utilities (for animations) ---
 // Compiled into the main thread bundle. Must NOT be called from render code.
@@ -101,10 +107,14 @@ function sampleIndeterminate(t: number) {
   return { containerDeg, arcLength };
 }
 
+////////////////////////////////////////////////////////////////////////////////////
+
 // --- Animation constants ---
 
 const INDETERMINATE_DURATION = 1200;
 const TRANSITION_DURATION = 300;
+
+////////////////////////////////////////////////////////////////////////////////////
 
 // --- Components ---
 
@@ -115,6 +125,8 @@ export interface ProgressCircleRootProps extends ProgressCircleVariantProps, Lyn
 }
 
 export type RootProps = ProgressCircleRootProps;
+
+////////////////////////////////////////////////////////////////////////////////////
 
 /**
  * Lynx에서 SVG를 사용할 수 없어 CSS clip-path 기반 pie sector로 구현.
@@ -160,6 +172,8 @@ export const ProgressCircleRoot = (props: ProgressCircleRootProps) => {
   );
 };
 
+////////////////////////////////////////////////////////////////////////////////////
+
 export const ProgressCircleRange = () => {
   const { numSize, isDeterminate, progress, classes } = useProgressCircleCtx();
 
@@ -171,6 +185,8 @@ export const ProgressCircleRange = () => {
 };
 
 type Classes = ReturnType<typeof progressCircle>;
+
+////////////////////////////////////////////////////////////////////////////////////
 
 function DeterminateRange({
   numSize,
@@ -294,6 +310,8 @@ function DeterminateRange({
     </>
   );
 }
+
+////////////////////////////////////////////////////////////////////////////////////
 
 function IndeterminateRange({ numSize, classes }: { numSize: number; classes: Classes }) {
   const containerRef = useMainThreadRef<MainThread.Element>(null);

--- a/packages/lynx-react/src/components/ProgressCircle/ProgressCircle.tsx
+++ b/packages/lynx-react/src/components/ProgressCircle/ProgressCircle.tsx
@@ -11,12 +11,9 @@ import type { MainThread } from "@lynx-js/types";
 import clsx from "clsx";
 import { progressCircle } from "@seed-design/lynx-css/recipes/progress-circle";
 import type { ProgressCircleVariantProps } from "@seed-design/lynx-css/recipes/progress-circle";
-
-type Tone = "neutral" | "brand" | "staticWhite" | "inherit";
-type Size = "14" | "16" | "18" | "24" | "40";
+import type { LynxElementProps } from "../../types";
 
 interface ProgressCircleContextValue {
-  tone: Tone;
   numSize: number;
   isDeterminate: boolean;
   progress: number;
@@ -111,12 +108,10 @@ const TRANSITION_DURATION = 300;
 
 // --- Components ---
 
-export interface ProgressCircleRootProps extends ProgressCircleVariantProps {
+export interface ProgressCircleRootProps extends ProgressCircleVariantProps, LynxElementProps {
   minValue?: number;
   maxValue?: number;
   value?: number;
-  children?: React.ReactNode;
-  className?: string;
 }
 
 export type RootProps = ProgressCircleRootProps;
@@ -132,8 +127,8 @@ export type RootProps = ProgressCircleRootProps;
  * Lynx SVG + stroke-dasharray 지원 시 CSS-only 애니메이션으로 전환 예정.
  */
 export const ProgressCircleRoot = (props: ProgressCircleRootProps) => {
-  const size: Size = (props.size as Size) ?? "40";
-  const tone: Tone = (props.tone as Tone) ?? "neutral";
+  const size = props.size ?? "40";
+  const tone = props.tone ?? "neutral";
   const numSize = Number(size);
 
   const isDeterminate =
@@ -149,8 +144,8 @@ export const ProgressCircleRoot = (props: ProgressCircleRootProps) => {
   const classes = progressCircle({ tone, size });
 
   const ctx = useMemo(
-    () => ({ tone, numSize, isDeterminate, progress, classes }),
-    [tone, numSize, isDeterminate, progress, classes],
+    () => ({ numSize, isDeterminate, progress, classes }),
+    [numSize, isDeterminate, progress, classes],
   );
 
   return (

--- a/packages/lynx-react/src/components/ProgressCircle/ProgressCircle.tsx
+++ b/packages/lynx-react/src/components/ProgressCircle/ProgressCircle.tsx
@@ -1,6 +1,7 @@
-import type * as React from "@lynx-js/react";
+import type * as React from "react";
 import {
   createContext,
+  forwardRef,
   runOnMainThread,
   useContext,
   useEffect,
@@ -11,7 +12,7 @@ import type { MainThread } from "@lynx-js/types";
 import clsx from "clsx";
 import { progressCircle } from "@seed-design/lynx-css/recipes/progress-circle";
 import type { ProgressCircleVariantProps } from "@seed-design/lynx-css/recipes/progress-circle";
-import type { LynxElementProps } from "../../types";
+import type { LynxStyledElementProps } from "../../types";
 
 ////////////////////////////////////////////////////////////////////////////////////
 
@@ -118,7 +119,9 @@ const TRANSITION_DURATION = 300;
 
 // --- Components ---
 
-export interface ProgressCircleRootProps extends ProgressCircleVariantProps, LynxElementProps {
+export interface ProgressCircleRootProps
+  extends ProgressCircleVariantProps,
+    LynxStyledElementProps {
   minValue?: number;
   maxValue?: number;
   value?: number;
@@ -138,20 +141,17 @@ export type RootProps = ProgressCircleRootProps;
  *
  * Lynx SVG + stroke-dasharray 지원 시 CSS-only 애니메이션으로 전환 예정.
  */
-export const ProgressCircleRoot = (props: ProgressCircleRootProps) => {
-  const size = props.size ?? "40";
-  const tone = props.tone ?? "neutral";
+export const ProgressCircleRoot = forwardRef<unknown, ProgressCircleRootProps>((props, ref) => {
+  const [variantProps, otherProps] = progressCircle.splitVariantProps(props);
+  const { children, className, style, minValue, maxValue, value } = otherProps;
+  const size = variantProps.size ?? "40";
+  const tone = variantProps.tone ?? "neutral";
   const numSize = Number(size);
 
-  const isDeterminate =
-    props.minValue !== undefined && props.maxValue !== undefined && props.value !== undefined;
+  const isDeterminate = minValue !== undefined && maxValue !== undefined && value !== undefined;
 
-  const range = (props.maxValue ?? 1) - (props.minValue ?? 0);
-  const progress = isDeterminate
-    ? range === 0
-      ? 0
-      : ((props.value ?? 0) - (props.minValue ?? 0)) / range
-    : 0;
+  const range = (maxValue ?? 1) - (minValue ?? 0);
+  const progress = isDeterminate ? (range === 0 ? 0 : ((value ?? 0) - (minValue ?? 0)) / range) : 0;
 
   const classes = progressCircle({ tone, size });
 
@@ -163,14 +163,15 @@ export const ProgressCircleRoot = (props: ProgressCircleRootProps) => {
   return (
     <ProgressCircleContext.Provider value={ctx}>
       <view
-        className={clsx(classes.root, props.className)}
-        style={{ width: `${numSize}px`, height: `${numSize}px` }}
+        {...(ref ? { ref: ref as React.Ref<SVGViewElement> } : {})}
+        className={clsx(classes.root, className)}
+        style={{ ...style, width: `${numSize}px`, height: `${numSize}px` }}
       >
-        {props.children}
+        {children}
       </view>
     </ProgressCircleContext.Provider>
   );
-};
+});
 
 ////////////////////////////////////////////////////////////////////////////////////
 

--- a/packages/lynx-react/src/components/ProgressCircle/__tests__/ProgressCircle.test.tsx
+++ b/packages/lynx-react/src/components/ProgressCircle/__tests__/ProgressCircle.test.tsx
@@ -1,33 +1,72 @@
-import { describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import "@testing-library/jest-dom";
+import { render } from "@lynx-js/react/testing-library";
+import { describe, expect, it, vi } from "vitest";
 
-const currentDir = dirname(fileURLToPath(import.meta.url));
-const progressCircleSource = readFileSync(
-  join(currentDir, "..", "ProgressCircle.tsx"),
-  "utf8",
-);
+import { ProgressCircleRange, ProgressCircleRoot } from "../ProgressCircle";
 
-function readEffectDependencies(marker: string): string {
-  const markerIndex = progressCircleSource.indexOf(marker);
-  expect(markerIndex).toBeGreaterThanOrEqual(0);
+vi.mock("@lynx-js/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lynx-js/react")>();
 
-  const dependencyStart = progressCircleSource.indexOf("}, [", markerIndex);
-  expect(dependencyStart).toBeGreaterThanOrEqual(0);
+  return {
+    ...actual,
+    runOnMainThread: () => () => undefined,
+  };
+});
 
-  const dependencyEnd = progressCircleSource.indexOf("]);", dependencyStart);
-  expect(dependencyEnd).toBeGreaterThanOrEqual(0);
+function getRenderedRoot() {
+  const root = elementTree.root;
 
-  return progressCircleSource.slice(dependencyStart, dependencyEnd);
+  if (!root) {
+    throw new Error("Expected Lynx render root to exist.");
+  }
+
+  return root;
+}
+
+function getRenderedElement(selector: string) {
+  const root = getRenderedRoot();
+
+  if (root.matches(selector)) return root;
+
+  const element = root.querySelector(selector);
+  if (!element) {
+    throw new Error(`Expected ${selector} to be rendered.`);
+  }
+
+  return element;
 }
 
 describe("ProgressCircle", () => {
-  it("restarts indeterminate animation when size changes", () => {
-    expect(readEffectDependencies("runOnMainThread(startLoop)")).toContain("numSize");
+  it("renders an indeterminate range with root classes and size-owned dimensions", () => {
+    render(
+      <ProgressCircleRoot
+        size="24"
+        className="custom-progress"
+        style={{ width: "1px", height: "1px", opacity: 0.5 }}
+      >
+        <ProgressCircleRange />
+      </ProgressCircleRoot>,
+    );
+
+    const root = getRenderedElement(".seed-progress-circle__root");
+
+    expect(root).toHaveClass("custom-progress");
+    expect(root).toHaveStyle({ width: "24px", height: "24px", opacity: "0.5" });
+    expect(root.querySelector(".seed-progress-circle__range")).toBeInTheDocument();
+    expect(root.querySelectorAll(".seed-progress-circle__cap")).toHaveLength(2);
   });
 
-  it("restarts determinate transition when size changes", () => {
-    expect(readEffectDependencies("runOnMainThread(startAnimation)")).toContain("numSize");
+  it("renders a determinate range without depending on source string assertions", () => {
+    render(
+      <ProgressCircleRoot size="40" minValue={0} maxValue={1} value={0.5}>
+        <ProgressCircleRange />
+      </ProgressCircleRoot>,
+    );
+
+    const root = getRenderedElement(".seed-progress-circle__root");
+
+    expect(root).toHaveStyle({ width: "40px", height: "40px" });
+    expect(root.querySelector(".seed-progress-circle__range")).toBeInTheDocument();
+    expect(root.querySelectorAll(".seed-progress-circle__cap")).toHaveLength(2);
   });
 });

--- a/packages/lynx-react/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/lynx-react/src/components/RadioGroup/RadioGroup.tsx
@@ -1,20 +1,18 @@
 import * as React from "react";
-import { cloneElement, isValidElement, type CSSProperties, type ReactElement } from "react";
+import { isValidElement, type ReactElement } from "react";
 import clsx from "clsx";
-import type { MainThread } from "@lynx-js/types";
 
 import { radio } from "@seed-design/lynx-css/recipes/radio";
 import type { RadioVariantProps } from "@seed-design/lynx-css/recipes/radio";
 import { radiomark } from "@seed-design/lynx-css/recipes/radiomark";
 import type { RadiomarkVariantProps } from "@seed-design/lynx-css/recipes/radiomark";
 import { radioGroup } from "@seed-design/lynx-css/recipes/radio-group";
-import { vars as radiomarkVars } from "@seed-design/lynx-css/vars/component/radiomark";
 
 import { useControllableState } from "../../hooks/useControllableState";
-import { useIconColor } from "../../hooks/useIconColor";
 import { usePressTap } from "../../hooks/usePressTap";
-import { capitalize, resolveRecipeToken } from "../../utils/resolve-recipe-token";
+import type { LynxIconElementProps, LynxStyledElementProps } from "../../types";
 import { splitMultipleVariantsProps } from "../../utils/split-multiple-variants-props";
+import { InternalIcon } from "../Icon/Icon";
 
 /**
  * @platform Lynx
@@ -29,22 +27,17 @@ import { splitMultipleVariantsProps } from "../../utils/split-multiple-variants-
  * recipe 의 `color` 토큰을 `tint-color` 로 동기화한다.
  */
 
-type RadioSize = NonNullable<RadioVariantProps["size"]>;
-type RadioWeight = NonNullable<RadioVariantProps["weight"]>;
-type RadiomarkTone = NonNullable<RadiomarkVariantProps["tone"]>;
-
-interface RadioGroupContextValue {
+interface RadioGroupApi {
   value: string | null;
   setValue: (value: string) => void;
   disabled: boolean;
-  size: RadioSize;
-  weight: RadioWeight;
-  tone: RadiomarkTone;
+  radioVariantProps: RadioVariantProps;
+  radiomarkVariantProps: RadiomarkVariantProps;
 }
 
-const RadioGroupContext = React.createContext<RadioGroupContextValue | null>(null);
+const RadioGroupContext = React.createContext<RadioGroupApi | null>(null);
 
-function useRadioGroupContext(consumer: string): RadioGroupContextValue {
+function useRadioGroupContext(consumer: string): RadioGroupApi {
   const ctx = React.useContext(RadioGroupContext);
   if (!ctx) {
     throw new Error(`<${consumer}/> must be rendered inside <RadioGroupRoot/>.`);
@@ -52,18 +45,17 @@ function useRadioGroupContext(consumer: string): RadioGroupContextValue {
   return ctx;
 }
 
-interface RadioGroupItemContextValue {
+interface RadioGroupItemApi {
   value: string;
   checked: boolean;
   disabled: boolean;
   pressed: boolean;
-  tone: RadiomarkTone;
-  size: RadioSize;
+  select: () => void;
 }
 
-const RadioGroupItemContext = React.createContext<RadioGroupItemContextValue | null>(null);
+const RadioGroupItemContext = React.createContext<RadioGroupItemApi | null>(null);
 
-function useRadioGroupItemContext(consumer: string): RadioGroupItemContextValue {
+function useRadioGroupItemContext(consumer: string): RadioGroupItemApi {
   const ctx = React.useContext(RadioGroupItemContext);
   if (!ctx) {
     throw new Error(`<${consumer}/> must be rendered inside <RadioGroupItem/>.`);
@@ -71,10 +63,15 @@ function useRadioGroupItemContext(consumer: string): RadioGroupItemContextValue 
   return ctx;
 }
 
-const RadiomarkIconClassContext = React.createContext<string | null>(null);
+interface RadiomarkControlContextValue {
+  iconClassName: string;
+  radiomarkVariantProps: RadiomarkVariantProps;
+}
 
-function useRadiomarkIconClass(consumer: string): string {
-  const ctx = React.useContext(RadiomarkIconClassContext);
+const RadiomarkControlContext = React.createContext<RadiomarkControlContextValue | null>(null);
+
+function useRadiomarkControlContext(consumer: string): RadiomarkControlContextValue {
+  const ctx = React.useContext(RadiomarkControlContext);
   if (!ctx) {
     throw new Error(`<${consumer}/> must be rendered inside <RadioGroupItemControl/>.`);
   }
@@ -85,9 +82,8 @@ function useRadiomarkIconClass(consumer: string): string {
 
 export interface RadioGroupRootProps
   extends RadioVariantProps,
-    Omit<RadiomarkVariantProps, "size" | "checked" | "disabled"> {
-  children?: React.ReactNode;
-  className?: string;
+    Omit<RadiomarkVariantProps, "size" | "checked" | "disabled">,
+    LynxStyledElementProps {
   value?: string;
   defaultValue?: string;
   disabled?: boolean;
@@ -106,9 +102,6 @@ export const RadioGroupRoot = React.forwardRef<unknown, RadioGroupRootProps>((pr
   } = props;
   const [{ radio: radioVariantProps, radiomark: radiomarkVariantProps }, nativeProps] =
     splitMultipleVariantsProps(restProps, { radio, radiomark });
-  const weight: RadioWeight = radioVariantProps.weight ?? "regular";
-  const size: RadioSize = radioVariantProps.size ?? "medium";
-  const tone: RadiomarkTone = radiomarkVariantProps.tone ?? "brand";
 
   const handleChange = React.useCallback(
     (next: string | null) => {
@@ -132,13 +125,19 @@ export const RadioGroupRoot = React.forwardRef<unknown, RadioGroupRootProps>((pr
 
   const rootClassName = radioGroup().root;
 
-  const ctx = React.useMemo<RadioGroupContextValue>(
-    () => ({ value, setValue, disabled, size, weight, tone }),
-    [value, setValue, disabled, size, weight, tone],
+  const api = React.useMemo<RadioGroupApi>(
+    () => ({
+      value,
+      setValue,
+      disabled,
+      radioVariantProps,
+      radiomarkVariantProps,
+    }),
+    [value, setValue, disabled, radioVariantProps, radiomarkVariantProps],
   );
 
   return (
-    <RadioGroupContext.Provider value={ctx}>
+    <RadioGroupContext.Provider value={api}>
       <view
         {...(ref ? { ref: ref as React.Ref<SVGViewElement> } : {})}
         className={clsx(rootClassName, className)}
@@ -153,10 +152,8 @@ RadioGroupRoot.displayName = "RadioGroupRoot";
 
 ////////////////////////////////////////////////////////////////////////////////////
 
-export interface RadioGroupItemProps {
+export interface RadioGroupItemProps extends LynxStyledElementProps {
   value: string;
-  children?: React.ReactNode;
-  className?: string;
   disabled?: boolean;
 }
 
@@ -168,42 +165,35 @@ export const RadioGroupItem = React.forwardRef<unknown, RadioGroupItemProps>((pr
     className,
     ...nativeProps
   } = props;
-  const {
-    value: groupValue,
-    setValue,
-    disabled: groupDisabled,
-    size,
-    weight,
-    tone,
-  } = useRadioGroupContext("RadioGroupItem");
+  const groupApi = useRadioGroupContext("RadioGroupItem");
 
-  const disabled = groupDisabled || itemDisabled;
-  const checked = groupValue === itemValue;
+  const disabled = groupApi.disabled || itemDisabled;
+  const checked = groupApi.value === itemValue;
+  const select = React.useCallback(() => {
+    if (checked) return;
+    groupApi.setValue(itemValue);
+  }, [checked, groupApi, itemValue]);
 
   const { pressed, ...pressHandlers } = usePressTap({
     disabled,
-    onTap: () => {
-      if (checked) return;
-      setValue(itemValue);
-    },
+    onTap: select,
   });
 
-  const rootClassName = radio({ weight, size, disabled }).root;
+  const rootClassName = radio({ ...groupApi.radioVariantProps, disabled }).root;
 
-  const itemCtx = React.useMemo<RadioGroupItemContextValue>(
+  const itemApi = React.useMemo<RadioGroupItemApi>(
     () => ({
       value: itemValue,
       checked,
       disabled,
       pressed,
-      tone,
-      size,
+      select,
     }),
-    [itemValue, checked, disabled, pressed, tone, size],
+    [itemValue, checked, disabled, pressed, select],
   );
 
   return (
-    <RadioGroupItemContext.Provider value={itemCtx}>
+    <RadioGroupItemContext.Provider value={itemApi}>
       <view
         {...(ref ? { ref: ref as React.Ref<SVGViewElement> } : {})}
         className={clsx(rootClassName, className)}
@@ -219,32 +209,29 @@ RadioGroupItem.displayName = "RadioGroupItem";
 
 ////////////////////////////////////////////////////////////////////////////////////
 
-export interface RadioGroupItemControlProps extends Pick<RadiomarkVariantProps, "tone"> {
-  children?: React.ReactNode;
-  className?: string;
-}
+export interface RadioGroupItemControlProps
+  extends Pick<RadiomarkVariantProps, "tone">,
+    LynxStyledElementProps {}
 
 export const RadioGroupItemControl = React.forwardRef<unknown, RadioGroupItemControlProps>(
   (props, ref) => {
     const [variantProps, restProps] = radiomark.splitVariantProps(props);
     const { children, className, ...nativeProps } = restProps;
-    const {
-      checked,
-      disabled,
-      pressed,
-      tone: ctxTone,
-      size,
-    } = useRadioGroupItemContext("RadioGroupItemControl");
-
-    const tone: RadiomarkTone = variantProps.tone ?? ctxTone;
-
-    const classes = React.useMemo(
-      () => radiomark({ tone, size, checked, disabled, pressed }),
-      [tone, size, checked, disabled, pressed],
-    );
+    const groupApi = useRadioGroupContext("RadioGroupItemControl");
+    const itemApi = useRadioGroupItemContext("RadioGroupItemControl");
+    const radiomarkVariantProps: RadiomarkVariantProps = {
+      ...groupApi.radiomarkVariantProps,
+      ...variantProps,
+      checked: itemApi.checked,
+      disabled: itemApi.disabled,
+      pressed: itemApi.pressed,
+    };
+    const classes = radiomark(radiomarkVariantProps);
 
     return (
-      <RadiomarkIconClassContext.Provider value={classes.icon}>
+      <RadiomarkControlContext.Provider
+        value={{ iconClassName: classes.icon, radiomarkVariantProps }}
+      >
         <view
           {...(ref ? { ref: ref as React.Ref<SVGViewElement> } : {})}
           className={clsx(classes.root, className)}
@@ -252,7 +239,7 @@ export const RadioGroupItemControl = React.forwardRef<unknown, RadioGroupItemCon
         >
           {children}
         </view>
-      </RadiomarkIconClassContext.Provider>
+      </RadiomarkControlContext.Provider>
     );
   },
 );
@@ -260,70 +247,59 @@ RadioGroupItemControl.displayName = "RadioGroupItemControl";
 
 ////////////////////////////////////////////////////////////////////////////////////
 
-type IconElementProps = {
-  className?: string;
-  style?: CSSProperties;
-  ref?: React.Ref<MainThread.Element>;
-  "main-thread:binduiappear"?: () => void;
-};
-
-export interface RadioGroupItemIndicatorProps {
+export interface RadioGroupItemIndicatorProps
+  extends Pick<LynxStyledElementProps, "className" | "style"> {
   /** Icon rendered when not checked. Optional — falls back to default `<view>` dot when omitted. */
-  unchecked?: ReactElement<IconElementProps>;
+  unchecked?: ReactElement<LynxIconElementProps>;
   /** Icon rendered when the item is checked. Optional — falls back to default `<view>` dot when omitted. */
-  checked?: ReactElement<IconElementProps>;
-  className?: string;
-  style?: CSSProperties;
+  checked?: ReactElement<LynxIconElementProps>;
 }
 
 export function RadioGroupItemIndicator(props: RadioGroupItemIndicatorProps) {
   const { unchecked, checked: checkedIcon, className, style } = props;
-  const { checked, disabled, pressed, tone, size } =
-    useRadioGroupItemContext("RadioGroupItemIndicator");
-  const iconClassName = useRadiomarkIconClass("RadioGroupItemIndicator");
-  const iconColor = useIconColor([checked, disabled, pressed, tone, size]);
+  const itemApi = useRadioGroupItemContext("RadioGroupItemIndicator");
+  const { iconClassName, radiomarkVariantProps } =
+    useRadiomarkControlContext("RadioGroupItemIndicator");
 
-  const icon = checked ? checkedIcon : unchecked;
+  const icon = itemApi.checked ? checkedIcon : unchecked;
 
   // 사용자가 custom icon 을 주지 않으면 default `<view>` 로 동그란 점을 그린다.
   // radiomark.icon recipe 가 borderRadius/backgroundColor/width/height 를 적용해
   // 라디오의 inner dot 모양을 재현. 웹 RadioGroup 의 default `<svg><circle/></svg>` 동작과 일치.
-  if (!icon || !isValidElement<IconElementProps>(icon)) {
+  if (!icon || !isValidElement<LynxIconElementProps>(icon)) {
     return <view className={clsx(iconClassName, className)} style={style} />;
   }
 
-  // lynx-monochrome-icon 이 `<image style={{ width, height, ...style }}>` 로 자체 default size 를 박으므로
-  // recipe 토큰에서 꺼낸 사이즈를 inline 으로 주입해 덮는다.
-  const iconSize = resolveRecipeToken(radiomarkVars, [
-    `size${capitalize(size)}`,
-    disabled ? "disabled" : "enabled",
-    "icon",
-    "size",
-  ]);
-
-  return cloneElement(icon, {
-    ...iconColor,
-    className: clsx(iconClassName, icon.props.className, className),
-    style: iconSize
-      ? { width: iconSize, height: iconSize, ...icon.props.style, ...style }
-      : { ...icon.props.style, ...style },
-  });
+  return (
+    <InternalIcon
+      icon={icon}
+      className={clsx(iconClassName, className)}
+      style={style}
+      deps={[
+        itemApi.checked,
+        itemApi.disabled,
+        itemApi.pressed,
+        radiomarkVariantProps.tone,
+        radiomarkVariantProps.size,
+      ]}
+    />
+  );
 }
 RadioGroupItemIndicator.displayName = "RadioGroupItemIndicator";
 
 ////////////////////////////////////////////////////////////////////////////////////
 
-export interface RadioGroupItemLabelProps {
-  children?: React.ReactNode;
-  className?: string;
-}
+export interface RadioGroupItemLabelProps extends LynxStyledElementProps {}
 
 export const RadioGroupItemLabel = React.forwardRef<unknown, RadioGroupItemLabelProps>(
   (props, ref) => {
     const { children, className, ...nativeProps } = props;
-    const { disabled } = useRadioGroupItemContext("RadioGroupItemLabel");
-    const { size, weight } = useRadioGroupContext("RadioGroupItemLabel");
-    const labelClassName = radio({ weight, size, disabled }).label;
+    const itemApi = useRadioGroupItemContext("RadioGroupItemLabel");
+    const groupApi = useRadioGroupContext("RadioGroupItemLabel");
+    const labelClassName = radio({
+      ...groupApi.radioVariantProps,
+      disabled: itemApi.disabled,
+    }).label;
 
     return (
       <text

--- a/packages/lynx-react/src/components/RadioGroup/__tests__/RadioGroup.test.tsx
+++ b/packages/lynx-react/src/components/RadioGroup/__tests__/RadioGroup.test.tsx
@@ -1,0 +1,94 @@
+import "@testing-library/jest-dom";
+import { getQueriesForElement, render } from "@lynx-js/react/testing-library";
+import { radio } from "@seed-design/lynx-css/recipes/radio";
+import { radiomark } from "@seed-design/lynx-css/recipes/radiomark";
+import * as React from "react";
+import { describe, expect, it } from "vitest";
+
+import type { LynxIconElementProps } from "../../../types";
+import {
+  RadioGroupItem,
+  RadioGroupItemControl,
+  RadioGroupItemIndicator,
+  RadioGroupItemLabel,
+  RadioGroupRoot,
+} from "../RadioGroup";
+
+function getRenderedQueries() {
+  return getQueriesForElement(getRenderedRoot());
+}
+
+function getRenderedRoot() {
+  const root = elementTree.root;
+
+  if (!root) {
+    throw new Error("Expected Lynx render root to exist.");
+  }
+
+  return root;
+}
+
+const MockIcon = React.forwardRef<unknown, LynxIconElementProps>((props, ref) => {
+  const { className, style, ...rest } = props;
+
+  return (
+    <image
+      {...rest}
+      {...(ref ? { "main-thread:ref": ref as React.Ref<unknown> } : {})}
+      className={className}
+      style={style}
+    />
+  );
+});
+MockIcon.displayName = "MockIcon";
+
+describe("RadioGroup", () => {
+  it("merges group and local item variant props through context", () => {
+    render(
+      <RadioGroupRoot defaultValue="a" size="large" weight="bold" tone="neutral">
+        <RadioGroupItem value="a">
+          <RadioGroupItemControl tone="brand" />
+          <RadioGroupItemLabel>옵션 A</RadioGroupItemLabel>
+        </RadioGroupItem>
+      </RadioGroupRoot>,
+    );
+
+    const root = getRenderedRoot();
+    const { getByText } = getRenderedQueries();
+
+    expect(root.querySelector(".seed-radio__root")).toHaveClass(
+      radio({ size: "large", weight: "bold", disabled: false }).root,
+    );
+    expect(root.querySelector(".seed-radiomark__root")).toHaveClass(
+      radiomark({
+        tone: "brand",
+        size: "large",
+        checked: true,
+        disabled: false,
+        pressed: false,
+      }).root,
+    );
+    expect(getByText("옵션 A")).toHaveClass(
+      radio({ size: "large", weight: "bold", disabled: false }).label,
+    );
+  });
+
+  it("wraps a custom indicator icon with the final radiomark icon class", () => {
+    render(
+      <RadioGroupRoot defaultValue="a">
+        <RadioGroupItem value="a">
+          <RadioGroupItemControl>
+            <RadioGroupItemIndicator checked={<MockIcon />} />
+          </RadioGroupItemControl>
+        </RadioGroupItem>
+      </RadioGroupRoot>,
+    );
+
+    const root = getRenderedRoot();
+    const iconWrapper = root.querySelector(".seed-radiomark__icon");
+    const image = iconWrapper?.querySelector("image");
+
+    expect(iconWrapper).toBeInTheDocument();
+    expect(image).toHaveStyle({ width: "100%", height: "100%" });
+  });
+});

--- a/packages/lynx-react/src/components/Switch/Switch.tsx
+++ b/packages/lynx-react/src/components/Switch/Switch.tsx
@@ -9,6 +9,7 @@ import type { SwitchmarkVariantProps } from "@seed-design/lynx-css/recipes/switc
 import { splitMultipleVariantsProps } from "../../utils/split-multiple-variants-props";
 import { useControllableState } from "../../hooks/useControllableState";
 import { usePressTap } from "../../hooks/usePressTap";
+import type { LynxStyledElementProps } from "../../types";
 
 /**
  * @platform Lynx
@@ -23,19 +24,17 @@ import { usePressTap } from "../../hooks/usePressTap";
  *   switchmark recipe 와 Switch 컴포넌트에 boolean variant 로 노출.
  */
 
-type SwitchSize = NonNullable<SwitchVariantProps["size"]>;
-type SwitchTone = NonNullable<SwitchmarkVariantProps["tone"]>;
-
-interface SwitchContextValue {
+interface SwitchApi {
   checked: boolean;
   disabled: boolean;
-  size: SwitchSize;
-  tone: SwitchTone;
+  switchVariantProps: SwitchVariantProps;
+  switchmarkVariantProps: SwitchmarkVariantProps;
+  toggle: () => void;
 }
 
-const SwitchContext = React.createContext<SwitchContextValue | null>(null);
+const SwitchContext = React.createContext<SwitchApi | null>(null);
 
-function useSwitchContext(consumer: string): SwitchContextValue {
+function useSwitchContext(consumer: string): SwitchApi {
   const ctx = React.useContext(SwitchContext);
   if (!ctx) {
     throw new Error(`<${consumer}/> must be rendered inside <SwitchRoot/>.`);
@@ -43,10 +42,15 @@ function useSwitchContext(consumer: string): SwitchContextValue {
   return ctx;
 }
 
-const SwitchmarkThumbClassContext = React.createContext<string | null>(null);
+interface SwitchmarkControlContextValue {
+  thumbClassName: string;
+  switchmarkVariantProps: SwitchmarkVariantProps;
+}
 
-function useSwitchmarkThumbClass(consumer: string): string {
-  const ctx = React.useContext(SwitchmarkThumbClassContext);
+const SwitchmarkControlContext = React.createContext<SwitchmarkControlContextValue | null>(null);
+
+function useSwitchmarkControlContext(consumer: string): SwitchmarkControlContextValue {
+  const ctx = React.useContext(SwitchmarkControlContext);
   if (!ctx) {
     throw new Error(`<${consumer}/> must be rendered inside <SwitchControl/>.`);
   }
@@ -55,9 +59,10 @@ function useSwitchmarkThumbClass(consumer: string): string {
 
 ////////////////////////////////////////////////////////////////////////////////////
 
-export interface SwitchRootProps extends SwitchVariantProps, Omit<SwitchmarkVariantProps, "size"> {
-  children?: React.ReactNode;
-  className?: string;
+export interface SwitchRootProps
+  extends SwitchVariantProps,
+    Omit<SwitchmarkVariantProps, "size">,
+    LynxStyledElementProps {
   checked?: boolean;
   defaultChecked?: boolean;
   disabled?: boolean;
@@ -76,8 +81,6 @@ export const SwitchRoot = React.forwardRef<unknown, SwitchRootProps>((props, ref
   } = props;
   const [{ switch: switchVariantProps, switchmark: switchmarkVariantProps }, nativeProps] =
     splitMultipleVariantsProps(restProps, { switch: switchStyle, switchmark });
-  const size: SwitchSize = switchVariantProps.size ?? "32";
-  const tone: SwitchTone = switchmarkVariantProps.tone ?? "brand";
 
   const [checked, setChecked] = useControllableState({
     value: checkedProp,
@@ -85,20 +88,28 @@ export const SwitchRoot = React.forwardRef<unknown, SwitchRootProps>((props, ref
     onChange: onCheckedChange,
   });
 
+  const toggle = React.useCallback(() => setChecked(!checked), [checked, setChecked]);
+
   const { pressed: _pressed, ...pressHandlers } = usePressTap({
     disabled,
-    onTap: () => setChecked(!checked),
+    onTap: toggle,
   });
 
-  const rootClassName = switchStyle({ size }).root;
+  const rootClassName = switchStyle({ ...switchVariantProps, disabled }).root;
 
-  const ctx = React.useMemo<SwitchContextValue>(
-    () => ({ checked, disabled, size, tone }),
-    [checked, disabled, size, tone],
+  const api = React.useMemo<SwitchApi>(
+    () => ({
+      checked,
+      disabled,
+      switchVariantProps,
+      switchmarkVariantProps,
+      toggle,
+    }),
+    [checked, disabled, switchVariantProps, switchmarkVariantProps, toggle],
   );
 
   return (
-    <SwitchContext.Provider value={ctx}>
+    <SwitchContext.Provider value={api}>
       <view
         {...(ref ? { ref: ref as React.Ref<SVGViewElement> } : {})}
         className={clsx(rootClassName, className)}
@@ -114,26 +125,26 @@ SwitchRoot.displayName = "SwitchRoot";
 
 ////////////////////////////////////////////////////////////////////////////////////
 
-export interface SwitchControlProps extends Pick<SwitchmarkVariantProps, "tone" | "size"> {
-  children?: React.ReactNode;
-  className?: string;
-}
+export interface SwitchControlProps
+  extends Pick<SwitchmarkVariantProps, "tone" | "size">,
+    LynxStyledElementProps {}
 
 export const SwitchControl = React.forwardRef<unknown, SwitchControlProps>((props, ref) => {
   const [variantProps, restProps] = switchmark.splitVariantProps(props);
   const { children, className, ...nativeProps } = restProps;
-  const { checked, disabled, tone: ctxTone, size: ctxSize } = useSwitchContext("SwitchControl");
-
-  const tone: SwitchTone = variantProps.tone ?? ctxTone;
-  const size: SwitchSize = variantProps.size ?? ctxSize;
-
-  const classes = React.useMemo(
-    () => switchmark({ tone, size, checked, disabled }),
-    [tone, size, checked, disabled],
-  );
+  const api = useSwitchContext("SwitchControl");
+  const switchmarkVariantProps: SwitchmarkVariantProps = {
+    ...api.switchmarkVariantProps,
+    ...variantProps,
+    checked: api.checked,
+    disabled: api.disabled,
+  };
+  const classes = switchmark(switchmarkVariantProps);
 
   return (
-    <SwitchmarkThumbClassContext.Provider value={classes.thumb}>
+    <SwitchmarkControlContext.Provider
+      value={{ thumbClassName: classes.thumb, switchmarkVariantProps }}
+    >
       <view
         {...(ref ? { ref: ref as React.Ref<SVGViewElement> } : {})}
         className={clsx(classes.root, className)}
@@ -141,20 +152,18 @@ export const SwitchControl = React.forwardRef<unknown, SwitchControlProps>((prop
       >
         {children}
       </view>
-    </SwitchmarkThumbClassContext.Provider>
+    </SwitchmarkControlContext.Provider>
   );
 });
 SwitchControl.displayName = "SwitchControl";
 
 ////////////////////////////////////////////////////////////////////////////////////
 
-export interface SwitchThumbProps {
-  className?: string;
-}
+export interface SwitchThumbProps extends Pick<LynxStyledElementProps, "className" | "style"> {}
 
 export const SwitchThumb = React.forwardRef<unknown, SwitchThumbProps>((props, ref) => {
   const { className, ...nativeProps } = props;
-  const thumbClassName = useSwitchmarkThumbClass("SwitchThumb");
+  const { thumbClassName } = useSwitchmarkControlContext("SwitchThumb");
 
   return (
     <view
@@ -168,15 +177,15 @@ SwitchThumb.displayName = "SwitchThumb";
 
 ////////////////////////////////////////////////////////////////////////////////////
 
-export interface SwitchLabelProps {
-  children?: React.ReactNode;
-  className?: string;
-}
+export interface SwitchLabelProps extends LynxStyledElementProps {}
 
 export const SwitchLabel = React.forwardRef<unknown, SwitchLabelProps>((props, ref) => {
   const { children, className, ...nativeProps } = props;
-  const { disabled, size } = useSwitchContext("SwitchLabel");
-  const labelClassName = switchStyle({ size, disabled }).label;
+  const api = useSwitchContext("SwitchLabel");
+  const labelClassName = switchStyle({
+    ...api.switchVariantProps,
+    disabled: api.disabled,
+  }).label;
 
   return (
     <text

--- a/packages/lynx-react/src/components/TagGroup/TagGroup.tsx
+++ b/packages/lynx-react/src/components/TagGroup/TagGroup.tsx
@@ -6,6 +6,7 @@ import {
   type TagGroupItemVariantProps,
 } from "@seed-design/lynx-css/recipes/tag-group-item";
 
+import type { LynxStyledElementProps } from "../../types";
 import { createSlotRecipeContext } from "../../utils/create-slot-recipe-context";
 import { splitMultipleVariantsProps } from "../../utils/split-multiple-variants-props";
 
@@ -22,9 +23,10 @@ const { PropsProvider, useProps, ClassNamesProvider, useClassNames } =
  * - `flexShrink` prop: CSS variable 동적 주입 제한
  * - 아이콘 slot: Lynx 3.7 SVG 지원 후 검토 (Tier B)
  */
-export interface TagGroupRootProps extends TagGroupVariantProps, TagGroupItemVariantProps {
-  children?: React.ReactNode;
-  className?: string;
+export interface TagGroupRootProps
+  extends TagGroupVariantProps,
+    TagGroupItemVariantProps,
+    LynxStyledElementProps {
   /**
    * children 사이에 삽입되는 구분자. 기본값 `" · "`.
    */
@@ -79,10 +81,7 @@ TagGroupRoot.displayName = "TagGroupRoot";
  * - `asChild` prop: Lynx Slot 미지원
  * - `flexShrink` prop: CSS variable 동적 주입 제한
  */
-export interface TagGroupItemProps extends TagGroupItemVariantProps {
-  children?: React.ReactNode;
-  className?: string;
-}
+export interface TagGroupItemProps extends TagGroupItemVariantProps, LynxStyledElementProps {}
 
 export const TagGroupItem = React.forwardRef<unknown, TagGroupItemProps>((props, ref) => {
   const parentVariantProps = useProps();
@@ -104,10 +103,7 @@ export const TagGroupItem = React.forwardRef<unknown, TagGroupItemProps>((props,
 });
 TagGroupItem.displayName = "TagGroupItem";
 
-export interface TagGroupItemLabelProps {
-  children?: React.ReactNode;
-  className?: string;
-}
+export interface TagGroupItemLabelProps extends LynxStyledElementProps {}
 
 export const TagGroupItemLabel = React.forwardRef<unknown, TagGroupItemLabelProps>((props, ref) => {
   const classes = useClassNames();

--- a/packages/lynx-react/src/components/TagGroup/TagGroup.tsx
+++ b/packages/lynx-react/src/components/TagGroup/TagGroup.tsx
@@ -9,9 +9,12 @@ import {
 import type { LynxStyledElementProps } from "../../types";
 import { createSlotRecipeContext } from "../../utils/create-slot-recipe-context";
 import { splitMultipleVariantsProps } from "../../utils/split-multiple-variants-props";
+import { useStyleProps, type StyleProps } from "../../utils/styled";
 
 const { PropsProvider, useProps, ClassNamesProvider, useClassNames } =
   createSlotRecipeContext(tagGroupItem);
+
+////////////////////////////////////////////////////////////////////////////////////
 
 /**
  * @platform Lynx
@@ -20,7 +23,6 @@ const { PropsProvider, useProps, ClassNamesProvider, useClassNames } =
  * - `truncate` prop: Lynx flex 모델에서는 item 단위 wrap만 가능해 웹 수준의
  *   "한 줄 유지 + label ellipsis" 조합을 재현할 수 없음
  * - `asChild` prop: Lynx Slot 미지원
- * - `flexShrink` prop: CSS variable 동적 주입 제한
  * - 아이콘 slot: Lynx 3.7 SVG 지원 후 검토 (Tier B)
  */
 export interface TagGroupRootProps
@@ -74,26 +76,32 @@ export const TagGroupRoot = React.forwardRef<unknown, TagGroupRootProps>((props,
 });
 TagGroupRoot.displayName = "TagGroupRoot";
 
+////////////////////////////////////////////////////////////////////////////////////
+
 /**
  * @platform Lynx
  *
  * 웹 대비 미지원 기능:
  * - `asChild` prop: Lynx Slot 미지원
- * - `flexShrink` prop: CSS variable 동적 주입 제한
  */
-export interface TagGroupItemProps extends TagGroupItemVariantProps, LynxStyledElementProps {}
+export interface TagGroupItemProps
+  extends TagGroupItemVariantProps,
+    Pick<StyleProps, "flexShrink">,
+    LynxStyledElementProps {}
 
 export const TagGroupItem = React.forwardRef<unknown, TagGroupItemProps>((props, ref) => {
   const parentVariantProps = useProps();
   const [localVariantProps, otherProps] = tagGroupItem.splitVariantProps(props);
   const classes = tagGroupItem({ ...parentVariantProps, ...localVariantProps });
-  const { children, className, ...nativeProps } = otherProps;
+  const { style, restProps } = useStyleProps(otherProps);
+  const { children, className, ...nativeProps } = restProps;
 
   return (
     <ClassNamesProvider value={classes}>
       <view
         {...(ref ? { ref: ref as React.Ref<SVGViewElement> } : {})}
         className={clsx(classes.root, className)}
+        style={style}
         {...nativeProps}
       >
         {children}
@@ -102,6 +110,8 @@ export const TagGroupItem = React.forwardRef<unknown, TagGroupItemProps>((props,
   );
 });
 TagGroupItem.displayName = "TagGroupItem";
+
+////////////////////////////////////////////////////////////////////////////////////
 
 export interface TagGroupItemLabelProps extends LynxStyledElementProps {}
 

--- a/packages/lynx-react/src/components/TagGroup/__tests__/TagGroup.test.tsx
+++ b/packages/lynx-react/src/components/TagGroup/__tests__/TagGroup.test.tsx
@@ -1,0 +1,37 @@
+import "@testing-library/jest-dom";
+import { getQueriesForElement, render } from "@lynx-js/react/testing-library";
+import { describe, expect, it } from "vitest";
+
+import * as TagGroup from "../TagGroup.namespace";
+
+function getRenderedQueries() {
+  return getQueriesForElement(getRenderedRoot());
+}
+
+function getRenderedRoot() {
+  const root = elementTree.root;
+
+  if (!root) {
+    throw new Error("Expected Lynx render root to exist.");
+  }
+
+  return root;
+}
+
+describe("TagGroup", () => {
+  it("applies flexShrink through style props on items", () => {
+    render(
+      <TagGroup.Root>
+        <TagGroup.Item className="tag-item" flexShrink={false}>
+          <TagGroup.ItemLabel>Tag label</TagGroup.ItemLabel>
+        </TagGroup.Item>
+      </TagGroup.Root>,
+    );
+
+    const { getByText } = getRenderedQueries();
+    const item = getByText("Tag label").parentElement;
+
+    expect(item).toHaveClass("tag-item");
+    expect(item).toHaveStyle({ flexShrink: "0" });
+  });
+});

--- a/packages/lynx-react/src/components/Text/Text.tsx
+++ b/packages/lynx-react/src/components/Text/Text.tsx
@@ -10,6 +10,7 @@ import {
   type TextStyle,
   type TextStyleProps,
 } from "../../utils/styled";
+import type { LynxStyledElementProps } from "../../types";
 
 function capitalize<T extends string>(value: T): Capitalize<T> {
   return (value.charAt(0).toUpperCase() + value.slice(1)) as Capitalize<T>;
@@ -21,11 +22,7 @@ function getTypographyStyle(textStyle: TextStyle | undefined) {
   return value.enabled.root;
 }
 
-export interface TextProps extends TextStyleProps {
-  className?: string;
-  style?: React.CSSProperties;
-  children?: React.ReactNode;
-}
+export interface TextProps extends TextStyleProps, LynxStyledElementProps {}
 
 export const Text = React.forwardRef<unknown, TextProps>((props, ref) => {
   const {

--- a/packages/lynx-react/src/components/index.ts
+++ b/packages/lynx-react/src/components/index.ts
@@ -2,6 +2,7 @@ export * from "./ActionButton";
 export * from "./Box";
 export * from "./BottomSheet";
 export * from "./Checkbox";
+export * from "./Icon";
 export * from "./ProgressCircle";
 export * from "./RadioGroup";
 export * from "./Stack";

--- a/packages/lynx-react/src/hooks/useIconColor.ts
+++ b/packages/lynx-react/src/hooks/useIconColor.ts
@@ -7,24 +7,30 @@ type IconElement = MainThread.Element & {
   getComputedCssProperty?: (name: string) => string;
 };
 
+export interface UseIconColorOptions {
+  sourceRef?: RefObject<MainThread.Element>;
+}
+
 // Lynx `<image>` 의 `tint-color` attribute 에 CSS variable 문자열을 직접 넣는 경로는
 // 안정적으로 동작하지 않는다. CSS `color` 는 computed style 로 resolved color 를 읽을 수
 // 있으므로 main-thread 에서 한 번 읽어 `tint-color` 로 mirror 한다.
-function syncTintColor(ref: RefObject<IconElement>) {
+function syncTintColor(targetRef: RefObject<IconElement>, sourceRef?: RefObject<IconElement>) {
   "main thread";
 
-  const el = ref.current;
-  if (!el) return;
+  const target = targetRef.current;
+  if (!target) return;
+
+  const source = sourceRef?.current ?? target;
 
   let color: string | undefined;
-  if (typeof el.getComputedStyleProperty === "function") {
-    color = el.getComputedStyleProperty("color");
-  } else if (typeof el.getComputedCssProperty === "function") {
-    color = el.getComputedCssProperty("color");
+  if (typeof source.getComputedStyleProperty === "function") {
+    color = source.getComputedStyleProperty("color");
+  } else if (typeof source.getComputedCssProperty === "function") {
+    color = source.getComputedCssProperty("color");
   }
 
   if (color) {
-    el.setAttribute("tint-color", color);
+    target.setAttribute("tint-color", color);
   }
 }
 
@@ -37,20 +43,24 @@ function syncTintColor(ref: RefObject<IconElement>) {
  * return cloneElement(iconChild, iconColorProps);
  * ```
  */
-export function useIconColor(deps: DependencyList): {
+export function useIconColor(
+  deps: DependencyList,
+  options?: UseIconColorOptions,
+): {
   ref: RefObject<MainThread.Element>;
   "main-thread:binduiappear": () => void;
 } {
   const ref = useMainThreadRef<IconElement>(null);
+  const sourceRef = options?.sourceRef as RefObject<IconElement> | undefined;
 
   function syncOnUiAppear() {
     "main thread";
-    syncTintColor(ref);
+    syncTintColor(ref, sourceRef);
   }
 
   // deps 는 caller 가 책임.
   useEffect(() => {
-    runOnMainThread(syncTintColor)(ref);
+    runOnMainThread(syncTintColor)(ref, sourceRef);
   }, deps);
 
   return { ref, "main-thread:binduiappear": syncOnUiAppear };

--- a/packages/lynx-react/src/index.test.ts
+++ b/packages/lynx-react/src/index.test.ts
@@ -35,12 +35,4 @@ describe("components public exports", () => {
     expect(implementation).toContain("export const ProgressCircleRoot");
     expect(implementation).toContain("export const ProgressCircleRange");
   });
-
-  it("exports Icon slot prop types from the Icon entrypoint", () => {
-    const index = readComponentFile("Icon", "index.ts");
-
-    expect(index).toContain("type IconProps");
-    expect(index).toContain("type PrefixIconProps");
-    expect(index).toContain("type SuffixIconProps");
-  });
 });

--- a/packages/lynx-react/src/index.test.ts
+++ b/packages/lynx-react/src/index.test.ts
@@ -1,38 +1,55 @@
 import { describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 
-const currentDir = dirname(fileURLToPath(import.meta.url));
-const componentsDir = join(currentDir, "components");
-
-function readComponentFile(componentName: string, fileName: string): string {
-  return readFileSync(join(componentsDir, componentName, fileName), "utf8");
-}
+import {
+  Checkbox,
+  CheckboxControl,
+  CheckboxGroup,
+  CheckboxIndicator,
+  CheckboxLabel,
+  CheckboxRoot,
+} from "./components/Checkbox";
+import {
+  ProgressCircle,
+  ProgressCircleRange,
+  ProgressCircleRoot,
+} from "./components/ProgressCircle";
+import {
+  RadioGroup,
+  RadioGroupItem,
+  RadioGroupItemControl,
+  RadioGroupItemIndicator,
+  RadioGroupItemLabel,
+  RadioGroupRoot,
+} from "./components/RadioGroup";
+import { Switch, SwitchControl, SwitchLabel, SwitchRoot, SwitchThumb } from "./components/Switch";
+import { TagGroup, TagGroupItem, TagGroupItemLabel, TagGroupRoot } from "./components/TagGroup";
 
 describe("components public exports", () => {
   it("exposes compound components through namespace exports", () => {
-    for (const componentName of ["Switch", "Checkbox", "RadioGroup", "TagGroup"]) {
-      expect(readComponentFile(componentName, "index.ts")).toContain(
-        `export * as ${componentName} from "./${componentName}.namespace";`,
-      );
-      expect(readComponentFile(componentName, `${componentName}.namespace.ts`)).toContain(
-        " as Root",
-      );
-    }
+    expect(Switch.Root).toBe(SwitchRoot);
+    expect(Switch.Control).toBe(SwitchControl);
+    expect(Switch.Thumb).toBe(SwitchThumb);
+    expect(Switch.Label).toBe(SwitchLabel);
+
+    expect(Checkbox.Root).toBe(CheckboxRoot);
+    expect(Checkbox.Control).toBe(CheckboxControl);
+    expect(Checkbox.Indicator).toBe(CheckboxIndicator);
+    expect(Checkbox.Label).toBe(CheckboxLabel);
+    expect(Checkbox.Group).toBe(CheckboxGroup);
+
+    expect(RadioGroup.Root).toBe(RadioGroupRoot);
+    expect(RadioGroup.Item).toBe(RadioGroupItem);
+    expect(RadioGroup.ItemControl).toBe(RadioGroupItemControl);
+    expect(RadioGroup.ItemIndicator).toBe(RadioGroupItemIndicator);
+    expect(RadioGroup.ItemLabel).toBe(RadioGroupItemLabel);
+
+    expect(TagGroup.Root).toBe(TagGroupRoot);
+    expect(TagGroup.Item).toBe(TagGroupItem);
+    expect(TagGroup.ItemLabel).toBe(TagGroupItemLabel);
   });
 
   it("keeps ProgressCircle namespace usage while exposing flat slots", () => {
-    const index = readComponentFile("ProgressCircle", "index.ts");
-    const implementation = readComponentFile("ProgressCircle", "ProgressCircle.tsx");
-    const namespace = readComponentFile("ProgressCircle", "ProgressCircle.namespace.ts");
-
-    expect(index).toContain('export * as ProgressCircle from "./ProgressCircle.namespace";');
-    expect(index).toContain("ProgressCircleRoot");
-    expect(index).toContain("ProgressCircleRange");
-    expect(namespace).toContain("ProgressCircleRoot as Root");
-    expect(namespace).toContain("ProgressCircleRange as Range");
-    expect(implementation).toContain("export const ProgressCircleRoot");
-    expect(implementation).toContain("export const ProgressCircleRange");
+    expect(ProgressCircle.Root).toBe(ProgressCircleRoot);
+    expect(ProgressCircle.Range).toBe(ProgressCircleRange);
   });
 });

--- a/packages/lynx-react/src/index.test.ts
+++ b/packages/lynx-react/src/index.test.ts
@@ -35,4 +35,12 @@ describe("components public exports", () => {
     expect(implementation).toContain("export const ProgressCircleRoot");
     expect(implementation).toContain("export const ProgressCircleRange");
   });
+
+  it("exports Icon slot prop types from the Icon entrypoint", () => {
+    const index = readComponentFile("Icon", "index.ts");
+
+    expect(index).toContain("type IconProps");
+    expect(index).toContain("type PrefixIconProps");
+    expect(index).toContain("type SuffixIconProps");
+  });
 });

--- a/packages/lynx-react/src/index.ts
+++ b/packages/lynx-react/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./components";
 export * from "./hooks";
+export type * from "./types";
 export * from "./utils";

--- a/packages/lynx-react/src/types.ts
+++ b/packages/lynx-react/src/types.ts
@@ -1,0 +1,31 @@
+import type * as React from "react";
+import type { MainThread, TouchEvent } from "@lynx-js/types";
+
+export interface LynxElementProps {
+  children?: React.ReactNode;
+  className?: string;
+}
+
+export interface LynxStyledElementProps extends LynxElementProps {
+  style?: React.CSSProperties;
+}
+
+export interface LynxPressableProps {
+  bindtap?: () => void;
+  "main-thread:bindtap"?: () => void;
+}
+
+export interface LynxTouchProps {
+  bindtap?: (event: TouchEvent) => void;
+  bindtouchstart?: (event: TouchEvent) => void;
+  bindtouchend?: (event: TouchEvent) => void;
+  bindtouchcancel?: (event: TouchEvent) => void;
+  "main-thread:bindtap"?: () => void;
+}
+
+export interface LynxIconElementProps {
+  className?: string;
+  style?: React.CSSProperties;
+  ref?: React.Ref<MainThread.Element>;
+  "main-thread:binduiappear"?: () => void;
+}

--- a/packages/lynx-react/src/utils/__tests__/create-slot-recipe-context.test.tsx
+++ b/packages/lynx-react/src/utils/__tests__/create-slot-recipe-context.test.tsx
@@ -85,6 +85,14 @@ describe("createSlotRecipeContext", () => {
   });
 
   describe("withRootProvider", () => {
+    it("rejects intrinsic native tags to avoid Lynx BackgroundSnapshot errors", () => {
+      const { withRootProvider } = createSlotRecipeContext(mockSlotRecipe);
+
+      expect(() => withRootProvider<MockVariantProps>("view")).toThrow(
+        /literal JSX.*BackgroundSnapshot/,
+      );
+    });
+
     it("injects classnames into context without applying className on the root element", () => {
       const { Mock: Root, received: rootReceived } = createMock("Root");
       const { Mock: Child, received: childReceived } = createMock("Child");
@@ -105,6 +113,14 @@ describe("createSlotRecipeContext", () => {
   });
 
   describe("withProvider", () => {
+    it("rejects intrinsic native tags to avoid Lynx BackgroundSnapshot errors", () => {
+      const { withProvider } = createSlotRecipeContext(mockSlotRecipe);
+
+      expect(() => withProvider<unknown, MockVariantProps>("view", "root")).toThrow(
+        /literal JSX.*BackgroundSnapshot/,
+      );
+    });
+
     it("applies slot className to the provider element and injects context", () => {
       const { Mock: Root, received: rootReceived } = createMock("Root");
       const { Mock: Child, received: childReceived } = createMock("Child");
@@ -165,6 +181,14 @@ describe("createSlotRecipeContext", () => {
   });
 
   describe("withContext", () => {
+    it("rejects intrinsic native tags to avoid Lynx BackgroundSnapshot errors", () => {
+      const { withContext } = createSlotRecipeContext(mockSlotRecipe);
+
+      expect(() => withContext<unknown, Record<string, unknown>>("text", "label")).toThrow(
+        /literal JSX.*BackgroundSnapshot/,
+      );
+    });
+
     it("reads slot className from ClassNamesProvider", () => {
       const { Mock: Label, received } = createMock("Label");
       const { ClassNamesProvider, withContext } = createSlotRecipeContext(mockSlotRecipe);

--- a/packages/lynx-react/src/utils/create-slot-recipe-context.tsx
+++ b/packages/lynx-react/src/utils/create-slot-recipe-context.tsx
@@ -8,6 +8,14 @@ type SlotRecipe<
   splitVariantProps: <T extends Props>(props: T) => [Props, Omit<T, keyof Props>];
 };
 
+function assertNotIntrinsicComponent(Component: React.ElementType<any>, caller: string) {
+  if (typeof Component !== "string") return;
+
+  throw new Error(
+    `${caller} cannot wrap intrinsic tag "${Component}" in Lynx. Native <view>/<text> slots must be rendered as literal JSX in the component file; passing intrinsic strings through createSlotRecipeContext can cause BackgroundSnapshot not found errors.`,
+  );
+}
+
 export function createSlotRecipeContext<
   Props extends Record<string, string | boolean | undefined>,
   Classnames extends Record<string, string>,
@@ -50,6 +58,7 @@ export function createSlotRecipeContext<
       defaultProps?: Partial<P>;
     },
   ): React.ForwardRefExoticComponent<React.PropsWithoutRef<P>> => {
+    assertNotIntrinsicComponent(Component, "withRootProvider");
     const { defaultProps } = options ?? {};
 
     const StyledComponent = (innerProps: any) => {
@@ -80,6 +89,7 @@ export function createSlotRecipeContext<
       defaultProps?: Partial<P>;
     },
   ): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>> => {
+    assertNotIntrinsicComponent(Component, "withProvider");
     const { defaultProps } = options ?? {};
 
     const StyledComponent = forwardRef<any, any>((innerProps, ref) => {
@@ -114,6 +124,7 @@ export function createSlotRecipeContext<
       defaultProps?: Partial<P>;
     },
   ): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>> => {
+    assertNotIntrinsicComponent(Component, "withContext");
     const { defaultProps } = options ?? {};
 
     const StyledComponent = forwardRef<any, any>((innerProps, ref) => {

--- a/packages/lynx-react/src/utils/styled.ts
+++ b/packages/lynx-react/src/utils/styled.ts
@@ -26,7 +26,7 @@ export function handleColor(color: string | undefined) {
   return vars.$color[type]?.[value] ?? color;
 }
 
-export function handleDimension(dimension: string | 0 | undefined): string | undefined {
+export function handleDimension(dimension: number | string | undefined): string | undefined {
   if (dimension == null) {
     return undefined;
   }
@@ -43,6 +43,14 @@ export function handleDimension(dimension: string | 0 | undefined): string | und
 
   // @ts-expect-error token category is derived from the public string contract.
   return vars.$dimension[dimension] ?? vars.$dimension[type]?.[value] ?? dimension;
+}
+
+export function resolveFlexValue(
+  value: number | string | boolean | undefined,
+): number | string | undefined {
+  if (value === true) return 1;
+  if (value === false) return 0;
+  return value;
 }
 
 function handleBorderWidth(width: 0 | 1 | (string & {}) | undefined) {
@@ -354,8 +362,8 @@ export function useStyleProps<T extends UseStyleProps>(
       overflowX,
       overflowY,
       zIndex,
-      flexGrow: flexGrow === true ? 1 : flexGrow === false ? 0 : flexGrow,
-      flexShrink: flexShrink === true ? 1 : flexShrink === false ? 0 : flexShrink,
+      flexGrow: resolveFlexValue(flexGrow),
+      flexShrink: resolveFlexValue(flexShrink),
       flexDirection: handleFlexDirection(flexDirection),
       flexWrap: flexWrap === true ? "wrap" : flexWrap === false ? "nowrap" : flexWrap,
       justifyContent: handleJustifyContent(justifyContent),


### PR DESCRIPTION
## 요약

- Lynx 공통 `Icon`, `PrefixIcon`, `SuffixIcon` 구조를 도입하고 `ActionButton layout="iconOnly"` 검증을 React 패턴에 맞춰 정리했습니다.
- 기존 `icon`, `prefixIcon`, `suffixIcon` prop은 호환 API로 유지하되 내부적으로 새 icon slot 경로를 타도록 맞췄습니다.
- Checkbox, RadioGroup, Switch의 context 구조를 `*Api` + recipe variant bucket + final slot/control context 형태로 정리했습니다.
- 반복되던 Lynx element/press/style prop 타입을 공통 타입으로 묶고 public props는 interface 중심으로 정리했습니다.
- ActionButton 예제와 Lynx icon color 문서를 최소 범위로 갱신했습니다.

## 확인한 내용

- `changeset`은 추가하지 않았습니다.
- `packages/lynx-css/recipes`, `packages/lynx-css/vars`, `packages/qvism-preset/src/vars` 직접 변경은 없습니다.
- Lynx native tag는 공통 factory로 빼지 않고 각 컴포넌트 파일의 literal `<view>` / `<text>` 렌더링을 유지했습니다.

## 테스트

- `bun --filter @seed-design/lynx-react test`
- `bun --filter @seed-design/lynx-react build`
- `bun generate:all`
- `bun test:all`
- `git diff --check`

> `@lynx-js/react` sourcemap 경고는 테스트 중 출력되지만 실패는 아니었습니다.
