### PR TITLE
fix(tabs): scope carousel reInit to slide height changes

### DIFF
--- a/.changeset/tabs-watch-resize-height-only.md
+++ b/.changeset/tabs-watch-resize-height-only.md
@@ -1,0 +1,6 @@
+---
+"@seed-design/react-tabs": patch
+"@seed-design/react": patch
+---
+
+iOS 환경에서 ChipTabs + ScrollFog 사용 시 가로 스크롤이 동작하지 않는 문제를 해결합니다.

--- a/examples/stackflow-spa/src/activities/ActivityChipTabsScrollFog.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityChipTabsScrollFog.tsx
@@ -1,0 +1,161 @@
+import { Box, ScrollFog } from "@seed-design/react";
+import type { StaticActivityComponentType } from "@stackflow/react/future";
+import { useFlow } from "@stackflow/react/future";
+import { Suspense, useEffect, useState } from "react";
+import * as React from "react";
+import {
+  AppBar,
+  AppBarBackButton,
+  AppBarIconButton,
+  AppBarLeft,
+  AppBarMain,
+  AppBarRight,
+} from "seed-design/ui/app-bar";
+import { AppScreen, AppScreenContent } from "seed-design/ui/app-screen";
+import {
+  ChipTabsCarousel,
+  ChipTabsContent,
+  ChipTabsList,
+  ChipTabsRoot,
+  ChipTabsTrigger,
+} from "seed-design/ui/chip-tabs";
+import { IconHouseLine } from "@karrotmarket/react-monochrome-icon";
+
+declare module "@stackflow/config" {
+  interface Register {
+    ActivityChipTabsScrollFog: {};
+  }
+}
+
+/**
+ * Pattern A: AsyncContent (useState + setTimeout)
+ * Simulates async data loading that causes content height to change
+ */
+const AsyncContent = ({ delay, children }: { delay: number; children: React.ReactNode }) => {
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setLoaded(true);
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [delay]);
+
+  return loaded ? <>{children}</> : <Box p="x4">Loading...</Box>;
+};
+
+/**
+ * Pattern B: React.lazy + Suspense
+ * Simulates real-world lazy component loading pattern
+ */
+function createLazyComponent(delay: number, height: string) {
+  return React.lazy(
+    () =>
+      new Promise<{ default: React.ComponentType }>((resolve) => {
+        setTimeout(() => {
+          resolve({
+            default: () => (
+              <Box bg="bg.criticalSolid" p="x4" height={height} color="fg.criticalContrast">
+                Lazy loaded content ({height} tall, {delay}ms delay)
+              </Box>
+            ),
+          });
+        }, delay);
+      }),
+  );
+}
+
+const LazyTallContent = createLazyComponent(1500, "400px");
+
+const ActivityChipTabsScrollFog: StaticActivityComponentType<"ActivityChipTabsScrollFog"> = () => {
+  const { push } = useFlow();
+
+  return (
+    <AppScreen>
+      <AppBar>
+        <AppBarLeft>
+          <AppBarBackButton />
+        </AppBarLeft>
+        <AppBarMain title="ChipTabs ScrollFog + LazyMount" />
+        <AppBarRight>
+          <AppBarIconButton aria-label="Home" onClick={() => push("ActivityHome", {})}>
+            <IconHouseLine />
+          </AppBarIconButton>
+        </AppBarRight>
+      </AppBar>
+      <AppScreenContent>
+        <Box p="x4" color="fg.neutralMuted">
+          Check 1 (DES-1532): tab 2/4 content loads after a delay and the carousel height follows.
+          {"\n"}
+          Check 2 (DES-1889): the chip strip scrolls horizontally on WKWebView/Safari.
+        </Box>
+        <ChipTabsRoot defaultValue="1" lazyMount contentLayout="hug" variant="neutralSolid">
+          {/* Chip strip wrapped in ScrollFog for horizontal scroll + edge gradients */}
+          <ScrollFog placement={["left", "right"]}>
+            <ChipTabsList style={{ paddingLeft: "20px", paddingRight: "20px" }}>
+              <ChipTabsTrigger value="1">Immediate</ChipTabsTrigger>
+              <ChipTabsTrigger value="2">Async</ChipTabsTrigger>
+              <ChipTabsTrigger value="3">Immediate 2</ChipTabsTrigger>
+              <ChipTabsTrigger value="4">Suspense</ChipTabsTrigger>
+              <ChipTabsTrigger value="5">Immediate 3</ChipTabsTrigger>
+              <ChipTabsTrigger value="6">라벨6</ChipTabsTrigger>
+              <ChipTabsTrigger value="7">라벨7</ChipTabsTrigger>
+              <ChipTabsTrigger value="8">라벨8</ChipTabsTrigger>
+              <ChipTabsTrigger value="9">라벨9</ChipTabsTrigger>
+              <ChipTabsTrigger value="10">라벨10</ChipTabsTrigger>
+            </ChipTabsList>
+          </ScrollFog>
+          <ChipTabsCarousel autoHeight swipeable>
+            {/* Tab 1: Immediate render, short content (baseline) */}
+            <ChipTabsContent value="1">
+              <Box bg="bg.informativeSolid" p="x4" height="100px" color="fg.informativeContrast">
+                Tab 1: Immediate (100px)
+              </Box>
+            </ChipTabsContent>
+
+            {/* Tab 2: Pattern A - AsyncContent with setTimeout delay */}
+            <ChipTabsContent value="2">
+              <AsyncContent delay={1000}>
+                <Box bg="bg.criticalSolid" p="x4" height="500px" color="fg.criticalContrast">
+                  Tab 2: Async loaded (500px, 1s delay)
+                </Box>
+              </AsyncContent>
+            </ChipTabsContent>
+
+            {/* Tab 3: Immediate render, medium content */}
+            <ChipTabsContent value="3">
+              <Box bg="bg.positiveSolid" p="x4" height="200px" color="fg.positiveContrast">
+                Tab 3: Immediate (200px)
+              </Box>
+            </ChipTabsContent>
+
+            {/* Tab 4: Pattern B - React.lazy + Suspense */}
+            <ChipTabsContent value="4">
+              <Suspense fallback={<Box p="x4">Suspense loading...</Box>}>
+                <LazyTallContent />
+              </Suspense>
+            </ChipTabsContent>
+
+            {/* Tab 5: Immediate render, short content */}
+            <ChipTabsContent value="5">
+              <Box bg="bg.warningSolid" p="x4" height="150px" color="fg.warningContrast">
+                Tab 5: Immediate (150px)
+              </Box>
+            </ChipTabsContent>
+
+            {/* Tabs 6-10: filler to make the chip strip overflow (scroll fog) */}
+            {[6, 7, 8, 9, 10].map((value) => (
+              <ChipTabsContent key={value} value={String(value)}>
+                <Box bg="bg.neutral" p="x4" height="120px" color="fg.neutral">
+                  Tab {value}: Immediate (120px)
+                </Box>
+              </ChipTabsContent>
+            ))}
+          </ChipTabsCarousel>
+        </ChipTabsRoot>
+      </AppScreenContent>
+    </AppScreen>
+  );
+};
+
+export default ActivityChipTabsScrollFog;

