### PR TITLE
experiment(stackflow): animate the true landing screen on multi-pop

### DIFF
--- a/examples/stackflow-spa/src/activities/ActivityPopTest.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityPopTest.tsx
@@ -42,7 +42,8 @@ const ActivityPopTest: StaticActivityComponentType<"ActivityPopTest"> = () => {
   );
 
   return (
-    <AppScreen>
+    // 실험: iOS slide 전환에서 측정하기 위해 cupertino로 고정
+    <AppScreen theme="cupertino">
       <AppBar>
         <AppBarLeft>
           <AppBarBackButton />

--- a/examples/stackflow-spa/src/global.css
+++ b/examples/stackflow-spa/src/global.css
@@ -29,3 +29,10 @@ body {
 .bg-brandSolid {
   background-color: var(--seed-color-bg-brand-solid);
 }
+
+/* 실험(landing-aware): 한 번에 여러 개가 닫힐 때, 나가는 중인 "중간" 화면은 숨긴다.
+   WAAPI는 나가는 top + 진짜 착지 화면만 굴리므로, 그 사이의 화면들이 슬라이드 중
+   비치지 않게 한다. (나가는 top=is-top은 애니메이션되므로 제외) */
+[data-part="activity"][data-transition-state^="exit"]:not([data-activity-is-top]) {
+  visibility: hidden;
+}

--- a/packages/stackflow/src/primitive/GlobalInteraction/dom.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/dom.ts
@@ -64,8 +64,14 @@ export function findTransitionTargets(stackEl: HTMLElement): TransitionTargets {
     const topId = topActivity.dataset["activityId"];
     const topIdx = all.findIndex((el) => el.dataset["activityId"] === topId);
     for (let i = topIdx - 1; i >= 0; i--) {
-      if (all[i].dataset["activityId"]) {
-        behindActivity = all[i];
+      const el = all[i];
+      const ts = el.dataset["transitionState"] ?? "";
+      // 한 번에 여러 개가 닫힐 때(연속 pop) 중간의 나가는 액티비티는 건너뛰고
+      // 실제 착지 화면(나가는 중이 아닌 첫 액티비티)을 behind로 잡는다.
+      // → WAAPI가 "나가는 top + 진짜 착지 화면"을 직접 굴려, 중간 화면이 끼어드는
+      //   pair 한계를 없앤다.
+      if (el.dataset["activityId"] && !ts.startsWith("exit")) {
+        behindActivity = el;
         break;
       }
     }

--- a/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.ts
@@ -1,4 +1,3 @@
-import { useStack } from "@stackflow/react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { useTopActivity } from "../private/useTopActivity";
 import {
@@ -8,7 +7,6 @@ import {
   readTransitionStyle,
   applySwipeStyles,
   clearAllStyles,
-  clearTopActivityStyles,
   setIdlePositions,
   setPostExitPositions,
 } from "./dom";
@@ -259,7 +257,6 @@ export function useGlobalInteraction() {
   }, [stopRunningAnims, stopAppBarBgScrub, setSwipeBackState]);
 
   const topActivity = useTopActivity();
-  const stack = useStack();
 
   // ── WAAPI push/pop transitions triggered by stackflow state changes ──
   const prevTransitionStateRef = useRef<string>(topActivity.transitionState);
@@ -328,23 +325,6 @@ export function useGlobalInteraction() {
       });
     }
   }, [topActivity.transitionState, stopRunningAnims, cancelPendingPushRAF]);
-
-  // ── Settle safety-net ──
-  // top + behind 쌍 모델은 즉시 인접한 behind 한 겹만 다룬다. 전환이 겹쳐
-  // (동시 pop, swipe-back race 등) 쌍 모델이 풀지 못한 경로로 끝나면, 착지
-  // 화면이 임시 스타일에 stuck될 수 있다 — layer가 -30%에 남아 1/3 밀리거나,
-  // appBar root가 opacity 0(setPostExitPositions)에 남아 앱바가 통째로 사라진다.
-  //
-  // 보장: 모든 게 정착하면(globalTransitionState === "idle") top은 항상 깨끗한
-  // 기본 상태여야 한다. top 액티비티에 남은 inline을 모두 지운다 — behind는
-  // 건드리지 않고(−30% 유지), idle일 때만 돌며 이미 깨끗하면 no-op이다.
-  useLayoutEffect(() => {
-    if (stack?.globalTransitionState !== "idle") return;
-    const stackEl = stackRef.current;
-    if (stackEl) {
-      clearTopActivityStyles(stackEl);
-    }
-  }, [stack?.globalTransitionState]);
 
   // Cancel any pending push rAF and running animations on unmount so
   // late-firing finished handlers can't run against a torn-down stack.


### PR DESCRIPTION
> 🧪 **실험 PR (draft)** — 동시 pop의 "pair만 애니메이션" 한계를 **애니메이션 레벨에서** 푸는 접근. base는 `concurrent-pop-deduplication`(#1650)라 diff가 델타만.

## 문제 (root)

WAAPI는 **"top + 바로 아래(immediate behind)" 딱 두 개**만 굴립니다. 한 번에 여러 개가 닫히면(`pop(2)`, 연타) 진짜 착지 화면은 "바로 아래"가 아니라 더 깊은 곳 → 중간 화면이 끼어들어 착지 화면이 스냅(flicker)되거나 stuck.
- #1650 effect = 사후 정리(cleanup)
- Option C(#1677) = CSS role 스냅으로 **flicker** 발생

## 접근: 착지 인식(landing-aware) 애니메이션

WAAPI가 **"나가는 top → 진짜 착지 화면"** 을 직접 굴리게:
- `findTransitionTargets`: behind 고를 때 **exit 중인 액티비티는 스킵** → 진짜 착지 화면을 behind로.
- 중간 나가는 화면들은 **CSS로 숨김**(슬라이드 중 안 비침).
- settle **effect 제거** — 애니메이션이 착지 화면을 처음부터 제대로 굴리니 사후 정리 불필요.

## 변경

- `packages/stackflow/.../GlobalInteraction/dom.ts`: `findTransitionTargets`가 behind 찾을 때 exit-active 스킵.
- `examples/.../global.css`: 중간(exit·non-top) 액티비티 `visibility: hidden` (PoC — 실제론 package/recipe로).
- `useGlobalInteraction`: settle effect 제거.
- `ActivityPopTest`: iOS 측정용 `theme="cupertino"` 고정.

## 측정 (PopTest, iOS slide)

| | |
|---|---|
| `pop(2)` / `pop();pop()` | end-state 깨끗 (layer 0%, appBar 표시) — **effect 없이** |
| 단일 pop / `pop(2)` 개수 | −1 / −2 정확 |
| `bun test:unit` | 634 pass |
| **중간 전환 부드러움** | ⚠️ **라이브 프리뷰에서 확인 요망** (browse 도구로는 350ms 전환 캡처 불가. Option C의 flicker 대비 부드러운지 눈으로) |

## 남은 일 / 메모

- 중간 숨김 CSS는 예제 global.css(PoC) → 실제론 package나 recipe로 이동.
- **연타(따로따로 pop())** 겹침 시 진행 중 애니의 re-target 동작 추가 검증 필요.
- iOS만 측정(PopTest cupertino). android/fadeIn은 같은 메커니즘이라 같이 동작 예상(검증 필요).
- **swipe-back**과의 상호작용 확인 필요.
- `dom.ts`의 `clearTopActivityStyles` 미사용 → 제거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
