### PR TITLE
feat(lynx): add accessibility props type and conventions

### DIFF
--- a/.changeset/lynx-accessibility-props.md
+++ b/.changeset/lynx-accessibility-props.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/lynx-react": minor
+---
+
+native element의 접근성 속성을 표준화한 `LynxAccessibilityProps` 타입을 추가했습니다. 컴포넌트가 이 타입을 확장해 `accessibility-label`/`accessibility-role-description`/`accessibility-value`/`accessibility-elements-hidden` 등을 받아 native element에 전달할 수 있습니다.

--- a/packages/lynx-react/src/types.ts
+++ b/packages/lynx-react/src/types.ts
@@ -43,3 +43,34 @@ export interface LynxIconElementProps {
   ref?: LynxMainThreadRef;
   "main-thread:binduiappear"?: IntrinsicElements["image"]["main-thread:binduiappear"];
 }
+
+/**
+ * @platform Lynx
+ *
+ * native element(`<view>`/`<text>`/`<image>` 등)가 공유하는 접근성 속성 모음.
+ * `@lynx-js/types`의 StandardProps 접근성 속성을 표준화한 타입으로, 컴포넌트가
+ * 확장해 native element에 패스스루한다. 모든 native tag가 동일한 공통 속성을
+ * 가지며 tag별 차이는 없다.
+ *
+ * web ARIA 대응:
+ * - `accessibility-label` ← `aria-label`
+ * - `accessibility-role-description` ← `role` (switch/checkbox/progressbar)
+ * - `accessibility-value` ← `aria-checked` / `aria-valuenow`
+ * - `accessibility-elements-hidden` ← `aria-hidden`
+ *
+ * `accessibility-traits`는 단일 값이라 `selected`+`disabled` 동시 표현이 안 된다.
+ * 역할은 `accessibility-role-description`, 상태는 `accessibility-value`로 분담한다.
+ */
+export type LynxAccessibilityProps = Pick<
+  LynxViewProps,
+  | "accessibility-label"
+  | "accessibility-traits"
+  | "accessibility-element"
+  | "accessibility-value"
+  | "accessibility-role-description"
+  | "accessibility-elements-hidden"
+  | "accessibility-heading"
+  | "accessibility-actions"
+  | "accessibility-exclusive-focus"
+  | "ios-platform-accessibility-id"
+>;

--- a/skills/create-component/references/lynx-patterns.md
+++ b/skills/create-component/references/lynx-patterns.md
@@ -42,6 +42,61 @@ Web과 Lynx의 차이는 타입과 문서가 같은 말을 해야 한다.
 - `docs/content/lynx/components/<name>.mdx`에 “웹 버전과의 차이”와 “Lynx 미지원 기능”을 작성한다.
 - SVG/icon 기능은 `@karrotmarket/lynx-monochrome-icon` 같은 Lynx icon element와 `<image tint-color>` 기반 wrapper를 우선 검토한다.
 
