### PR TITLE
feat(lynx-react): add reactive useSeedClassName hook for theme changes

### DIFF
--- a/.changeset/eager-pages-subscribe.md
+++ b/.changeset/eager-pages-subscribe.md
@@ -1,0 +1,22 @@
+---
+"@seed-design/lynx-react": minor
+---
+
+(BREAKING CHANGE: `@lynx-js/react`를 `0.117.0` 이상으로 업그레이드해야 합니다.) 테마 변경에 반응하는 `useSeedClassName` 훅을 추가합니다.
+
+- root `<page>`에서 `getSeedClassName()` 대신 `useSeedClassName()`을 사용하면, host가 `lynx.__globalProps.theme`을 변경할 때 자동으로 리렌더되어 테마가 즉시 반영됩니다.
+- `getSeedClassName()` 순수 함수는 그대로 유지됩니다. 테마 변경에 반응할 필요가 없는 정적 컨텍스트에서 계속 사용할 수 있습니다.
+- `useGlobalProps()`에 의존하므로 `@lynx-js/react` `0.117.0` 이상이 필요합니다.
+
+```tsx
+import { useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+  return (
+    <page className={seedClassName}>
+      <App />
+    </page>
+  );
+}
+```

--- a/bun.lock
+++ b/bun.lock
@@ -483,7 +483,7 @@
         "clsx": "^2.1.1",
       },
       "devDependencies": {
-        "@lynx-js/react": "^0.116.3",
+        "@lynx-js/react": "^0.117.0",
         "@lynx-js/types": "^3.7.0",
         "@seed-design/lynx-css": "0.4.0",
         "@testing-library/jest-dom": "^6.9.1",
@@ -493,7 +493,7 @@
         "vitest": "^3.2.4",
       },
       "peerDependencies": {
-        "@lynx-js/react": ">=0.100.0",
+        "@lynx-js/react": ">=0.117.0",
         "@lynx-js/types": ">=3.7.0",
         "@seed-design/lynx-css": "0.0.0 || >=0.1.0 <1.0.0",
       },
@@ -6863,8 +6863,6 @@
 
     "@seed-design/figma-extractor/@figma/rest-api-spec": ["@figma/rest-api-spec@0.27.0", "", {}, "sha512-jRGYwBLdybit9X7puOmztx8XUt1dq9a7jtBO2KEK4OrxP8GKGX5yY2+efV/XNRHnqTbzFue0qdZklSBs/EaGNw=="],
 
