### PR TITLE
docs(skill): point create-component lynx headless path to lynx-react-headless

### DIFF
--- a/skills/create-component/SKILL.md
+++ b/skills/create-component/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-component
-description: End-to-end SEED component implementation guide for React Web, Lynx, and cross-platform component work. Starts by deciding the target platform, then clarifies requirements, makes architecture decisions, follows the platform/category-specific pattern, and runs verification. Use this whenever the user is adding a new component, changing behavior across component layers, extending a snippet, or touching component docs — even if they don't explicitly say "create component". Always invoke before touching rootage YAML, qvism or lynx-qvism recipes, react/lynx-react/lynx-headless packages, docs registry snippets, or component docs. Covers all 5 component categories and refuses to skip platform gating or requirements brainstorming.
+description: End-to-end SEED component implementation guide for React Web, Lynx, and cross-platform component work. Starts by deciding the target platform, then clarifies requirements, makes architecture decisions, follows the platform/category-specific pattern, and runs verification. Use this whenever the user is adding a new component, changing behavior across component layers, extending a snippet, or touching component docs — even if they don't explicitly say "create component". Always invoke before touching rootage YAML, qvism or lynx-qvism recipes, react/lynx-react/lynx-react-headless packages, docs registry snippets, or component docs. Covers all 5 component categories and refuses to skip platform gating or requirements brainstorming.
 ---
 
 # Create Component
@@ -35,7 +35,7 @@ Phase 0 Pre 전에 target platform을 `react` / `lynx` / `cross-platform` 중 �
 ### 🔒 게이트 Platform → 0Pre
 - target platform 확정
 - `cross-platform`이면 shared Rootage/API와 플랫폼별 구현 분리 원칙 확인
-- 새 `packages/lynx-headless/<component>` 패키지가 필요하면 사용자 확인 전 구현 금지
+- 새 `packages/lynx-react-headless/<component>` 패키지가 필요하면 사용자 확인 전 구현 금지
 
 ---
 

--- a/skills/create-component/references/architecture-decisions.md
+++ b/skills/create-component/references/architecture-decisions.md
@@ -76,14 +76,14 @@ Phase 0 산출물에 다음을 남긴다:
 **React 기존 headless 패키지** (`packages/react-headless/`):
 avatar, checkbox, collapsible, dialog, drawer, field, field-button, fieldset, image, popover, portal, primitive, progress, pull-to-refresh, radio-group, scrollable, segmented-control, slider, snackbar, supports, switch, tabs, text-field, toggle, use-controllable-state
 
-**Lynx headless 패키지** (`packages/lynx-headless/`):
-현재 repo에 있는 패키지를 먼저 확인한다. stateful Lynx 컴포넌트에서 press/tap, controlled/uncontrolled, context, render props를 재사용해야 하면 `packages/lynx-headless/*`를 우선 검토한다. 새 패키지가 필요하면 “새 패키지 추가” boundary이므로 사용자 확인 전 구현하지 않는다.
+**Lynx headless 패키지** (`packages/lynx-react-headless/`):
+현재 repo에 있는 패키지를 먼저 확인한다. stateful Lynx 컴포넌트에서 press/tap, controlled/uncontrolled, context, render props를 재사용해야 하면 `packages/lynx-react-headless/*`를 우선 검토한다. 새 패키지가 필요하면 “새 패키지 추가” boundary이므로 사용자 확인 전 구현하지 않는다.
 
 - **재사용 가능**: 기존 패키지의 훅/컨텍스트를 그대로 사용 (예: collapsible → Accordion)
 - **확장 필요**: 기존 패키지를 기반으로 새 훅 추가
 - **신규 생성**: 완전히 새로운 headless 패키지 필요
 
-신규 생성 시 target platform에 따라 `packages/react-headless/AGENTS.md` 또는 `packages/lynx-headless/AGENTS.md`의 컨벤션을 반드시 확인한다.
+신규 생성 시 target platform에 따라 `packages/react-headless/AGENTS.md` 또는 `packages/lynx-react-headless/AGENTS.md`의 컨벤션을 반드시 확인한다.
 
 ## 3. 의존성 분석 (BLOCKING GATE)
 
