### PR TITLE
refactor(qvism): skip layered output instead of deleting stale files

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -187,10 +187,8 @@
         "@seed-design/qvism-core": "0.0.0",
         "cac": "^7.0.0",
         "cosmiconfig": "^9.0.0",
-        "fs-extra": "^11.3.0",
       },
       "devDependencies": {
-        "@types/fs-extra": "^11.0.4",
         "@types/node": "^25.0.0",
         "typescript": "^6.0.0",
       },

--- a/ecosystem/qvism/cli/package.json
+++ b/ecosystem/qvism/cli/package.json
@@ -25,11 +25,9 @@
   "dependencies": {
     "@seed-design/qvism-core": "0.0.0",
     "cac": "^7.0.0",
-    "cosmiconfig": "^9.0.0",
-    "fs-extra": "^11.3.0"
+    "cosmiconfig": "^9.0.0"
   },
   "devDependencies": {
-    "@types/fs-extra": "^11.0.4",
     "@types/node": "^25.0.0",
     "typescript": "^6.0.0"
   },

--- a/ecosystem/qvism/cli/src/bin/qvism.test.ts
+++ b/ecosystem/qvism/cli/src/bin/qvism.test.ts
@@ -95,20 +95,12 @@ test("generates layered output by default", async () => {
   });
 });
 
-test("config can disable layered output and stale layered files are removed", async () => {
+test("config can disable layered output", async () => {
   await withTempDir(async (tempDir) => {
     // given
     const outputDir = path.join(tempDir, "dist");
     const recipesDir = path.join(outputDir, "recipes");
     await fs.mkdir(recipesDir, { recursive: true });
-    await Promise.all([
-      fs.writeFile(path.join(outputDir, "all.layered.css"), "stale"),
-      fs.writeFile(path.join(outputDir, "all.layered.min.css"), "stale"),
-      fs.writeFile(path.join(outputDir, "base.layered.css"), "stale"),
-      fs.writeFile(path.join(outputDir, "base.layered.min.css"), "stale"),
-      fs.writeFile(path.join(recipesDir, "badge.layered.css"), "stale"),
-      fs.writeFile(path.join(recipesDir, "badge.layered.mjs"), "stale"),
-    ]);
     const configPath = await writeConfig(tempDir, false);
 
     // when

--- a/ecosystem/qvism/cli/src/bin/qvism.ts
+++ b/ecosystem/qvism/cli/src/bin/qvism.ts
@@ -3,7 +3,7 @@
 import { cac } from "cac";
 import { cosmiconfig } from "cosmiconfig";
 import pkg from "../../package.json" with { type: "json" };
-import fs from "fs-extra";
+import fs from "node:fs";
 import path from "node:path";
 import {
   generateAllBundle,
@@ -17,10 +17,6 @@ import {
 
 function resolveGenerateLayeredCss(config: Partial<Config>, cliLayered?: boolean): boolean {
   return cliLayered ?? config.generateLayeredCss ?? true;
-}
-
-function removeFileIfExists(filePath: string) {
-  fs.removeSync(filePath);
 }
 
 async function writeBundles(outputDir: string, config: Config) {
@@ -41,14 +37,7 @@ async function writeBundles(outputDir: string, config: Config) {
   console.log("Writing minified base css bundle to", path.join(outputDir, "base.min.css"));
   fs.writeFileSync(path.join(outputDir, "base.min.css"), minifiedBaseCss);
 
-  if (!generateLayeredCss) {
-    // Remove stale layered bundles from earlier runs.
-    removeFileIfExists(path.join(outputDir, "all.layered.css"));
-    removeFileIfExists(path.join(outputDir, "all.layered.min.css"));
-    removeFileIfExists(path.join(outputDir, "base.layered.css"));
-    removeFileIfExists(path.join(outputDir, "base.layered.min.css"));
-    return;
-  }
+  if (!generateLayeredCss) return;
 
   const layeredBundles = [
     {
@@ -100,14 +89,9 @@ async function writeRecipes(recipesDir: string, config: Config) {
       console.log("Writing", name, "to", path.join(recipesDir, `${name}.d.ts`));
       fs.writeFileSync(path.join(recipesDir, `${name}.d.ts`), dtsCode);
 
+      if (!generateLayeredCss) return;
+
       const layeredJsPath = path.join(recipesDir, `${name}.layered.mjs`);
-
-      if (!generateLayeredCss) {
-        // Remove stale layered recipe JS from earlier runs.
-        removeFileIfExists(layeredJsPath);
-        return;
-      }
-
       const layeredJsCode = generateJs(definition, {
         ...options,
         cssImportPath: `./${name}.layered.css`,
@@ -123,18 +107,13 @@ async function writeRecipes(recipesDir: string, config: Config) {
     console.log("Writing", name, "to", path.join(recipesDir, `${name}.css`));
     fs.writeFileSync(path.join(recipesDir, `${name}.css`), css);
 
-    const layeredCssPath = path.join(recipesDir, `${name}.layered.css`);
-
-    if (!generateLayeredCss) {
-      // Remove stale layered recipe CSS from earlier runs.
-      removeFileIfExists(layeredCssPath);
-      continue;
-    }
+    if (!generateLayeredCss) continue;
 
     if (layeredCss == null) {
       throw new Error(`Layered CSS was not generated for ${name}.`);
     }
 
+    const layeredCssPath = path.join(recipesDir, `${name}.layered.css`);
     console.log("Writing", name, "to", layeredCssPath);
     fs.writeFileSync(layeredCssPath, layeredCss);
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 레이어드 출력이 비활성화된 경우, 기존 레이어드 산출물을 삭제하지 않고 단순히 생성만 건너뛰도록 동작이 정리되었습니다.
  * 관련 테스트도 기존 파일 정리 시나리오 대신, 레이어드 파일이 새로 만들어지지 않는지 확인하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->