+## Accessibility
+
+Lynx는 web ARIA가 아니라 자체 `accessibility-*` 속성을 쓴다. **모든 native tag(`<view>`/`<text>`/`<image>`/`<list>`/...)가 동일한 공통 속성을 공유**하며 tag별 차이는 없다. `lynx-react`의 `LynxAccessibilityProps`(`packages/lynx-react/src/types.ts`)가 이 속성들을 모은 표준 타입이다 — 컴포넌트 props가 이를 확장해 native element에 패스스루한다.
+
+### 속성 레퍼런스 (`@lynx-js/types` StandardProps)
+
+| 속성 | 타입 | web 대응 |
+|------|------|----------|
+| `accessibility-label` | `string` | `aria-label` (스크린리더가 읽을 이름) |
+| `accessibility-traits` | `'button'｜'image'｜'link'｜'header'｜'selected'｜'disabled'｜'adjustable'｜'tabbar'｜...｜'none'` (**단일 값**) | `role`/state 일부 |
+| `accessibility-element` | `boolean` | a11y 트리 포함 여부 (`<view>`는 명시 필요, `<text>`/`<image>`는 기본 `true`) |
+| `accessibility-value` | `string` | `aria-checked` / `aria-valuenow` (상태 텍스트) |
+| `accessibility-role-description` | `'switch'｜'checkbox'｜'image'｜'progressbar'｜string` | `role` |
+| `accessibility-elements-hidden` | `boolean` | `aria-hidden` |
+| `accessibility-heading` | `boolean` | `role="heading"` |
+| `accessibility-actions` | `string[]` | 커스텀 액션 (`bindaccessibilityaction` 이벤트와 함께) |
+| `accessibility-exclusive-focus` | `boolean` | focus 격리 |
+| `ios-platform-accessibility-id` | `string` | iOS 테스트 식별자 |
+
+- 이벤트: `bindaccessibilityaction` (`AccessibilityAction`) · 메서드: `requestAccessibilityFocus()`
+- **타입 미제공**(가이드 문서엔 언급): `accessibility-elements`(읽기 순서), `accessibilityAnnounce`(전역 announce) — 필요 시 런타임/버전 확인 후 사용한다.
+
+### 책임 분리
+
+- **headless(`packages/lynx-headless/*`)**: a11y 속성을 만들지 않는다. 상태(`pressed`/`checked`/`disabled`)만 노출한다.
+- **styled(`packages/lynx-react/*`)**: 내부 상태·prop에 따라 `accessibility-*`를 native element에 **직접 작성**한다. (web `react-headless`가 `stateProps`로 `aria-*`를 붙이는 역할을 Lynx에선 styled가 담당)
+- 공통 헬퍼는 두지 않는다. 컴포넌트마다 label/role/value가 달라 직접 작성이 명확하다.
+
+### 결정 트리
+
+- **interactive (button/toggle/checkbox/switch)**: `accessibility-element={true}` + `accessibility-role-description`(역할) + `accessibility-value`(상태 텍스트) + `accessibility-label`(이름). `disabled`면 `accessibility-traits="disabled"`.
+  - `traits`는 단일 값이라 `selected`+`disabled` 동시 표현 불가 → **역할은 `role-description`, 상태는 `value`**로 분담한다.
+- **decorative (장식 image/icon)**: `accessibility-elements-hidden={true}` (스크린리더에서 숨김).
+- **의미 있는 image**: `accessibility-label`(대체 텍스트) + `accessibility-traits="image"`.
+- **layout (Box/Stack/AspectRatio)**: 보통 불필요. 자식이 a11y를 담당한다.
+
+### 예시
+
+```tsx
+// Switch(styled) — 상태에 따라 a11y를 native <view>에 직접 작성
+<view
+  {...pressHandlers}
+  accessibility-element={true}
+  accessibility-role-description="switch"
+  accessibility-value={checked ? "켜짐" : "꺼짐"}
+  accessibility-traits={disabled ? "disabled" : "button"}
+  accessibility-label={label}
+/>
+
+// 장식 아이콘 — 스크린리더에서 숨김
+<image src={iconSrc} accessibility-elements-hidden={true} />
+```
+
+`accessibility-value`/`accessibility-label`의 텍스트("켜짐"/"꺼짐" 등)는 i18n 대상이므로 headless가 아니라 컴포넌트/소비처가 제공한다.
+
 ## Docs and registry
 
 - Lynx snippet은 `docs/registry/lynx/ui/<name>.tsx`에 둔다.


### PR DESCRIPTION
## Summary
Lynx 접근성 인프라 — 컴포넌트별 a11y 적용을 위한 **공통 타입 + 컨벤션 문서**. (컴포넌트 실제 적용은 후속 PR)

## Changes
- **`LynxAccessibilityProps`** (`packages/lynx-react/src/types.ts`): `@lynx-js/types` StandardProps의 accessibility 속성(`accessibility-label`/`traits`/`element`/`value`/`role-description`/`elements-hidden`/`heading`/`actions`/`exclusive-focus`/`ios-platform-accessibility-id`)을 표준화. **모든 native tag 공통**(tag별 차이 없음 확인) → 컴포넌트가 확장해 native에 패스스루.
- **create-component `lynx-patterns.md` "Accessibility" 섹션**: 속성 레퍼런스 표, web aria ↔ Lynx 매핑, 결정 트리(interactive/decorative/image/layout), **headless(상태만) ↔ styled(a11y 직접 작성) 책임 분리**, 예시.

## Notes
- web ARIA 대부분 대응 가능: `aria-label`→`accessibility-label`, `role`→`accessibility-role-description`, `aria-checked`→`accessibility-value`, `aria-hidden`→`accessibility-elements-hidden`.
- `accessibility-traits`는 단일 값 → 역할은 `role-description`, 상태는 `value`로 분담.
- 헬퍼는 두지 않음(컴포넌트마다 label/role/value가 달라 직접 작성이 명확).

## Out of scope (후속 PR)
- 컴포넌트별 a11y 적용 (ActionButton `aria-label`→`accessibility-label`, Checkbox/Switch role 등)
- docs/content/lynx 사용자 가이드

## Verification
- lynx-react typecheck + build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 주요 변경사항

* **새로운 기능**
  * 접근성 속성의 표준화를 통해 컴포넌트에서 네이티브 엘리먼트로 접근성 레이블, 역할 설명, 값 등을 더욱 일관성 있게 전달할 수 있습니다.

* **문서**
  * Lynx 접근성 패턴에 대한 포괄적인 가이드가 추가되었으며, 속성 매핑, 이벤트, 메서드, 책임 분리 원칙, 그리고 실제 사용 예시를 포함합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->