--- a/examples/stackflow-spa/src/activities/ActivityHome.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityHome.tsx
@@ -262,6 +262,10 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
           title: "TabsAutoHeightLazy",
           onClick: () => push("ActivityTabsAutoHeightLazy", {}),
         },
+        {
+          title: "ChipTabsScrollFog",
+          onClick: () => push("ActivityChipTabsScrollFog", {}),
+        },
       ],
     },
     {

--- a/examples/stackflow-spa/src/stackflow/Stack.tsx
+++ b/examples/stackflow-spa/src/stackflow/Stack.tsx
@@ -86,6 +86,7 @@ export const { Stack, actions, stepActions } = stackflow({
     ActivitySwipeableTabs: lazy(() => import("../activities/ActivitySwipeableTabs")),
     ActivityTabs: lazy(() => import("../activities/ActivityTabs")),
     ActivityTabsAutoHeightLazy: lazy(() => import("../activities/ActivityTabsAutoHeightLazy")),
+    ActivityChipTabsScrollFog: lazy(() => import("../activities/ActivityChipTabsScrollFog")),
     ActivityForm: lazy(() => import("../activities/ActivityForm")),
     ActivityCategorySheet: lazy(() => import("../activities/ActivityCategorySheet")),
     ActivityToggleButton: lazy(() => import("../activities/ActivityToggleButton")),

--- a/examples/stackflow-spa/src/stackflow/stackflow.config.ts
+++ b/examples/stackflow-spa/src/stackflow/stackflow.config.ts
@@ -57,6 +57,7 @@ export const config = defineConfig({
     { route: "/swipeable-tabs", name: "ActivitySwipeableTabs" },
     { route: "/tabs", name: "ActivityTabs" },
     { route: "/tabs-auto-height-lazy", name: "ActivityTabsAutoHeightLazy" },
+    { route: "/chip-tabs-scroll-fog", name: "ActivityChipTabsScrollFog" },
     { route: "/form", name: "ActivityForm" },
     { route: "/category-sheet", name: "ActivityCategorySheet" },
     { route: "/toggle-button", name: "ActivityToggleButton" },

--- a/packages/react-headless/tabs/src/useTabsCarousel.ts
+++ b/packages/react-headless/tabs/src/useTabsCarousel.ts
@@ -66,7 +66,7 @@ const useTabsCarouselState = (props: UseTabsCarouselStateProps) => {
           const prevHeight = heights.get(slide);
           heights.set(slide, newHeight);
 
-          if (prevHeight !== undefined && Math.abs(newHeight - prevHeight) >= 0.5) {
+          if (prevHeight !== undefined && newHeight !== prevHeight) {
             emblaApi.reInit();
             return false;
           }

--- a/packages/react-headless/tabs/src/useTabsCarousel.ts
+++ b/packages/react-headless/tabs/src/useTabsCarousel.ts
@@ -33,6 +33,7 @@ const plugins = [autoHeight];
 
 const useTabsCarouselState = (props: UseTabsCarouselStateProps) => {
   const api = useTabsContext();
+  const slideHeights = useRef(new WeakMap<HTMLElement, number>());
   const [emblaRef, emblaApi] = useEmblaCarousel(
     {
       loop: props.loop,
@@ -47,11 +48,25 @@ const useTabsCarouselState = (props: UseTabsCarouselStateProps) => {
         return true;
       },
       // Workaround for Embla v8 AutoHeight plugin not detecting lazy-loaded content height changes.
-      // When a slide's content changes size (e.g. after lazy mount), reInit recalculates the height.
       // ref: https://github.com/davidjerleke/embla-carousel/discussions/1142
+      // Embla's default resize handler only reInits on axis-size (width, for a horizontal carousel)
+      // changes, so a slide growing taller (e.g. after lazy mount) never triggers a recalculation.
+      // We reInit manually, but ONLY when a slide's *height* actually changes — reInit-ing on every
+      // slide resize (including width fluctuations during horizontal scroll) re-applies Embla's
+      // translate3d mid-scroll and breaks momentum scrolling in WKWebView/Safari.
       watchResize: (emblaApi, entries) => {
+        const heights = slideHeights.current;
+        const slides = emblaApi.slideNodes();
+
         for (const entry of entries) {
-          if (entry.target !== emblaApi.containerNode()) {
+          const slide = slides.find((node) => node === entry.target);
+          if (!slide) continue;
+
+          const newHeight = slide.offsetHeight;
+          const prevHeight = heights.get(slide);
+          heights.set(slide, newHeight);
+
+          if (prevHeight !== undefined && Math.abs(newHeight - prevHeight) >= 0.5) {
             emblaApi.reInit();
             return false;
           }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * iOS 환경에서 ChipTabs와 ScrollFog 사용 시 가로 스크롤이 동작하지 않던 문제를 해결했습니다.
  * 탭/캐러셀의 높이 변경 감지 로직을 개선하여 불필요한 재초기화로 인한 깜빡임과 성능 저하를 줄였습니다.

* **New Features**
  * ChipTabs + ScrollFog 동작을 확인할 수 있는 예제 화면(지연 로딩 및 많은 탭 포함)을 추가하고 내비게이션 경로를 등록했습니다.

* **Chores**
  * 패키지 메타데이터에 패치 버전 범프가 기록되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->