### PR TITLE
feat(drawer): deprecate noBodyStyles and preventScrollRestoration

### DIFF
--- a/.changeset/deprecate-drawer-body-lock-props.md
+++ b/.changeset/deprecate-drawer-body-lock-props.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react-drawer": patch
+---
+
+SEED React 1.3에서 제거될 예정인 Drawer/BottomSheet의 `noBodyStyles`, `preventScrollRestoration` 옵션을 deprecated 처리합니다. 1.3부터는 두 옵션 모두 기본값(`noBodyStyles=true`, `preventScrollRestoration=false`)처럼 동작합니다.

--- a/.changeset/deprecate-drawer-body-lock-props.md
+++ b/.changeset/deprecate-drawer-body-lock-props.md
@@ -2,4 +2,4 @@
 "@seed-design/react-drawer": patch
 ---
 
-SEED React 1.3에서 제거될 예정인 Drawer/BottomSheet의 `noBodyStyles`, `preventScrollRestoration` 옵션을 deprecated 처리합니다. 1.3부터는 두 옵션 모두 기본값(`noBodyStyles=true`, `preventScrollRestoration=false`)처럼 동작합니다.
+SEED React 2.0.0에서 제거될 예정인 Drawer/BottomSheet의 `noBodyStyles`, `preventScrollRestoration` 옵션을 deprecated 처리합니다. 2.0.0부터는 두 옵션 모두 기본값(`noBodyStyles=true`, `preventScrollRestoration=false`)처럼 동작합니다.

--- a/docs/content/docs/migration/deprecations.mdx
+++ b/docs/content/docs/migration/deprecations.mdx
@@ -10,8 +10,8 @@ description: Deprecated 항목의 현황과 제거 계획을 관리합니다.
 | 항목                                   | 종류          | Deprecated 버전 | 제거 예정 버전 | 대체안                 | 비고                                                         |
 | -------------------------------------- | ------------- | --------------- | -------------- | ---------------------- | ------------------------------------------------------------ |
 | AppBar - divider 옵션                  | 컴포넌트 옵션 | 1.2.x           | 1.3.0          | -                      | 제거 후 하단 구분선 미표시. rootage top-navigation 옵션 정리 |
-| Drawer - noBodyStyles 옵션             | 컴포넌트 옵션 | 1.2.x           | 1.3.0          | -                      | 1.3부터 무시되어 기본값(true)처럼 동작                       |
-| Drawer - preventScrollRestoration 옵션 | 컴포넌트 옵션 | 1.2.x           | 1.3.0          | -                      | 1.3부터 무시되어 기본값(false)처럼 동작                      |
+| Drawer - noBodyStyles 옵션             | 컴포넌트 옵션 | 1.2.x           | 2.0.0          | -                      | 2.0.0부터 무시되어 기본값(true)처럼 동작                     |
+| Drawer - preventScrollRestoration 옵션 | 컴포넌트 옵션 | 1.2.x           | 2.0.0          | -                      | 2.0.0부터 무시되어 기본값(false)처럼 동작                    |
 | Image Frame - rounded 옵션             | 컴포넌트 옵션 | 1.2.x           | 1.3.0          | borderRadius="r2"      | rootage image-frame 옵션 정리                                |
 | $color.bg.layer-fill                   | 디자인 토큰   | 1.2.x           | 1.3.0          | $color.bg.neutral-weak | 더이상 사용하지 않음 (elevation 문서 안내)                   |
 | $gradient.fade-layer-floating          | 디자인 토큰   | 1.2.x           | 1.3.0          | -                      | 대체안 미정                                                  |

--- a/docs/content/docs/migration/deprecations.mdx
+++ b/docs/content/docs/migration/deprecations.mdx
@@ -7,13 +7,15 @@ description: Deprecated 항목의 현황과 제거 계획을 관리합니다.
 
 ## Deprecated 현황
 
