### PR TITLE
fix(lynx-spa): stabilize icon catalog virtualization

### DIFF
--- a/examples/lynx-spa/src/components/icon-grid-rows.ts
+++ b/examples/lynx-spa/src/components/icon-grid-rows.ts
@@ -1,0 +1,22 @@
+import type { ComponentType } from "@lynx-js/react";
+import type { LynxIconElementProps } from "@seed-design/lynx-react";
+
+export interface IconProps extends LynxIconElementProps {
+  color?: string;
+  size?: number;
+}
+
+export interface IconEntry {
+  component: ComponentType<IconProps>;
+  name: string;
+}
+
+export function chunkIconEntries(icons: IconEntry[], columnCount: number) {
+  const rows: IconEntry[][] = [];
+
+  for (let index = 0; index < icons.length; index += columnCount) {
+    rows.push(icons.slice(index, index + columnCount));
+  }
+
+  return rows;
+}

--- a/examples/lynx-spa/src/components/icon-virtual-grid.test.ts
+++ b/examples/lynx-spa/src/components/icon-virtual-grid.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+
+import { chunkIconEntries, type IconEntry } from "./icon-grid-rows";
+
+function createEntry(name: string): IconEntry {
+  return {
+    component: (() => null) as IconEntry["component"],
+    name,
+  };
+}
+
+describe("chunkIconEntries", () => {
+  it("groups icons into four-column rows while preserving order", () => {
+    const rows = chunkIconEntries(
+      ["A", "B", "C", "D", "E", "F", "G"].map((name) => createEntry(name)),
+      4,
+    );
+
+    expect(rows.map((row) => row.map((icon) => icon.name))).toEqual([
+      ["A", "B", "C", "D"],
+      ["E", "F", "G"],
+    ]);
+  });
+});

--- a/examples/lynx-spa/src/components/icon-virtual-grid.tsx
+++ b/examples/lynx-spa/src/components/icon-virtual-grid.tsx
@@ -1,14 +1,17 @@
-import type { ComponentType } from "@lynx-js/react";
 import { vars } from "@seed-design/lynx-css/vars";
-import { Icon as SeedIcon, type LynxIconElementProps } from "@seed-design/lynx-react";
+import { Icon as SeedIcon } from "@seed-design/lynx-react";
+
+import { chunkIconEntries, type IconEntry } from "./icon-grid-rows";
+
+export type { IconEntry, IconProps } from "./icon-grid-rows";
 
 const { $color } = vars;
 
 const COLUMN_COUNT = 4;
 const ITEM_HEIGHT = 76;
-const PRELOAD_ITEM_COUNT = COLUMN_COUNT * 8;
+const PRELOAD_ROW_COUNT = 8;
 
-// Flow-list positions reused cells from measured inline layout, so keep these metrics explicit.
+// Row-level virtualization needs stable list-item metrics before the first scroll.
 const titleStyle = {
   color: $color.fg.neutral,
   fontSize: "20px",
@@ -35,6 +38,7 @@ const iconCellStyle = {
   height: `${ITEM_HEIGHT}px`,
   justifyContent: "center",
   padding: "8px 4px",
+  width: "25%",
 } as const;
 
 const iconLabelStyle = {
@@ -46,15 +50,12 @@ const iconLabelStyle = {
   wordBreak: "break-all",
 } as const;
 
-export interface IconProps extends LynxIconElementProps {
-  color?: string;
-  size?: number;
-}
-
-export interface IconEntry {
-  component: ComponentType<IconProps>;
-  name: string;
-}
+const iconRowStyle = {
+  display: "flex",
+  flexDirection: "row",
+  height: `${ITEM_HEIGHT}px`,
+  width: "100%",
+} as const;
 
 interface VirtualIconGridProps {
   iconColor?: string;
@@ -64,6 +65,8 @@ interface VirtualIconGridProps {
 }
 
 export function VirtualIconGrid({ iconColor, icons, packageName, title }: VirtualIconGridProps) {
+  const iconRows = chunkIconEntries(icons, COLUMN_COUNT);
+
   return (
     <view className="flex flex-1 min-h-0 flex-col px-x4">
       <text style={titleStyle}>{title}</text>
@@ -72,26 +75,30 @@ export function VirtualIconGrid({ iconColor, icons, packageName, title }: Virtua
       </text>
 
       <list
-        list-type="flow"
-        span-count={COLUMN_COUNT}
+        list-type="single"
+        span-count={1}
         scroll-orientation="vertical"
-        preload-buffer-count={PRELOAD_ITEM_COUNT}
+        preload-buffer-count={PRELOAD_ROW_COUNT}
         style={iconListStyle}
       >
-        {icons.map(({ component: IconComp, name }) => (
+        {iconRows.map((row) => (
           <list-item
-            key={name}
-            item-key={name}
+            key={`icon-row-${row[0]?.name}`}
+            item-key={`icon-row-${row[0]?.name}`}
             estimated-main-axis-size-px={ITEM_HEIGHT}
-            reuse-identifier="icon-cell"
+            reuse-identifier="icon-row"
           >
-            <view style={iconCellStyle}>
-              {iconColor == null ? (
-                <IconComp size={24} />
-              ) : (
-                <SeedIcon icon={<IconComp />} size={24} color={iconColor} />
-              )}
-              <text style={iconLabelStyle}>{name}</text>
+            <view style={iconRowStyle}>
+              {row.map(({ component: IconComp, name }) => (
+                <view key={name} style={iconCellStyle}>
+                  {iconColor == null ? (
+                    <IconComp size={24} />
+                  ) : (
+                    <SeedIcon icon={<IconComp />} size={24} color={iconColor} />
+                  )}
+                  <text style={iconLabelStyle}>{name}</text>
+                </view>
+              ))}
             </view>
           </list-item>
         ))}


### PR DESCRIPTION
## Summary
- Lynx SPA 아이콘 카탈로그에서 개별 아이콘 단위 `flow` list 가상화를 row 단위 `single` list 가상화로 변경했습니다.
- 아이콘을 4개씩 chunking해 하나의 row `list-item`으로 렌더하고, row/list-item/cell 높이를 `76px` 기준으로 고정했습니다.
- monochrome `SeedIcon` 색상 처리, multicolor direct icon 렌더링, `createIconEntries` 순서는 유지했습니다.

## Why
초기 진입 시 `flow` list의 inline layout 측정이 불안정해 일부 row 사이에 큰 빈 공간이 생기고, 스크롤 후 재측정되면서 아이콘이 다시 보이는 현상이 있었습니다. row 단위로 명시적인 main-axis size를 제공해 첫 렌더와 스크롤 전후 간격을 안정화합니다.

## Test Plan
- [x] `bun biome check examples/lynx-spa`
- [x] `git diff --check`
- [x] `bun test examples/lynx-spa/src/components/icon-virtual-grid.test.ts`
- [x] `bun --filter lynx-spa build`
- [x] `bun generate:all`
- [x] `bun test:all`

## Manual QA
- local dev server preview Home 렌더까지 확인했습니다.
- in-app Browser 자동화 입력이 Lynx preview의 `bindtap` 이벤트까지 전달되지 않아 monochrome/multicolor 페이지 진입 후 스크롤 전후 화면 검증은 실제 Lynx preview/simulator에서 추가 확인이 필요합니다.
