### PR TITLE
docs(skill): add upgrading guide and integrate compat into seed-design skill

### DIFF
--- a/docs/content/react/migration/from-sprout.mdx
+++ b/docs/content/react/migration/from-sprout.mdx
@@ -1,5 +1,5 @@
 ---
-title: Guide
+title: From Sprout
 description: Sprout에서 SEED로 마이그레이션하기 위해 필요한 작업들을 안내합니다.
 ---
 

--- a/docs/content/react/migration/meta.json
+++ b/docs/content/react/migration/meta.json
@@ -1,3 +1,4 @@
 {
-  "title": "Migration"
+  "title": "Migration",
+  "pages": ["upgrading", "from-sprout", "migrating-icons"]
 }

--- a/docs/content/react/migration/upgrading.mdx
+++ b/docs/content/react/migration/upgrading.mdx
@@ -1,0 +1,109 @@
+---
+title: Upgrading
+description: SEED 패키지 버전을 올릴 때 호환성을 확인하고 안전하게 업그레이드하는 방법을 안내합니다.
+---
+
+SEED 패키지(`@seed-design/react`, `@seed-design/css` 등)의 버전을 올릴 때 호환성을 확인하고 안전하게 업그레이드하는 방법을 안내합니다.
+
+## 버저닝 정책
+
+SEED는 **2.0을 분기점**으로 버저닝 정책이 다릅니다.
+
+| 구간 | 정책 |
+| --- | --- |
+| **2.0 이상** | strict SemVer를 따릅니다. breaking change는 **major에서만** 발생하고, minor·patch는 하위 호환을 보장합니다. |
+| **2.0 미만 (1.x)** | minor·patch에서도 breaking이 있을 수 있었습니다. 이 구간은 아래 **호환성** 섹션의 방법으로 실제 호환 범위를 확인합니다. |
+
+<Callout>
+2.0 이상에서는 같은 major 안에서 minor·patch를 자유롭게 올릴 수 있습니다. 1.x 구간을 올릴 때 호환성 확인이 특히 중요합니다.
+</Callout>
+
+## 호환성: react ↔ css
+
+`@seed-design/react`는 `@seed-design/css`를 런타임 기반(클래스네임·스타일)으로 사용합니다. **두 패키지를 호환되지 않는 버전으로 섞으면 클래스네임이 어긋나 스타일이 깨질 수 있습니다.**
+
+- **2.0 이상**: `react`가 `peerDependencies`로 호환되는 `css` 범위(`^N.M.0`)를 선언합니다. 선언을 따르면 안전합니다.
+- **2.0 미만**: 선언이 불완전하거나 같은 minor끼리 맞춰 릴리즈(lockstep)되던 구간이 있어, CLI가 호환성 매니페스트로 실제 호환 범위를 판단합니다.
+
+### 호환성 확인하기
+
+설치된 조합이 맞는지 `compat`으로 확인합니다.
+
+```bash
+npx @seed-design/cli@latest compat
+```
+
+- 설치된 `react`·`css`의 **실제 버전**을 읽어 서로 호환되는지 검사하고, 안 맞으면 어느 버전으로 올려야 하는지 알려줍니다.
+- 호환 이슈가 있으면 종료 코드 `1`로 끝나므로 CI 게이트로도 쓸 수 있습니다.
+
+올리기 **전에** 특정 버전 조합이 호환되는지 미리 확인하려면 `--with`를 사용합니다.
+
+```bash
+npx @seed-design/cli@latest compat --with react@2.0.0 --with css@2.0.0
+```
+
+스크립트나 도구에서 쓸 JSON 출력은 `--json`을 사용합니다.
+
+```bash
+npx @seed-design/cli@latest compat --json
+```
+
+## 버전 올리기
+
+<Steps>
+
+<Step>
+### 현재 호환 상태 확인
+
+```bash
+npx @seed-design/cli@latest compat
+```
+
+지금 설치된 조합에 문제가 없는지 먼저 확인합니다.
+</Step>
+
+<Step>
+### 변경사항 확인
+
+목표 버전까지 무엇이 바뀌는지(특히 breaking change) 확인합니다.
+
+```bash
+npx @seed-design/cli@latest docs react/updates/changelog/react/{현재버전} --raw
+```
+
+이 명령은 **현재 버전 이후 최신까지** 모든 변경사항을 반환합니다. 특정 목표 버전까지만 보려면 그보다 높은 버전 섹션은 건너뛰세요.
+</Step>
+
+<Step>
+### react와 css를 함께 올리기
+
+<Callout type="warn">
+1.x 구간을 넘나들 때는 `react`와 `css`를 **호환되는 버전으로 함께** 올려야 합니다. 한쪽만 올리면 스타일이 깨질 수 있습니다.
+</Callout>
+
+```package-install
+@seed-design/react@{목표버전} @seed-design/css@{목표버전}
+```
+</Step>
+
+<Step>
+### snippet 재설치
+
+일부 버전 경계에서는 내부 구조 변경으로 snippet 재설치가 필요합니다. 변경사항에 "재설치 필요"로 표시된 컴포넌트는 다시 받습니다.
+
+```bash
+npx @seed-design/cli@latest add ui:{component}
+```
+</Step>
+
+<Step>
+### 검증
+
+업그레이드 후 다시 `compat`으로 호환을 확인하고, 화면 스타일과 동작을 점검합니다.
+</Step>
+
+</Steps>
+
+<Callout>
+복잡한 버전 점프나 여러 패키지를 한 번에 올릴 때는 Claude Code 등에서 `/seed-design` 스킬에게 "현재 버전에서 X로 업그레이드하고 싶어"라고 요청하면 호환 진단, 업그레이드 경로, 재설치할 snippet 목록을 정리해 줍니다.
+</Callout>

