### PR TITLE
refactor: remove import from @seed-design/css/vars/component in @seed-design/react

### DIFF
--- a/packages/react/src/components/ImageFrame/ImageFrame.tsx
+++ b/packages/react/src/components/ImageFrame/ImageFrame.tsx
@@ -11,7 +11,6 @@ import {
   type ImageFrameIndicatorVariantProps,
 } from "@seed-design/css/recipes/image-frame-indicator";
 import { imageFrameReactionButton } from "@seed-design/css/recipes/image-frame-reaction-button";
-import { imageFrameFloater as floaterVars } from "@seed-design/css/vars/component";
 import { mergeProps } from "@seed-design/dom-utils";
 import { Image } from "@seed-design/react-image";
 import { Toggle as TogglePrimitive, useToggleContext } from "@seed-design/react-toggle";
@@ -107,19 +106,9 @@ export interface ImageFrameFloaterProps extends FloatProps {}
 
 /**
  * ImageFrame 내에서 오버레이 요소를 배치하기 위한 컴포넌트
- *
- * @remarks
- * offsetX, offsetY 기본값은 rootage 스펙(image-frame-floater)에서 가져옵니다.
  */
 export const ImageFrameFloater = React.forwardRef<HTMLDivElement, ImageFrameFloaterProps>(
-  (
-    {
-      offsetX = floaterVars.base.enabled.root.offset,
-      offsetY = floaterVars.base.enabled.root.offset,
-      ...rest
-    },
-    ref,
-  ) => {
+  ({ offsetX = "x1_5", offsetY = "x1_5", ...rest }, ref) => {
     return <Float ref={ref} offsetX={offsetX} offsetY={offsetY} {...rest} />;
   },
 );

--- a/packages/react/src/components/ScrollFog/ScrollFog.tsx
+++ b/packages/react/src/components/ScrollFog/ScrollFog.tsx
@@ -1,7 +1,6 @@
 import { scrollFog, type ScrollFogVariantProps } from "@seed-design/css/recipes/scroll-fog";
 import clsx from "clsx";
 import { forwardRef, useMemo } from "react";
-import { scrollFog as vars } from "@seed-design/css/vars/component";
 
 type ScrollPlacement = "top" | "bottom" | "left" | "right";
 
@@ -35,15 +34,7 @@ export interface ScrollFogProps
 
 export const ScrollFog = forwardRef<HTMLDivElement, ScrollFogProps>(
   (
-    {
-      className,
-      hideScrollBar,
-      placement = ["top", "bottom"],
-      size = vars.base.enabled.root.size,
-      sizes,
-      style,
-      ...props
-    },
+    { className, hideScrollBar, placement = ["top", "bottom"], size = 20, sizes, style, ...props },
     ref,
   ) => {
     const [variantProps, restProps] = scrollFog.splitVariantProps({
@@ -51,7 +42,7 @@ export const ScrollFog = forwardRef<HTMLDivElement, ScrollFogProps>(
       ...props,
     });
     const scrollFogClassName = scrollFog(variantProps);
-    const sizePx = typeof size === "number" ? `${size}px` : size;
+    const sizePx = typeof size === "number" ? `${size}px` : size; // TODO: redundant typeof?
 
     const sizeStyle = useMemo(() => {
       const finalSizes = {

--- a/packages/rootage/components/image-frame-floater.yaml
+++ b/packages/rootage/components/image-frame-floater.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=./schema.json
-# NOTE: do not remove this file unless you're bumping the major version of @seed-design/react; vars generated from here are imported in react/src/components/ImageFrame/ImageFrame.tsx
+# NOTE: do not remove this file unless you're bumping the major version of @seed-design/react; vars generated from here have been imported in react/src/components/ImageFrame/ImageFrame.tsx
 kind: ComponentSpec
 metadata:
   id: image-frame-floater
@@ -16,5 +16,5 @@ data:
     base:
       enabled:
         root:
-          # NOTE: do not move/remove this property unless you're bumping the major version of @seed-design/react; vars generated from here are imported in react/src/components/ImageFrame/ImageFrame.tsx
+          # NOTE: do not move/remove this property unless you're bumping the major version of @seed-design/react; vars generated from here have been imported in react/src/components/ImageFrame/ImageFrame.tsx
           offset: 6px

--- a/packages/rootage/components/image-frame-floater.yaml
+++ b/packages/rootage/components/image-frame-floater.yaml
@@ -1,4 +1,5 @@
 # yaml-language-server: $schema=./schema.json
+# NOTE: do not remove this file unless you're bumping the major version of @seed-design/react; vars generated from here are imported in react/src/components/ImageFrame/ImageFrame.tsx
 kind: ComponentSpec
 metadata:
   id: image-frame-floater
@@ -15,4 +16,5 @@ data:
     base:
       enabled:
         root:
+          # NOTE: do not move/remove this property unless you're bumping the major version of @seed-design/react; vars generated from here are imported in react/src/components/ImageFrame/ImageFrame.tsx
           offset: 6px

--- a/packages/rootage/components/scroll-fog.yaml
+++ b/packages/rootage/components/scroll-fog.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=./schema.json
-# NOTE: do not remove this file unless you're bumping the major version of @seed-design/react; vars generated from here are imported in react/src/components/ScrollFog/ScrollFog.tsx
+# NOTE: do not remove this file unless you're bumping the major version of @seed-design/react; vars generated from here have been imported in react/src/components/ScrollFog/ScrollFog.tsx
 kind: ComponentSpec
 metadata:
   id: scroll-fog
@@ -21,5 +21,5 @@ data:
         root:
           fromColor: "#00000000"
           toColor: "#000000ff"
-          # NOTE: do not move/remove this property unless you're bumping the major version of @seed-design/react; vars generated from here are imported in react/src/components/ScrollFog/ScrollFog.tsx
+          # NOTE: do not move/remove this property unless you're bumping the major version of @seed-design/react; vars generated from here have been imported in react/src/components/ScrollFog/ScrollFog.tsx
           size: 20px

--- a/packages/rootage/components/scroll-fog.yaml
+++ b/packages/rootage/components/scroll-fog.yaml
@@ -1,4 +1,5 @@
 # yaml-language-server: $schema=./schema.json
+# NOTE: do not remove this file unless you're bumping the major version of @seed-design/react; vars generated from here are imported in react/src/components/ScrollFog/ScrollFog.tsx
 kind: ComponentSpec
 metadata:
   id: scroll-fog
@@ -20,4 +21,5 @@ data:
         root:
           fromColor: "#00000000"
           toColor: "#000000ff"
+          # NOTE: do not move/remove this property unless you're bumping the major version of @seed-design/react; vars generated from here are imported in react/src/components/ScrollFog/ScrollFog.tsx
           size: 20px


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 이미지 프레임 오버레이의 기본 오프셋 값이 더 일관된 값으로 조정되었습니다.
  * 스크롤 안개 효과의 기본 크기가 고정값으로 적용되어 표시가 안정화되었습니다.
* **Documentation**
  * 이미지 프레임 플로터/스크롤 안개 관련 vars 생성 및 변경 안내 주석이 추가되어, 설정 변경 시 확인할 사항이 더 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->