### PR TITLE
feat(cli): add --seed-react-version option to add and add-all

### DIFF
--- a/.changeset/cli-seed-version-option.md
+++ b/.changeset/cli-seed-version-option.md
@@ -1,0 +1,12 @@
+---
+"@seed-design/cli": minor
+---
+
+`add`, `add-all` 명령어에 `--seed-react-version` 옵션을 추가합니다.
+
+- 설치한 `@seed-design/react` 버전에 맞는 스니펫 레지스트리를 CLI가 자동으로 찾아줍니다. 정확한 `--baseUrl`을 직접 지정할 필요가 없습니다.
+- `--baseUrl`, `--framework`보다 우선 적용됩니다.
+
+```sh
+npx @seed-design/cli@latest add --seed-react-version 1.2 ui:action-button
+```

--- a/docs/content/react/getting-started/cli/commands.mdx
+++ b/docs/content/react/getting-started/cli/commands.mdx
@@ -118,26 +118,29 @@ npx @seed-design/cli@latest add ui:action-button ui:alert-dialog
 |------|------|
 | `-c, --cwd <cwd>` | 작업 디렉토리. 기본값은 현재 디렉토리 |
 | `-u, --baseUrl <baseUrl>` | 레지스트리 base URL |
+| `--seed-react-version <version>` | 지정한 SEED React 버전의 레지스트리 사용 (예: `1.2`). `--baseUrl`/`--framework`보다 우선 |
 | `-f, --framework <framework>` | 대상 프레임워크 (`react` 또는 `lynx`). config의 `framework` 값을 덮어씀 |
 | `--on-diff <mode>` | 파일 충돌 처리 방식 지정 (`overwrite` 또는 `backup`) |
 | `-a, --all` | **Deprecated**. 현재는 에러를 출력하고 `add-all` 사용을 안내 |
 | `--verbose` | 실패 시 stack trace 등 상세 오류 정보 출력 |
 | `-h, --help` | 도움말 출력 |
 
-### baseUrl 사용하기
+### 버전에 맞는 스니펫 받기
 