--- a/skills/seed-design/SKILL.md
+++ b/skills/seed-design/SKILL.md
@@ -39,8 +39,8 @@ argument-hint: "[질문 또는 주제]"
 | 컴포넌트 관련 질문 (어떤 컴포넌트 있어?, 버튼 쓰고 싶은데) | `references/components.md` |
 | 파운데이션/토큰 질문 (색상, 타이포, 스페이싱, 테마) | `references/foundation.md` |
 | CLI 명령어 관련 (init, add, docs 등) | `references/usage.md` |
-| 버전 호환/마이그레이션 | `references/migration.md` |
-| 패키지 업그레이드 진단 | `references/upgrade.md` |
+| 스니펫 버전 맞추기/파일 충돌 | `references/migration.md` |
+| 버전 업그레이드·호환 진단 (react↔css, 마이그레이션 경로) | `references/upgrade.md` |
 
 사용자가 명시적으로 주제를 말한 경우 프로젝트 분석을 건너뛰고 해당 시나리오로 직행해도 됩니다.
 
@@ -98,5 +98,5 @@ npx @seed-design/cli@latest docs {component-name}
 | `references/components.md` | 컴포넌트 탐색/추가 방법 | 컴포넌트 관련 질문 시 |
 | `references/foundation.md` | 파운데이션 llms.txt 인덱스 | 색상, 타이포, 스페이싱, 테마 질문 시 |
 | `references/usage.md` | CLI 명령어 상세 | CLI 사용법 질문 시 |
-| `references/migration.md` | 스니펫 버전 호환/마이그레이션 | 버전 불일치 또는 마이그레이션 시 |
-| `references/upgrade.md` | 패키지 업그레이드 진단 | 업그레이드 질문 시 |
+| `references/migration.md` | 스니펫 버전 맞추기/파일 충돌 해결 | 스니펫 버전 불일치 시 |
+| `references/upgrade.md` | 버전 업그레이드·호환 진단 (react↔css, changelog, 마이그레이션 경로) | 업그레이드·호환 질문 시 |

--- a/skills/seed-design/references/migration.md
+++ b/skills/seed-design/references/migration.md
@@ -1,4 +1,6 @@
-# Migration
+# Migration (스니펫)
+
+> 패키지 버전 업그레이드·호환 진단(react↔css, changelog, 마이그레이션 경로)은 `upgrade.md`를 참고하세요. 이 문서는 **스니펫**을 프로젝트 버전에 맞추고 파일 충돌을 해결하는 방법입니다.
 
 ## Pre-Check Compatibility
 
