### PR TITLE
fix(cli): accept dotted --seed-react-version values like 1.0

### DIFF
--- a/.changeset/witty-pandas-parse.md
+++ b/.changeset/witty-pandas-parse.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/cli": patch
+---
+
+`--seed-react-version` 옵션에 `1.0`과 같은 버전 값을 넘길 때 파싱 에러가 발생하던 문제를 수정합니다.

--- a/packages/cli/src/commands/add-all.ts
+++ b/packages/cli/src/commands/add-all.ts
@@ -10,7 +10,7 @@ import type { CAC } from "cac";
 import { BASE_URL } from "../constants";
 import { analytics } from "../utils/analytics";
 import { highlight } from "../utils/color";
-import { resolveSeedVersion } from "../utils/registry-source";
+import { readRawOptionValue, resolveSeedVersion } from "../utils/registry-source";
 import {
   analyzeRegistryItemCompatibility,
   getProjectSeedPackageVersionSpecs,
@@ -65,7 +65,9 @@ export const addAllCommand = (cli: CAC) => {
       p.intro("seed-design add-all");
 
       try {
-        const parsed = addAllOptionsSchema.safeParse({ registryIds, ...opts });
+        // CAC가 --seed-react-version 값을 숫자로 뭉개므로 rawArgs에서 원본 문자열을 읽어 덮어쓴다.
+        const seedReactVersion = readRawOptionValue(cli.rawArgs, "--seed-react-version");
+        const parsed = addAllOptionsSchema.safeParse({ registryIds, ...opts, seedReactVersion });
         if (!parsed.success) {
           throw parsed.error;
         }

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 import type { CAC } from "cac";
 import { BASE_URL } from "../constants";
 import { highlight } from "../utils/color";
-import { resolveSeedVersion } from "../utils/registry-source";
+import { readRawOptionValue, resolveSeedVersion } from "../utils/registry-source";
 import { installDependencies } from "../utils/install";
 import { analytics } from "../utils/analytics";
 import {
@@ -64,7 +64,9 @@ export const addCommand = (cli: CAC) => {
       p.intro("seed-design add");
 
       try {
-        const parsed = addOptionsSchema.safeParse({ itemIds, ...opts });
+        // CAC가 --seed-react-version 값을 숫자로 뭉개므로 rawArgs에서 원본 문자열을 읽어 덮어쓴다.
+        const seedReactVersion = readRawOptionValue(cli.rawArgs, "--seed-react-version");
+        const parsed = addOptionsSchema.safeParse({ itemIds, ...opts, seedReactVersion });
         if (!parsed.success) {
           throw parsed.error;
         }

--- a/packages/cli/src/tests/registry-source.test.ts
+++ b/packages/cli/src/tests/registry-source.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { readRawOptionValue, resolveSeedVersion } from "../utils/registry-source";
+
+describe("readRawOptionValue", () => {
+  it("`--flag value` 형식에서 원본 문자열을 읽는다", () => {
+    // CAC는 이 값을 숫자 1로 뭉개지만 rawArgs엔 "1.0"이 그대로 남아있다.
+    expect(
+      readRawOptionValue(
+        ["node", "cli", "add", "--seed-react-version", "1.0"],
+        "--seed-react-version",
+      ),
+    ).toBe("1.0");
+  });
+
+  it("`--flag=value` 형식에서 원본 문자열을 읽는다", () => {
+    expect(
+      readRawOptionValue(
+        ["node", "cli", "add", "--seed-react-version=1.2"],
+        "--seed-react-version",
+      ),
+    ).toBe("1.2");
+  });
+
+  it("플래그가 없으면 undefined를 반환한다", () => {
+    expect(readRawOptionValue(["node", "cli", "add"], "--seed-react-version")).toBeUndefined();
+  });
+});
+
+describe("resolveSeedVersion", () => {
+  it("지원하는 버전을 아카이브 baseUrl로 해석한다", () => {
+    expect(resolveSeedVersion({ seedReactVersion: "1.0" })).toEqual({
+      framework: "react",
+      baseUrl: "https://v1-0.seed-design.io",
+    });
+    expect(resolveSeedVersion({ seedReactVersion: "1.2" })).toEqual({
+      framework: "react",
+      baseUrl: "https://v1-2.seed-design.io",
+    });
+  });
+
+  it("버전이 없으면 null을 반환한다", () => {
+    expect(resolveSeedVersion({})).toBeNull();
+  });
+
+  it("지원하지 않는 버전이면 에러를 던진다", () => {
+    expect(() => resolveSeedVersion({ seedReactVersion: "9.9" })).toThrow();
+  });
+});

--- a/packages/cli/src/utils/registry-source.ts
+++ b/packages/cli/src/utils/registry-source.ts
@@ -36,3 +36,19 @@ export function resolveSeedVersion(opts: {
 
   return { framework: "react", baseUrl };
 }
+
+/**
+ * CLI rawArgs에서 옵션의 원본 문자열 값을 직접 읽는다.
+ *
+ * CAC(내부 mri)는 `--seed-react-version 1.0`의 값을 숫자 1로 강제변환해 trailing zero를
+ * 잃는다(→ z.string() 검증도 깨진다). 원본 문자열은 rawArgs에 그대로 남아있으므로 여기서
+ * 직접 읽어 coercion을 우회한다. `--flag value`와 `--flag=value` 두 형식을 지원한다.
+ */
+export function readRawOptionValue(rawArgs: string[], flag: string): string | undefined {
+  for (let i = 0; i < rawArgs.length; i++) {
+    const arg = rawArgs[i];
+    if (arg === flag) return rawArgs[i + 1];
+    if (arg.startsWith(`${flag}=`)) return arg.slice(flag.length + 1);
+  }
+  return undefined;
+}


### PR DESCRIPTION
## 문제

`seed-design add --seed-react-version 1.0` 실행 시 `ZodError: seedReactVersion: Expected string, received number`로 크래시했습니다.

## 원인

CAC(내부 mri)가 숫자형 옵션 값을 강제로 number로 변환합니다 (`1.0` → `1`). 그래서:
- 스키마 `seedReactVersion: z.string()`가 number를 거부 → ZodError
- `1.0`은 JS에서 `1`과 같아 trailing zero까지 소실

실측 결과 `opts.seedReactVersion`은 뭉개진 `1`이지만, `cli.rawArgs`엔 원본 `"1.0"`이 그대로 남아있었습니다.

## 해결

`cli.rawArgs`에서 `--seed-react-version` 원본 문자열을 직접 읽어 coercion을 우회합니다. **스키마와 리졸버(`resolveSeedVersion`)는 변경하지 않았습니다.**

- `registry-source.ts`: `readRawOptionValue` 헬퍼 추가 (`--flag value` / `--flag=value` 지원)
- `add.ts` / `add-all.ts`: action에서 rawArgs 원본을 `safeParse`에 주입

## 검증

- `1.0` / `1.1` / `1.2` 모두 정상 동작
- 관리하지 않는 버전(예: `9.9`)은 기존 한국어 힌트로 안내: `사용 가능한 버전: 1.0, 1.1, 1.2`
- 테스트 6개 추가 (`registry-source.test.ts`), 6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `add` 및 `add-all` 명령에서 버전 옵션이 올바르게 전달되지 않던 문제를 수정했습니다.
  * `--seed-react-version`에 `1.0` 같은 값을 넣어도 파싱 오류 없이 처리됩니다.

* **Tests**
  * 버전 옵션을 다양한 입력 형식으로 읽는 동작과, 지원 버전 처리 관련 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->