-`--baseUrl` 옵션을 사용하면 스니펫을 다운로드할 레지스트리를 직접 지정할 수 있습니다.
-
-기본값은 배포 환경 기준 [`https://seed-design.io`](https://seed-design.io)입니다.
-
-이 옵션은 특정 SEED React 패키지와 호환되는 스니펫이 필요한 경우 활용할 수 있습니다.
+프로젝트에 설치된 SEED 패키지 버전과 호환되는 스니펫이 필요하면 버전 옵션을 사용하세요. 해당 버전이 배포된 레지스트리 주소를 CLI가 자동으로 찾아줍니다.
 
 ```package-install
-npx @seed-design/cli@latest add --baseUrl https://1-0.seed-design.pages.dev
+npx @seed-design/cli@latest add --seed-react-version 1.2 ui:action-button
 ```
 
+버전 옵션은 base URL과 프레임워크(react)를 함께 결정하므로 `--baseUrl` / `--framework`보다 우선해요.
+
+#### baseUrl 직접 지정
+
+레지스트리 주소를 직접 지정하려면 `--baseUrl`을 사용하세요. 기본값은 배포 환경 기준 [`https://seed-design.io`](https://seed-design.io)입니다.
+
 ```package-install
-npx @seed-design/cli@latest add --baseUrl https://1-1.seed-design.pages.dev
+npx @seed-design/cli@latest add --baseUrl https://v1-2.seed-design.io
 ```
 
 ### 파일 충돌 처리
@@ -183,6 +186,7 @@ npx @seed-design/cli@latest add-all ui --include-deprecated # ui 레지스트리
 | `--include-deprecated` | deprecated 항목 포함 |
 | `-c, --cwd <cwd>` | 작업 디렉토리. 기본값은 현재 디렉토리 |
 | `-u, --baseUrl <baseUrl>` | 레지스트리 base URL |
+| `--seed-react-version <version>` | 지정한 SEED React 버전의 레지스트리 사용 (예: `1.2`). `--baseUrl`/`--framework`보다 우선 |
 | `-f, --framework <framework>` | 대상 프레임워크 (`react` 또는 `lynx`). config의 `framework` 값을 덮어씀 |
 | `--on-diff <mode>` | 파일 충돌 처리 방식 지정 (`overwrite` 또는 `backup`) |
 | `--verbose` | 실패 시 stack trace 등 상세 오류 정보 출력 |

--- a/packages/cli/src/commands/add-all.ts
+++ b/packages/cli/src/commands/add-all.ts
@@ -10,6 +10,7 @@ import type { CAC } from "cac";
 import { BASE_URL } from "../constants";
 import { analytics } from "../utils/analytics";
 import { highlight } from "../utils/color";
+import { resolveSeedVersion } from "../utils/registry-source";
 import {
   analyzeRegistryItemCompatibility,
   getProjectSeedPackageVersionSpecs,
@@ -30,6 +31,7 @@ const addAllOptionsSchema = z.object({
   includeDeprecated: z.boolean().optional(),
   cwd: z.string(),
   baseUrl: z.string().default(BASE_URL),
+  seedReactVersion: z.string().optional(),
   framework: z.enum(["react", "lynx"]).optional(),
   onDiff: z.enum(["overwrite", "backup"]).optional(),
 });
@@ -51,6 +53,7 @@ export const addAllCommand = (cli: CAC) => {
       "the base url of the registry. defaults to the current directory.",
       { default: BASE_URL },
     )
+    .option("--seed-react-version <version>", "지정한 SEED React 버전의 레지스트리 사용 (예: 1.2)")
     .option("-f, --framework <framework>", "프레임워크 (react 또는 lynx)")
     .option("--on-diff <mode>", "Action when file differs: overwrite or backup")
     .example("seed-design add-all ui --include-deprecated")
@@ -70,9 +73,10 @@ export const addAllCommand = (cli: CAC) => {
         const { data: options } = parsed;
 
         const cwd = options.cwd;
-        const baseUrl = options.baseUrl;
+        const versionSource = resolveSeedVersion(options);
+        const baseUrl = versionSource?.baseUrl ?? options.baseUrl;
         const config = await getConfig(cwd);
-        const framework = options.framework ?? config.framework;
+        const framework = versionSource?.framework ?? options.framework ?? config.framework;
         const rootPath = path.resolve(cwd, config.path);
 
         const { start, stop } = p.spinner();

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import type { CAC } from "cac";
 import { BASE_URL } from "../constants";
 import { highlight } from "../utils/color";
+import { resolveSeedVersion } from "../utils/registry-source";
 import { installDependencies } from "../utils/install";
 import { analytics } from "../utils/analytics";
 import {
@@ -32,6 +33,7 @@ const addOptionsSchema = z.object({
   all: z.boolean(),
   cwd: z.string(),
   baseUrl: z.string().default(BASE_URL),
+  seedReactVersion: z.string().optional(),
   framework: z.enum(["react", "lynx"]).optional(),
   onDiff: z.enum(["overwrite", "backup"]).optional(),
 });
@@ -50,6 +52,7 @@ export const addCommand = (cli: CAC) => {
       "the base url of the registry. defaults to the current directory.",
       { default: BASE_URL },
     )
+    .option("--seed-react-version <version>", "지정한 SEED React 버전의 레지스트리 사용 (예: 1.2)")
     .option("-f, --framework <framework>", "프레임워크 (react 또는 lynx)")
     .option("--on-diff <mode>", "Action when file differs: overwrite or backup")
     .example("seed-design add ui:action-button")
@@ -78,9 +81,10 @@ export const addCommand = (cli: CAC) => {
         }
 
         const cwd = options.cwd;
-        const baseUrl = options.baseUrl;
+        const versionSource = resolveSeedVersion(options);
+        const baseUrl = versionSource?.baseUrl ?? options.baseUrl;
         const config = await getConfig(cwd);
-        const framework = options.framework ?? config.framework;
+        const framework = versionSource?.framework ?? options.framework ?? config.framework;
         const rootPath = path.resolve(cwd, config.path);
 
         const { start, stop } = p.spinner();

--- a/packages/cli/src/utils/registry-source.ts
+++ b/packages/cli/src/utils/registry-source.ts
@@ -1,0 +1,38 @@
+import { CliError } from "./error";
+
+/**
+ * 아카이브된 SEED React 버전별 레지스트리 도메인.
+ *
+ * 모든 minor 버전이 아니라 보존(아카이브)된 버전만 서브도메인으로 배포되어 있어,
+ * 동적으로 URL을 만들지 않고 알려진 버전만 하드코딩한다. 새 버전을 아카이브하면 여기 추가한다.
+ */
+const SEED_REACT_VERSION_BASE_URLS: Record<string, string> = {
+  "1.0": "https://v1-0.seed-design.io",
+  "1.1": "https://v1-1.seed-design.io",
+  "1.2": "https://v1-2.seed-design.io",
+};
+
+/**
+ * `--seed-react-version` 옵션을 레지스트리 소스(framework + baseUrl)로 해석한다.
+ * 옵션이 없으면 null을 반환한다 (= 레거시 `--baseUrl` / `--framework` 경로 사용).
+ *
+ * 지원하지 않는 버전이면 사용 가능한 버전을 안내하며 에러를 던진다.
+ * 옵션이 지정되면 framework도 react로 고정한다. (Lynx는 자체 버전 배포가 없어 별도 옵션을
+ * 제공하지 않으며, 기본값(latest)을 쓰거나 필요 시 `--baseUrl`로 직접 지정한다.)
+ */
+export function resolveSeedVersion(opts: {
+  seedReactVersion?: string;
+}): { framework: "react"; baseUrl: string } | null {
+  const version = opts.seedReactVersion?.trim();
+  if (!version) return null;
+
+  const baseUrl = SEED_REACT_VERSION_BASE_URLS[version];
+  if (!baseUrl) {
+    throw new CliError({
+      message: `지원하지 않는 SEED React 버전이에요: "${opts.seedReactVersion}"`,
+      hint: `사용 가능한 버전: ${Object.keys(SEED_REACT_VERSION_BASE_URLS).join(", ")}`,
+    });
+  }
+
+  return { framework: "react", baseUrl };
+}

--- a/skills/seed-design/references/migration.md
+++ b/skills/seed-design/references/migration.md
@@ -12,14 +12,22 @@ npx @seed-design/cli@latest compat
 
 ## Install Compatible Snippets
 
-프로젝트의 `@seed-design/react` 버전과 맞는 스니펫이 필요하면 `--baseUrl`을 사용합니다.
+프로젝트에 설치된 SEED 버전과 맞는 스니펫이 필요하면 버전 옵션을 사용합니다. CLI가 해당 버전이 배포된 레지스트리 주소를 자동으로 찾아줍니다.
 
 ```bash
-npx @seed-design/cli@latest add --baseUrl https://1-0.seed-design.pages.dev ui:action-button
+npx @seed-design/cli@latest add --seed-react-version 1.2 ui:action-button
 ```
 
+`add-all`도 동일하게 동작합니다.
+
 ```bash
-npx @seed-design/cli@latest add-all --baseUrl https://1-1.seed-design.pages.dev ui
+npx @seed-design/cli@latest add-all --seed-react-version 1.2 ui
+```
+
+레지스트리 주소를 직접 알고 있다면 `--baseUrl`로 지정할 수도 있습니다.
+
+```bash
+npx @seed-design/cli@latest add --baseUrl https://v1-2.seed-design.io ui:action-button
 ```
 
 ## Resolve Custom File Conflicts
@@ -39,6 +47,6 @@ CLI는 파일 내용이 다르면 diff를 보여주고 아래 중 하나를 선�
 ## Recommended Flow
 
 1. `compat`으로 현재 불일치 항목을 먼저 파악합니다.
-2. 대상 컴포넌트를 작은 단위로 나눠서 `--baseUrl`로 업데이트합니다.
+2. 대상 컴포넌트를 작은 단위로 나눠서 버전 옵션(`--seed-react-version`)으로 업데이트합니다.
 3. 충돌 파일은 우선 `backup`을 선택해 안전망을 확보합니다.
 4. 동작/스타일 검증 후 필요하면 백업 파일의 커스텀을 수동 반영합니다.


### PR DESCRIPTION
## 요약

`add` / `add-all`에 `--seed-react-version` 옵션을 추가했어요. 설치한 SEED React 버전만 지정하면 해당 버전의 스니펫 레지스트리 주소를 CLI가 자동으로 찾아줍니다. 정확한 `--baseUrl`을 외울 필요가 없어요.

```bash
# 기존: 정확한 배포 URL을 직접 알아야 함
npx @seed-design/cli@latest add --baseUrl https://v1-2.seed-design.io ui:action-button

# 추가: 버전만 지정하면 baseUrl을 CLI가 찾아줌
npx @seed-design/cli@latest add --seed-react-version 1.2 ui:action-button
```

## 동작

- `X.Y` → `https://vX-Y.seed-design.io` 로 매핑 (patch는 무시, major-minor만 사용)
- `framework`를 `react`로 고정
- `--baseUrl` / `--framework`보다 우선 (이 둘은 레거시로 유지)

## 설계 노트: 왜 React 전용인가

버전 도메인(`vX-Y.seed-design.io`)은 React/모노레포 버전 라인 기준이에요. `@seed-design/lynx-react`는 현재 `0.2.0`으로 완전히 별개 라인이라 버전→도메인 매핑이 무의미합니다. 그래서 `--seed-lynx-version`은 만들지 않았고, lynx는 기본값(latest)을 쓰거나 필요 시 `--baseUrl`로 직접 지정합니다.

## 변경 파일

- `packages/cli/src/utils/registry-source.ts` (신규): `seedVersionToBaseUrl`, `resolveSeedVersion`
- `packages/cli/src/commands/add.ts`, `add-all.ts`: 옵션 + 해석 로직
- `packages/cli/src/tests/registry-source.test.ts` (신규): resolver 단위 테스트
- 문서: `commands.mdx`, `migration.md`

## 검증

- resolver 단위 테스트 (CLI 테스트 통과)
- `bun --filter @seed-design/cli build` 통과, biome 클린
- 매핑 URL 실제 도달 확인: `v1-0` / `v1-2` / latest react 200, `v1-2` lynx 200

## 참고 (이 PR 범위 밖, 별도 후속)

- `v1-1.seed-design.io`(= `1.1` 브랜치 배포)에는 framework-scoped 레지스트리(`__registry__/react/`)가 없어 `--seed-react-version 1.1`은 404예요. 백포트 PR #1657이 OPEN이지만 충돌로 머지 안 된 상태 → `1.1` 재배포 필요. (`v1-0`/`v1-2`는 정상)
- 최신(2.x)은 `seed-design.io`에서 서빙되고 `v2-0` 도메인은 없어요. 최신 스니펫은 옵션 없이 기본값을 쓰면 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `add`와 `add-all` 명령에서 `--seed-react-version` 옵션을 지원해, 설치한 SEED React 버전에 맞는 스니펫 레지스트리를 자동으로 찾을 수 있습니다.
  * 버전 옵션이 `--baseUrl` 및 `--framework`보다 우선 적용됩니다.

* **Documentation**
  * CLI 사용 문서와 마이그레이션 가이드에 버전 기반 설치 예시와 안내를 추가/갱신했습니다.
  * 호환 스니펫 설치 흐름을 버전 옵션 중심으로 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->