### PR TITLE
docs(create-component): add Lynx platform routing

### DIFF
--- a/skills/create-component/SKILL.md
+++ b/skills/create-component/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-component
-description: End-to-end SEED component implementation guide that starts with a brainstorming session to clarify requirements, then makes architecture decisions, follows the category-specific pattern, and runs through verification. Use this whenever the user is adding a new component, changing behavior across component layers, or extending a snippet — even if they don't explicitly say "create component". Always invoke this skill before touching rootage YAML, qvism recipes, react packages, or component docs. Covers all 5 component categories (simple, compound stateless, compound stateful, multi-recipe, layout) and refuses to skip the requirements brainstorming.
+description: End-to-end SEED component implementation guide for React Web, Lynx, and cross-platform component work. Starts by deciding the target platform, then clarifies requirements, makes architecture decisions, follows the platform/category-specific pattern, and runs verification. Use this whenever the user is adding a new component, changing behavior across component layers, extending a snippet, or touching component docs — even if they don't explicitly say "create component". Always invoke before touching rootage YAML, qvism or lynx-qvism recipes, react/lynx-react/lynx-headless packages, docs registry snippets, or component docs. Covers all 5 component categories and refuses to skip platform gating or requirements brainstorming.
 ---
 
 # Create Component
@@ -10,8 +10,8 @@ description: End-to-end SEED component implementation guide that starts with a b
 ## 핵심 흐름
 
 ```text
-Phase 0 Pre (Brainstorm)  →  Phase 0 (Architecture)  →  Phase 1 (Implementation)  →  Phase 2 (Verification)
-       사용자 합의              아키텍처 결정              레이어별 구현                자동·수동 검증
+Platform Gate  →  Phase 0 Pre (Brainstorm)  →  Phase 0 (Architecture)  →  Phase 1 (Implementation)  →  Phase 2 (Verification)
+ React/Lynx 결정          사용자 합의              아키텍처 결정              레이어별 구현                자동·수동 검증
 ```
 
 각 Phase 사이에 **게이트**가 있다. 게이트 통과 전까지 다음 Phase로 가지 않는다. 흐름이 깨지면 빠진 요구사항·어긋난 아키텍처·우회된 검증이 누적되어 다른 컴포넌트까지 흔든다.
