### PR TITLE
feat(docs): add fresh-node-ids option to bypass Figma image cache per node

### DIFF
--- a/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: false
+      bypass-cache-node-ids:
+        description: "Comma-separated Figma node IDs to bypass cache for (fetch fresh)"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -66,6 +71,7 @@ jobs:
         env:
           # docs uses Next static export, so NEXT_PUBLIC_* values must be present at build time.
           FIGMA_CACHE_DISABLED: ${{ inputs.skip-figma-cache && '1' || '0' }}
+          FIGMA_BYPASS_CACHE_NODE_IDS: ${{ inputs.bypass-cache-node-ids }}
           NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
           NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
         run: |

--- a/docs/app/env.ts
+++ b/docs/app/env.ts
@@ -8,6 +8,10 @@ export const env = {
     "Missing environment variable: FIGMA_PERSONAL_ACCESS_TOKEN, continuing build without Figma integration...",
   ),
   figmaCacheDisabled: process.env.FIGMA_CACHE_DISABLED === "1",
+  figmaBypassCacheNodeIds:
+    process.env.FIGMA_BYPASS_CACHE_NODE_IDS?.split(",")
+      .map((id) => id.trim())
+      .filter(Boolean) ?? [],
 };
 
 function warnIfUndefined<T>(v: T | undefined, warningMessage: string): T | undefined {

--- a/docs/components/figma-image/fetch-figma-image-urls.ts
+++ b/docs/components/figma-image/fetch-figma-image-urls.ts
@@ -73,7 +73,7 @@ export async function fetchFigmaImageUrls({
   imageUrlCache.load(CACHE_ID, cacheDir);
 
   for (const nodeId of nodeIds) {
-    const cached = env.figmaCacheDisabled
+    const cached = shouldBypassCache(nodeId)
       ? undefined
       : imageUrlCache.get<string>(getCacheKey(nodeId, options));
 
@@ -104,7 +104,7 @@ export async function fetchFigmaImageUrls({
     // Recheck cache after acquiring semaphore — earlier calls may have populated it while we waited
     imageUrlCache.load(CACHE_ID, cacheDir);
     const pendingIds = uncachedIds.filter((nodeId) => {
-      const cached = env.figmaCacheDisabled
+      const cached = shouldBypassCache(nodeId)
         ? undefined
         : imageUrlCache.get<string>(getCacheKey(nodeId, options));
 
@@ -161,6 +161,10 @@ export async function fetchFigmaImageUrls({
 }
 
 // Helpers
+
+function shouldBypassCache(nodeId: string): boolean {
+  return env.figmaCacheDisabled || env.figmaBypassCacheNodeIds.includes(nodeId);
+}
 
 function getCacheKey(nodeId: string, options: FetchFigmaImageUrlsOptions): string {
   const optionsKey = JSON.stringify(options, Object.keys(options).sort());


### PR DESCRIPTION
## 배경

docs alpha 미리보기에서 특정 컴포넌트 문서의 Figma 이미지가 stale해지는 문제가 있습니다. 캐시(`docs/.cache/figma-image/urls`)는 노드 ID → 이미지 URL을 저장하는데, Figma에서 디자인을 바꿔도 노드 ID는 그대로라 옛 렌더 URL이 계속 캐시 적중됩니다.

기존 `skip-figma-cache=true`(`FIGMA_CACHE_DISABLED`)는 **전역**이라 전체 이미지를 fresh fetch하는데, `fetchFigmaImageUrls`가 `MAX_CONCURRENCY=1` + 429 재시도 구조라 이미지가 많으면 rate limit으로 "Build Docs"가 실패합니다.

## 변경

특정 노드만 캐시를 무시(bypass)하는 `bypass-cache-node-ids` 옵션을 추가합니다.

- `env.figmaBypassCacheNodeIds` ← `FIGMA_BYPASS_CACHE_NODE_IDS` (콤마 구분 노드 ID)
- `workflow_dispatch` input `bypass-cache-node-ids` → `FIGMA_BYPASS_CACHE_NODE_IDS` env 배선
- `shouldBypassCache(nodeId)` = 전역 disable이거나 해당 노드가 목록에 있으면 캐시 우회

fresh fetch 결과는 그대로 캐시에 `set/save`되므로, 특정 문서 이미지를 **한 번 갱신**하는 용도입니다. 모든 Figma 이미지 경로(본문 `FigmaImage`, cover, blog)가 `fetchFigmaImageUrls`를 통과하므로 일괄 적용됩니다.

## 사용 예

\`\`\`bash
gh workflow run deploy-seed-design-docs-alpha-pages.yml \
  --ref <branch> -f bypass-cache-node-ids="1702:4339,1705:5564"
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 문서 빌드 과정에서 Figma 디자인 이미지의 캐시를 선택적으로 갱신할 수 있는 기능이 추가되었습니다.
  * GitHub Actions 워크플로우에서 `bypass-cache-node-ids`로 노드 ID 목록을 지정하면, 해당 이미지에 대해서는 캐시를 건너뛰고 항상 최신 버전으로 다시 로드합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->