@@ -161,7 +161,7 @@ APG가 heading 계층이나 landmark 구조를 요구하는 컴포넌트는 이 
 
 - **Headless reference**: ________________
   - React 경로: `packages/react-headless/{name}/` 또는 `packages/react-headless/{name}/src/`
-  - Lynx 경로: `packages/lynx-headless/{name}/` 또는 styled-local hook/context
+  - Lynx 경로: `packages/lynx-react-headless/{name}/` 또는 styled-local hook/context
 - **Styled UI reference**: ________________
   - React 경로: `packages/react/src/components/{Name}/`
   - Lynx 경로: `packages/lynx-react/src/components/{Name}/`

--- a/skills/create-component/references/brainstorming.md
+++ b/skills/create-component/references/brainstorming.md
@@ -100,7 +100,7 @@
 
 - Headless ref:
   - React: `packages/react-headless/<name>` 중 어느 것?
-  - Lynx: `packages/lynx-headless/<name>` 또는 local hook/context 중 어느 것?
+  - Lynx: `packages/lynx-react-headless/<name>` 또는 local hook/context 중 어느 것?
 - Styled ref:
   - React: `packages/react/src/components/<Name>` 중 어느 것?
   - Lynx: `packages/lynx-react/src/components/<Name>` 중 어느 것?

--- a/skills/create-component/references/guide.md
+++ b/skills/create-component/references/guide.md
@@ -34,7 +34,7 @@ Platform Gate → Architecture Analysis → Headless (선택) → Rootage YAML �
 |----------|----------------|---------------|--------|
 | 토큰/스타일 변수 | `packages/rootage/` | `packages/rootage/` | `bun generate:all` |
 | Recipe source | `packages/qvism-preset/src/recipes/` | `packages/lynx-qvism-preset/src/recipes/` | `bun qvism:generate` |
-| Headless/state | `packages/react-headless/` | `packages/lynx-headless/` 또는 styled-local | package build/test |
+| Headless/state | `packages/react-headless/` | `packages/lynx-react-headless/` 또는 styled-local | package build/test |
 | Styled UI | `packages/react/src/components/` | `packages/lynx-react/src/components/` | `bun packages:build` |
 | Snippet | `docs/registry/react/ui/` | `docs/registry/lynx/ui/` | docs registry generate |
 | 문서 | `docs/content/react/` | `docs/content/lynx/` | `bun docs:test` |
@@ -51,7 +51,7 @@ Platform Gate → Architecture Analysis → Headless (선택) → Rootage YAML �
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐
-│  1. HEADLESS (Optional) - react-headless or lynx-headless   │
+│  1. HEADLESS (Optional) - react-headless or lynx-react-headless   │
 └─────────────────────────────────────────────────────────────┘
                            │
                            ▼
@@ -95,7 +95,7 @@ Platform Gate → Architecture Analysis → Headless (선택) → Rootage YAML �
 4. React는 `packages/qvism-preset/src/recipes/[name].ts`, Lynx는 `packages/lynx-qvism-preset/src/recipes/[name].ts` 작성
 5. target preset entry에 recipe export 추가
 6. React는 `packages/react/src/components/[Name]/`, Lynx는 `packages/lynx-react/src/components/[Name]/` 구현
-7. stateful Lynx에서 필요하면 `packages/lynx-headless/[name]/`를 먼저 설계하고 사용자 확인 후 추가
+7. stateful Lynx에서 필요하면 `packages/lynx-react-headless/[name]/`를 먼저 설계하고 사용자 확인 후 추가
 8. platform snippet/docs/example 작성
 9. Visual Test 실행
 

--- a/skills/create-component/references/implementation-steps.md
+++ b/skills/create-component/references/implementation-steps.md
@@ -8,7 +8,7 @@
 
 **위치**:
 - React: `packages/react-headless/[name]/`
-- Lynx: `packages/lynx-headless/[name]/` 또는 `packages/lynx-react/src/components/[ComponentName]/` 내부 hook/context
+- Lynx: `packages/lynx-react-headless/[name]/` 또는 `packages/lynx-react/src/components/[ComponentName]/` 내부 hook/context
 
 **조건**: 데이터 로직이 필요한 경우만 (단순 UI 컴포넌트는 생략)
 
