### PR TITLE
docs(stackflow): document pop behavior and back-button guard

### DIFF
--- a/docs/content/react/stackflow/getting-started.mdx
+++ b/docs/content/react/stackflow/getting-started.mdx
@@ -101,25 +101,25 @@ import type { SeedPluginOptions } from "@seed-design/stackflow";
 - 화면 왼쪽 가장자리에서 오른쪽으로 스와이프하면 이전 Activity로 이동합니다.
 - 스와이프 정도에 따라 `AppScreen`이 위치를 업데이트합니다.
 
-## Pop과 백버튼 동작
+## Pop 다루기
 
-화면을 닫는 동작(pop)에 대해 `seedPlugin`이 보장하는 것과, 직접 만드는 버튼에서 권장하는 패턴을 정리합니다.
+화면을 닫는 동작(pop)의 기본 동작과, pop이 짧은 시간에 여러 번 호출될 수 있을 때 전환이 겹치지 않게 막는 패턴을 정리합니다.
 
 ### 프로그래매틱 pop은 그대로 동작합니다
 
 `seedPlugin`은 코드로 호출하는 pop을 가로채지 않습니다. `pop()`, `pop(2)`, 연속 호출한 `pop(); pop();`은 모두 [Stackflow의 기본 동작](https://stackflow.so/)을 그대로 따릅니다. 예를 들어 `pop(2)`와 `pop(); pop();`은 화면 2개를 닫습니다.
 
-개발자가 의도한 pop 호출을 프레임워크가 임의로 무시하지 않도록 하기 위함입니다.
+개발자가 의도한 pop 호출을 프레임워크가 임의로 무시하지 않도록 하기 위함입니다. 대신 **중복 호출을 막는 책임은 pop을 호출하는 쪽**에 있습니다.
 
-### 전환이 겹쳐도 화면은 깨끗하게 정착합니다
+### 전환 중 중복 pop 막기
 
-`theme="cupertino"`의 화면 전환은 성능을 위해 현재 화면과 바로 뒤 화면을 명령형으로 애니메이션합니다(실시간 Swipe Back parallax를 위해). 이 때문에 전환이 빠르게 겹치면(동시 pop, 빠른 연타 등) 착지하는 화면에 직전 전환의 임시 스타일이 남아, 화면이 약간 밀리거나 `AppBar`가 잠깐 보이지 않을 수 있습니다.
+하나의 전환이 진행 중일 때 또 다른 pop이 호출되면, 의도와 달리 화면이 한 번에 여러 개 닫힐 수 있습니다. pop을 트리거하는 지점이 짧은 간격으로 여러 번 실행될 수 있는 상황에서 특히 그렇습니다.
 
-`seedPlugin`은 전환이 모두 정착하면(`globalTransitionState === "idle"`) 최상단 화면에 남은 임시 스타일을 정리해, 항상 기본 위치·표시 상태로 놓이도록 보장합니다. 별도 설정은 필요 없습니다.
+- 백버튼이나 "닫기"·"취소" 버튼을 실수로 빠르게 여러 번 누를 때
+- pop을 호출하는 여러 affordance(버튼, 제스처 등)가 거의 동시에 동작할 때
+- 콜백이나 `useEffect`에서 조건이 맞을 때 pop을 호출하는데 짧은 간격으로 여러 번 발화할 때
 
-### 백버튼 중복 클릭 방지
-
-사용자가 인앱 백버튼을 실수로 빠르게 여러 번 누르면 의도와 달리 화면이 여러 개 닫힐 수 있습니다. SEED의 `AppBarBackButton` 스니펫은 전환이 진행 중일 때(`globalTransitionState === "loading"`) pop을 건너뛰어, 빠르게 눌러도 한 번만 닫히도록 합니다.
+이럴 때는 pop을 호출하기 전에 전환이 진행 중인지(`globalTransitionState === "loading"`)를 확인하고, 진행 중이면 건너뛰면 됩니다. 이미 진행 중인 전환 위에 또 다른 전환이 겹치지 않게 하는 패턴입니다.
 
 ```tsx
 import { useActions, useStack } from "@stackflow/react";
@@ -127,17 +127,16 @@ import { useActions, useStack } from "@stackflow/react";
 const actions = useActions();
 const stack = useStack();
 
-const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-  onClick?.(e);
-  // 전환 중에는 중복 pop을 건너뛴다.
-  if (!e.defaultPrevented && stack?.globalTransitionState !== "loading") {
+function handlePop() {
+  // 전환이 진행 중이면 건너뛴다 — 이미 진행 중인 전환에 또 다른 전환이 겹치지 않게.
+  if (stack?.globalTransitionState !== "loading") {
     actions.pop();
   }
-};
+}
 ```
 
-직접 `pop()`을 호출하는 버튼을 만들 때도 같은 패턴을 권장합니다.
+SEED의 `AppBarBackButton` 스니펫은 이 패턴을 기본으로 적용해, 백버튼을 빠르게 여러 번 눌러도 한 번만 닫히도록 되어 있습니다. 직접 pop을 호출하는 버튼이나 코드에서도 같은 패턴을 권장합니다.
 
 <Callout type="info">
-  OS·브라우저의 하드웨어 뒤로 가기는 Stackflow의 history 동기화 경로로 처리되어 이 가드를 거치지 않습니다. 이 패턴은 인앱에서 직접 `pop()`을 호출하는 버튼에만 적용됩니다.
+  OS·브라우저의 하드웨어 뒤로 가기는 Stackflow의 history 동기화 경로로 처리되어 이 가드를 거치지 않습니다. 이 패턴은 직접 `pop()`을 호출하는 코드·버튼에만 적용됩니다.
 </Callout>

--- a/docs/content/react/stackflow/getting-started.mdx
+++ b/docs/content/react/stackflow/getting-started.mdx
@@ -100,3 +100,44 @@ import type { SeedPluginOptions } from "@seed-design/stackflow";
 
 - 화면 왼쪽 가장자리에서 오른쪽으로 스와이프하면 이전 Activity로 이동합니다.
 - 스와이프 정도에 따라 `AppScreen`이 위치를 업데이트합니다.
+
+## Pop과 백버튼 동작
+
+화면을 닫는 동작(pop)에 대해 `seedPlugin`이 보장하는 것과, 직접 만드는 버튼에서 권장하는 패턴을 정리합니다.
+
+### 프로그래매틱 pop은 그대로 동작합니다
+
+`seedPlugin`은 코드로 호출하는 pop을 가로채지 않습니다. `pop()`, `pop(2)`, 연속 호출한 `pop(); pop();`은 모두 [Stackflow의 기본 동작](https://stackflow.so/)을 그대로 따릅니다. 예를 들어 `pop(2)`와 `pop(); pop();`은 화면 2개를 닫습니다.
+
+개발자가 의도한 pop 호출을 프레임워크가 임의로 무시하지 않도록 하기 위함입니다.
+
+### 전환이 겹쳐도 화면은 깨끗하게 정착합니다
+
+`theme="cupertino"`의 화면 전환은 성능을 위해 현재 화면과 바로 뒤 화면을 명령형으로 애니메이션합니다(실시간 Swipe Back parallax를 위해). 이 때문에 전환이 빠르게 겹치면(동시 pop, 빠른 연타 등) 착지하는 화면에 직전 전환의 임시 스타일이 남아, 화면이 약간 밀리거나 `AppBar`가 잠깐 보이지 않을 수 있습니다.
+
+`seedPlugin`은 전환이 모두 정착하면(`globalTransitionState === "idle"`) 최상단 화면에 남은 임시 스타일을 정리해, 항상 기본 위치·표시 상태로 놓이도록 보장합니다. 별도 설정은 필요 없습니다.
+
+### 백버튼 중복 클릭 방지
+
+사용자가 인앱 백버튼을 실수로 빠르게 여러 번 누르면 의도와 달리 화면이 여러 개 닫힐 수 있습니다. SEED의 `AppBarBackButton` 스니펫은 전환이 진행 중일 때(`globalTransitionState === "loading"`) pop을 건너뛰어, 빠르게 눌러도 한 번만 닫히도록 합니다.
+
+```tsx
+import { useActions, useStack } from "@stackflow/react";
+
+const actions = useActions();
+const stack = useStack();
+
+const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+  onClick?.(e);
+  // 전환 중에는 중복 pop을 건너뛴다.
+  if (!e.defaultPrevented && stack?.globalTransitionState !== "loading") {
+    actions.pop();
+  }
+};
+```
+
+직접 `pop()`을 호출하는 버튼을 만들 때도 같은 패턴을 권장합니다.
+
+<Callout type="info">
+  OS·브라우저의 하드웨어 뒤로 가기는 Stackflow의 history 동기화 경로로 처리되어 이 가드를 거치지 않습니다. 이 패턴은 인앱에서 직접 `pop()`을 호출하는 버튼에만 적용됩니다.
+</Callout>


### PR DESCRIPTION
## 무엇을

Stackflow `getting-started` 가이드에 **"Pop 다루기"** 섹션을 추가합니다.

## 왜

pop이 짧은 시간에 **여러 번 호출될 수 있는 상황**(백버튼·닫기 버튼 연타, 여러 affordance, effect·콜백 등)에서 전환이 겹치지 않게 막는 패턴과, 그에 대한 우리 팀의 가치관을 문서로 명시해 예측 가능하게 쓰도록 합니다.

## 내용

- **프로그래매틱 pop은 그대로**: `pop()`/`pop(2)`/`pop(); pop();`는 Stackflow 기본대로 동작 — `seedPlugin`이 가로채지 않음. *중복을 막는 책임은 호출하는 쪽*에 있다는 점을 명시.
- **전환 중 중복 pop 막기**: `globalTransitionState !== "loading"` 가드 패턴을 **일반 패턴**으로 안내(백버튼뿐 아니라 닫기/취소 버튼, 여러 affordance, effect 등). `AppBarBackButton` 스니펫이 이 패턴의 기본 적용 예시. OS 하드웨어 뒤로가기는 우회됨(`<Callout>`).

> 처음 초안에 있던 "전환이 겹쳐도 깨끗하게 정착(렌더러 견고성)" 설명은 사용 가이드엔 불필요한 내부 디테일이라 제외했습니다.

## 관련 PR (권장 머지 순서: #1650 → #1673 → **본 PR**)

- 🏗️ 프레임워크 렌더러 견고화: #1650
- 🧩 스니펫 백버튼 가드: #1673

## 리뷰 포인트

- 일반화한 가드 패턴 서술/예시가 적절한지, 가치관(프로그래매틱 미차단 vs 호출부 가드)이 팀 합의와 맞는지.
- 문구/배치(getting-started 섹션 vs 별도 페이지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서 업데이트**
  * Stackflow의 Pop 동작 처리 방식에 대한 설명 추가
  * seedPlugin이 기본 pop 동작을 가로채지 않음을 명시
  * 화면 전환 중 중복 pop 호출로 인한 예상치 못한 동작 방지 방법 제시
  * 하드웨어 뒤로 가기 버튼의 동작 방식 관련 안내 포함

<!-- end of auto-generated comment: release notes by coderabbit.ai -->