-    "@seed-design/lynx-react/@lynx-js/react": ["@lynx-js/react@0.116.5", "", { "dependencies": { "preact": "npm:@hongzhiyuan/preact@10.28.0-fc4af453" }, "peerDependencies": { "@lynx-js/types": "*", "@types/react": "^18" }, "optionalPeers": ["@lynx-js/types"] }, "sha512-qhh9mZv7d5hKMQOXoiAOYaWQe/My6MhJ8EcJAi/c9g1EH4TQQoR0Q1o/7dIWj/pZbIiXSt6bgXpTJNQpXr+Qyg=="],
-
     "@seed-design/mcp/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@seed-design/postcss-responsive/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -8028,8 +8026,6 @@
     "@sanity/sdk/@sanity/types/@sanity/media-library-types": ["@sanity/media-library-types@1.0.1", "", {}, "sha512-lyjDQqq0IkVMBKPsm1+IeTpOki3OeFvSCyFms8pPTYcMaH0U5S+wK553QDI4HnmmPx0SiWpOWtLlTh1qkh+IFA=="],
 
     "@sanity/ui/motion/framer-motion": ["framer-motion@12.23.24", "", { "dependencies": { "motion-dom": "^12.23.23", "motion-utils": "^12.23.6", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-HMi5HRoRCTou+3fb3h9oTLyJGBxHfW+HnNE25tAXOvVx/IvwMHK0cx7IR4a2ZU6sh3IX1Z+4ts32PcYBOqka8w=="],
-
-    "@seed-design/lynx-react/@lynx-js/react/preact": ["@hongzhiyuan/preact@10.28.0-fc4af453", "", {}, "sha512-TrM2g079OZN1poroDnU2kQd1gNUB1DMfVoKyz23AE3hZvl9ypRgG2MdgxAJtwT5u3BmYvI4Z0EbdpJTdf428IQ=="],
 
     "@seed-design/react-menu/vitest/@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
 

--- a/docs/content/lynx/getting-started/theming.mdx
+++ b/docs/content/lynx/getting-started/theming.mdx
@@ -12,15 +12,16 @@ SEED Design은 라이트 모드와 다크 모드를 지원하는 테마 시스�
 
 ## 전역 설정 적용
 
-`@seed-design/lynx-react`의 `getSeedClassName()` 함수를 사용하여 `<page>` 요소에 테마 클래스를 설정합니다.
+`@seed-design/lynx-react`의 `useSeedClassName()` 훅을 사용하여 `<page>` 요소에 테마 클래스를 설정합니다.
 
 ```tsx
 import { root } from "@lynx-js/react";
-import { getSeedClassName } from "@seed-design/lynx-react";
+import { useSeedClassName } from "@seed-design/lynx-react";
 
 function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
   return (
-    <page className={getSeedClassName({ colorMode: "system" })}>
+    <page className={seedClassName}>
       <App />
     </page>
   );
@@ -29,7 +30,11 @@ function Root() {
 root.render(<Root />);
 ```
 
-`getSeedClassName()`은 `colorMode` 옵션에 따라 `seed-user-color-scheme-light` 또는 `seed-user-color-scheme-dark` 클래스를 반환합니다.
+`useSeedClassName()`은 `colorMode` 옵션에 따라 `seed-user-color-scheme-light` 또는 `seed-user-color-scheme-dark` 클래스를 반환합니다. `lynx.__globalProps.theme` 변경을 구독하므로, 시스템 테마가 바뀌면 자동으로 리렌더되어 클래스가 갱신됩니다.
+
+<Callout>
+`getSeedClassName()`은 동일한 클래스를 반환하는 순수 함수 버전입니다. 테마 변경에 반응할 필요가 없는 정적 컨텍스트에서 사용하세요. 자세한 내용은 [`useSeedClassName`](/lynx/hooks/use-seed-class-name)을 참고하세요.
+</Callout>
 
 ### `colorMode` 옵션
 
@@ -48,7 +53,7 @@ SEED Design의 Lynx 테마 시스템은 두 종류의 클래스 이름을 사용
 
 ### `seed-user-color-scheme-*` (루트 레벨 테마)
 
-`getSeedClassName()`이 `<page>` 요소에 적용하는 클래스입니다. 현재 해석(resolve)된 테마를 나타냅니다.
+`useSeedClassName()`이 `<page>` 요소에 적용하는 클래스입니다. 현재 해석(resolve)된 테마를 나타냅니다.
 
 - `seed-user-color-scheme-light`: 라이트 모드가 적용됨
 - `seed-user-color-scheme-dark`: 다크 모드가 적용됨
@@ -138,4 +143,4 @@ function MyComponent() {
 | 전역 테마 설정 | `data-seed-color-mode` + `data-seed-user-color-scheme` 속성을 `<html>`에 적용 | `seed-user-color-scheme-*` 클래스를 `<page>`에 적용 |
 | 테마 오버라이드 | `data-seed-color-mode="light-only"` 또는 `"dark-only"` 속성 | `seed-color-mode-light-only` 또는 `seed-color-mode-dark-only` 클래스 |
 | 토큰 상속 | CSS 커스텀 프로퍼티 상속 | CSS 커스텀 프로퍼티 상속 (동일) |
-| 테마 설정 방법 | 번들러 플러그인이 `<script>` 주입 | `getSeedClassName()` 함수로 className 직접 설정 |
+| 테마 설정 방법 | 번들러 플러그인이 `<script>` 주입 | `useSeedClassName()` 훅으로 className 설정 |

--- a/docs/content/lynx/hooks/meta.json
+++ b/docs/content/lynx/hooks/meta.json
@@ -1,4 +1,10 @@
 {
   "title": "Hooks",
-  "pages": ["use-controllable-state", "use-icon-color", "use-press-tap", "use-safe-area"]
+  "pages": [
+    "use-controllable-state",
+    "use-icon-color",
+    "use-press-tap",
+    "use-safe-area",
+    "use-seed-class-name"
+  ]
 }

--- a/docs/content/lynx/hooks/use-seed-class-name.mdx
+++ b/docs/content/lynx/hooks/use-seed-class-name.mdx
@@ -1,0 +1,77 @@
+---
+title: useSeedClassName
+description: root `<page>`에 적용할 테마 className을 반환하고 테마 변경을 구독하는 훅입니다.
+---
+
+## Import
+
+```ts
+import { useSeedClassName } from "@seed-design/lynx-react";
+```
+
+`useSeedClassName`은 `@seed-design/lynx-react` 패키지에 포함되어 있습니다. `getSeedClassName()`의 reactive 버전으로, `useGlobalProps()`를 통해 `lynx.__globalProps.theme` 변경을 구독하여 테마가 바뀌면 갱신된 className을 반환합니다.
+
+## Usage
+
+### 기본 사용
+
+root `<page>` 요소에 적용합니다.
+
+```tsx
+import { root } from "@lynx-js/react";
+import { useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+  return (
+    <page className={seedClassName}>
+      <App />
+    </page>
+  );
+}
+
+root.render(<Root />);
+```
+
+### `colorMode` 옵션
+
+| `colorMode` 설정 | 기기 설정 | 반환되는 테마 클래스 |
+|---|---|---|
+| `system` (기본값) | 라이트 모드 | `seed-user-color-scheme-light` |
+| `system` | 다크 모드 | `seed-user-color-scheme-dark` |
+| `light-only` | (무관) | `seed-user-color-scheme-light` |
+| `dark-only` | (무관) | `seed-user-color-scheme-dark` |
+
+`system`일 때 `lynx.__globalProps.theme` 값을 읽어 기기의 다크 모드 설정을 따릅니다.
+
+## 동작 방식
+
+`useSeedClassName()`은 내부적으로 `useGlobalProps()`로 `lynx.__globalProps`를 구독합니다. host가 테마를 변경하면 이 훅을 사용하는 컴포넌트가 리렌더되어, 갱신된 테마에 맞는 className을 반환합니다.
+
+className 매핑 로직은 순수 함수인 `getSeedClassName()`과 동일합니다. 차이는 테마 변경 구독 여부뿐입니다.
+
+- `useSeedClassName()`: 테마 변경을 구독하는 훅. **root `<page>`처럼 테마 변경에 반응해야 하는 곳에 사용합니다.**
+- `getSeedClassName()`: 호출 시점의 테마를 한 번만 읽는 순수 함수. 테마 변경에 반응할 필요가 없는 정적 컨텍스트에서 사용합니다.
+
+<Callout>
+웹(React) 환경에서는 번들러 플러그인이 테마를 자동으로 처리하지만, Lynx에서는 `useSeedClassName()`으로 명시적으로 구독합니다. 테마 시스템 전반은 [Theming](/lynx/getting-started/theming) 문서를 참고하세요.
+</Callout>
+
+## API
+
+### Parameters
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `colorMode` | `"system" \| "light-only" \| "dark-only"` | `"system"` | 테마 결정 방식입니다. `system`은 기기 설정을 따르고, `light-only` / `dark-only`는 테마를 고정합니다. |
+
+### Return
+
+| Type | Description |
+|------|-------------|
+| `string` | 적용할 테마 클래스(`seed-user-color-scheme-light` 또는 `seed-user-color-scheme-dark`)입니다. |
+
+## 사용 시 주의사항
+
+- `useGlobalProps()`에 의존하므로 `@lynx-js/react` `0.117.0` 이상이 필요합니다.
+- 훅이므로 컴포넌트 본문에서만 호출할 수 있습니다. 테마 변경에 반응할 필요가 없다면 순수 함수인 `getSeedClassName()`을 사용하세요.

--- a/examples/lynx-spa/src/index.tsx
+++ b/examples/lynx-spa/src/index.tsx
@@ -10,7 +10,7 @@ import {
 
 import "./styles/global.css";
 
-import { getSeedClassName } from "@seed-design/lynx-react";
+import { useSeedClassName } from "@seed-design/lynx-react";
 
 import { App } from "./App.jsx";
 
@@ -22,8 +22,9 @@ initNetworkMonitor();
 initPerformanceMonitor();
 
 function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
   return (
-    <page className={`${getSeedClassName({ colorMode: "system" })} bg-bg-layer-default`}>
+    <page className={`${seedClassName} bg-bg-layer-default`}>
       <App />
     </page>
   );

--- a/packages/lynx-react/package.json
+++ b/packages/lynx-react/package.json
@@ -29,12 +29,12 @@
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit"
   },
   "peerDependencies": {
-    "@lynx-js/react": ">=0.100.0",
+    "@lynx-js/react": ">=0.117.0",
     "@lynx-js/types": ">=3.7.0",
     "@seed-design/lynx-css": "0.0.0 || >=0.1.0 <1.0.0"
   },
   "devDependencies": {
-    "@lynx-js/react": "^0.116.3",
+    "@lynx-js/react": "^0.117.0",
     "@lynx-js/types": "^3.7.0",
     "@seed-design/lynx-css": "0.4.0",
     "@testing-library/jest-dom": "^6.9.1",

--- a/packages/lynx-react/src/hooks/index.ts
+++ b/packages/lynx-react/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from "./useControllableState";
 export * from "./useIconColor";
 export * from "./usePressTap";
 export * from "./useSafeArea";
+export * from "./useSeedClassName";

--- a/packages/lynx-react/src/hooks/useSeedClassName.ts
+++ b/packages/lynx-react/src/hooks/useSeedClassName.ts
@@ -1,0 +1,35 @@
+import { useGlobalProps, useMemo } from "@lynx-js/react";
+
+import { getSeedClassName, type GetSeedClassNameOptions } from "../utils/get-seed-class-name";
+
+/**
+ * Lynx 앱의 root `<page>` 요소에 적용할 SEED Design className을 반환하는 훅이다.
+ *
+ * `getSeedClassName()`의 reactive 버전으로, `useGlobalProps()`를 통해
+ * `lynx.__globalProps.theme` 변경을 구독한다. host가 테마를 변경하면 이 훅을
+ * 사용하는 컴포넌트가 리렌더되어 className이 갱신된다.
+ *
+ * @example
+ * ```tsx
+ * import { root } from "@lynx-js/react";
+ * import { useSeedClassName } from "@seed-design/lynx-react";
+ *
+ * function Root() {
+ *   const seedClassName = useSeedClassName({ colorMode: "system" });
+ *   return (
+ *     <page className={seedClassName}>
+ *       <App />
+ *     </page>
+ *   );
+ * }
+ *
+ * root.render(<Root />);
+ * ```
+ */
+export function useSeedClassName(options?: GetSeedClassNameOptions): string {
+  // useGlobalProps()로 lynx.__globalProps를 구독한다.
+  // host가 theme을 변경하면 이 훅을 사용하는 컴포넌트가 리렌더되어 className이 갱신된다.
+  const globalProps = useGlobalProps() as { theme?: unknown };
+
+  return useMemo(() => getSeedClassName(options), [globalProps.theme, options?.colorMode]);
+}

--- a/packages/lynx-react/src/utils/get-seed-class-name.ts
+++ b/packages/lynx-react/src/utils/get-seed-class-name.ts
@@ -15,6 +15,9 @@ export interface GetSeedClassNameOptions {
  *
  * 테마(dark/light)를 자동 감지하여 렌더링 전에 올바른 CSS 변수가 적용되도록 한다.
  *
+ * 호출 시점의 테마를 한 번만 읽는 순수 함수다. 런타임 테마 변경에 반응해야 하면
+ * reactive 버전인 `useSeedClassName` 훅을 사용한다.
+ *
  * @example
  * ```tsx
  * import { getSeedClassName } from "@seed-design/lynx-react";


### PR DESCRIPTION
## 문제

Lynx에서 host가 테마(`lynx.__globalProps.theme`)를 변경해도 root `<page>`의 className이 갱신되지 않아 변경된 테마가 적용되지 않는 버그가 있었습니다.

**원인**: `getSeedClassName()`은 순수 함수라 호출 시점의 theme을 한 번만 읽고 ReactLynx의 globalProps 구독에 걸리지 않습니다. 이전 Root는 `useSafeArea()`를 호출했고, 이 훅이 본문에서 `lynx.__globalProps`를 읽어 **우연히** Root를 globalProps 구독자로 만들어줬는데, 그 훅이 빠지면서 버그가 드러났습니다.

## 변경

- **`useSeedClassName()` 훅 신설** (`packages/lynx-react`): `useGlobalProps()`로 theme을 구독하는 reactive 버전. className 매핑은 기존 `getSeedClassName()`에 위임하고 `colorMode` 옵션을 그대로 지원합니다.
- **`getSeedClassName()` 순수 함수는 유지** — 테마 변경에 반응할 필요가 없는 정적 컨텍스트용. JSDoc에 교차 참조만 추가했습니다.
- **`@lynx-js/react` peer `>=0.117.0` / dev `^0.117.0`로 상향** — `useGlobalProps`/`useGlobalPropsChanged`가 0.117.0에서 추가됐기 때문입니다. 0.116 이하 사용자에게 breaking이라 changeset에 `BREAKING CHANGE` 접두사를 붙였습니다.
- **example** `lynx-spa` Root를 새 훅으로 교체했습니다.
- **docs** `theming.mdx` 갱신 + 새 훅 문서 `use-seed-class-name.mdx` 추가 + meta 등록.
- **changeset** `@seed-design/lynx-react` minor.

## 검증

- typecheck / build / biome / example `tsc --noEmit` / **publint(All good)** / `docs:test` 전부 통과.
- 빌드 산출물(`lib`)에 `useSeedClassName`이 정상 export됨을 확인했습니다.

## 남은 것 (런타임 수동 검증)

실제 리렌더 동작은 Lynx 런타임이 필요해 자동 검증이 불가합니다. `examples/lynx-spa`를 Lynx Explorer/시뮬레이터로 띄워 테마를 라이트↔다크 토글하며 즉시 반영되는지 최종 확인이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 테마 변경에 자동으로 반응하는 새 훅이 추가되어, 루트 페이지의 클래스명이 시스템 테마 변경 시 즉시 갱신됩니다.
  * 관련 사용 예시와 문서가 추가되어 테마 적용 방법을 더 쉽게 확인할 수 있습니다.

* **Bug Fixes**
  * 정적 방식으로만 동작하던 테마 클래스 적용 가이드를 최신 동작 방식에 맞게 정리했습니다.

* **Chores**
  * `@lynx-js/react` 0.117.0 이상이 필요합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->