### PR TITLE
feat(app-bar): deprecate divider option

### DIFF
--- a/.changeset/tame-walls-brake.md
+++ b/.changeset/tame-walls-brake.md
@@ -1,0 +1,7 @@
+---
+"@seed-design/stackflow": patch
+"@seed-design/rootage-artifacts": patch
+"@seed-design/css": patch
+---
+
+AppBar 하단에 구분선을 표시하는 `divider` 옵션을 deprecated 처리합니다. SEED React 1.3에서 제거될 예정이며, 제거 이후에는 AppBar 하단 구분선이 표시되지 않습니다.

--- a/docs/content/docs/migration/deprecations.mdx
+++ b/docs/content/docs/migration/deprecations.mdx
@@ -9,6 +9,7 @@ description: Deprecated 항목의 현황과 제거 계획을 관리합니다.
 
 | 항목                          | 종류          | Deprecated 버전 | 제거 예정 버전 | 대체안                 | 비고                                       |
 | ----------------------------- | ------------- | --------------- | -------------- | ---------------------- | ------------------------------------------ |
+| AppBar - divider 옵션         | 컴포넌트 옵션 | 1.2.x           | 1.3.0          | -                      | 제거 후 하단 구분선 미표시. rootage top-navigation 옵션 정리 |
 | Image Frame - rounded 옵션    | 컴포넌트 옵션 | 1.2.x           | 1.3.0          | borderRadius="r2"      | rootage image-frame 옵션 정리              |
 | $color.bg.layer-fill          | 디자인 토큰   | 1.2.x           | 1.3.0          | $color.bg.neutral-weak | 더이상 사용하지 않음 (elevation 문서 안내) |
 | $gradient.fade-layer-floating | 디자인 토큰   | 1.2.x           | 1.3.0          | -                      | 대체안 미정                                |

--- a/docs/public/rootage/components/top-navigation.json
+++ b/docs/public/rootage/components/top-navigation.json
@@ -20,12 +20,6 @@
             "color": {
               "type": "color"
             },
-            "strokeColor": {
-              "type": "color"
-            },
-            "strokeWidth": {
-              "type": "dimension"
-            },
             "gradient": {
               "type": "gradient"
             },
@@ -134,13 +128,6 @@
           },
           "defaultValue": "false",
           "description": "tone=transparent일 때만 동작합니다."
-        },
-        "divider": {
-          "values": {
-            "true": {},
-            "false": {}
-          },
-          "defaultValue": "true"
         },
         "titleLayout": {
           "values": {
@@ -327,39 +314,6 @@
             }
           }
         ]
-      },
-      {
-        "variants": {
-          "divider": "true"
-        },
-        "definitions": [
-          {
-            "states": [
-              "enabled"
-            ],
-            "slots": {
-              "root": {
-                "strokeColor": {
-                  "type": "color",
-                  "value": "$color.stroke.neutral-subtle"
-                },
-                "strokeWidth": {
-                  "type": "dimension",
-                  "value": {
-                    "value": 1,
-                    "unit": "px"
-                  }
-                }
-              }
-            }
-          }
-        ]
-      },
-      {
-        "variants": {
-          "divider": "false"
-        },
-        "definitions": []
       },
       {
         "variants": {

--- a/packages/css/vars/component/top-navigation.d.ts
+++ b/packages/css/vars/component/top-navigation.d.ts
@@ -64,15 +64,6 @@ export declare const vars: {
       }
     }
   },
