### PR TITLE
feat(bottom-sheet): deprecate direction prop

### DIFF
--- a/.changeset/deprecate-bottom-sheet-direction.md
+++ b/.changeset/deprecate-bottom-sheet-direction.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react": patch
+---
+
+SEED React 2.0.0에서 제거될 예정인 BottomSheet의 `direction` 옵션을 deprecated 처리합니다. 2.0.0부터 BottomSheet는 항상 아래에서 올라오며 `direction`을 받지 않습니다.

--- a/docs/content/docs/migration/deprecations.mdx
+++ b/docs/content/docs/migration/deprecations.mdx
@@ -10,6 +10,7 @@ description: Deprecated 항목의 현황과 제거 계획을 관리합니다.
 | 항목                                   | 종류          | Deprecated 버전 | 제거 예정 버전 | 대체안                 | 비고                                                         |
 | -------------------------------------- | ------------- | --------------- | -------------- | ---------------------- | ------------------------------------------------------------ |
 | AppBar - divider 옵션                  | 컴포넌트 옵션 | 1.2.x           | 2.0.0          | -                      | 제거 후 하단 구분선 미표시. rootage top-navigation 옵션 정리 |
+| BottomSheet - direction 옵션           | 컴포넌트 옵션 | 1.2.x           | 2.0.0          | -                      | 2.0.0부터 제거. 항상 아래에서 올라옴                         |
 | Drawer - noBodyStyles 옵션             | 컴포넌트 옵션 | 1.2.x           | 2.0.0          | -                      | 2.0.0부터 무시되어 기본값(true)처럼 동작                     |
 | Drawer - preventScrollRestoration 옵션 | 컴포넌트 옵션 | 1.2.x           | 2.0.0          | -                      | 2.0.0부터 무시되어 기본값(false)처럼 동작                    |
 | Image Frame - rounded 옵션             | 컴포넌트 옵션 | 1.2.x           | 2.0.0          | borderRadius="r2"      | rootage image-frame 옵션 정리                                |

--- a/packages/react/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/react/src/components/BottomSheet/BottomSheet.tsx
@@ -10,7 +10,14 @@ const { withRootProvider, withContext } = createSlotRecipeContext(bottomSheet);
 
 ////////////////////////////////////////////////////////////////////////////////////
 
-export interface BottomSheetRootProps extends BottomSheetVariantProps, Drawer.RootProps {}
+export interface BottomSheetRootProps
+  extends BottomSheetVariantProps,
+    Omit<Drawer.RootProps, "direction"> {
+  /**
+   * @deprecated SEED React 2.0.0에서 제거됩니다. BottomSheet는 항상 아래에서 올라오므로 2.0.0부터 이 옵션은 무시됩니다.
+   */
+  direction?: Drawer.RootProps["direction"];
+}
 
 export const BottomSheetRoot = withRootProvider<BottomSheetRootProps>(Drawer.Root, {
   defaultProps: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Deprecations**
  * BottomSheet 컴포넌트의 `direction` 옵션이 더 이상 사용되지 않습니다. 현재 이 옵션은 무시되며, 향후 주요 버전에서 제거될 예정입니다. 2.0.0부터는 BottomSheet가 항상 아래쪽에서 올라오는 동작만 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->