### PR TITLE
docs: use canonical seed-design.io URL in create-component snippet example

### DIFF
--- a/skills/create-component/references/api-design.md
+++ b/skills/create-component/references/api-design.md
@@ -201,7 +201,7 @@ import * as React from "react";
 import * as SeedComponent from "@seed-design/react/components/Component";
 
 /**
- * @see https://seed-design.pages.dev/react/components/component
+ * @see https://seed-design.io/react/components/component
  */
 export interface ComponentProps extends Omit<SeedComponent.RootProps, "children"> {
   // 편의 props (label, description 등)


### PR DESCRIPTION
## 요약

`create-component` 스킬의 스니펫 작성 예시(`references/api-design.md`)에서 `@see` URL이 Cloudflare 프리뷰 도메인(`seed-design.pages.dev`)을 가리키고 있어, 정식 도메인 `seed-design.io`로 바꿉니다.

```diff
- * @see https://seed-design.pages.dev/react/components/component
+ * @see https://seed-design.io/react/components/component
```

스킬 문서 한 줄 변경으로 패키지 영향 없음 (changeset 불필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서
  * API 설계 참고 자료의 컴포넌트 문서 링크가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->