-  "dividerTrue": {
-    "enabled": {
-      "root": {
-        "strokeColor": "var(--seed-color-stroke-neutral-subtle)",
-        "strokeWidth": "1px"
-      }
-    }
-  },
-  "dividerFalse": {},
   "titleLayoutTitleOnly": {
     "enabled": {
       "title": {

--- a/packages/css/vars/component/top-navigation.mjs
+++ b/packages/css/vars/component/top-navigation.mjs
@@ -56,15 +56,6 @@ export const vars = {
       }
     }
   },
-  "dividerTrue": {
-    "enabled": {
-      "root": {
-        "strokeColor": "var(--seed-color-stroke-neutral-subtle)",
-        "strokeWidth": "1px"
-      }
-    }
-  },
-  "dividerFalse": {},
   "titleLayoutTitleOnly": {
     "enabled": {
       "title": {

--- a/packages/qvism-preset/src/stackflow/app-bar.ts
+++ b/packages/qvism-preset/src/stackflow/app-bar.ts
@@ -258,7 +258,7 @@ export const appBar = defineSlotRecipe({
     divider: {
       true: {
         background: {
-          boxShadow: `inset 0px calc(-1 * ${vars.dividerTrue.enabled.root.strokeWidth}) 0 ${vars.dividerTrue.enabled.root.strokeColor}`,
+          boxShadow: `inset 0px calc(-1 * 1px) 0 ${tokens.$color.stroke.neutralSubtle}`,
         },
       },
     },

--- a/packages/qvism-preset/src/vars/component/top-navigation.d.ts
+++ b/packages/qvism-preset/src/vars/component/top-navigation.d.ts
@@ -64,15 +64,6 @@ export declare const vars: {
       }
     }
   },
-  "dividerTrue": {
-    "enabled": {
-      "root": {
-        "strokeColor": "var(--seed-color-stroke-neutral-subtle)",
-        "strokeWidth": "1px"
-      }
-    }
-  },
-  "dividerFalse": {},
   "titleLayoutTitleOnly": {
     "enabled": {
       "title": {

--- a/packages/qvism-preset/src/vars/component/top-navigation.mjs
+++ b/packages/qvism-preset/src/vars/component/top-navigation.mjs
@@ -56,15 +56,6 @@ export const vars = {
       }
     }
   },
-  "dividerTrue": {
-    "enabled": {
-      "root": {
-        "strokeColor": "var(--seed-color-stroke-neutral-subtle)",
-        "strokeWidth": "1px"
-      }
-    }
-  },
-  "dividerFalse": {},
   "titleLayoutTitleOnly": {
     "enabled": {
       "title": {

--- a/packages/rootage/components/top-navigation.yaml
+++ b/packages/rootage/components/top-navigation.yaml
@@ -14,10 +14,6 @@ data:
             type: dimension
           color:
             type: color
-          strokeColor:
-            type: color
-          strokeWidth:
-            type: dimension
           gradient:
             type: gradient
           bleedBottom:
@@ -33,7 +29,8 @@ data:
         description: title과 subtitle을 포함하는 영역입니다.
       right:
         properties: {}
-        description: 오른쪽 영역입니다. 일반적으로 Top Navigation Icon Button 또는 Top Navigation Text
+        description:
+          오른쪽 영역입니다. 일반적으로 Top Navigation Icon Button 또는 Top Navigation Text
           Button이 위치합니다.
       title:
         properties:
@@ -80,7 +77,8 @@ data:
         description: tone=transparent일 때만 동작합니다.
         values:
           "false":
-            description: false로 사용하는 것을 권장하지 않습니다. gradient 없이 사용하면 Top Navigation의 콘텐츠 가독성을
+            description:
+              false로 사용하는 것을 권장하지 않습니다. gradient 없이 사용하면 Top Navigation의 콘텐츠 가독성을
               직접 확보해야 합니다. 스크린 배경 색상이 Top Navigation에 보이기를 원하는 경우 tone=layer를
               사용하세요.
   definitions:
@@ -127,12 +125,6 @@ data:
               - color: "#00000000"
                 position: 1
           bleedBottom: $dimension.x5
-    divider=true:
-      enabled:
-        root:
-          strokeColor: $color.stroke.neutral-subtle
-          strokeWidth: 1px
-    divider=false: {}
     titleLayout=titleOnly:
       enabled:
         title:

--- a/packages/stackflow/src/components/AppBar/AppBar.tsx
+++ b/packages/stackflow/src/components/AppBar/AppBar.tsx
@@ -26,7 +26,12 @@ export const AppBarPropsProvider = PropsProvider;
 export interface AppBarProps
   extends AppBarVariantProps,
     AppBarPrimitive.RootProps,
-    BoxBackgroundProps {}
+    BoxBackgroundProps {
+  /**
+   * @deprecated SEED React 1.3에서 제거될 예정인 옵션입니다. 옵션 제거 이후에는 AppBar 하단 구분선이 표시되지 않습니다.
+   */
+  divider?: AppBarVariantProps["divider"];
+}
 
 export const AppBarRoot = forwardRef<HTMLDivElement, AppBarProps>((props, ref) => {
   const { style: boxStyle, restProps: propsWithoutBoxProps } = useBoxBackgroundProps(props);


### PR DESCRIPTION
closes #1567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * AppBar의 divider 옵션이 deprecated로 문서에 추가되었습니다(1.3.0 제거 예정) 및 관련 변경 점이 명시되었습니다.
* **Style**
  * AppBar의 divider 시각적 표현이 변경되어 하단 구분선 스타일이 업데이트되었습니다.
* **Chores**
  * 상단 내비게이션 스펙과 컴포넌트 타입/설명이 정리·갱신되었으며, 배포용 변경 메타데이터(패치 릴리스)가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daangn/seed-design/pull/1616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->