### PR TITLE
build(lynx-react): switch build to vite

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -470,6 +470,8 @@
         "@seed-design/lynx-css": "0.0.0",
         "@testing-library/jest-dom": "^6.9.1",
         "jsdom": "^29.0.2",
+        "vite": "^8.0.0",
+        "vite-plugin-dts": "^4.5.4",
         "vitest": "^3.2.4",
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "format:all": "bun biome format --fix",
     "test:all": "bun test:unit && bun test:lynx-react",
     "test:unit": "bun test --path-ignore-patterns='packages/lynx-react/**'",
-    "test:lynx-react": "bun --filter @seed-design/lynx-react typecheck:test && bun --filter @seed-design/lynx-react test",
+    "test:lynx-react": "bun run --filter '@seed-design/lynx-react' typecheck && bun run --filter '@seed-design/lynx-react' test",
     "generate:all": "bun rootage:generate && bun qvism:generate && bun docs:generate",
     "figma:sync": "bun figma-extractor --config=scripts/.config/figma-extractor.config.ts scripts/data variables && bun run ./scripts/figma-to-rootage.ts",
     "images:convert": "bun scripts/convert-images-to-webp.ts",

--- a/packages/lynx-react/package.json
+++ b/packages/lynx-react/package.json
@@ -23,10 +23,10 @@
   ],
   "scripts": {
     "clean": "rm -rf lib",
-    "build": "tsc",
+    "build": "vite build",
     "lint:publish": "bun publint",
     "test": "vitest run",
-    "typecheck:test": "tsc -p tsconfig.test.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit"
   },
   "peerDependencies": {
     "@lynx-js/react": ">=0.100.0",
@@ -39,6 +39,8 @@
     "@seed-design/lynx-css": "0.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "jsdom": "^29.0.2",
+    "vite": "^8.0.0",
+    "vite-plugin-dts": "^4.5.4",
     "vitest": "^3.2.4"
   },
   "publishConfig": {

--- a/packages/lynx-react/vite.config.ts
+++ b/packages/lynx-react/vite.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
+
+const jsOrJsxFileName = (chunkInfo: { facadeModuleId?: string | null }) => {
+  return chunkInfo.facadeModuleId?.endsWith(".tsx") ? "[name].jsx" : "[name].js";
+};
+
+export default defineConfig({
+  logLevel: "warn",
+  plugins: [
+    dts({
+      entryRoot: "src",
+      staticImport: true,
+      tsconfigPath: "tsconfig.json",
+      exclude: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    }),
+  ],
+  oxc: false,
+  build: {
+    target: "esnext",
+    minify: false,
+    outDir: "lib",
+    lib: {
+      entry: "src/index.ts",
+      formats: ["es"],
+    },
+    rolldownOptions: {
+      external: [/^@lynx-js\/.+/, /^@seed-design\/lynx-css(\/.*)?$/, "clsx"],
+      output: {
+        format: "es",
+        preserveModules: true,
+        preserveModulesRoot: "src",
+        entryFileNames: jsOrJsxFileName,
+        chunkFileNames: jsOrJsxFileName,
+        exports: "named",
+      },
+    },
+  },
+});


### PR DESCRIPTION
## 요약
- `@seed-design/lynx-react`의 JS 산출물 생성을 `tsc` emit에서 Vite build로 전환했습니다.
- `typecheck` 하나에서 source와 test tsconfig를 모두 `--noEmit`으로 검사하도록 정리했습니다.
- `vite-plugin-dts`로 declaration 생성을 Vite build 흐름에 포함하고, Lynx JSX는 `oxc: false`로 preserve되도록 설정했습니다.

## 확인한 내용
- Rslib와 `@vitejs/plugin-react`는 추가하지 않았습니다.
- 산출물에 `react/jsx-runtime`, `react/jsx-dev-runtime`, `@lynx-js/react/jsx-runtime`이 없는 것을 확인했습니다.
- TSX 원본 산출물은 `.jsx`로 남고 `<view>` / `<text>` literal JSX가 유지됩니다.
- `@lynx-js/*`, `@seed-design/lynx-css/*`, `clsx`는 bundle되지 않고 import로 유지됩니다.
- 대표 산출물 `Box.jsx`, `ActionButton.jsx`를 `@lynx-js/react/transform`으로 검증했을 때 `createSnapshot`이 생성됩니다.

## 테스트
- [x] `bun install`
- [x] `bun install --frozen-lockfile`
- [x] `bun run --filter '@seed-design/lynx-react' typecheck`
- [x] `bun run --filter '@seed-design/lynx-react' build`
- [x] `bun run --filter '@seed-design/lynx-react' lint:publish`
- [x] `bun test:lynx-react`
- [x] `bun run --filter lynx-spa build`
- [x] `bun generate:all`
- [x] `bun test:all`
- [x] 산출물 grep 및 ReactLynx transform 확인