@@ -27,10 +27,10 @@ Headless 훅은 하나의 `use{Component}`로 끝낼 필요가 없다. compound 
 
 Stateful Lynx 컴포넌트는 `references/lynx-patterns.md`를 따른다.
 
-- `packages/lynx-headless/*`는 상태, press/tap, controlled/uncontrolled, context, render props를 소유한다.
-- `packages/lynx-headless/*`는 자동 state class, recipe, SEED token, className 조합을 넣지 않는다.
+- `packages/lynx-react-headless/*`는 상태, press/tap, controlled/uncontrolled, context, render props를 소유한다.
+- `packages/lynx-react-headless/*`는 자동 state class, recipe, SEED token, className 조합을 넣지 않는다.
 - `packages/lynx-react`는 headless 상태를 읽어 `@seed-design/lynx-css/recipes/*` variant와 className을 조합한다.
-- 새 `packages/lynx-headless/<component>` 패키지가 필요하면 사용자 확인을 먼저 받는다.
+- 새 `packages/lynx-react-headless/<component>` 패키지가 필요하면 사용자 확인을 먼저 받는다.
 
 **카테고리 C/D에서 새 headless를 만들 때**: Phase 0에서 정리한 ARIA APG 패턴과 키보드 인터랙션 스펙을 이 단계에서 구현한다. `references/external-references.md`의 접근성 체크리스트를 따른다. 외부 라이브러리(Base UI, Radix)의 동일 컴포넌트 구현도 참조하여 인터페이스 설계를 검증한다.
 

--- a/skills/create-component/references/lynx-patterns.md
+++ b/skills/create-component/references/lynx-patterns.md
@@ -8,12 +8,12 @@ Stateful Lynx 컴포넌트의 기본 계약은 다음과 같다.
 
 | 레이어 | 책임 | 넣지 않는 것 |
 |--------|------|--------------|
-| `packages/lynx-headless/*` | 상태, press/tap, controlled/uncontrolled, context, render props | SEED recipe, token, className 자동 주입 |
+| `packages/lynx-react-headless/*` | 상태, press/tap, controlled/uncontrolled, context, render props | SEED recipe, token, className 자동 주입 |
 | `packages/lynx-react/*` | native slot JSX, recipe variant 조합, className 병합, icon/image wiring | 중복 상태 계산, Web DOM/form/focus API |
 | `packages/lynx-qvism-preset/*` | Lynx CSS 제약에 맞춘 recipe source | Web-only CSS, pseudo selector 의존 |
 | `packages/lynx-css/*` | generated CSS/recipe output | 직접 수정 |
 
-`lynx-headless`는 자동 state class를 주입하지 않는다. `active`, `checked`, `disabled` 같은 순수 상태를 context/render props로 노출하고, `lynx-react`가 그 상태를 recipe boolean/string variant로 전달한다.
+`lynx-react-headless`는 자동 state class를 주입하지 않는다. `active`, `checked`, `disabled` 같은 순수 상태를 context/render props로 노출하고, `lynx-react`가 그 상태를 recipe boolean/string variant로 전달한다.
 
 ## Native JSX 제약
 
@@ -80,7 +80,7 @@ Lynx는 web ARIA가 아니라 자체 `accessibility-*` 속성을 쓴다. **모�
 
 ### 책임 분리
 
-- **headless(`packages/lynx-headless/*`)**: a11y 속성을 만들지 않는다. 상태(`pressed`/`checked`/`disabled`)만 노출한다.
+- **headless(`packages/lynx-react-headless/*`)**: a11y 속성을 만들지 않는다. 상태(`pressed`/`checked`/`disabled`)만 노출한다.
 - **styled(`packages/lynx-react/*`)**: 내부 상태·prop에 따라 `accessibility-*`를 native element에 **직접 작성**한다. (web `react-headless`가 `stateProps`로 `aria-*`를 붙이는 역할을 Lynx에선 styled가 담당)
 - 공통 헬퍼는 두지 않는다. 컴포넌트마다 label/role/value가 달라 직접 작성이 명확하다.
 