@@ -8,17 +10,19 @@
 npx @seed-design/cli@latest compat
 ```
 
-호환성 이슈가 있으면 종료 코드 `1`로 끝나므로 CI에서도 게이트로 사용할 수 있습니다.
+호환성 이슈가 있으면 종료 코드 `1`로 끝나므로 CI에서도 게이트로 사용할 수 있습니다. (설치된 react↔css peer 호환까지 보려면 `upgrade.md`의 `compat --json`을 참고하세요.)
 
 ## Install Compatible Snippets
 
-프로젝트의 `@seed-design/react` 버전과 맞는 스니펫이 필요하면 `--baseUrl`을 사용합니다.
+프로젝트의 `@seed-design/react` 버전과 맞는 스니펫이 필요하면 `--baseUrl`로 버전별 배포를 가리킵니다. 도메인 패턴은 `{major}-{minor}.seed-design.pages.dev`입니다(예: `1-0`, `1-1`, `1-2`). 사용 가능한 버전은 문서 사이트의 버전 스위처에서 확인합니다.
 
 ```bash
+# 예: 1.0.x 스니펫
 npx @seed-design/cli@latest add --baseUrl https://1-0.seed-design.pages.dev ui:action-button
 ```
 
 ```bash
+# 예: 1.1.x 스니펫
 npx @seed-design/cli@latest add-all --baseUrl https://1-1.seed-design.pages.dev ui
 ```
 
@@ -29,6 +33,14 @@ CLI는 파일 내용이 다르면 diff를 보여주고 아래 중 하나를 선�
 1. `overwrite`: 기존 파일을 새 내용으로 덮어쓰기
 2. `backup`: 기존 파일을 `legacy-<파일명>-<timestamp>`로 백업 후 교체
 3. `skip`: 현재 파일 유지
+
+비대화형(CI·스크립트)에서는 `--on-diff` 플래그로 미리 정합니다.
+
+```bash
+npx @seed-design/cli@latest add --on-diff backup ui:action-button
+```
+
+`--on-diff`는 `overwrite` | `backup`만 받습니다. `skip`은 인터랙티브 선택에서만 가능합니다.
 
 ## Decision Guide
 

--- a/skills/seed-design/references/upgrade.md
+++ b/skills/seed-design/references/upgrade.md
@@ -1,184 +1,170 @@
-# Upgrade Diagnosis
+# Upgrade & Compatibility Diagnosis
 
 ## Overview
 
-업그레이드 진단은 CLI 프리미티브(`docs`, `compat`)를 조합하여 수행합니다. CLI는 데이터 fetch만 담당하고, 이 스킬이 해석과 분석을 담당합니다.
+업그레이드 진단은 CLI 프리미티브(`docs`, `compat`)를 조합하여 수행합니다. **CLI는 데이터 fetch와 호환 판단을 담당하고, 이 스킬은 해석·경로 제시·마이그레이션 안내를 담당합니다.**
 
-## Upgrade Diagnosis Workflow
+다루는 두 가지:
+
+- **현재 호환 진단**: 설치된 `@seed-design/react`와 `@seed-design/css`가 서로 호환되는지 (`compat`)
+- **버전 업그레이드**: 현재 → 목표 버전 사이의 변경사항과 마이그레이션 경로 (`docs ... changelog`)
+
+소비자용 문서는 https://seed-design.io/react/migration/upgrading 를 참고하세요. 이 스킬은 그 절차를 자동화·구체화합니다.
+
+## 2.0 전후 버저닝 정책 (먼저 판단)
+
+SEED는 **2.0을 분기점**으로 정책이 다르므로 진단 방식도 달라집니다.
+
+| 구간 | 정책 | 진단 방식 |
+| --- | --- | --- |
+| **2.0 이상** | strict SemVer. breaking은 major에서만. minor·patch는 하위 호환. | minor/patch 업그레이드는 안전. major를 넘을 때만 breaking을 확인. `peerDependencies` 선언을 신뢰. |
+| **2.0 미만 (0.x·1.x)** | minor·patch에서도 breaking 가능. react↔css가 lockstep(같은 minor)이던 구간 존재. | `compat`의 호환 매니페스트로 react↔css 호환을 판단. minor 업그레이드도 breaking 확인 필요. |
+
+## Changelog 경로 규칙 (반드시 준수)
+
+changelog fetch URL을 조립할 때:
+
+- **카테고리는 항상 `react`** — framework가 lynx여도 `react/updates/changelog/...`를 사용합니다. (`lynx/updates/changelog/...`는 404)
+- **package slug = 패키지명에서 `@seed-design/` 제거**: `@seed-design/react`→`react`, `@seed-design/css`→`css`, `@seed-design/lynx-react`→`lynx-react`, `@seed-design/lynx-css`→`lynx-css`
+
+| 목적 | 경로 |
+| --- | --- |
+| 특정 버전 이후 changelog | `react/updates/changelog/{slug}/{version}` |
+| 버전 인덱스(사용 가능한 버전 목록) | `react/updates/changelog/{slug}` |
+| 전체 changelog(모든 패키지) | `react/updates/changelog` |
+
+## Workflow
 
 ### Step 1: 패키지와 버전 결정
 
-사용자의 요청에서 **어떤 패키지**의 **어떤 버전부터** 변경사항을 확인할지 파악합니다. 아래 판단 트리를 따릅니다.
+사용자의 요청에서 **어떤 패키지**의 **어떤 버전부터** 확인할지 파악합니다.
 
 ```text
 사용자 요청 분석
