### PR TITLE
fix(tabs): keep carousel slide slots mounted under lazyMount

### DIFF
--- a/.changeset/tabs-lazymount-carousel-index.md
+++ b/.changeset/tabs-lazymount-carousel-index.md
@@ -1,0 +1,6 @@
+---
+"@seed-design/react-tabs": patch
+"@seed-design/react": patch
+---
+
+lazyMount를 사용하는 Tabs · ChipTabs에서 멀리 떨어진 탭을 선택하면 다른 탭이 열리던 문제를 해결합니다. lazyMount 및 TabsCarousel 사용 시 TabsContent 자체를 항상 렌더하고, TabsContent의 children만 lazy mount하도록 변경합니다.

--- a/packages/react-headless/tabs/src/Tabs.tsx
+++ b/packages/react-headless/tabs/src/Tabs.tsx
@@ -95,22 +95,32 @@ export interface TabsContentProps
     React.HTMLAttributes<HTMLDivElement> {}
 
 export const TabsContent = forwardRef<HTMLDivElement, TabsContentProps>((props, ref) => {
-  const { value, ...otherProps } = props;
+  const { value, children, ...otherProps } = props;
   const api = useTabsContext();
   const carouselApi = useTabsCarouselContext({ strict: false });
+  const inCarousel = carouselApi != null;
   const renderStrategyProps = useRenderStrategyPropsContext();
   const { unmounted } = useRenderStrategy({
     ...renderStrategyProps,
     present: api.value === value,
   });
 
-  if (unmounted) return null;
+  // Outside a carousel, an unmounted tab renders nothing at all.
+  // Inside a carousel, every tab must keep its slide slot even while unmounted:
+  // the carousel syncs by numeric index, so collapsing the slide set (returning
+  // null for lazy/exited tabs) makes embla's snap index drift from the tab's
+  // logical index, and clicking/swiping to a far tab lands on the wrong one.
+  // We keep the slot but still honor lazyMount/unmountOnExit for the children,
+  // so expensive content stays lazy — only the empty slide wrapper persists.
+  if (unmounted && !inCarousel) return null;
 
   return (
     <Primitive.div
       ref={ref}
       {...mergeProps(api.getContentProps({ value }), carouselApi?.stateProps ?? {}, otherProps)}
-    />
+    >
+      {unmounted ? null : children}
+    </Primitive.div>
   );
 });
 TabsContent.displayName = "TabsContent";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * `lazyMount` 사용 시 먼 거리의 탭을 선택했을 때 다른 탭이 열리는 문제 해결
  * `lazyMount`와 `TabsCarousel` 함께 사용 시 탭 콘텐츠 렌더링 동작 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->