@@ -129,6 +129,6 @@ Lynx 작업의 핵심 검증은 다음을 우선한다.
 - `bun test:all`
 - `bun packages:build`
 - `bun --filter @seed-design/lynx-react typecheck`와 `bun --filter @seed-design/lynx-react test`가 package script에 있으면 실행
-- `packages/lynx-headless/*`를 바꿨다면 해당 package build/test 또는 root `lynx-headless:*` script가 있으면 실행
+- `packages/lynx-react-headless/*`를 바꿨다면 해당 package build/test 또는 root `lynx-react-headless:*` script가 있으면 실행
 - snippet/example 변경이 있으면 `bun --filter lynx-spa build`
 - generated registry가 최신인지 `bun --filter @seed-design/docs generate:registry` 또는 docs generate script로 확인

--- a/skills/create-component/references/pattern-catalog.md
+++ b/skills/create-component/references/pattern-catalog.md
@@ -137,7 +137,7 @@ Lynx 작업은 React reference를 API/semantic 비교 대상으로만 사용하�
 | D. Multi-Recipe | `packages/lynx-react/src/components/Checkbox/`, `Switch/`, `RadioGroup/` | `splitMultipleVariantsProps`, headless state와 recipe variant 분리 |
 | E. Layout | `packages/lynx-react/src/components/Box/`, `Stack/` | Lynx style props, native layout primitive |
 
-Lynx stateful 컴포넌트에서 `packages/lynx-headless/*`가 있거나 필요하면 `lynx-headless = 상태/이벤트/context`, `lynx-react = recipe/native UI wiring` 분리를 기본값으로 둔다.
+Lynx stateful 컴포넌트에서 `packages/lynx-react-headless/*`가 있거나 필요하면 `lynx-react-headless = 상태/이벤트/context`, `lynx-react = recipe/native UI wiring` 분리를 기본값으로 둔다.
 
 ## Lynx 핵심 유틸리티 위치
 

--- a/skills/create-component/references/platform-gate.md
+++ b/skills/create-component/references/platform-gate.md
@@ -9,7 +9,7 @@
 | Platform | 신호 | 기본 구현 표면 |
 |----------|------|----------------|
 | `react` | `packages/react`, `packages/react-headless`, `docs/content/react`, Storybook, stackflow-spa | Rootage → `packages/qvism-preset` → `packages/css` → `packages/react` → docs/example. Registry snippet은 Delivery Surface Gate에서 필요 시 |
-| `lynx` | `packages/lynx-react`, `packages/lynx-css`, `docs/content/lynx`, `examples/lynx-spa`, Lynx native tag | Rootage → `packages/lynx-qvism-preset` → `packages/lynx-css` → `packages/lynx-headless`(필요 시) → `packages/lynx-react` → docs/example. Registry snippet은 Delivery Surface Gate에서 필요 시 |
+| `lynx` | `packages/lynx-react`, `packages/lynx-css`, `docs/content/lynx`, `examples/lynx-spa`, Lynx native tag | Rootage → `packages/lynx-qvism-preset` → `packages/lynx-css` → `packages/lynx-react-headless`(필요 시) → `packages/lynx-react` → docs/example. Registry snippet은 Delivery Surface Gate에서 필요 시 |
 | `cross-platform` | “React와 Lynx 둘 다”, 같은 컴포넌트의 Web/Lynx parity, shared token/recipe vocabulary | shared Rootage/semantic API를 먼저 정하고 React/Lynx 구현과 문서를 각각 분리 |
 
 요청이 `lynx-*`, `@lynx-js/react`, `<view>`/`<text>`, `docs/content/lynx`, `docs/registry/lynx/ui` 중 하나를 포함하면 `lynx`로 본다. 요청이 `@seed-design/react`, `docs/content/react`, Storybook 중심이면 `react`로 본다.
@@ -30,7 +30,7 @@ Lynx가 Web API를 그대로 재현할 수 없으면 타입에 열어두지 않�
 | 판단 영역 | React | Lynx |
 |-----------|-------|------|
 | Styled component | `packages/react/src/components/*` | `packages/lynx-react/src/components/*` |