-├─ 패키지와 버전 모두 명확함
-│   예: "react 1.2.5에서 최신까지 변경사항 알려줘"
-│   → 바로 Step 2로 진행
-│
-├─ 패키지는 명확하지만 버전이 불명확함
-│   예: "react 패키지 업그레이드 변경사항 알려줘"
-│   ├─ 프로젝트 환경이 있음 → package.json에서 버전 확인
-│   └─ 프로젝트 환경이 없음 → 사용자에게 현재 버전 질문
-│
-├─ 패키지도 버전도 불명확함
-│   예: "seed-design 업그레이드하고 싶어"
-│   ├─ 프로젝트 환경이 있음 → package.json에서 설치된 @seed-design/* 패키지 전체 확인
-│   └─ 프로젝트 환경이 없음 → 사용자에게 어떤 패키지/버전인지 질문
-│
-└─ 특정 버전 범위를 지정함
-    예: "react 1.2.5에서 1.2.7까지 변경사항"
-    → from 버전으로 fetch 후 Step 3에서 범위 필터링
+├─ 패키지·버전 모두 명확함 (예: "react 1.2.5에서 최신까지")  → Step 2
+├─ 패키지만 명확함 (예: "react 업그레이드 변경사항")
+│   ├─ 프로젝트 환경 있음 → package.json에서 버전 확인
+│   └─ 없음 → 사용자에게 현재 버전 질문
+├─ 둘 다 불명확함 (예: "seed-design 업그레이드하고 싶어")
+│   ├─ 프로젝트 환경 있음 → package.json의 @seed-design/* 전체 확인
+│   └─ 없음 → 패키지 범위(전체/특정) → 버전 순서로 질문
+└─ 특정 범위 지정 (예: "1.2.5에서 1.2.7까지")  → from으로 fetch 후 Step 4에서 필터
 ```
 
-**프로젝트 환경에서 버전 확인 방법:**
+**버전 확인**: `package.json`을 읽어 `@seed-design/react`, `@seed-design/css` 등의 버전을 확인합니다(source of truth).
 
-`package.json`을 직접 읽어 `@seed-design/react`, `@seed-design/css` 등의 버전을 확인합니다. `package.json`이 버전의 source of truth입니다.
+**semver range 처리**: 버전이 `^1.1.0`, `~1.2.3` 같은 range면 **명시된 최소 버전**을 from 버전으로 사용합니다(`^1.1.0`→`1.1.0`). 정확한 설치 버전이 필요하면 `compat`이 node_modules의 실제 버전을 읽습니다.
 
-**사용자에게 질문이 필요한 경우:**
+**질문 원칙**: 추측 금지(잘못된 패키지/버전은 무의미한 결과). 한 번에 하나씩. 프로젝트 환경이 있으면 package.json에서 읽어 질문 최소화.
 
-패키지나 버전을 특정할 수 없으면 추측하지 말고 반드시 사용자에게 질문하여 명확한 답을 얻은 후 진행합니다.
+### Step 2: 현재 호환 진단 (compat)
 
-**질문 판단 흐름:**
-
-```text
-정보 부족 판단
-├─ 패키지가 불명확함
-│   → 먼저 사용자의 의도를 파악:
-│   │
-│   ├─ "전체 @seed-design 패키지의 변경사항을 모두 보고 싶으신가요,
-│   │    아니면 특정 패키지(react, css 등)를 지정하실 수 있나요?"
-│   │
-│   ├─ 사용자가 "전체" → 프로젝트 환경이 있으면 package.json에서
-│   │   설치된 @seed-design/* 패키지 전체에 대해 각각 진단
-│   │
-│   └─ 사용자가 특정 패키지 지정 → 해당 패키지로 진행
-│
-├─ 패키지는 명확하지만 버전이 불명확함 (프로젝트 환경 없음)
-│   → "현재 사용 중인 @seed-design/{패키지} 버전이 어떻게 되나요?"
-│   → 사용자 답변을 받은 후 해당 버전으로 진행
-│
-└─ 패키지도 버전도 불명확함 (프로젝트 환경 없음)
-    → 위 두 질문을 순서대로 진행:
-      1. 먼저 패키지 범위 확인 (전체 vs 특정)
-      2. 그다음 버전 확인
-```
-
-**질문 원칙:**
-- 추측하지 말 것 — 잘못된 패키지/버전으로 진행하면 무의미한 결과가 나옴
-- 한 번에 하나씩 — 패키지와 버전을 동시에 묻지 말고 순서대로 확인
-- 프로젝트 환경이 있으면 질문 최소화 — package.json에서 읽을 수 있는 정보는 직접 확인
-
-### Step 2: Changelog fetch
-
-`docs --raw` 명령으로 changelog를 가져옵니다. Step 1에서 결정된 패키지와 버전에 따라 적절한 경로를 사용합니다.
+프로젝트 환경이 있으면 먼저 설치된 패키지들이 서로 호환되는지 확인합니다.
 
 ```bash
-# 전체 changelog (모든 패키지) — 패키지 목록 파악에도 사용
-npx @seed-design/cli@latest docs react/updates/changelog --raw
-
-# 특정 패키지의 버전 인덱스 (사용 가능한 버전 목록)
-npx @seed-design/cli@latest docs react/updates/changelog/react --raw
-
-# 특정 패키지의 특정 버전 이후 changelog (가장 일반적인 케이스)
-npx @seed-design/cli@latest docs react/updates/changelog/react/1.2.5 --raw
+npx @seed-design/cli@latest compat --json
 ```
 
-버전이 결정된 경우 마지막 형태(`{package}/{version}`)를 사용합니다. 이 엔드포인트는 해당 버전 이후부터 최신까지의 변경사항을 반환합니다.
+- 설치된 react/css의 **실제 버전**(node_modules)을 읽어 peer 호환을 검사합니다.
+- `--json`의 `packages.issues`에 호환 위반이 담깁니다(예: react가 요구하는 css 범위를 설치된 css가 불만족). 사람용 출력은 `--json` 없이.
+- 목표 버전 조합을 **올리기 전에** 미리 검증하려면 `--with`:
+  ```bash
+  npx @seed-design/cli@latest compat --with react@2.0.0 --with css@2.0.0
+  ```
 
-**전체 패키지 목록 확인:**
+**effective peer 해소** (compat 내부 로직 — 매니페스트를 직접 읽을 때 참고): `packages[pkg].versions[v].peers`(declared) → `correction` overlay(해당 범위면 덮어씀) → `backfill` overlay(비어있으면 채움) 순으로 호환 범위를 결정합니다. `known-bad` overlay는 알려진 사고 조합입니다.
 
-전체 changelog(`react/updates/changelog --raw`)의 `## @seed-design/{pkg}` 헤더를 파싱하면 changelog를 제공하는 모든 패키지 목록을 얻을 수 있습니다. "전체 진단"이 필요한데 프로젝트 환경이 없는 경우(package.json에서 읽을 수 없는 경우) 이 방법으로 패키지 목록을 확인합니다.
+### Step 3: Changelog fetch
 
-프로젝트 환경이 있는 경우에는 package.json의 `@seed-design/*` 의존성이 곧 대상 패키지 목록이므로 전체 changelog를 fetch할 필요 없이 각 패키지별로 버전 지정 fetch를 사용합니다.
+위 **경로 규칙**에 따라 조립합니다.
 
-### Step 3: 버전 범위 파싱 (필요 시)
-
-llms.txt 엔드포인트는 "since version → latest" 형태로 응답합니다. 사용자가 특정 target 버전까지만 확인하고 싶은 경우 (예: 1.2.5 → 1.2.7), 마크다운에서 해당 버전 범위의 섹션만 추출합니다.
-
-changelog 마크다운 형식:
-```md
-# @seed-design/react — Changes since {version}
-
-## {latest-version}
-### Patch Changes
-- ...
-
-## {next-version}
-### Patch Changes
-- ...
+```bash
+npx @seed-design/cli@latest docs react/updates/changelog/react/{from버전} --raw
 ```
 
-각 `## {version}` 섹션이 하나의 릴리즈입니다. target 버전이 있으면 해당 버전보다 높은 섹션만 필터링합니다.
+이 엔드포인트는 **from 버전 이후부터 최신까지** 모든 변경을 반환합니다(응답 최상단이 최신). 별도로 최신 버전을 조회할 필요가 없습니다.
 
-### Step 4: 프로젝트 영향도 분석 (선택)
+**버전이 존재하지 않으면(404 등)**: 버전 인덱스(`react/updates/changelog/{slug}`)로 사용 가능한 버전을 확인하고 사용자에게 올바른 버전을 안내합니다. 추측하지 마세요.
 
-프로젝트 환경이 있는 경우에만 수행합니다.
+### Step 4: target 버전까지 필터 (필요 시)
 
-changelog에서 언급된 컴포넌트/API를 기준으로 프로젝트 코드를 검색합니다:
+엔드포인트는 "from → latest"를 반환하므로, 사용자가 특정 target까지만 원하면 그보다 높은 섹션을 제외합니다. 각 `## {version}` 섹션을 SemVer로 비교해 **target보다 높은(>) 버전 섹션을 제거**합니다. (예: 1.2.5→1.2.7 요청 시 2.0.0·1.2.10·1.2.8 제외, 1.2.6·1.2.7만 사용.)
 
-- **Breaking Changes / Minor Changes**: 변경된 컴포넌트 이름, prop 이름, API 시그니처를 프로젝트에서 grep
-- **Patch Changes**: 버그 수정으로 인한 동작 변경이 프로젝트에 영향을 주는지 확인
-- **Updated Dependencies**: 하위 패키지 변경이 프로젝트의 직접 import에 영향을 주는지 확인
+changelog 섹션 형식: `## {version}` 아래 `### Major Changes` / `### Minor Changes` / `### Patch Changes` / `### Updated Dependencies`.
 
-프로젝트 환경이 없으면 changelog 요약만 제공합니다.
+### Step 5: 마이그레이션 경로 구성
 
-### Step 5: 영향도 보고
+목표까지 가는 경로를 구성합니다.
 
-보고 형식:
+- **breaking 경계**: changelog의 Major/Minor Changes와 "BREAKING CHANGE"·"재설치 필요" 표시를 모읍니다. 1.x 구간에서는 매니페스트의 `breaking-boundary` overlay도 경계를 표시합니다.
+- **재설치 snippet**: 경계에서 재설치가 필요한 컴포넌트는 `add ui:{component}`로 다시 받도록 안내합니다.
+- **react↔css 함께 올리기**: 1.x 구간을 넘나들면 react와 css를 호환되는 버전으로 **함께** 올려야 합니다(한쪽만 올리면 클래스네임이 어긋나 스타일이 깨짐). Step 2의 호환 범위를 사용합니다.
+
+### Step 6: 프로젝트 영향도 분석 (선택)
+
+프로젝트 환경이 있을 때만 수행합니다. changelog에서 언급된 컴포넌트/API를 프로젝트 코드에서 grep:
+
+- **Breaking/Minor Changes**: 변경된 컴포넌트·prop·API 시그니처를 grep
+- **Patch Changes**: 버그 수정으로 인한 동작 변경 영향 확인
+- **Updated Dependencies**: 하위 패키지 변경이 직접 import에 영향을 주는지 확인
+
+### Step 7: 보고 (상황별 형식)
+
+**A. 업그레이드 필요 (breaking 있음)**
 
 ```md
-## 업그레이드 진단: @seed-design/react {현재버전} → {최신버전}
-
+## 업그레이드 진단: @seed-design/react {현재} → {목표}
 ### 수정 필요
-- [변경 내용]: [영향받는 파일과 라인] — [수정 방법]
-
+- [변경]: [영향 파일·라인] — [수정 방법]
 ### 확인 권장
-- [변경 내용]: [관련 파일] — [확인 포인트]
-
+- [변경]: [관련 파일] — [확인 포인트]
 ### 영향 없음
-- [변경 내용]: 프로젝트에서 사용하지 않음
+- [변경]: 프로젝트에서 사용하지 않음
 ```
 
-프로젝트 환경이 없는 경우:
+**B. 이미 최신**
 
 ```md
-## @seed-design/react {from버전} → {to버전} 변경사항
-
-### Breaking Changes
-- ...
-
-### Patch Changes
-- ...
-
-### Updated Dependencies
-- ...
+@seed-design/react: {버전} = 최신. 업그레이드 불필요.
+(다른 패키지도 확인하려면 `compat --all`)
 ```
 
-### Step 6: 업그레이드 안내
+**C. 다패키지** — 패키지별 요약 테이블 + 통합 breaking + 단계별 경로
 
-프로젝트 환경이 있는 경우 업그레이드 명령을 안내합니다:
+```md
+| 패키지 | 현재 | 목표/최신 | 호환 | 액션 |
+| --- | --- | --- | --- | --- |
+| @seed-design/react | ... | ... | ✓/⚠ | ... |
+| @seed-design/css   | ... | ... | ✓/⚠ | ... |
+```
+
+### Step 8: 업그레이드 안내
 
 ```bash
-bun add @seed-design/react@{최신버전}
+bun add @seed-design/react@{목표} @seed-design/css@{목표}
 ```
 
-수정이 필요한 항목이 있으면 업그레이드 전후로 어떤 코드를 바꿔야 하는지 구체적인 diff를 제시합니다.
+1.x 구간은 react·css를 함께 올립니다. 재설치가 필요한 snippet은 `add ui:{component}`로. 업그레이드 후 다시 `compat`으로 검증합니다.
 
 ## CLI Primitives
 
-이 스킬이 조합하는 CLI 명령어:
-
 | 명령어 | 역할 |
-|--------|------|
-| `docs react/updates/changelog --raw` | 전체 changelog fetch (패키지 목록 파악에도 사용) |
-| `docs react/updates/changelog/{pkg} --raw` | 특정 패키지의 버전 인덱스 (사용 가능한 버전 목록) |
-| `docs react/updates/changelog/{pkg}/{ver} --raw` | 특정 버전 이후 changelog fetch |
-| `compat --all` | 프로젝트의 설치된 seed 패키지 버전 + 스니펫 호환성 확인 |
+| --- | --- |
+| `compat --json` | 설치된 패키지들의 peer 호환 진단(구조화 출력) |
+| `compat --with {pkg}@{ver}` | 가정한 버전 조합의 호환을 미리 검증 |
+| `compat --all` | 스니펫 호환까지 포함 |
+| `docs react/updates/changelog/{slug}/{ver} --raw` | from 버전 이후 changelog |
+| `docs react/updates/changelog/{slug} --raw` | 버전 인덱스(버전 목록) |
+| `docs react/updates/changelog --raw` | 전체 changelog(모든 패키지) |
 
 ## Decision Guide
 
-- 최신 버전과 동일하면 "이미 최신 버전"으로 종료합니다.
-- Breaking Changes가 있으면 반드시 수정 후 업그레이드합니다.
-- Patch 릴리스는 대체로 안전하지만, 회귀 가능성을 고려해 변경사항을 확인한 후 업그레이드하는 것을 권장합니다.
-- Updated Dependencies에서 하위 패키지를 직접 import하는 경우 해당 변경사항도 확인합니다.
+- 최신과 동일 → "이미 최신".
+- **2.0 이상**: minor/patch는 안전(strict semver). major를 넘을 때 breaking 확인.
+- **2.0 미만**: minor도 breaking 가능 → 항상 changelog 확인 + react↔css 호환(`compat`) 확인.
+- react↔css는 호환 범위 안에서 **함께** 올립니다.
+- Breaking이 있으면 수정 후 업그레이드.
+
+## 다패키지 진단
+
+프로젝트의 `@seed-design/*` 각각에 대해 Step 1~5를 수행하고 Step 7-C 형식으로 통합 보고합니다. react는 css를 의존하므로 css 변경이 react로 전파될 수 있음을 고려합니다.

--- a/skills/seed-design/references/usage.md
+++ b/skills/seed-design/references/usage.md
@@ -65,6 +65,16 @@ npx @seed-design/cli@latest compat -c action-button -c alert-dialog
 npx @seed-design/cli@latest compat --all
 ```
 
+설치된 패키지들끼리(react↔css)의 peer 호환을 검사하거나, 가정한 버전 조합을 미리 확인하고, 구조화 출력을 받을 수 있습니다.
+
+```bash
+# 가정한 버전 조합의 호환 미리 검증
+npx @seed-design/cli@latest compat --with react@2.0.0 --with css@2.0.0
+
+# JSON 출력 (스크립트·도구용)
+npx @seed-design/cli@latest compat --json
+```
+
 ### 5) Docs 조회
 
 컴포넌트/파운데이션에 대한 문서 링크, LLM용 텍스트 링크, 스니펫 링크를 조회합니다.


### PR DESCRIPTION
## 배경

SEED는 2.0 이전(0.x·1.x)에 minor/patch에서도 breaking이 발생했고, `@seed-design/react`와 `@seed-design/css`를 호환되지 않는 버전으로 섞으면 클래스네임이 어긋나 스타일이 깨지는 문제가 있었습니다. 이 PR의 base인 `feat/compat-manifest`가 호환 매니페스트 + `compat` peer 검사로 "react@X ↔ css@Y 호환"을 판단하는 인프라를 추가했습니다.

이 PR은 그 위에 **소비자용 업그레이드 가이드 + `/seed-design` 스킬 통합**을 얹습니다. 서브에이전트 검증 결과 **새 CLI 없이** 지금 있는 것(공개 manifest + `compat` + changelog)만으로 호환 진단·마이그레이션 경로 제시가 가능함을 확인했기에, **CLI 코드 변경은 없습니다.**

## 변경 사항

### docs
- **신규** `react/migration/upgrading.mdx` — 2.0 전후 버저닝 정책, react↔css 호환(`compat` 사용법), 단계별 업그레이드
- **개명** `guide.mdx` → `from-sprout.mdx` — Sprout→SEED 이주 전용 문서임을 명확히
- `meta.json` — 페이지 순서 (upgrading 우선)

### skills/seed-design
- `upgrade.md` — compat `--json`/`--with` 통합, effective peers 해소(declared→correction→backfill), **react↔css lockstep**, changelog 경로 규칙(카테고리 항상 `react`·slug), semver range→from, target 필터, 2.0 전후 정책, 상황별 보고 형식
- `migration.md` — 스니펫 중심으로 명확화 + baseUrl 패턴 + 비대화형 `--on-diff`
- `usage.md`, `SKILL.md` — compat 새 옵션, 분기 라벨

## 검증
- `bun docs:test` 통과 (편집마다 hook)
- changelog 경로 라이브 200 확인
- 서브에이전트 시나리오 재검증 **6/6 PASS** (lockstep·경로·range·target·effective peers·2.0 정책)

## 참고
- **Stacked PR**: base가 `feat/compat-manifest`입니다. 해당 PR 머지 후 이 PR을 머지하거나 base를 `dev`로 retarget하세요.
- 단일 출처: 버저닝 정책(기여자)은 changeset 스킬의 `version-matrix.md`, 소비자 업그레이드/호환은 `upgrading.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)