-| 항목                          | 종류          | Deprecated 버전 | 제거 예정 버전 | 대체안                 | 비고                                       |
-| ----------------------------- | ------------- | --------------- | -------------- | ---------------------- | ------------------------------------------ |
-| AppBar - divider 옵션         | 컴포넌트 옵션 | 1.2.x           | 1.3.0          | -                      | 제거 후 하단 구분선 미표시. rootage top-navigation 옵션 정리 |
-| Image Frame - rounded 옵션    | 컴포넌트 옵션 | 1.2.x           | 1.3.0          | borderRadius="r2"      | rootage image-frame 옵션 정리              |
-| $color.bg.layer-fill          | 디자인 토큰   | 1.2.x           | 1.3.0          | $color.bg.neutral-weak | 더이상 사용하지 않음 (elevation 문서 안내) |
-| $gradient.fade-layer-floating | 디자인 토큰   | 1.2.x           | 1.3.0          | -                      | 대체안 미정                                |
-| $gradient.fade-layer-default  | 디자인 토큰   | 1.2.x           | 1.3.0          | -                      | 대체안 미정                                |
+| 항목                                   | 종류          | Deprecated 버전 | 제거 예정 버전 | 대체안                 | 비고                                                         |
+| -------------------------------------- | ------------- | --------------- | -------------- | ---------------------- | ------------------------------------------------------------ |
+| AppBar - divider 옵션                  | 컴포넌트 옵션 | 1.2.x           | 1.3.0          | -                      | 제거 후 하단 구분선 미표시. rootage top-navigation 옵션 정리 |
+| Drawer - noBodyStyles 옵션             | 컴포넌트 옵션 | 1.2.x           | 1.3.0          | -                      | 1.3부터 무시되어 기본값(true)처럼 동작                       |
+| Drawer - preventScrollRestoration 옵션 | 컴포넌트 옵션 | 1.2.x           | 1.3.0          | -                      | 1.3부터 무시되어 기본값(false)처럼 동작                      |
+| Image Frame - rounded 옵션             | 컴포넌트 옵션 | 1.2.x           | 1.3.0          | borderRadius="r2"      | rootage image-frame 옵션 정리                                |
+| $color.bg.layer-fill                   | 디자인 토큰   | 1.2.x           | 1.3.0          | $color.bg.neutral-weak | 더이상 사용하지 않음 (elevation 문서 안내)                   |
+| $gradient.fade-layer-floating          | 디자인 토큰   | 1.2.x           | 1.3.0          | -                      | 대체안 미정                                                  |
+| $gradient.fade-layer-default           | 디자인 토큰   | 1.2.x           | 1.3.0          | -                      | 대체안 미정                                                  |
 
 ## 제거 완료 히스토리
 

--- a/packages/react-headless/drawer/src/useDrawer.ts
+++ b/packages/react-headless/drawer/src/useDrawer.ts
@@ -43,7 +43,7 @@ export interface UseDrawerProps {
   /**
    * When `true` the `body` doesn't get any styles assigned from Drawer
    * @default true
-   * @deprecated SEED React 1.3에서 제거됩니다. 1.3부터 항상 기본값 `true`처럼 동작합니다.
+   * @deprecated SEED React 2.0.0에서 제거됩니다. 2.0.0부터 항상 기본값 `true`처럼 동작합니다.
    */
   noBodyStyles?: boolean;
   onOpenChange?: (open: boolean, details?: DrawerChangeDetails) => void;
@@ -106,7 +106,7 @@ export interface UseDrawerProps {
    */
   onAnimationEnd?: (open: boolean) => void;
   /**
-   * @deprecated SEED React 1.3에서 제거됩니다. 1.3부터 항상 기본값 `false`처럼 동작합니다.
+   * @deprecated SEED React 2.0.0에서 제거됩니다. 2.0.0부터 항상 기본값 `false`처럼 동작합니다.
    */
   preventScrollRestoration?: boolean;
   autoFocus?: boolean;

--- a/packages/react-headless/drawer/src/useDrawer.ts
+++ b/packages/react-headless/drawer/src/useDrawer.ts
@@ -43,6 +43,7 @@ export interface UseDrawerProps {
   /**
    * When `true` the `body` doesn't get any styles assigned from Drawer
    * @default true
+   * @deprecated SEED React 1.3에서 제거됩니다. 1.3부터 항상 기본값 `true`처럼 동작합니다.
    */
   noBodyStyles?: boolean;
   onOpenChange?: (open: boolean, details?: DrawerChangeDetails) => void;
@@ -104,6 +105,9 @@ export interface UseDrawerProps {
    * Useful to revert any state changes for example.
    */
   onAnimationEnd?: (open: boolean) => void;
+  /**
+   * @deprecated SEED React 1.3에서 제거됩니다. 1.3부터 항상 기본값 `false`처럼 동작합니다.
+   */
   preventScrollRestoration?: boolean;
   autoFocus?: boolean;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * `Drawer/BottomSheet`의 `noBodyStyles` 및 `preventScrollRestoration` 옵션을 deprecated로 전환(제거 예정: **2.0.0**).
  * **2.0.0**부터 두 옵션은 기본값 기준으로 동작합니다(`noBodyStyles=true`, `preventScrollRestoration=false`).
  * 마이그레이션 가이드와 deprecated 표에 관련 안내를 추가했으며, 옵션 관련 JSDoc에도 폐기 정보를 반영했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->