### PR TITLE
refactor(side-panel): pick only relevant Drawer props for SidePanelRootProps

### DIFF
--- a/packages/react/src/components/SidePanel/SidePanel.tsx
+++ b/packages/react/src/components/SidePanel/SidePanel.tsx
@@ -10,7 +10,20 @@ const { withRootProvider, withContext } = createSlotRecipeContext(sidePanel);
 
 export interface SidePanelRootProps
   extends SidePanelVariantProps,
-    Drawer.RootProps {
+    Pick<
+      Drawer.RootProps,
+      | "children"
+      | "open"
+      | "defaultOpen"
+      | "onOpenChange"
+      | "modal"
+      | "dismissible"
+      | "closeOnEscape"
+      | "closeOnInteractOutside"
+      | "lazyMount"
+      | "unmountOnExit"
+      | "onAnimationEnd"
+    > {
   /** Direction the side panel slides in from. @default "right" */
   direction?: "left" | "right";
 }


### PR DESCRIPTION
## Summary

`SidePanelRootProps` extended the **full** `Drawer.RootProps`, so the public API leaked many drawer-only props that don't apply to a side panel (`snapPoints`, `fadeFromIndex`, `handleOnly`, `onDrag`/`onRelease`, `closeThreshold`, `scrollLockTimeout`, `fixed`, `nested`, `repositionInputs`, `snapToSequentialPoint`, `activeSnapPoint`, `autoFocus`, `container`, the 4-way `direction`, …).

This narrows it to only the lifecycle / dismiss / mount props that are meaningful for a side panel, via `Pick`:

`children`, `open`, `defaultOpen`, `onOpenChange`, `modal`, `dismissible`, `closeOnEscape`, `closeOnInteractOutside`, `lazyMount`, `unmountOnExit`, `onAnimationEnd`

The local 2-way `direction` override (`"left" | "right"`) and `SidePanelVariantProps` are kept as-is.

## Notes

- `children` is intentionally included in the `Pick` — `withRootProvider<P>` types the component props as exactly `P` and does not auto-add children, so dropping it would break `<SidePanel.Root>…</SidePanel.Root>`.
- Snippets (`docs/registry/.../side-panel.tsx`, `examples/.../side-panel.tsx`) `extends SeedSidePanel.RootProps {}`, so the narrowing propagates automatically — no snippet/registry regeneration needed.
- `ResponsiveSidePanelRootProps` uses `Omit<…, "children" | "open" | "defaultOpen" | "onOpenChange">`, which stays safe.
- No new changeset: SidePanel is still unreleased (folded into the existing `side-panel.md` minor on `alpha`), so this has no semver impact.

## Out of scope

`onAnimationEnd` fires on both open and close, but the timer only waits `EXIT_DURATION` (asymmetric) — tracked as a separate backlog issue, not touched here.

## Verification

- `bun test packages/react` → 630 pass, 0 fail
- `tsc --noEmit -p packages/react` → no SidePanel type errors