-| Headless/state | `packages/react-headless/*` | `packages/lynx-headless/*` when stateful; otherwise local Lynx hooks/context |
+| Headless/state | `packages/react-headless/*` | `packages/lynx-react-headless/*` when stateful; otherwise local Lynx hooks/context |
 | Recipe source | `packages/qvism-preset/src/recipes/*` | `packages/lynx-qvism-preset/src/recipes/*` |
 | Generated CSS | `packages/css/*` | `packages/lynx-css/*` |
 | Docs | `docs/content/react/*` | `docs/content/lynx/*` |
@@ -41,7 +41,7 @@ Registry snippet을 제공하기로 결정한 경우 source of truth는 docs reg
 
 ## 4. Ask-first boundary
 
-새 `packages/lynx-headless/<component>` 패키지가 필요하면 repo의 “새 패키지 추가” boundary에 해당한다. 구현 전에 사용자에게 다음을 보고하고 확인받는다.
+새 `packages/lynx-react-headless/<component>` 패키지가 필요하면 repo의 “새 패키지 추가” boundary에 해당한다. 구현 전에 사용자에게 다음을 보고하고 확인받는다.
 
 - 왜 `packages/lynx-react` 내부 hook/context만으로 부족한가
 - 어떤 상태/이벤트/접근성 계약을 headless 패키지가 소유하는가

--- a/skills/create-component/references/review-prompts.md
+++ b/skills/create-component/references/review-prompts.md
@@ -17,7 +17,7 @@
 
 확인할 것:
 - target platform을 `lynx`로 판별한다.
-- stateful 로직은 `packages/lynx-headless/*`와 `packages/lynx-react` 책임 분리로 설계한다.
+- stateful 로직은 `packages/lynx-react-headless/*`와 `packages/lynx-react` 책임 분리로 설계한다.
 - 자동 state class를 headless에 넣지 않고, `lynx-react`가 recipe variant/className을 조합한다.
 
 ## 3. Cross-platform 컴포넌트

--- a/skills/create-component/references/verification-checklist.md
+++ b/skills/create-component/references/verification-checklist.md
@@ -18,8 +18,8 @@
 - [ ] 의존성 API 안정성 확인? (불안정 시 구현 중단)
 - [ ] 외부 라이브러리 인터페이스 조사? (카테고리 C/D 필수, A/B/E 최소 prop naming)
 - [ ] ARIA APG 패턴 확인? (카테고리 C/D)
-- [ ] Lynx 작업이면 `lynx-headless` / `lynx-react` / `lynx-css` 책임 분리 결정?
-- [ ] 새 `packages/lynx-headless/<component>` 패키지가 필요하면 사용자 확인?
+- [ ] Lynx 작업이면 `lynx-react-headless` / `lynx-react` / `lynx-css` 책임 분리 결정?
+- [ ] 새 `packages/lynx-react-headless/<component>` 패키지가 필요하면 사용자 확인?
 - [ ] **사용자에게 Phase 0 결과 요약 보고 + 컨펌? (게이트 0→1)**
 
 ## Phase 1: 구현 확인


### PR DESCRIPTION
## Background

The lynx headless packages are being renamed to scope them under `lynx-react`:
- folder `packages/lynx-headless/` → `packages/lynx-react-headless/`
- `@seed-design/lynx-*` → `@seed-design/lynx-react-*`

(see #1645, #1646, #1647)

## Change

The `create-component` skill referenced the old `packages/lynx-headless` path in 10 files. This PR updates those references to `packages/lynx-react-headless`. The web `packages/react-headless` references are left unchanged.

## Note

Merge alongside or after the rename PRs (#1645–#1647) so the documented path matches the actual package location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 컴포넌트 생성 가이드 및 아키텍처 참조 문서를 업데이트하여 Lynx 헤드리스 패키지 경로를 일관되게 변경했습니다.
  * 책임 분리 원칙을 명확히 하고, 검증 체크리스트 및 구현 단계별 지침을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->