@@ -26,11 +26,24 @@ Phase 0 Pre (Brainstorm)  →  Phase 0 (Architecture)  →  Phase 1 (Implementat
 
 ---
 
+## Platform Gate: 대상 플랫폼 결정
+
+**진입 시 즉시 읽기 → `references/platform-gate.md`**
+
+Phase 0 Pre 전에 target platform을 `react` / `lynx` / `cross-platform` 중 하나로 확정한다. 플랫폼이 정해져야 Headless, Recipe, Styled UI, Snippet, Docs, Example, Verification 경로가 결정된다.
+
+### 🔒 게이트 Platform → 0Pre
+- target platform 확정
+- `cross-platform`이면 shared Rootage/API와 플랫폼별 구현 분리 원칙 확인
+- 새 `packages/lynx-headless/<component>` 패키지가 필요하면 사용자 확인 전 구현 금지
+
+---
+
 ## Phase 0 Pre: 요구사항 Brainstorming
 
 **진입 시 즉시 읽기 → `references/brainstorming.md`**
 
-사용자와 5개 영역(Purpose / 기존과의 관계 / 엣지케이스 / 토큰 의존성 / 외부 레퍼런스 우선순위)을 1:1 대화로 합의한다. 질문은 한 번에 하나씩, 객관식 우선. 추측해서 채우지 않는다.
+Platform Gate 결과를 전제로 사용자와 5개 영역(Purpose / 기존과의 관계 / 엣지케이스 / 토큰 의존성 / 외부 레퍼런스 우선순위)을 1:1 대화로 합의한다. 질문은 한 번에 하나씩, 객관식 우선. 추측해서 채우지 않는다.
 
 산출물: 합의 요약 (메모 또는 PR description 초안).
 
@@ -48,6 +61,7 @@ Phase 0 Pre의 합의를 입력으로 받아 컴포넌트 카테고리(A~E), Hea
 **조건부 추가 reference:**
 - 카테고리 확정 후 → `references/pattern-catalog.md` (카테고리별 레퍼런스 + 유틸리티 맵)
 - 외부 라이브러리 조사 / 차용 결정 시 → `references/external-references.md` (라이브러리 우선순위 + 차용 결정 트리 + ARIA/WCAG)
+- target platform이 `lynx` 또는 `cross-platform`이면 → `references/lynx-patterns.md` (Lynx runtime 제약 + headless/styled 책임 분리)
 
 ### 🔒 게이트 0 → 1
 - architecture-decisions.md 체크리스트 모든 항목 완료
@@ -67,10 +81,10 @@ Phase 0 Pre의 합의를 입력으로 받아 컴포넌트 카테고리(A~E), Hea
 
 | 단계 | 읽을 reference |
 |------|---------------|
-| Recipe 작성 | `references/recipe-patterns.md` |
-| React 컴포넌트 작성 | `references/react-patterns.md` |
+| Recipe 작성 | React는 `references/recipe-patterns.md`, Lynx는 `references/lynx-patterns.md` + `packages/lynx-qvism-preset/AGENTS.md` |
+| Styled UI 작성 | React는 `references/react-patterns.md`, Lynx는 `references/lynx-patterns.md` |
 | Snippet 레이어 설계 | `references/api-design.md` |
-| Headless 훅 설계 (카테고리 C/D) | `references/external-references.md` |
+| Headless 훅/primitive 설계 (카테고리 C/D) | React는 `references/external-references.md`, Lynx는 `references/lynx-patterns.md` |
 
 ### 🔒 게이트 1 → 2
 자동 검증 4개 명령이 모두 통과해야 Phase 2 진입:
@@ -90,10 +104,15 @@ bun docs:test             # 문서 정합성
 
 **진입 시 읽기 → `references/verification-checklist.md` + `references/visual-testing.md`**
 
-모든 카테고리에서 필수:
+React 작업에서 필수:
 - Storybook 4종 테마/스케일 (Light / Dark / FontScaling ExtraSmall / ExtraExtraExtraLarge)
 - `examples/stackflow-spa`의 유사 Activity 확인 (없으면 신설 검토)
 - docs 사이트의 컴포넌트 페이지 렌더링
+
+Lynx 작업에서 필수:
+- `examples/lynx-spa`의 유사 page 또는 vendored snippet 확인
+- `docs/content/lynx`와 `docs/registry/lynx/ui`의 API/미지원 기능 동기화
+- Lynx package build/test 또는 root Lynx 검증 script 확인
 
 마지막에 `/changeset` 스킬로 changeset 생성.
 
@@ -108,14 +127,17 @@ bun docs:test             # 문서 정합성
 | Phase | 파일 | 언제 읽는가 |
 |-------|------|------------|
 | 공통 | `references/sticking-policy.md` | 막혔을 때 |
+| Platform | `references/platform-gate.md` | 컴포넌트 작업 시작 즉시 |
 | 0 Pre | `references/brainstorming.md` | Phase 0 Pre 진입 즉시 |
 | 0 | `references/architecture-decisions.md` | Phase 0 진입 즉시 |
 | 0 | `references/pattern-catalog.md` | 카테고리 확정 후 |
 | 0 | `references/external-references.md` | 외부 조사 / 차용 결정 시 (Phase 1의 Headless 훅 설계 시에도) |
+| 0/1 | `references/lynx-patterns.md` | target platform이 `lynx` 또는 `cross-platform`일 때 |
 | 1 | `references/guide.md` | Phase 1 진입 시 보조 |
 | 1 | `references/implementation-steps.md` | Phase 1 진입 시 |
 | 1 | `references/recipe-patterns.md` | Recipe 작성 단계 |
-| 1 | `references/react-patterns.md` | React 컴포넌트 단계 |
+| 1 | `references/react-patterns.md` | React Styled UI 단계 |
 | 1 | `references/api-design.md` | Snippet 레이어 단계 |
 | 2 | `references/verification-checklist.md` | Phase 2 진입 시 |
 | 2 | `references/visual-testing.md` | Phase 2 진입 시 |
+| 유지보수 | `references/review-prompts.md` | 이 스킬 자체를 수정한 뒤 문서 리뷰할 때 |

--- a/skills/create-component/references/api-design.md
+++ b/skills/create-component/references/api-design.md
@@ -1,6 +1,12 @@
 # API 설계 원칙
 
-Snippet 레이어(`docs/registry/ui/`)와 컴포넌트 공개 API 설계 시 따르는 원칙.
+Snippet 레이어와 컴포넌트 공개 API 설계 시 따르는 원칙.
+
+Platform별 snippet 경로:
+- React: `docs/registry/react/ui/`
+- Lynx: `docs/registry/lynx/ui/`
+
+Lynx snippet은 React snippet을 그대로 복사하지 않는다. `@lynx-js/react`, `@seed-design/lynx-react`, Lynx icon package, unsupported Web API 차이를 반영해 별도 user-facing API로 설계한다.
 
 ## Snippet 레이어 필요 여부
 
@@ -173,6 +179,10 @@ Snippet의 최상위 export 이름은 사용자가 설치 후 import하는 이�
 ## Registry 등록
 
 Registry 등록 절차는 `implementation-steps.md`의 Registry UI 단계가 기준이다. API 설계 단계에서는 snippet이 stable user API인지, 설치 후 사용자가 작성할 최소 코드가 무엇인지, version/dependency metadata에 영향을 주는 public surface가 있는지만 결정한다.
+
+- React registry: `docs/registry/react/registry-ui.ts`
+- Lynx registry: `docs/registry/lynx/registry-ui.ts`
+- Lynx snippet dependency range에는 `@seed-design/lynx-react`와 `@seed-design/lynx-css`가 포함되어야 한다.
 
 ## Block 패턴
 

--- a/skills/create-component/references/architecture-decisions.md
+++ b/skills/create-component/references/architecture-decisions.md
@@ -2,7 +2,20 @@
 
 > **전제조건**: `references/brainstorming.md`의 Phase 0 Pre가 완료되어 있어야 한다. 즉 사용자와 Purpose, 기존과의 관계, 엣지케이스, 토큰 의존성, 외부 레퍼런스 우선순위가 합의된 상태에서 진입한다. 합의되지 않았으면 Phase 0 Pre로 돌아간다.
 
-구현을 시작하기 전에 이 문서의 모든 섹션을 완료한다. 여기서 내린 결정이 이후 모든 단계의 파일 구조, 유틸리티 선택, recipe 타입을 결정한다.
+구현을 시작하기 전에 이 문서의 모든 섹션을 완료한다. 여기서 내린 결정이 이후 모든 단계의 파일 구조, 유틸리티 선택, recipe 타입, 플랫폼별 검증 표면을 결정한다.
+
+## 0. Platform Gate 결과 확인
+
+Phase 0에 들어오기 전에 `references/platform-gate.md`의 target platform이 확정되어 있어야 한다.
+
+| 항목 | 값 |
+|------|----|
+| Target platform | react / lynx / cross-platform |
+| Docs/registry target | React: `docs/content/react` + `docs/registry/react/ui`, Lynx: `docs/content/lynx` + `docs/registry/lynx/ui` |
+| Headless ownership | React headless / Lynx headless / styled-local / 없음 |
+| Lynx support delta | N/A 또는 웹 대비 차이 |
+
+`lynx` 또는 `cross-platform`이면 `references/lynx-patterns.md`를 함께 읽고, native tag literal JSX와 headless/styled 책임 분리 제약을 Phase 1 계획에 반영한다.
 
 Phase 0 Pre의 산출물(합의 요약)이 다음 항목의 입력이 된다:
 - 합의된 **유사 컴포넌트 매트릭스** → §6 패턴 참조 컴포넌트의 기본값
@@ -29,7 +42,7 @@ Phase 0 Pre의 산출물(합의 요약)이 다음 항목의 입력이 된다:
 
 카테고리가 결정되면 `references/pattern-catalog.md`에서 해당 카테고리의 레퍼런스 컴포넌트와 필수 유틸리티를 확인한다.
 
-| 카테고리 | Recipe 타입 | React 패턴 | Namespace | 레퍼런스 |
+| 카테고리 | Recipe 타입 | React Web 패턴 | Namespace | React 레퍼런스 |
 |----------|------------|-----------|-----------|---------|
 | A. Simple | defineRecipe | splitVariantProps + forwardRef | 없음 | Badge |
 | B. Compound (Stateless) | defineSlotRecipe | createSlotRecipeContext | 있음 | Avatar |
@@ -41,14 +54,17 @@ Phase 0 Pre의 산출물(합의 요약)이 다음 항목의 입력이 된다:
 
 카테고리 C/D인 경우 headless 레이어가 필요하다. 기존 패키지를 재사용할 수 있는지 먼저 확인한다.
 
-**기존 headless 패키지** (packages/react-headless/):
+**React 기존 headless 패키지** (`packages/react-headless/`):
 avatar, checkbox, collapsible, dialog, drawer, field, field-button, fieldset, image, popover, portal, primitive, progress, pull-to-refresh, radio-group, scrollable, segmented-control, slider, snackbar, supports, switch, tabs, text-field, toggle, use-controllable-state
+
+**Lynx headless 패키지** (`packages/lynx-headless/`):
+현재 repo에 있는 패키지를 먼저 확인한다. stateful Lynx 컴포넌트에서 press/tap, controlled/uncontrolled, context, render props를 재사용해야 하면 `packages/lynx-headless/*`를 우선 검토한다. 새 패키지가 필요하면 “새 패키지 추가” boundary이므로 사용자 확인 전 구현하지 않는다.
 
 - **재사용 가능**: 기존 패키지의 훅/컨텍스트를 그대로 사용 (예: collapsible → Accordion)
 - **확장 필요**: 기존 패키지를 기반으로 새 훅 추가
 - **신규 생성**: 완전히 새로운 headless 패키지 필요
 
-신규 생성 시 `packages/react-headless/AGENTS.md`의 컨벤션을 반드시 확인한다.
+신규 생성 시 target platform에 따라 `packages/react-headless/AGENTS.md` 또는 `packages/lynx-headless/AGENTS.md`의 컨벤션을 반드시 확인한다.
 
 ## 3. 의존성 분석 (BLOCKING GATE)
 
@@ -112,9 +128,9 @@ APG가 heading 계층이나 landmark 구조를 요구하는 컴포넌트는 이 
 
 해당하는 항목에 체크하고, Yes이면 명시된 문서를 참조한다:
 
-- [ ] Expand/collapse 애니메이션 → `recipe-patterns.md` §애니메이션
-- [ ] Modal/Sheet 진입/퇴장 애니메이션 → `recipe-patterns.md` §Presence
-- [ ] Form Field 컨텍스트 통합 → `react-patterns.md` §Form/Field 통합
+- [ ] Expand/collapse 애니메이션 → React는 `recipe-patterns.md` §애니메이션, Lynx는 `lynx-patterns.md`
+- [ ] Modal/Sheet 진입/퇴장 애니메이션 → React는 `recipe-patterns.md` §Presence, Lynx는 `lynx-patterns.md`
+- [ ] Form Field 컨텍스트 통합 → React는 `react-patterns.md` §Form/Field 통합, Lynx는 지원 여부 별도 결정
 - [ ] Snippet 레이어 필요 (3+ sub-component 또는 서드파티) → `api-design.md`
 - [ ] 새 유틸리티 패키지 필요 → 구현 전 결정
 - [ ] 아이콘 slot (prefix/suffix) → `recipe-patterns.md` §아이콘 헬퍼
@@ -125,15 +141,19 @@ APG가 heading 계층이나 landmark 구조를 요구하는 컴포넌트는 이 
 참조 컴포넌트는 하나만 고르지 않는다. 레이어별로 가장 유사한 참조를 따로 선택하고, 이후 구현 단계에서 해당 파일을 **먼저 읽고** 패턴을 따른다.
 
 - **Headless reference**: ________________
-  - 경로: `packages/react-headless/{name}/` 또는 `packages/react-headless/{name}/src/`
-- **Styled React reference**: ________________
-  - 경로: `packages/react/src/components/{Name}/`
+  - React 경로: `packages/react-headless/{name}/` 또는 `packages/react-headless/{name}/src/`
+  - Lynx 경로: `packages/lynx-headless/{name}/` 또는 styled-local hook/context
+- **Styled UI reference**: ________________
+  - React 경로: `packages/react/src/components/{Name}/`
+  - Lynx 경로: `packages/lynx-react/src/components/{Name}/`
 - **Snippet reference**: ________________
-  - 경로: `docs/registry/ui/{name}.tsx`
+  - React 경로: `docs/registry/react/ui/{name}.tsx`
+  - Lynx 경로: `docs/registry/lynx/ui/{name}.tsx`
 - **Rootage vocabulary reference**: ________________
   - 경로: `packages/rootage/components/{name}.yaml`
 - **Docs reference** (선택): ________________
-  - 경로: `docs/content/react/components/{name}.mdx`
+  - React 경로: `docs/content/react/components/{name}.mdx`
+  - Lynx 경로: `docs/content/lynx/components/{name}.mdx`
 
 기록 시 아래를 함께 남긴다:
 - 각 레이어에서 **무엇을 따라갈지** (예: slot 구조, prop naming, token vocabulary, example composition)

--- a/skills/create-component/references/brainstorming.md
+++ b/skills/create-component/references/brainstorming.md
@@ -1,6 +1,6 @@
 # Phase 0 Pre: 요구사항 Brainstorming
 
-컴포넌트를 만들기 전에 사용자와 **5개 영역**을 합의한다. 합의 없이 Phase 0(아키텍처 분석)으로 넘어가지 않는다.
+컴포넌트를 만들기 전에 Platform Gate를 완료하고, 사용자와 **5개 영역**을 합의한다. 합의 없이 Phase 0(아키텍처 분석)으로 넘어가지 않는다.
 
 이 단계가 빠지면 다음 통증이 누적된다:
 - 구현 후에 "사실 이게 필요한 게 아니었다"는 재작업
@@ -96,15 +96,21 @@
 | **대체** | 기존 컴포넌트의 deprecation 대상 | 마이그레이션 경로, deprecation 일정 |
 
 ### 유사 컴포넌트 매트릭스
-패턴 참조용으로 다음 4개 경로를 함께 합의:
+패턴 참조용으로 target platform에 맞는 경로를 함께 합의:
 
-- Headless ref: `packages/react-headless/<name>` 중 어느 것?
-- Styled ref: `packages/react/src/components/<Name>` 중 어느 것?
-- Snippet ref: `docs/registry/ui/<name>.tsx` 중 어느 것? (or N/A)
+- Headless ref:
+  - React: `packages/react-headless/<name>` 중 어느 것?
+  - Lynx: `packages/lynx-headless/<name>` 또는 local hook/context 중 어느 것?
+- Styled ref:
+  - React: `packages/react/src/components/<Name>` 중 어느 것?
+  - Lynx: `packages/lynx-react/src/components/<Name>` 중 어느 것?
+- Snippet ref:
+  - React: `docs/registry/react/ui/<name>.tsx` 중 어느 것? (or N/A)
+  - Lynx: `docs/registry/lynx/ui/<name>.tsx` 중 어느 것? (or N/A)
 - Rootage ref: `packages/rootage/components/<name>.yaml` 중 어느 것?
 
 ### 합의 확인
-"_[유형]_으로 가고, 패턴 참조는 Headless=_[X]_, Styled=_[Y]_, Snippet=_[Z]_, Rootage=_[W]_야, 맞지?"
+"_[유형]_으로 가고, Platform=_[react/lynx/cross-platform]_, 패턴 참조는 Headless=_[X]_, Styled=_[Y]_, Snippet=_[Z]_, Rootage=_[W]_야, 맞지?"
 
 ---
 
@@ -208,6 +214,13 @@ Phase 0 Pre가 끝나면 다음 템플릿을 채워 메모(또는 PR description
 
 ```markdown
 ## 컴포넌트: <Name>
+
+### Platform
+- Target: react / lynx / cross-platform
+- 이유: <요청/경로/import/docs 근거>
+- Lynx support delta: <웹 대비 차이 또는 N/A>
+- Headless ownership: React headless / Lynx headless / styled-local / 없음
+- Docs/registry target: <docs/content/... + docs/registry/... 경로>
 
 ### Purpose
 - 1차 사용자/사용 사례: <한 문장>

--- a/skills/create-component/references/guide.md
+++ b/skills/create-component/references/guide.md
@@ -4,50 +4,54 @@
 
 ## Quick Start
 
-1. **Phase 0**: `references/architecture-decisions.md`를 완성하여 카테고리와 패턴을 확정합니다.
-2. **Phase 1**: Rootage → Recipe → React → Snippet → Storybook → Docs 순서로 구현합니다.
-3. **Phase 2**: `bun generate:all`, `bun test:all`, `bun docs:test`와 필요한 개별 build를 완료합니다.
-4. 상세 구현은 `references/implementation-steps.md`와 `references/verification-checklist.md`를 사용합니다.
+1. **Platform Gate**: `references/platform-gate.md`로 target platform을 `react` / `lynx` / `cross-platform` 중 하나로 확정합니다.
+2. **Phase 0**: `references/architecture-decisions.md`를 완성하여 카테고리와 플랫폼별 패턴을 확정합니다.
+3. **Phase 1**: Rootage → platform recipe → styled UI → snippet/docs/example 순서로 구현합니다.
+4. **Phase 2**: `bun generate:all`, `bun test:all`, `bun docs:test`와 필요한 개별 build를 완료합니다.
+5. 상세 구현은 `references/implementation-steps.md`와 `references/verification-checklist.md`를 사용합니다.
 
 ## 핵심 흐름
 
 ```text
-Architecture Analysis → Headless (선택) → Rootage YAML → bun generate:all → Recipe → React → Snippet → Storybook → Docs → Visual Test
+Platform Gate → Architecture Analysis → Headless (선택) → Rootage YAML → bun generate:all → Recipe → Styled UI → Snippet → Docs/Examples → Visual Test
 ```
 
 ## 카테고리별 Quick Reference
 
-| 카테고리 | Recipe | React 패턴 | Namespace | 참조 |
-|----------|--------|-----------|-----------|------|
-| A. Simple | defineRecipe | splitVariantProps | 없음 | Badge |
-| B. Compound (Stateless) | defineSlotRecipe | createSlotRecipeContext | 있음 | Avatar |
-| C. Compound (Stateful) | defineSlotRecipe | + createWithStateProps | 있음 | TextField |
-| D. Multi-Recipe | defineSlotRecipe ×2 | splitMultipleVariantsProps | 있음 | Checkbox |
-| E. Layout | 없음 | Box 확장 | 없음 | Flex |
+| 카테고리 | Recipe | Styled UI 패턴 | Namespace | React 참조 | Lynx 참조 |
+|----------|--------|----------------|-----------|-----------|-----------|
+| A. Simple | defineRecipe | splitVariantProps | 없음 | Badge | ActionButton/Text |
+| B. Compound (Stateless) | defineSlotRecipe | slot context | 있음 | Avatar | TagGroup |
+| C. Compound (Stateful) | defineSlotRecipe | headless + styled wrapper | 있음 | TextField | BottomSheet |
+| D. Multi-Recipe | defineSlotRecipe ×2 | splitMultipleVariantsProps | 있음 | Checkbox | Checkbox/Switch |
+| E. Layout | 없음 | Box 확장 | 없음 | Flex | Box/Stack |
 
 카테고리 결정 방법은 `references/architecture-decisions.md`를 참조합니다.
 
 ## 수정 진입점
 
-| 수정 대상 | 시작 위치 | 명령어 |
-|----------|----------|--------|
-| 토큰/스타일 변수 | `packages/rootage/` | `bun generate:all` |
-| CSS Recipe | `packages/qvism-preset/src/recipes/` | `bun qvism:generate` |
-| 컴포넌트 로직 | `packages/react-headless/` | 직접 수정 |
-| 컴포넌트 UI | `packages/react/` | `bun packages:build` |
-| 문서 | `docs/content/` | 직접 수정 |
+| 수정 대상 | React 시작 위치 | Lynx 시작 위치 | 명령어 |
+|----------|----------------|---------------|--------|
+| 토큰/스타일 변수 | `packages/rootage/` | `packages/rootage/` | `bun generate:all` |
+| Recipe source | `packages/qvism-preset/src/recipes/` | `packages/lynx-qvism-preset/src/recipes/` | `bun qvism:generate` |
+| Headless/state | `packages/react-headless/` | `packages/lynx-headless/` 또는 styled-local | package build/test |
+| Styled UI | `packages/react/src/components/` | `packages/lynx-react/src/components/` | `bun packages:build` |
+| Snippet | `docs/registry/react/ui/` | `docs/registry/lynx/ui/` | docs registry generate |
+| 문서 | `docs/content/react/` | `docs/content/lynx/` | `bun docs:test` |
 
 ## 생성 파일 (수정 금지)
 
 - `packages/css/**` ← rootage에서 생성
 - `packages/qvism-preset/src/vars/**` ← rootage에서 생성
+- `packages/lynx-css/**` ← rootage/lynx-qvism에서 생성
+- `packages/lynx-qvism-preset/src/vars/**` ← rootage에서 생성
 - `docs/public/__registry__/**` ← docs registry script에서 생성
 
 ## 전체 파이프라인
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐
-│  1. HEADLESS (Optional) - packages/react-headless/          │
+│  1. HEADLESS (Optional) - react-headless or lynx-headless   │
 └─────────────────────────────────────────────────────────────┘
                            │
                            ▼
@@ -57,17 +61,17 @@ Architecture Analysis → Headless (선택) → Rootage YAML → bun generate:al
                            │ bun generate:all
                            ▼
 ┌─────────────────────────────────────────────────────────────┐
-│  3. RECIPE - packages/qvism-preset/src/recipes/             │
+│  3. RECIPE - qvism-preset or lynx-qvism-preset              │
 └─────────────────────────────────────────────────────────────┘
                            │
                            ▼
 ┌─────────────────────────────────────────────────────────────┐
-│  4. UI - packages/react/src/components/[ComponentName]/     │
+│  4. UI - packages/react or packages/lynx-react              │
 └─────────────────────────────────────────────────────────────┘
                            │
                            ▼
 ┌─────────────────────────────────────────────────────────────┐
-│  5. STORYBOOK - docs/stories/[ComponentName].stories.tsx    │
+│  5. EXAMPLE - Storybook or examples/lynx-spa                │
 └─────────────────────────────────────────────────────────────┘
                            │
                            ▼
@@ -85,18 +89,19 @@ Architecture Analysis → Headless (선택) → Rootage YAML → bun generate:al
 
 ### 새 컴포넌트 추가 시
 
-1. `packages/rootage/components/[name].yaml` 작성
-2. `bun generate:all` 실행
-3. `packages/qvism-preset/src/recipes/[name].ts` 작성
-4. `packages/qvism-preset/src/recipes/index.ts`에 export 추가
-5. `packages/react/src/components/[Name]/` 구현
-6. `docs/stories/[Name].stories.tsx` 작성
-7. `docs/content/react/components/[name].mdx` 작성
-8. Visual Test 실행
+1. target platform 확정 (`react` / `lynx` / `cross-platform`)
+2. `packages/rootage/components/[name].yaml` 작성
+3. `bun generate:all` 실행
+4. React는 `packages/qvism-preset/src/recipes/[name].ts`, Lynx는 `packages/lynx-qvism-preset/src/recipes/[name].ts` 작성
+5. target preset entry에 recipe export 추가
+6. React는 `packages/react/src/components/[Name]/`, Lynx는 `packages/lynx-react/src/components/[Name]/` 구현
+7. stateful Lynx에서 필요하면 `packages/lynx-headless/[name]/`를 먼저 설계하고 사용자 확인 후 추가
+8. platform snippet/docs/example 작성
+9. Visual Test 실행
 
 ### 스타일 수정 시
 
-1. `packages/rootage/` 또는 `packages/qvism-preset/src/recipes/` 수정
+1. `packages/rootage/`, React `packages/qvism-preset/src/recipes/`, Lynx `packages/lynx-qvism-preset/src/recipes/` 중 source 수정
 2. `bun generate:all` 실행
 3. Visual Test로 확인
 
@@ -115,5 +120,8 @@ Architecture Analysis → Headless (선택) → Rootage YAML → bun generate:al
 - [ ] `bun docs:test` 성공
 - [ ] 변경 범위에 해당하는 build 성공
   - React 패키지 변경: `bun --filter @seed-design/react build` 또는 여러 패키지 변경 시 `bun packages:build`
-  - Snippet/example 변경: vendored consumer build (예: `bun --cwd examples/stackflow-spa build`)
-- [ ] Storybook 테마별 확인 (Light, Dark, Font Scaling)
+  - Lynx 패키지 변경: `bun --filter @seed-design/lynx-react typecheck`와 `bun --filter @seed-design/lynx-react test`가 있으면 실행
+  - React snippet/example 변경: vendored consumer build (예: `bun --cwd examples/stackflow-spa build`)
+  - Lynx snippet/example 변경: `bun --filter lynx-spa build`
+- [ ] React: Storybook 테마별 확인 (Light, Dark, Font Scaling)
+- [ ] Lynx: `examples/lynx-spa` page/catalog 확인

--- a/skills/create-component/references/implementation-steps.md
+++ b/skills/create-component/references/implementation-steps.md
@@ -1,24 +1,36 @@
 # 컴포넌트 구현 상세 가이드
 
-> **전제조건**: `references/architecture-decisions.md`의 Phase 0을 완료해야 한다. 카테고리, 패턴 참조 컴포넌트, 접근성 스펙이 확정된 상태에서 구현을 시작한다.
+> **전제조건**: `references/platform-gate.md`와 `references/architecture-decisions.md`의 Phase 0을 완료해야 한다. target platform, 카테고리, 패턴 참조 컴포넌트, 접근성 스펙이 확정된 상태에서 구현을 시작한다.
 
 각 Step에서 **패턴 참조 컴포넌트의 해당 파일을 먼저 읽고** 패턴을 따른다.
 
 ## Step 1: Headless (선택)
 
-**위치**: `packages/react-headless/[name]/`
+**위치**:
+- React: `packages/react-headless/[name]/`
+- Lynx: `packages/lynx-headless/[name]/` 또는 `packages/lynx-react/src/components/[ComponentName]/` 내부 hook/context
+
 **조건**: 데이터 로직이 필요한 경우만 (단순 UI 컴포넌트는 생략)
 
 Headless 훅은 하나의 `use{Component}`로 끝낼 필요가 없다. compound stateful 컴포넌트는 가능하면 root/item 책임을 분리하고, render wiring과 상태 로직을 분리한다.
 
-분리 여부는 인터랙션 슬롯 수와 상태 소유권으로 판단한다. 독립 item state, roving focus/DOM query, trigger/content/indicator처럼 slot별 props가 필요하면 `use{Component}` + `use{Component}Item` 구조를 우선한다. 단일 root state만 있고 interactive slot이 하나라면 하나의 훅으로 충분할 수 있다. 분리는 중복 계산을 줄이고 재사용성을 높이지만, context와 파일 수가 늘어나므로 `packages/react-headless/AGENTS.md`의 책임 분리 기준을 함께 따른다.
+분리 여부는 인터랙션 슬롯 수와 상태 소유권으로 판단한다. 독립 item state, roving focus/DOM query, trigger/content/indicator처럼 slot별 props가 필요하면 `use{Component}` + `use{Component}Item` 구조를 우선한다. 단일 root state만 있고 interactive slot이 하나라면 하나의 훅으로 충분할 수 있다. 분리는 중복 계산을 줄이고 재사용성을 높이지만, context와 파일 수가 늘어나므로 target platform의 headless 또는 styled package `AGENTS.md` 책임 분리 기준을 함께 따른다.
 
-- root 수준 상태와 collection 관리는 `use{Component}` 또는 `useRootState` 계열 훅에 둔다.
-- item 수준 상태, 키보드 인터랙션, slot별 props 조합은 `use{Component}Item` 또는 `useItemState` 계열 훅으로 분리한다.
+- React root 수준 상태와 collection 관리는 `use{Component}` 또는 `useRootState` 계열 훅에 둔다.
+- React item 수준 상태, 키보드 인터랙션, slot별 props 조합은 `use{Component}Item` 또는 `useItemState` 계열 훅으로 분리한다.
 - 재사용 가능한 상태 전이, DOM query, 내부 id 생성, keyboard handler는 가능하면 `use*` 훅으로 내리고 컴포넌트 파일에는 hook이 만든 props와 ref를 연결하는 역할만 남긴다.
 - hook은 `rootProps` 하나만 반환할 필요가 없다. `triggerProps`, `contentProps`, `indicatorProps`처럼 slot별 props를 반환해도 된다.
-- hook이 반환하는 props는 ARIA, ids, keyboard handler, `data-*` state까지 포함한 **slot contract**를 목표로 하고, React 컴포넌트가 같은 로직을 다시 계산하지 않게 한다.
+- hook이 반환하는 props는 ARIA, ids, keyboard handler, `data-*` state까지 포함한 **slot contract**를 목표로 하고, styled UI 컴포넌트가 같은 로직을 다시 계산하지 않게 한다.
 - DOM query가 필요하면 ref `Set` 등록보다 내부 id + 안정적인 selector contract(`data-ownedby` 등)를 먼저 검토한다.
+
+### Lynx headless 분리 원칙
+
+Stateful Lynx 컴포넌트는 `references/lynx-patterns.md`를 따른다.
+
+- `packages/lynx-headless/*`는 상태, press/tap, controlled/uncontrolled, context, render props를 소유한다.
+- `packages/lynx-headless/*`는 자동 state class, recipe, SEED token, className 조합을 넣지 않는다.
+- `packages/lynx-react`는 headless 상태를 읽어 `@seed-design/lynx-css/recipes/*` variant와 className을 조합한다.
+- 새 `packages/lynx-headless/<component>` 패키지가 필요하면 사용자 확인을 먼저 받는다.
 
 **카테고리 C/D에서 새 headless를 만들 때**: Phase 0에서 정리한 ARIA APG 패턴과 키보드 인터랙션 스펙을 이 단계에서 구현한다. `references/external-references.md`의 접근성 체크리스트를 따른다. 외부 라이브러리(Base UI, Radix)의 동일 컴포넌트 구현도 참조하여 인터페이스 설계를 검증한다.
 
@@ -32,7 +44,7 @@ type UseComponentProps =
   | { multiple: true; collapsible?: never };
 ```
 
-위와 같은 union을 쓰면 React wrapper도 같은 contract를 유지해야 한다. wrapper에서 props를 다시 조합할 때는 mode별로 hook props를 분기해, `multiple: true`인 객체에 single-only prop이 섞이지 않게 한다.
+위와 같은 union을 쓰면 styled wrapper도 같은 contract를 유지해야 한다. wrapper에서 props를 다시 조합할 때는 mode별로 hook props를 분기해, `multiple: true`인 객체에 single-only prop이 섞이지 않게 한다.
 
 ## Step 2: Definition (Rootage)
 
@@ -43,29 +55,44 @@ type UseComponentProps =
 
 ## Step 3: Recipe (Qvism Preset)
 
-**위치**: `packages/qvism-preset/src/recipes/[name].ts`
-**추가 작업**: `recipes/index.ts`에 export 추가
-**컨벤션**: 구현 전 `packages/qvism-preset/AGENTS.md`를 읽고 해당 패키지의 컨벤션을 확인한다.
+**위치**:
+- React: `packages/qvism-preset/src/recipes/[name].ts`
+- Lynx: `packages/lynx-qvism-preset/src/recipes/[name].ts`
 
-Recipe 파일에서 `../vars/component/`의 생성된 토큰을 import하고, `defineRecipe` 또는 `defineSlotRecipe`로 스타일을 정의한다. 어떤 함수를 사용할지, 슬롯 구조, 전환 시 주의사항은 `packages/qvism-preset/AGENTS.md`에 명시되어 있다.
+**추가 작업**:
+- React: `packages/qvism-preset/src/recipes/index.ts`에 export 추가
+- Lynx: `packages/lynx-qvism-preset/src/recipes.ts` 또는 해당 preset entry에 export 추가
+
+Recipe 파일에서 생성된 component vars를 import하고, `defineRecipe` 또는 `defineSlotRecipe`로 스타일을 정의한다. 어떤 함수를 사용할지, 슬롯 구조, 전환 시 주의사항은 target preset의 `AGENTS.md`에 명시되어 있다.
 
 **추가 참조**: `references/recipe-patterns.md` — token 경로 컨벤션, pseudo 선택자, 아이콘 헬퍼, focus ring, 애니메이션 패턴
 
-**주의**: hover 대신 engaged 상태 사용 (모바일 우선)
+**주의**:
+- React recipe는 구현 전 `packages/qvism-preset/AGENTS.md`를 읽는다.
+- Lynx recipe는 구현 전 `packages/lynx-qvism-preset/AGENTS.md`와 `references/lynx-patterns.md`를 읽는다.
+- Lynx에서는 Web-only CSS나 pseudo selector 의존 대신 boolean/string variant를 우선한다.
+- hover 대신 engaged/pressed 상태 사용 (모바일 우선)
 
-## Step 4: React 컴포넌트
+## Step 4: Styled UI 컴포넌트
 
-**위치**: `packages/react/src/components/[ComponentName]/`
+**위치**:
+- React: `packages/react/src/components/[ComponentName]/`
+- Lynx: `packages/lynx-react/src/components/[ComponentName]/`
+
 **빌드**: 완료 후 `bun packages:build`
-**컨벤션**: 구현 전 `packages/react/AGENTS.md`를 읽고 해당 패키지의 컨벤션을 확인한다.
+**컨벤션**: 구현 전 target platform에 따라 `packages/react/AGENTS.md` 또는 `packages/lynx-react/AGENTS.md`를 읽고 해당 패키지의 컨벤션을 확인한다.
 
-Variant Props 처리 패턴, 단일/복합 슬롯 패턴, 금지 패턴 등의 상세는 `packages/react/AGENTS.md`에 명시되어 있다.
+Variant Props 처리 패턴, 단일/복합 슬롯 패턴, 금지 패턴 등의 상세는 각 패키지 `AGENTS.md`에 명시되어 있다.
 
-**추가 참조**: `references/react-patterns.md` — 카테고리별 유틸리티 선택 (createSlotRecipeContext, createWithStateProps, splitMultipleVariantsProps), Form/Field 통합, namespace 패턴
+**추가 참조**:
+- React: `references/react-patterns.md` — 카테고리별 유틸리티 선택 (createSlotRecipeContext, createWithStateProps, splitMultipleVariantsProps), Form/Field 통합, namespace 패턴
+- Lynx: `references/lynx-patterns.md` — native literal JSX 제약, ref null guard, children 분리, recipe import, unsupported Web API 문서화
 
 ## Step 5: Registry UI (Snippet 레이어)
 
-**위치**: `docs/registry/ui/[name].tsx`
+**위치**:
+- React: `docs/registry/react/ui/[name].tsx`
+- Lynx: `docs/registry/lynx/ui/[name].tsx`
 
 ### Snippet 레이어가 필요한 경우
 
@@ -76,12 +103,15 @@ Variant Props 처리 패턴, 단일/복합 슬롯 패턴, 금지 패턴 등의 �
 
 ### 반대로 Snippet이 필요 없는 경우
 
-- 단일 컴포넌트 (`<Button>`, `<Badge>` 등): `@seed-design/react`에서 직접 사용
+- 단일 컴포넌트 (`<Button>`, `<Badge>` 등): target styled package에서 직접 사용
 - 이미 심플한 API를 가진 경우
 
 ### Snippet 파일 작성 패턴
 
-Snippet 파일은 `"use client"` 선언으로 시작하며, `@seed-design/react`에서 compound 컴포넌트를 import하여 **convenience wrapper**를 우선 설계한다.
+Snippet 파일은 플랫폼 runtime에 맞춰 import하며 **convenience wrapper**를 우선 설계한다.
+
+- React snippet: `"use client"` 선언으로 시작하고 `@seed-design/react`에서 import한다.
+- Lynx snippet: `@lynx-js/react`와 `@seed-design/lynx-react`에서 import한다.
 
 - low-level re-export보다 사용자가 가장 짧게 쓸 수 있는 surface를 먼저 만든다.
 - Props는 단순 `RootProps extends`로 끝내지 말고, 실제 convenience prop(`title`, `description`, `suffixIcon` 등)을 먼저 설계한다.
@@ -91,29 +121,39 @@ Snippet 파일은 `"use client"` 선언으로 시작하며, `@seed-design/react`
 - 반드시 `React.forwardRef`로 감싸고, `displayName`은 exported symbol과 같은 단순 문자열을 우선한다. 예를 들어 `Avatar` export라면 `Avatar`, `AccordionTrigger` export라면 `AccordionTrigger`를 사용하고, namespace가 실제 runtime API가 아닌 경우 `Accordion.Trigger` 같은 dotted name은 쓰지 않는다.
 
 **추가 작업**:
-1. `docs/registry/registry-ui.ts`에 entry 추가 (의존성 버전은 해당 컴포넌트가 추가된 버전 기준)
+1. React는 `docs/registry/react/registry-ui.ts`, Lynx는 `docs/registry/lynx/registry-ui.ts`에 entry 추가 (의존성 버전은 해당 컴포넌트가 추가된 버전 기준)
 2. `bun --filter @seed-design/docs generate:registry` 실행
 
-### React 문서 업데이트
+### 문서 업데이트
 
 Snippet 레이어가 있는 컴포넌트의 문서는 반드시 다음 형태로 업데이트해야 합니다:
 - `## Installation` 섹션 추가: `npx @seed-design/cli@latest add ui:[name]` 명령어
-- `<ManualInstallation name="[name]" />` 컴포넌트 추가
+- React: `<ManualInstallation name="[name]" />`, Lynx: `<LynxManualInstallation name="[name]" />`
 - `## Usage`의 import 경로를 `seed-design/ui/[name]`으로 변경
-- Props 섹션 경로를 `./registry/ui/[name].tsx`로 변경
+- Props 섹션 경로를 React는 `./registry/react/ui/[name].tsx`, Lynx는 `./registry/lynx/ui/[name].tsx`로 변경
+- Lynx 문서에는 웹 버전과의 차이와 Lynx 미지원 기능을 함께 작성
 
 ## Step 6: Examples
 
-**위치**: `docs/examples/react/[name]/`
+**위치**:
+- React: `docs/examples/react/[name]/`
+- Lynx: `examples/lynx-spa/src/pages/` 또는 기존 Lynx catalog/page
 
-Snippet 레이어가 있는 경우 `seed-design/ui/[name]`에서 import하고, Layout 컴포넌트(Flex, VStack 등)는 `@seed-design/react`에서 import한다. Snippet 레이어가 없는 경우 `@seed-design/react`에서 직접 import한다.
+React snippet 레이어가 있는 경우 `seed-design/ui/[name]`에서 import하고, Layout 컴포넌트(Flex, VStack 등)는 `@seed-design/react`에서 import한다. Lynx snippet 레이어가 있는 경우 generated Lynx registry install path를 따른다. Snippet 레이어가 없는 경우 target package에서 직접 import한다.
 
-snippet을 vendoring해서 소비하는 example app이 있으면 해당 경로도 함께 확인한다. 현재는 `examples/stackflow-spa/src/seed-design/ui/`가 대표적이며, snippet API가 바뀌면 이 경로와 example app build도 함께 동기화해야 한다.
+snippet을 vendoring해서 소비하는 example app이 있으면 해당 경로도 함께 확인한다.
+
+- React 대표 경로: `examples/stackflow-spa/src/seed-design/ui/`
+- Lynx 대표 경로: `examples/lynx-spa/src/seed-design/ui/`
+
+snippet API가 바뀌면 target platform의 vendored copy와 example app build도 함께 동기화해야 한다.
 
 ## Step 7: Storybook
 
 **위치**: `docs/stories/[ComponentName].stories.tsx`
 **명령어**: `bun storybook` (docs 폴더에서)
+
+React 컴포넌트는 Storybook 스토리를 기본으로 추가한다. Lynx 컴포넌트는 Storybook 대신 `examples/lynx-spa`의 page/catalog에서 실제 사용 화면을 확인한다.
 
 필수 스토리:
 - `LightTheme` - 라이트 테마
@@ -125,6 +165,9 @@ snippet을 vendoring해서 소비하는 example app이 있으면 해당 경로�
 
 ### React 문서
 **위치**: `docs/content/react/components/[name].mdx`
+
+### Lynx 문서
+**위치**: `docs/content/lynx/components/[name].mdx`
 
 ### Design 문서
 **위치**: `docs/content/docs/components/[name].mdx`

--- a/skills/create-component/references/lynx-patterns.md
+++ b/skills/create-component/references/lynx-patterns.md
@@ -1,0 +1,63 @@
+# Lynx Component Patterns
+
+Lynx 컴포넌트는 React Web 패턴의 변형이 아니라 별도 런타임을 대상으로 하는 styled UI다. Web에서 가능한 DOM, CSS, SVG, form/focus 모델이 Lynx에서 그대로 동작한다고 가정하지 않는다.
+
+## 책임 분리
+
+Stateful Lynx 컴포넌트의 기본 계약은 다음과 같다.
+
+| 레이어 | 책임 | 넣지 않는 것 |
+|--------|------|--------------|
+| `packages/lynx-headless/*` | 상태, press/tap, controlled/uncontrolled, context, render props | SEED recipe, token, className 자동 주입 |
+| `packages/lynx-react/*` | native slot JSX, recipe variant 조합, className 병합, icon/image wiring | 중복 상태 계산, Web DOM/form/focus API |
+| `packages/lynx-qvism-preset/*` | Lynx CSS 제약에 맞춘 recipe source | Web-only CSS, pseudo selector 의존 |
+| `packages/lynx-css/*` | generated CSS/recipe output | 직접 수정 |
+
+`lynx-headless`는 자동 state class를 주입하지 않는다. `active`, `checked`, `disabled` 같은 순수 상태를 context/render props로 노출하고, `lynx-react`가 그 상태를 recipe boolean/string variant로 전달한다.
+
+## Native JSX 제약
+
+Lynx compiler는 native tag를 파일 안의 literal JSX로 봐야 한다. 다음 규칙을 지킨다.
+
+- native `<view>` / `<text>` / `<image>`는 최종 렌더링 컴포넌트 파일 안에 literal JSX로 작성한다.
+- `React.createElement("view")`, `const Tag = "view"; <Tag />`, `withContext("view", ...)`처럼 intrinsic tag를 런타임 값으로 넘기지 않는다.
+- native slot factory를 공통 유틸 파일로 빼지 않는다. 필요한 경우 같은 컴포넌트 파일 안의 작은 factory만 사용한다.
+- `forwardRef`를 쓸 때 null ref를 전달하지 않는다.
+- `{...nativeProps}`에 `children`이 섞이지 않도록 `children`은 먼저 분리해 JSX child로 전달한다.
+
+## Styling and recipe
+
+- recipe import는 `@seed-design/lynx-css/recipes/<name>`를 사용한다. Web의 `@seed-design/css`를 import하지 않는다.
+- variant props는 `recipe.splitVariantProps(props)` 또는 `splitMultipleVariantsProps`로 분리한다. 수동 destructuring이나 타입 캐스트로 variant를 꺼내지 않는다.
+- Lynx에서 상태는 pseudo selector보다 boolean/string variant로 모델링한다.
+- `inherit`, CSS-wide keyword, Web-only SVG stroke/fill CSS, `content`, unsupported shorthand에 의존하지 않는다.
+- style 변경은 `packages/lynx-qvism-preset/src/recipes/*` 또는 Rootage 원천에서 하고, generated `packages/lynx-css/*`는 직접 수정하지 않는다.
+
+## Unsupported Web API 문서화
+
+Web과 Lynx의 차이는 타입과 문서가 같은 말을 해야 한다.
+
+- Lynx에서 지원하지 않는 prop은 `Omit` 등으로 타입에서 제거한다.
+- 컴포넌트 props 위에 `@platform Lynx` JSDoc으로 미지원 목록과 이유를 남긴다.
+- `docs/content/lynx/components/<name>.mdx`에 “웹 버전과의 차이”와 “Lynx 미지원 기능”을 작성한다.
+- SVG/icon 기능은 `@karrotmarket/lynx-monochrome-icon` 같은 Lynx icon element와 `<image tint-color>` 기반 wrapper를 우선 검토한다.
+
+## Docs and registry
+
+- Lynx snippet은 `docs/registry/lynx/ui/<name>.tsx`에 둔다.
+- `docs/registry/lynx/registry-ui.ts`에 item을 등록하고 `@seed-design/lynx-react`, `@seed-design/lynx-css` dependency range를 확인한다.
+- `docs/content/lynx/components/<name>.mdx`의 install/usage/props는 Lynx snippet 경로를 가리킨다.
+- `examples/lynx-spa/src/seed-design/ui/<name>.tsx`가 vendored copy를 갖고 있으면 registry snippet과 동기화한다.
+- 실제 사용 화면은 `examples/lynx-spa`에 추가하거나 기존 page에서 확인한다.
+
+## Verification focus
+
+Lynx 작업의 핵심 검증은 다음을 우선한다.
+
+- `bun generate:all`
+- `bun test:all`
+- `bun packages:build`
+- `bun --filter @seed-design/lynx-react typecheck`와 `bun --filter @seed-design/lynx-react test`가 package script에 있으면 실행
+- `packages/lynx-headless/*`를 바꿨다면 해당 package build/test 또는 root `lynx-headless:*` script가 있으면 실행
+- snippet/example 변경이 있으면 `bun --filter lynx-spa build`
+- generated registry가 최신인지 `bun --filter @seed-design/docs generate:registry` 또는 docs generate script로 확인

--- a/skills/create-component/references/pattern-catalog.md
+++ b/skills/create-component/references/pattern-catalog.md
@@ -1,6 +1,8 @@
 # 패턴 카탈로그
 
-Phase 0에서 결정한 카테고리에 따라 아래 레퍼런스 컴포넌트와 유틸리티를 사용한다. 구현 시 각 단계에서 레퍼런스 컴포넌트의 해당 파일을 **먼저 읽고** 패턴을 따른다.
+Phase 0에서 결정한 target platform과 카테고리에 따라 아래 레퍼런스 컴포넌트와 유틸리티를 사용한다. 구현 시 각 단계에서 레퍼런스 컴포넌트의 해당 파일을 **먼저 읽고** 패턴을 따른다.
+
+아래 카테고리 A-E 표는 React Web의 canonical reference다. target platform이 `lynx` 또는 `cross-platform`이면 같은 카테고리 판단을 유지하되, 구현 파일과 유틸리티는 `references/lynx-patterns.md`의 Lynx mapping을 우선한다.
 
 ## 카테고리 A: Simple Presentational
 
@@ -123,7 +125,21 @@ Phase 0에서 결정한 카테고리에 따라 아래 레퍼런스 컴포넌트�
 **참조 경로**:
 - React: `packages/react/src/components/Flex/Flex.tsx`
 
-## 핵심 유틸리티 위치
+## Lynx 레퍼런스 매핑
+
+Lynx 작업은 React reference를 API/semantic 비교 대상으로만 사용하고, 실제 구현 패턴은 Lynx 파일을 먼저 읽는다.
+
+| 카테고리 | Lynx reference | 확인할 패턴 |
+|----------|----------------|-------------|
+| A. Simple | `packages/lynx-react/src/components/ActionButton/`, `Text/`, `Box/` | `@seed-design/lynx-css` recipe import, native `<view>`/`<text>`, ref null guard |
+| B. Compound Stateless | `packages/lynx-react/src/components/TagGroup/` | inline context, slot className 전달, separator/wrap 같은 Lynx layout 보정 |
+| C. Compound Stateful | `packages/lynx-react/src/components/BottomSheet/` | external Lynx UI primitive wrapping, controlled prop mapping, unsupported Web API 문서화 |
+| D. Multi-Recipe | `packages/lynx-react/src/components/Checkbox/`, `Switch/`, `RadioGroup/` | `splitMultipleVariantsProps`, headless state와 recipe variant 분리 |
+| E. Layout | `packages/lynx-react/src/components/Box/`, `Stack/` | Lynx style props, native layout primitive |
+
+Lynx stateful 컴포넌트에서 `packages/lynx-headless/*`가 있거나 필요하면 `lynx-headless = 상태/이벤트/context`, `lynx-react = recipe/native UI wiring` 분리를 기본값으로 둔다.
+
+## React 핵심 유틸리티 위치
 
 | 유틸리티 | 경로 | 용도 |
 |---------|------|-----|

--- a/skills/create-component/references/platform-gate.md
+++ b/skills/create-component/references/platform-gate.md
@@ -1,0 +1,50 @@
+# Platform Gate
+
+컴포넌트 작업을 시작하면 Phase 0 Pre 전에 대상 플랫폼을 먼저 확정한다. 같은 이름의 컴포넌트라도 React Web과 Lynx는 런타임, CSS 지원, snippet registry, 검증 표면이 다르므로 플랫폼을 모호하게 둔 채 Phase 0으로 들어가지 않는다.
+
+## 1. Target platform 결정
+
+사용자의 요청, 경로, import, 문서 위치를 보고 아래 중 하나를 고른다.
+
+| Platform | 신호 | 기본 구현 표면 |
+|----------|------|----------------|
+| `react` | `packages/react`, `packages/react-headless`, `docs/content/react`, Storybook, stackflow-spa | Rootage → `packages/qvism-preset` → `packages/css` → `packages/react` → `docs/registry/react/ui` |
+| `lynx` | `packages/lynx-react`, `packages/lynx-css`, `docs/content/lynx`, `examples/lynx-spa`, Lynx native tag | Rootage → `packages/lynx-qvism-preset` → `packages/lynx-css` → `packages/lynx-headless`(필요 시) → `packages/lynx-react` → `docs/registry/lynx/ui` |
+| `cross-platform` | “React와 Lynx 둘 다”, 같은 컴포넌트의 Web/Lynx parity, shared token/recipe vocabulary | shared Rootage/semantic API를 먼저 정하고 React/Lynx 구현과 문서를 각각 분리 |
+
+요청이 `lynx-*`, `@lynx-js/react`, `<view>`/`<text>`, `docs/content/lynx`, `docs/registry/lynx/ui` 중 하나를 포함하면 `lynx`로 본다. 요청이 `@seed-design/react`, `docs/content/react`, Storybook 중심이면 `react`로 본다.
+
+## 2. Cross-platform 기본값
+
+`cross-platform`은 한 파일에서 양쪽 런타임을 흡수하는 뜻이 아니다. 다음 순서로 나눈다.
+
+1. shared semantics: 이름, 사용자-facing API, 상태 모델, token vocabulary를 먼저 합의한다.
+2. React implementation: `react-patterns.md`와 React registry/docs 경로를 따른다.
+3. Lynx implementation: `lynx-patterns.md`와 Lynx registry/docs 경로를 따른다.
+4. parity report: 웹과 Lynx의 지원/미지원 차이를 문서화한다.
+
+Lynx가 Web API를 그대로 재현할 수 없으면 타입에 열어두지 않는다. unsupported prop은 Lynx 타입에서 제거하고 `docs/content/lynx`에 차이와 이유를 남긴다.
+
+## 3. Platform-specific source of truth
+
+| 판단 영역 | React | Lynx |
+|-----------|-------|------|
+| Styled component | `packages/react/src/components/*` | `packages/lynx-react/src/components/*` |
+| Headless/state | `packages/react-headless/*` | `packages/lynx-headless/*` when stateful; otherwise local Lynx hooks/context |
+| Recipe source | `packages/qvism-preset/src/recipes/*` | `packages/lynx-qvism-preset/src/recipes/*` |
+| Generated CSS | `packages/css/*` | `packages/lynx-css/*` |
+| Docs | `docs/content/react/*` | `docs/content/lynx/*` |
+| Registry snippet | `docs/registry/react/ui/*` | `docs/registry/lynx/ui/*` |
+| Vendored example copy | `examples/stackflow-spa/src/seed-design/ui/*` | `examples/lynx-spa/src/seed-design/ui/*` |
+
+Registry snippet의 source of truth는 docs registry다. example app의 vendored copy는 registry snippet을 따라간다.
+
+## 4. Ask-first boundary
+
+새 `packages/lynx-headless/<component>` 패키지가 필요하면 repo의 “새 패키지 추가” boundary에 해당한다. 구현 전에 사용자에게 다음을 보고하고 확인받는다.
+
+- 왜 `packages/lynx-react` 내부 hook/context만으로 부족한가
+- 어떤 상태/이벤트/접근성 계약을 headless 패키지가 소유하는가
+- `package.json`, root workspace, build/test script 변경이 필요한가
+
+확인 전에는 새 패키지를 만들지 않는다.

--- a/skills/create-component/references/react-patterns.md
+++ b/skills/create-component/references/react-patterns.md
@@ -1,6 +1,8 @@
 # React 컴포넌트 작성 패턴
 
-`packages/react/AGENTS.md`에 기본 컨벤션이 있다. 이 문서는 전체 73개 컴포넌트에서 추출한 공통 패턴을 보충한다.
+`packages/react/AGENTS.md`에 기본 컨벤션이 있다. 이 문서는 React Web 컴포넌트 공통 패턴을 보충한다.
+
+target platform이 `lynx` 또는 `cross-platform`의 Lynx 구현이면 이 문서를 API/semantic 비교용으로만 사용하고, 실제 구현 패턴은 `references/lynx-patterns.md`와 `packages/lynx-react/AGENTS.md`를 따른다.
 
 ## 필수 규칙 (모든 카테고리)
 

--- a/skills/create-component/references/recipe-patterns.md
+++ b/skills/create-component/references/recipe-patterns.md
@@ -1,6 +1,8 @@
 # Recipe 작성 패턴
 
-`packages/qvism-preset/AGENTS.md`에 기본 컨벤션이 있다. 이 문서는 전체 68개 recipe에서 추출한 공통 패턴을 보충한다.
+`packages/qvism-preset/AGENTS.md`에 기본 컨벤션이 있다. 이 문서는 React Web recipe 공통 패턴을 보충한다.
+
+target platform이 `lynx` 또는 `cross-platform`의 Lynx 구현이면 이 문서를 token vocabulary 비교용으로만 사용하고, 실제 recipe 구현은 `references/lynx-patterns.md`와 `packages/lynx-qvism-preset/AGENTS.md`를 따른다.
 
 ## Token 경로 컨벤션
 

--- a/skills/create-component/references/review-prompts.md
+++ b/skills/create-component/references/review-prompts.md
@@ -1,0 +1,30 @@
+# Skill Review Prompts
+
+`create-component` 스킬 자체를 수정한 뒤에는 full eval/benchmark 대신 아래 프롬프트로 문서 리뷰를 한다. 답변이 실제 구현을 시작하지 않고 올바른 계획/질문/게이트로 흐르는지 확인한다.
+
+## 1. React 신규 컴포넌트
+
+> SEED Design에 새 React 컴포넌트 `InlineNotice`를 추가하고 싶어. Badge와 Callout 중간 정도이고 docs registry snippet도 필요할 것 같아.
+
+확인할 것:
+- target platform을 `react`로 판별한다.
+- 기존 React Phase 흐름과 `packages/react`, `packages/react-headless`, `docs/registry/react/ui` 경로를 사용한다.
+- Lynx-only 제약을 React 작업에 적용하지 않는다.
+
+## 2. Lynx stateful 컴포넌트
+
+> Lynx에 Toggle 계열 컴포넌트를 추가해야 해. `checked/defaultChecked/onCheckedChange`가 필요하고 press 상태는 UI에만 반영하고 싶어.
+
+확인할 것:
+- target platform을 `lynx`로 판별한다.
+- stateful 로직은 `packages/lynx-headless/*`와 `packages/lynx-react` 책임 분리로 설계한다.
+- 자동 state class를 headless에 넣지 않고, `lynx-react`가 recipe variant/className을 조합한다.
+
+## 3. Cross-platform 컴포넌트
+
+> 같은 API로 React와 Lynx 양쪽에 `SegmentedControl`을 맞추고 싶어. 토큰은 공유하고 문서는 각각 만들자.
+
+확인할 것:
+- target platform을 `cross-platform`으로 판별한다.
+- shared Rootage/API 합의 후 React와 Lynx 구현/문서를 분리한다.
+- Lynx 미지원 기능은 타입과 `docs/content/lynx`에 별도 문서화하도록 안내한다.

--- a/skills/create-component/references/sticking-policy.md
+++ b/skills/create-component/references/sticking-policy.md
@@ -29,8 +29,8 @@
 | 토큰 누락 | 필요한 토큰이 rootage에 없음, 새 토큰 추가 필요 |
 | ARIA 패턴 충돌 | APG 패턴이 모호하거나 SEED 기존 패턴(`useControllableState`, namespace 등)과 충돌 |
 | 외부 레퍼런스 갈림 | Base UI / Radix / Chakra / shadcn 사이에서 인터페이스가 다르고 1순위 룰로도 정해지지 않음 |
-| 자동 검증 실패 | `bun generate:all` / `bun test:all` / `bun packages:build` / `bun docs:test` 중 어느 하나라도 실패 |
-| Visual 회귀 | Storybook 또는 stackflow-spa에서 기존 컴포넌트에 시각적 영향 발견 |
+| 자동 검증 실패 | `bun generate:all` / `bun test:all` / `bun packages:build` / `bun docs:test` / platform-specific build 중 어느 하나라도 실패 |
+| Visual 회귀 | Storybook, stackflow-spa, lynx-spa에서 기존 컴포넌트에 시각적 영향 발견 |
 
 ## 통증 메모 템플릿
 

--- a/skills/create-component/references/verification-checklist.md
+++ b/skills/create-component/references/verification-checklist.md
@@ -12,24 +12,28 @@
 
 ## Phase 0: 아키텍처 결정
 
+- [ ] Target platform 확정? (react / lynx / cross-platform)
 - [ ] 컴포넌트 카테고리 확정? (A/B/C/D/E)
 - [ ] 패턴 참조 컴포넌트 지정?
 - [ ] 의존성 API 안정성 확인? (불안정 시 구현 중단)
 - [ ] 외부 라이브러리 인터페이스 조사? (카테고리 C/D 필수, A/B/E 최소 prop naming)
 - [ ] ARIA APG 패턴 확인? (카테고리 C/D)
+- [ ] Lynx 작업이면 `lynx-headless` / `lynx-react` / `lynx-css` 책임 분리 결정?
+- [ ] 새 `packages/lynx-headless/<component>` 패키지가 필요하면 사용자 확인?
 - [ ] **사용자에게 Phase 0 결과 요약 보고 + 컨펌? (게이트 0→1)**
 
 ## Phase 1: 구현 확인
 
 - [ ] Rootage 정의가 완전한가?
 - [ ] `bun generate:all` 실행했는가?
-- [ ] Recipe가 `recipes/index.ts`에 export 되었는가?
-- [ ] React 컴포넌트가 빌드되는가? (`bun packages:build`)
+- [ ] Recipe가 target preset entry에 export 되었는가?
+- [ ] Styled UI 컴포넌트가 빌드되는가? (`bun packages:build`)
 - [ ] 문서가 실제 API와 일치하는가?
 - [ ] 예제가 동작하는가?
-- [ ] Storybook 스토리가 테마별로 정상인가?
+- [ ] React 작업이면 Storybook 스토리가 테마별로 정상인가?
+- [ ] Lynx 작업이면 `examples/lynx-spa` page/catalog가 정상인가?
 - [ ] generated registry output이 최신인가? (`docs/public/__registry__/` 확인)
-- [ ] vendored snippet consumer가 있으면 함께 동기화했는가? (예: `examples/stackflow-spa/src/seed-design/ui/`)
+- [ ] vendored snippet consumer가 있으면 함께 동기화했는가? (React: `examples/stackflow-spa/src/seed-design/ui/`, Lynx: `examples/lynx-spa/src/seed-design/ui/`)
 - [ ] 패키지별 `typecheck` 스크립트가 있으면 선택적으로 실행했는가?
 - [ ] **자동 검증 게이트 통과? (게이트 1→2)**
   - `bun generate:all` ✅
@@ -39,9 +43,11 @@
 
 ## Phase 2: 검증 (모든 카테고리 필수)
 
-- [ ] Storybook 4종 테마/스케일 확인? (Light, Dark, FontScaling ExtraSmall, ExtraExtraExtraLarge)
+- [ ] React: Storybook 4종 테마/스케일 확인? (Light, Dark, FontScaling ExtraSmall, ExtraExtraExtraLarge)
+- [ ] Lynx: `examples/lynx-spa`의 유사 page/catalog 확인?
 - [ ] docs 사이트의 컴포넌트 페이지 렌더링 확인?
-- [ ] **`examples/stackflow-spa`의 유사 Activity 확인 (없으면 신설 검토)** — snippet 레이어 유무와 무관하게 실 사용 환경 검증
+- [ ] React: **`examples/stackflow-spa`의 유사 Activity 확인 (없으면 신설 검토)** — snippet 레이어 유무와 무관하게 실 사용 환경 검증
+- [ ] Lynx: **`examples/lynx-spa`의 유사 page 확인 (없으면 신설 검토)** — snippet 레이어 유무와 무관하게 실 사용 환경 검증
 - [ ] Visual Test 결과 사용자에게 보고 + 컨펌? (게이트 2→완료)
 - [ ] `/changeset` 스킬로 changeset 생성?
 
@@ -60,17 +66,22 @@
 - [ ] Hook props와 component props를 중복 선언하지 않고 `Use*Props`를 재사용했는가?
 - [ ] Context `stateProps`를 중복 helper로 다시 만들지 않고 headless context를 재사용했는가?
 - [ ] Namespace 파일: compound이면 있고, simple이면 없는지?
+- [ ] Lynx: native `<view>` / `<text>`를 같은 컴포넌트 파일 안의 literal JSX로 작성했는가?
+- [ ] Lynx: `children`을 native props와 분리하고 ref null guard를 적용했는가?
+- [ ] Lynx: `@seed-design/lynx-css/recipes/*`를 import하고 Web `@seed-design/css`를 섞지 않았는가?
+- [ ] Lynx: headless 패키지가 자동 state class나 recipe 책임을 갖지 않는가?
+- [ ] Lynx: 웹 대비 미지원 기능을 타입/JSDoc/docs에 함께 반영했는가?
 - [ ] Changeset 생성? (`/changeset` 스킬 참조)
 
 ## 흔한 실수
 
 ### 잘못된 순서
 
-반드시 Rootage → generate → Recipe → React → Docs → Test 순서를 따른다. React를 먼저 작성하면 CSS 변수가 없어서 스타일이 깨진다.
+반드시 Platform Gate → Rootage → generate → Recipe → Styled UI → Docs/Examples → Test 순서를 따른다. Styled UI를 먼저 작성하면 CSS 변수나 recipe 타입이 없어서 스타일이 깨진다.
 
 ### Recipe export 누락
 
-Recipe 작성 후 반드시 `recipes/index.ts`에 export를 추가해야 한다. 누락하면 컴포넌트에서 import가 실패한다.
+Recipe 작성 후 target preset entry에 export를 추가해야 한다. React는 `packages/qvism-preset/src/recipes/index.ts`, Lynx는 `packages/lynx-qvism-preset/src/recipes.ts` 또는 해당 entry를 확인한다. 누락하면 컴포넌트에서 import가 실패한다.
 
 ### 테스트 생략
 
@@ -78,11 +89,15 @@ Recipe 작성 후 반드시 `recipes/index.ts`에 export를 추가해야 한다.
 
 ### Recipe-React 불일치
 
-Recipe 타입을 변경하거나 슬롯을 추가한 후에는 반드시 `bun generate:all`을 먼저 실행한 뒤 React 코드를 수정한다. 상세는 `packages/qvism-preset/AGENTS.md`와 `packages/css/AGENTS.md` 참조.
+Recipe 타입을 변경하거나 슬롯을 추가한 후에는 반드시 `bun generate:all`을 먼저 실행한 뒤 Styled UI 코드를 수정한다. React는 `packages/qvism-preset/AGENTS.md`와 `packages/css/AGENTS.md`, Lynx는 `packages/lynx-qvism-preset/AGENTS.md`와 `packages/lynx-css/AGENTS.md`를 참조.
 
 ### React 컴포넌트 패턴 위반
 
 variant props 수동 destructuring, 잘못된 import 경로, style prop 직접 사용 등의 금지 패턴은 `packages/react/AGENTS.md`에 명시되어 있다. 구현 전 반드시 확인한다.
+
+### Lynx 컴포넌트 패턴 위반
+
+native tag runtime 변수화, null ref 전달, `children`이 포함된 native props spread, Web CSS/DOM/form/focus API 사용 같은 금지 패턴은 `packages/lynx-react/AGENTS.md`와 `references/lynx-patterns.md`에 명시되어 있다. 구현 전 반드시 확인한다.
 
 ## 생성 파일 (수정 금지)
 
@@ -91,6 +106,9 @@ variant props 수동 destructuring, 잘못된 import 경로, style prop 직접 �
 | `packages/css/recipes/*` | rootage |
 | `packages/css/vars/component/*` | rootage |
 | `packages/qvism-preset/src/vars/component/*` | rootage |
+| `packages/lynx-css/recipes/*` | rootage/lynx-qvism |
+| `packages/lynx-css/vars/component/*` | rootage |
+| `packages/lynx-qvism-preset/src/vars/component/*` | rootage |
 | `packages/rootage/components/schema.json` | rootage |
 | `docs/public/__registry__/**` | docs registry script |
 

--- a/skills/create-component/references/visual-testing.md
+++ b/skills/create-component/references/visual-testing.md
@@ -13,7 +13,11 @@ cd docs && bun dev
 cd examples/stackflow-spa && bun dev
 # → localhost:5173
 
-# 터미널 3: Storybook
+# 터미널 3: lynx-spa 개발 서버 (Lynx 작업 시)
+cd examples/lynx-spa && bun dev
+# → Lynx dev server output 확인
+
+# 터미널 4: Storybook (React 작업 시)
 cd docs && bun storybook
 # → localhost:6006
 ```
@@ -60,16 +64,26 @@ agent-browser screenshot storybook-[name]-font-xxxl.png
 agent-browser close
 ```
 
+### 4. Lynx-SPA 테스트
+
+Lynx 컴포넌트는 Storybook 대신 `examples/lynx-spa`의 page/catalog에서 실제 사용 화면을 확인한다. snippet을 vendoring하는 컴포넌트라면 `examples/lynx-spa/src/seed-design/ui/`가 `docs/registry/lynx/ui/`와 동기화되어 있는지도 함께 본다.
+
+```bash
+cd examples/lynx-spa && bun dev
+# dev server URL과 QR/device target은 rspeedy output을 따른다.
+```
+
 ## 테스트 체크리스트
 
 | 환경 | URL | 확인 사항 |
 |------|-----|----------|
 | docs | localhost:3000 | 컴포넌트 렌더링, 예제 동작 |
-| stackflow-spa | localhost:5173 | 실제 앱 환경 동작 |
-| Storybook Light | localhost:6006 | 라이트 모드 스타일 |
-| Storybook Dark | localhost:6006 | 다크 모드 스타일 |
-| Storybook Font XS | localhost:6006 | 작은 폰트 스케일 |
-| Storybook Font XXXL | localhost:6006 | 큰 폰트 스케일 |
+| stackflow-spa (React) | localhost:5173 | 실제 앱 환경 동작 |
+| lynx-spa (Lynx) | rspeedy output | Lynx runtime/page/catalog 동작 |
+| Storybook Light (React) | localhost:6006 | 라이트 모드 스타일 |
+| Storybook Dark (React) | localhost:6006 | 다크 모드 스타일 |
+| Storybook Font XS (React) | localhost:6006 | 작은 폰트 스케일 |
+| Storybook Font XXXL (React) | localhost:6006 | 큰 폰트 스케일 |
 
 ## Figma 비교 (선택)
 


### PR DESCRIPTION
## Summary
- `create-component` 스킬의 description과 메인 흐름을 React 전용에서 React/Lynx/cross-platform 공통 컴포넌트 작업으로 확장했습니다.
- Phase 0 Pre 앞에 Platform Gate를 추가해 `react`, `lynx`, `cross-platform`을 먼저 판별하도록 했습니다.
- Lynx 작업 경로를 `lynx-qvism-preset`/`lynx-css`, `lynx-react`, `lynx-headless`, `docs/content/lynx`, `docs/registry/lynx/ui`, `examples/lynx-spa` 기준으로 분리했습니다.
- Stateful Lynx 컴포넌트의 기본 책임을 `lynx-headless = 로직/상태/context`, `lynx-react = recipe/className/native slot wiring`, `lynx-css = generated CSS/recipe`로 명시했습니다.
- Lynx 주의 규칙과 문서 리뷰 프롬프트를 별도 reference로 추가했습니다.

## Notes
- 실제 패키지 API는 변경하지 않았습니다.
- 새 `packages/lynx-headless/<component>` 패키지가 필요한 경우에는 repo 규칙상 사용자 확인을 받도록 스킬에 명시했습니다.
- 계획대로 full skill eval, baseline 비교, review viewer 생성은 생략했습니다.

## Validation
- [x] `git diff --check -- skills/create-component`
- [x] `rg -n "docs/registry/ui|Recipe → React|React 컴포넌트 단계|React를 먼저|packages/react-headless/AGENTS.md의|docs/registry/registry-ui" skills/create-component` 결과 매치 없음
- [x] `bun install --frozen-lockfile`
- [x] `bun ecosystem:build`
- [ ] `bun generate:all` 실패: `@seed-design/tailwind4-theme::rootage:generate` 단계에서 `spawn rootage ENOENT`
- [ ] `bun test:all` 실패: `test:unit`에서 286개 통과 후 `@seed-design/dom-utils`, `@seed-design/react-field`, `@seed-design/react-primitive` 등 workspace 패키지 모듈 해석 오류 발생


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **문서**
  * 컴포넌트 생성 가이드 전반을 플랫폼(React/Lynx/cross-platform) 지원을 중심으로 확장 및 재구성했습니다. 플랫폼 결정 절차, Lynx 특화 패턴, 아키텍처 결정, 검증 체크리스트 등이 보강되었습니다.
  * 새로운 참고 문서(플랫폼 게이트, Lynx 패턴, 리뷰 프롬프트)가 추가되어 단계별 지침이 명확해졌습니다.
  * 예제, 문서 경로, 빌드/테스트 항목이 플랫폼별로 명시되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->