### PR TITLE
feat(rootage): expose inline gradient stops and serialized in component vars

### DIFF
--- a/.changeset/quiet-moons-gather.md
+++ b/.changeset/quiet-moons-gather.md
@@ -1,0 +1,10 @@
+---
+"@seed-design/css": patch
+"@seed-design/lynx-css": patch
+---
+
+컴포넌트 vars의 gradient가 문자열 대신 `{ serialized, stops? }` 객체로 제공됩니다.
+
+- `serialized`: 기존과 동일한 CSS gradient 문자열입니다. `linear-gradient(88deg, ${vars.toneMagic.enabled.root.gradient.serialized})`처럼 사용합니다.
+- `stops`: `{ color, position }` 배열로, position이 0~1 원본 값이라 stop마다 `calc()`로 위치를 계산하는 등 동적으로 다룰 수 있습니다. 테마별로 값이 다른 gradient에는 제공되지 않습니다.
+- 생성되는 CSS는 이전과 동일합니다.

--- a/ecosystem/rootage/cli/src/index.ts
+++ b/ecosystem/rootage/cli/src/index.ts
@@ -3,6 +3,7 @@
 import {
   Authoring,
   buildContext,
+  createTokenValuesResolver,
   css,
   exchange,
   getComponentSpecDeclarations,
@@ -130,6 +131,7 @@ async function writeComponentSpec(prefix?: string) {
 
   const tsStringifier = typescript.createStringifier({
     prefix,
+    resolveTokenValues: createTokenValuesResolver(ctx),
   });
 
   const specs = getComponentSpecDeclarations(ctx);

--- a/ecosystem/rootage/core/src/analyzer/index.ts
+++ b/ecosystem/rootage/core/src/analyzer/index.ts
@@ -5,6 +5,11 @@ export {
   getTokenDeclarations,
   getSourceFiles,
 } from "./context";
-export { transformResolvedType, resolveReferences, resolveToken } from "./resolver";
+export {
+  createTokenValuesResolver,
+  transformResolvedType,
+  resolveReferences,
+  resolveToken,
+} from "./resolver";
 export type * from "./types";
 export { validate } from "./validate";

--- a/ecosystem/rootage/core/src/analyzer/resolver.test.ts
+++ b/ecosystem/rootage/core/src/analyzer/resolver.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { Authoring, visitEachChild, visitNode, type AST } from "../parser";
+import { Authoring, factory, visitEachChild, visitNode, type AST } from "../parser";
 import { buildContext } from "./context";
-import { transformResolvedType, resolveReferences, resolveToken } from "./resolver";
+import {
+  createTokenValuesResolver,
+  transformResolvedType,
+  resolveReferences,
+  resolveToken,
+} from "./resolver";
 import type { ResolvedTokenResult, SourceFile } from "./types";
 import type { Node } from "../parser/ast";
 
@@ -143,6 +148,107 @@ describe("resolveToken", () => {
       path: ["$color.bg.layer-default", "$color.bg.layer-1", "$color.palette.gray-00"],
       value: { kind: "ColorHexLit", value: "#000000" },
     } satisfies ResolvedTokenResult);
+  });
+});
+
+describe("createTokenValuesResolver", () => {
+  it("should resolve a token reference once per collection mode in declaration order", () => {
+    const ctx = buildContext([
+      {
+        fileName: "collection",
+        ast: Authoring.fromObject({
+          kind: "TokenCollections",
+          metadata: {
+            name: "collection",
+            id: "id",
+          },
+          data: [
+            {
+              name: "color",
+              modes: [{ id: "light" }, { id: "dark" }],
+            },
+          ],
+        }),
+      },
+      {
+        fileName: "tokens",
+        ast: Authoring.fromObject({
+          kind: "Tokens",
+          metadata: {
+            name: "tokens",
+            id: "id",
+          },
+          data: {
+            collection: "color",
+            tokens: {
+              "$color.palette.neutral": {
+                values: {
+                  light: "#ffffff",
+                  dark: "#000000",
+                },
+              },
+              "$color.bg.neutral": {
+                values: {
+                  light: "$color.palette.neutral",
+                  dark: "$color.palette.neutral",
+                },
+              },
+            },
+          },
+        }),
+      },
+    ]);
+    const resolveTokenValues = createTokenValuesResolver(ctx);
+
+    expect(resolveTokenValues(factory.createTokenLit("$color.bg.neutral"))).toEqual([
+      { kind: "ColorHexLit", value: "#ffffff" },
+      { kind: "ColorHexLit", value: "#000000" },
+    ]);
+  });
+
+  it("should return undefined when a token cannot be resolved for every mode", () => {
+    const ctx = buildContext([
+      {
+        fileName: "collection",
+        ast: Authoring.fromObject({
+          kind: "TokenCollections",
+          metadata: {
+            name: "collection",
+            id: "id",
+          },
+          data: [
+            {
+              name: "color",
+              modes: [{ id: "light" }, { id: "dark" }],
+            },
+          ],
+        }),
+      },
+      {
+        fileName: "tokens",
+        ast: Authoring.fromObject({
+          kind: "Tokens",
+          metadata: {
+            name: "tokens",
+            id: "id",
+          },
+          data: {
+            collection: "color",
+            tokens: {
+              "$color.incomplete": {
+                values: {
+                  light: "#ffffff",
+                },
+              },
+            },
+          },
+        }),
+      },
+    ]);
+    const resolveTokenValues = createTokenValuesResolver(ctx);
+
+    expect(resolveTokenValues(factory.createTokenLit("$color.incomplete"))).toBeUndefined();
+    expect(resolveTokenValues(factory.createTokenLit("$color.unknown"))).toBeUndefined();
   });
 });
 

--- a/ecosystem/rootage/core/src/analyzer/resolver.ts
+++ b/ecosystem/rootage/core/src/analyzer/resolver.ts
@@ -2,6 +2,35 @@ import { type AST, factory, visitEachChild, visitNode } from "../parser";
 import type { Node, TokenRef } from "../parser/ast";
 import type { ComponentSpecRef, ResolvedTokenResult, RootageCtx } from "./types";
 
+/**
+ * Creates a resolver that expands a token reference into one resolved value per collection mode.
+ * Values follow the collection's declared mode order. The resolver returns `undefined` when the
+ * token or its collection cannot be resolved for every mode.
+ */
+export function createTokenValuesResolver(ctx: RootageCtx) {
+  return (token: AST.TokenLit): AST.ValueLit[] | undefined => {
+    const node = ctx.dependencyGraph[token.identifier];
+
+    if (!node) return undefined;
+
+    const collection = ctx.tokenCollectionEntities[node.collection];
+
+    if (!collection) return undefined;
+
+    const values: AST.ValueLit[] = [];
+
+    for (const mode of collection.modes) {
+      try {
+        values.push(resolveToken(ctx, token.identifier, { [node.collection]: mode.id }).value);
+      } catch {
+        return undefined;
+      }
+    }
+
+    return values;
+  };
+}
+
 export function resolveToken(
   rootage: Pick<RootageCtx, "dependencyGraph" | "tokenEntities">,
   tokenId: TokenRef,

--- a/ecosystem/rootage/core/src/languages/typescript.test.ts
+++ b/ecosystem/rootage/core/src/languages/typescript.test.ts
@@ -1,7 +1,58 @@
 import { describe, expect, it, test } from "bun:test";
 import YAML from "yaml";
-import { Authoring } from "../parser";
+import { Authoring, factory } from "../parser";
 import { createStringifier, getExchangeDts, getExchangeMjs } from "./typescript";
+
+/** Creates a gradient value matching the per-mode values returned by resolveTokenValues. */
+function fakeGradient(...stops: [string, number][]) {
+  return factory.createGradientLit(
+    stops.map(([color, position]) =>
+      factory.createGradientStopLit(
+        { kind: "ColorHexLit", value: color as `#${string}` },
+        { kind: "NumberLit", value: position },
+      ),
+    ),
+  );
+}
+
+/**
+ * Creates a minimal spec that references a gradient token.
+ * The parser leaves token references as `UnresolvedPropertyDeclaration`, and the analyzer's
+ * `transformResolvedType` assigns their final kind through `getComponentSpecDeclarations`.
+ * This fixture uses the factory to represent that analyzed state directly.
+ */
+function tokenRefGradientSpec() {
+  return factory.createComponentSpecDeclaration(
+    "test",
+    "test",
+    factory.createSchemaDeclaration(
+      [
+        factory.createSlotSchemaDeclaration("root", [
+          factory.createPropertySchemaDeclaration("gradient", "gradient"),
+        ]),
+      ],
+      [],
+    ),
+    [
+      factory.createVariantDeclaration(
+        [],
+        [
+          factory.createStateDeclaration(
+            [],
+            [
+              factory.createSlotDeclaration("root", [
+                factory.createGradientPropertyDeclaration(
+                  "gradient",
+                  factory.createTokenLit("$gradient.mask-fade"),
+                ),
+              ]),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );
+}
 
 const { getComponentSpecDts, getComponentSpecMjs, getTokenDts, getTokenMjs } = createStringifier({
   prefix: "test",
@@ -323,6 +374,162 @@ data:
       }
     }"
   `);
+});
+
+test("getComponentSpecMjs exposes inline gradient as structured stops and serialized", () => {
+  const yaml = `
+kind: ComponentSpec
+metadata:
+  id: test
+  name: test
+data:
+  schema:
+    slots:
+      root:
+        properties:
+          gradient:
+            type: gradient
+  definitions:
+    base:
+      enabled:
+        root:
+          gradient:
+            type: gradient
+            value:
+              - color: "#00000000"
+                position: 0
+              - color: "#00000014"
+                position: 0.29
+              - color: "#000000ff"
+                position: 1
+`;
+  const model = Authoring.parseComponentSpecDocument(YAML.parse(yaml));
+
+  const result = getComponentSpecMjs(model.data);
+
+  // Structured stops preserve raw position values between 0 and 1.
+  expect(result).toContain('"stops"');
+  expect(result).toContain('"position": 0.29');
+  // A serialized CSS value remains available for static use.
+  expect(result).toContain('"serialized"');
+});
+
+test("getComponentSpecDts injects property JSDoc on the real property only, not gradient stop keys", () => {
+  const yaml = `
+kind: ComponentSpec
+metadata:
+  id: test
+  name: test
+data:
+  schema:
+    slots:
+      root:
+        properties:
+          color:
+            type: color
+            description: COLOR_DESC
+          gradient:
+            type: gradient
+  definitions:
+    base:
+      enabled:
+        root:
+          color: "#ffffff"
+          gradient:
+            type: gradient
+            value:
+              - color: "#00000000"
+                position: 0
+              - color: "#000000ff"
+                position: 1
+`;
+  const model = Authoring.parseComponentSpecDocument(YAML.parse(yaml));
+
+  const result = getComponentSpecDts(model.data);
+
+  // The color property description must be injected exactly once on the property declaration.
+  // An unanchored replacement would also inject it into the gradient stop's "color" key.
+  expect((result.match(/COLOR_DESC/g) || []).length).toBe(1);
+});
+
+const TOKEN_REF_GRADIENT_YAML = `
+kind: ComponentSpec
+metadata:
+  id: test
+  name: test
+data:
+  schema:
+    slots:
+      root:
+        properties:
+          gradient:
+            type: gradient
+          color:
+            type: color
+  definitions:
+    base:
+      enabled:
+        root:
+          gradient: $gradient.mask-fade
+          color: $color.fg.neutral
+`;
+
+test("getComponentSpecMjs resolves a mode-invariant gradient token into serialized and stops", () => {
+  // A mode-invariant gradient includes stops for dynamic operations.
+  const { getComponentSpecMjs: generate } = createStringifier({
+    prefix: "test",
+    resolveTokenValues: () => [
+      fakeGradient(["#00000000", 0], ["#000000ff", 1]),
+      fakeGradient(["#00000000", 0], ["#000000ff", 1]),
+    ],
+  });
+
+  const result = generate(tokenRefGradientSpec());
+
+  expect(result).toContain('"serialized": "var(--test-gradient-mask-fade)"');
+  expect(result).toContain('"stops"');
+  expect(result).toContain('"position": 1');
+});
+
+test("getComponentSpecMjs omits stops for a theme-dependent gradient token", () => {
+  // A mode-dependent gradient exposes only its serialized form because one stops array is invalid.
+  const { getComponentSpecMjs: generate } = createStringifier({
+    prefix: "test",
+    resolveTokenValues: () => [
+      fakeGradient(["#00000000", 0], ["#000000ff", 1]),
+      fakeGradient(["#ffffff00", 0], ["#ffffffff", 1]),
+    ],
+  });
+
+  const result = generate(tokenRefGradientSpec());
+
+  expect(result).toContain('"serialized": "var(--test-gradient-mask-fade)"');
+  expect(result).not.toContain('"stops"');
+});
+
+test("getComponentSpecMjs keeps non-gradient token references as plain strings", () => {
+  const model = Authoring.parseComponentSpecDocument(YAML.parse(TOKEN_REF_GRADIENT_YAML));
+
+  // Non-gradient properties remain var() strings regardless of the resolver.
+  const { getComponentSpecMjs: generate } = createStringifier({
+    prefix: "test",
+    resolveTokenValues: () => [fakeGradient(["#00000000", 0], ["#000000ff", 1])],
+  });
+
+  const result = generate(model.data);
+
+  expect(result).toContain('"color": "var(--test-color-fg-neutral)"');
+});
+
+test("getComponentSpecMjs keeps the gradient shape stable without a resolver", () => {
+  // Gradient properties keep their object shape without a resolver. Switching between strings and
+  // objects based on caller configuration would make consumer `.serialized` access silently fail.
+  const { getComponentSpecMjs: generate } = createStringifier({ prefix: "test" });
+
+  const result = generate(tokenRefGradientSpec());
+
+  expect(result).toContain('"serialized": "var(--test-gradient-mask-fade)"');
+  expect(result).not.toContain('"stops"');
 });
 
 test("getComponentSpecDts should generate typescript definitions", () => {

--- a/ecosystem/rootage/core/src/languages/typescript.ts
+++ b/ecosystem/rootage/core/src/languages/typescript.ts
@@ -1,11 +1,27 @@
 import { camelCase } from "change-case";
 import type {
   ComponentSpecDeclaration,
+  GradientLit,
+  PropertyDeclaration,
   StateExpression,
   TokenDeclaration,
+  TokenLit,
+  ValueLit,
   VariantExpression,
 } from "../parser/ast";
 import { createStringifier as createCssStringifier } from "./css";
+
+interface GradientStopVars {
+  color: string;
+  position: number;
+}
+
+/**
+ * A property value exposed through component vars.
+ * Gradients include a serialized CSS value for static use and structured stops for dynamic use.
+ * All other values remain flattened CSS strings.
+ */
+type PropertyValue = string | { serialized: string; stops?: GradientStopVars[] };
 
 interface TokenDefinition {
   key: string;
@@ -45,35 +61,95 @@ function stringifyStateKey(state: StateExpression[]): string {
   return camelCase(state.map((s) => s.value).join("-"));
 }
 
-export function createStringifier(options: { prefix?: string } = {}) {
+export function createStringifier(
+  options: {
+    prefix?: string;
+    /**
+     * Resolves a token reference to one value per collection mode.
+     * Values follow the collection's declared mode order; unresolved tokens return `undefined`.
+     */
+    resolveTokenValues?: (token: TokenLit) => ValueLit[] | undefined;
+  } = {},
+) {
   const cssStringifier = createCssStringifier(options);
+  const { resolveTokenValues } = options;
+
+  function stringifyStops(gradient: GradientLit): GradientStopVars[] {
+    return gradient.stops.map((stop) => ({
+      color:
+        stop.color.kind === "TokenLit"
+          ? cssStringifier.tokenReference(stop.color)
+          : stop.color.value,
+      position: stop.position.value,
+    }));
+  }
+
+  /**
+   * Returns stops when a gradient token has the same stops in every mode.
+   * Mode-dependent gradients cannot be represented by one stops array and return `undefined`.
+   */
+  function resolveModeInvariantStops(token: TokenLit): GradientStopVars[] | undefined {
+    const values = resolveTokenValues?.(token);
+
+    if (!values?.length || values.some((value) => value.kind !== "GradientLit")) {
+      return undefined;
+    }
+
+    const [first, ...rest] = (values as GradientLit[]).map(stringifyStops);
+
+    if (!first) return undefined;
+
+    return rest.every((stops) => JSON.stringify(stops) === JSON.stringify(first))
+      ? first
+      : undefined;
+  }
+
+  function stringifyProperty(decl: PropertyDeclaration): PropertyValue {
+    // Gradients expose both a serialized CSS value and structured stops for dynamic operations
+    // such as per-stop calc interpolation. Positions preserve their raw values between 0 and 1.
+    // Inline values and token references share the same AST kind, so their output shape is stable.
+    if (decl.kind === "GradientPropertyDeclaration") {
+      const { value } = decl;
+
+      if (value.kind === "GradientLit") {
+        return { serialized: cssStringifier.valueOrToken(value), stops: stringifyStops(value) };
+      }
+
+      const serialized = cssStringifier.tokenReference(value);
+      const stops = resolveModeInvariantStops(value);
+
+      return stops ? { serialized, stops } : { serialized };
+    }
+
+    return cssStringifier.valueOrToken(decl.value);
+  }
 
   function getComponentSpec(decl: ComponentSpecDeclaration) {
     const body = decl.body;
 
-    const result: Record<string, Record<string, Record<string, Record<string, string>>>> = {};
+    const result: Record<
+      string,
+      Record<string, Record<string, Record<string, PropertyValue>>>
+    > = {};
 
     for (const variantDecl of body) {
       const variantKey = stringifyVariantKey(variantDecl.variants);
-      const variant: Record<string, Record<string, Record<string, string>>> = {};
+      const variant: Record<string, Record<string, Record<string, PropertyValue>>> = {};
 
       for (const stateDecl of variantDecl.body) {
         const stateKey = stringifyStateKey(stateDecl.states);
-        const slot: Record<string, Record<string, string>> = {};
+        const slot: Record<string, Record<string, PropertyValue>> = {};
 
         for (const slotDecl of stateDecl.body) {
           const slotKey = slotDecl.slot;
-          const property: Record<string, string> = {};
+          const property: Record<string, PropertyValue> = {};
 
           for (const propertyDecl of slotDecl.body) {
             // An enum records a design decision rather than a value CSS can
             // consume, so it never becomes a custom property.
             if (propertyDecl.value.kind === "EnumLit") continue;
 
-            const propertyKey = propertyDecl.property;
-            const expr = propertyDecl.value;
-
-            property[propertyKey] = cssStringifier.valueOrToken(expr);
+            property[propertyDecl.property] = stringifyProperty(propertyDecl);
           }
 
           // A slot holding nothing but enums, or a state left with no slots, would
@@ -166,20 +242,25 @@ export function createStringifier(options: { prefix?: string } = {}) {
 
     let json = JSON.stringify(result, null, 2);
 
+    // Anchor JSDoc injection to the JSON indentation depth: variant 2, slot 6, property 8.
+    // ponytail: An unanchored replaceAll also injects into matching keys such as "color" or
+    // "position" inside gradient stops. The depth prefix limits matches to declaration lines and
+    // relies on the vars object retaining this fixed structure.
+
     // Add JSDoc for variant keys (indent: 2 spaces)
     for (const [key, descriptions] of variantKeyDescMap) {
       const jsdoc = `/**\n   * ${descriptions.join("\n   * ")}\n   */`;
-      json = json.replaceAll(`"${key}":`, `${jsdoc}\n  "${key}":`);
+      json = json.replaceAll(`\n  "${key}":`, `\n  ${jsdoc}\n  "${key}":`);
     }
 
     // Add JSDoc for slots (indent: 6 spaces)
     for (const [key, desc] of slotDescMap) {
-      json = json.replaceAll(`"${key}":`, `/** ${desc} */\n      "${key}":`);
+      json = json.replaceAll(`\n      "${key}":`, `\n      /** ${desc} */\n      "${key}":`);
     }
 
     // Add JSDoc for properties (indent: 8 spaces)
     for (const [key, desc] of propertyDescMap) {
-      json = json.replaceAll(`"${key}":`, `/** ${desc} */\n        "${key}":`);
+      json = json.replaceAll(`\n        "${key}":`, `\n        /** ${desc} */\n        "${key}":`);
     }
 
     return `export declare const vars: ${json}`;

--- a/packages/css/vars/component/callout.d.ts
+++ b/packages/css/vars/component/callout.d.ts
@@ -199,7 +199,9 @@ export declare const vars: {
   "toneMagic": {
     "enabled": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic)"
+        }
       },
       /** 아이콘은 Fill 타입 사용을 권장합니다. */
       "prefixIcon": {
@@ -221,7 +223,9 @@ export declare const vars: {
     },
     "pressed": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic-pressed)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic-pressed)"
+        }
       }
     }
   }

--- a/packages/css/vars/component/callout.mjs
+++ b/packages/css/vars/component/callout.mjs
@@ -169,7 +169,9 @@ export const vars = {
   "toneMagic": {
     "enabled": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic)"
+        }
       },
       "prefixIcon": {
         "color": "var(--seed-color-fg-neutral)"
@@ -189,7 +191,9 @@ export const vars = {
     },
     "pressed": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic-pressed)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic-pressed)"
+        }
       }
     }
   }

--- a/packages/css/vars/component/image-frame-reaction-button.d.ts
+++ b/packages/css/vars/component/image-frame-reaction-button.d.ts
@@ -10,7 +10,19 @@ export declare const vars: {
       },
       /** lineIcon 아래에 내려가는 하트 아이콘입니다. */
       "fillIcon": {
-        "gradient": "var(--seed-color-palette-static-black-alpha-600) 0%, var(--seed-color-palette-static-black-alpha-600) 100%",
+        "gradient": {
+          "serialized": "var(--seed-color-palette-static-black-alpha-600) 0%, var(--seed-color-palette-static-black-alpha-600) 100%",
+          "stops": [
+            {
+              "color": "var(--seed-color-palette-static-black-alpha-600)",
+              "position": 0
+            },
+            {
+              "color": "var(--seed-color-palette-static-black-alpha-600)",
+              "position": 1
+            }
+          ]
+        },
         /** 보이는 버튼 크기입니다. */
         "size": "var(--seed-dimension-x6)",
         "shadow": "0px 2px 4px 0px #00000026"
@@ -25,7 +37,19 @@ export declare const vars: {
     "selected": {
       /** lineIcon 아래에 내려가는 하트 아이콘입니다. */
       "fillIcon": {
-        "gradient": "#FF9A56 0%, #FF6600 100%"
+        "gradient": {
+          "serialized": "#FF9A56 0%, #FF6600 100%",
+          "stops": [
+            {
+              "color": "#FF9A56",
+              "position": 0
+            },
+            {
+              "color": "#FF6600",
+              "position": 1
+            }
+          ]
+        }
       },
       /** fillIcon 위로 올라가는 하트 아이콘입니다. */
       "lineIcon": {

--- a/packages/css/vars/component/image-frame-reaction-button.mjs
+++ b/packages/css/vars/component/image-frame-reaction-button.mjs
@@ -6,7 +6,19 @@ export const vars = {
         "targetSize": "var(--seed-dimension-x10)"
       },
       "fillIcon": {
-        "gradient": "var(--seed-color-palette-static-black-alpha-600) 0%, var(--seed-color-palette-static-black-alpha-600) 100%",
+        "gradient": {
+          "serialized": "var(--seed-color-palette-static-black-alpha-600) 0%, var(--seed-color-palette-static-black-alpha-600) 100%",
+          "stops": [
+            {
+              "color": "var(--seed-color-palette-static-black-alpha-600)",
+              "position": 0
+            },
+            {
+              "color": "var(--seed-color-palette-static-black-alpha-600)",
+              "position": 1
+            }
+          ]
+        },
         "size": "var(--seed-dimension-x6)",
         "shadow": "0px 2px 4px 0px #00000026"
       },
@@ -17,7 +29,19 @@ export const vars = {
     },
     "selected": {
       "fillIcon": {
-        "gradient": "#FF9A56 0%, #FF6600 100%"
+        "gradient": {
+          "serialized": "#FF9A56 0%, #FF6600 100%",
+          "stops": [
+            {
+              "color": "#FF9A56",
+              "position": 0
+            },
+            {
+              "color": "#FF6600",
+              "position": 1
+            }
+          ]
+        }
       },
       "lineIcon": {
         "color": "var(--seed-color-bg-transparent)"

--- a/packages/css/vars/component/page-banner.d.ts
+++ b/packages/css/vars/component/page-banner.d.ts
@@ -353,7 +353,9 @@ export declare const vars: {
   "toneMagicVariantWeak": {
     "enabled": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic)"
+        }
       },
       /** 아이콘은 Fill 타입 사용을 권장합니다. */
       "prefixIcon": {
@@ -374,7 +376,9 @@ export declare const vars: {
     },
     "pressed": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic-pressed)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic-pressed)"
+        }
       }
     }
   }

--- a/packages/css/vars/component/page-banner.mjs
+++ b/packages/css/vars/component/page-banner.mjs
@@ -308,7 +308,9 @@ export const vars = {
   "toneMagicVariantWeak": {
     "enabled": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic)"
+        }
       },
       "prefixIcon": {
         "color": "var(--seed-color-fg-neutral)"
@@ -328,7 +330,9 @@ export const vars = {
     },
     "pressed": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic-pressed)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic-pressed)"
+        }
       }
     }
   }

--- a/packages/css/vars/component/skeleton.d.ts
+++ b/packages/css/vars/component/skeleton.d.ts
@@ -56,7 +56,9 @@ export declare const vars: {
         "color": "var(--seed-color-palette-gray-200)"
       },
       "shimmer": {
-        "gradient": "var(--seed-gradient-shimmer-neutral)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-shimmer-neutral)"
+        }
       }
     }
   },
@@ -69,7 +71,9 @@ export declare const vars: {
         "color": "var(--seed-color-bg-magic-weak)"
       },
       "shimmer": {
-        "gradient": "var(--seed-gradient-shimmer-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-shimmer-magic)"
+        }
       }
     }
   }

--- a/packages/css/vars/component/skeleton.mjs
+++ b/packages/css/vars/component/skeleton.mjs
@@ -41,7 +41,9 @@ export const vars = {
         "color": "var(--seed-color-palette-gray-200)"
       },
       "shimmer": {
-        "gradient": "var(--seed-gradient-shimmer-neutral)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-shimmer-neutral)"
+        }
       }
     }
   },
@@ -51,7 +53,9 @@ export const vars = {
         "color": "var(--seed-color-bg-magic-weak)"
       },
       "shimmer": {
-        "gradient": "var(--seed-gradient-shimmer-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-shimmer-magic)"
+        }
       }
     }
   }

--- a/packages/css/vars/component/top-navigation.d.ts
+++ b/packages/css/vars/component/top-navigation.d.ts
@@ -58,7 +58,19 @@ export declare const vars: {
   "toneTransparentGradientTrue": {
     "enabled": {
       "root": {
-        "gradient": "#00000059 0%, #00000000 100%",
+        "gradient": {
+          "serialized": "#00000059 0%, #00000000 100%",
+          "stops": [
+            {
+              "color": "#00000059",
+              "position": 0
+            },
+            {
+              "color": "#00000000",
+              "position": 1
+            }
+          ]
+        },
         /** gradient가 표시될 때 하단 아래로 gradient가 확장되는 길이입니다. */
         "bleedBottom": "var(--seed-dimension-x5)"
       }

--- a/packages/css/vars/component/top-navigation.mjs
+++ b/packages/css/vars/component/top-navigation.mjs
@@ -51,7 +51,19 @@ export const vars = {
   "toneTransparentGradientTrue": {
     "enabled": {
       "root": {
-        "gradient": "#00000059 0%, #00000000 100%",
+        "gradient": {
+          "serialized": "#00000059 0%, #00000000 100%",
+          "stops": [
+            {
+              "color": "#00000059",
+              "position": 0
+            },
+            {
+              "color": "#00000000",
+              "position": 1
+            }
+          ]
+        },
         "bleedBottom": "var(--seed-dimension-x5)"
       }
     }

--- a/packages/lynx-css/vars/component/callout.d.ts
+++ b/packages/lynx-css/vars/component/callout.d.ts
@@ -199,7 +199,9 @@ export declare const vars: {
   "toneMagic": {
     "enabled": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic)"
+        }
       },
       /** 아이콘은 Fill 타입 사용을 권장합니다. */
       "prefixIcon": {
@@ -221,7 +223,9 @@ export declare const vars: {
     },
     "pressed": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic-pressed)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic-pressed)"
+        }
       }
     }
   }

--- a/packages/lynx-css/vars/component/callout.mjs
+++ b/packages/lynx-css/vars/component/callout.mjs
@@ -169,7 +169,9 @@ export const vars = {
   "toneMagic": {
     "enabled": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic)"
+        }
       },
       "prefixIcon": {
         "color": "var(--seed-color-fg-neutral)"
@@ -189,7 +191,9 @@ export const vars = {
     },
     "pressed": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic-pressed)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic-pressed)"
+        }
       }
     }
   }

--- a/packages/lynx-css/vars/component/image-frame-reaction-button.d.ts
+++ b/packages/lynx-css/vars/component/image-frame-reaction-button.d.ts
@@ -10,7 +10,19 @@ export declare const vars: {
       },
       /** lineIcon 아래에 내려가는 하트 아이콘입니다. */
       "fillIcon": {
-        "gradient": "var(--seed-color-palette-static-black-alpha-600) 0%, var(--seed-color-palette-static-black-alpha-600) 100%",
+        "gradient": {
+          "serialized": "var(--seed-color-palette-static-black-alpha-600) 0%, var(--seed-color-palette-static-black-alpha-600) 100%",
+          "stops": [
+            {
+              "color": "var(--seed-color-palette-static-black-alpha-600)",
+              "position": 0
+            },
+            {
+              "color": "var(--seed-color-palette-static-black-alpha-600)",
+              "position": 1
+            }
+          ]
+        },
         /** 보이는 버튼 크기입니다. */
         "size": "var(--seed-dimension-x6)",
         "shadow": "0px 2px 4px 0px #00000026"
@@ -25,7 +37,19 @@ export declare const vars: {
     "selected": {
       /** lineIcon 아래에 내려가는 하트 아이콘입니다. */
       "fillIcon": {
-        "gradient": "#FF9A56 0%, #FF6600 100%"
+        "gradient": {
+          "serialized": "#FF9A56 0%, #FF6600 100%",
+          "stops": [
+            {
+              "color": "#FF9A56",
+              "position": 0
+            },
+            {
+              "color": "#FF6600",
+              "position": 1
+            }
+          ]
+        }
       },
       /** fillIcon 위로 올라가는 하트 아이콘입니다. */
       "lineIcon": {

--- a/packages/lynx-css/vars/component/image-frame-reaction-button.mjs
+++ b/packages/lynx-css/vars/component/image-frame-reaction-button.mjs
@@ -6,7 +6,19 @@ export const vars = {
         "targetSize": "var(--seed-dimension-x10)"
       },
       "fillIcon": {
-        "gradient": "var(--seed-color-palette-static-black-alpha-600) 0%, var(--seed-color-palette-static-black-alpha-600) 100%",
+        "gradient": {
+          "serialized": "var(--seed-color-palette-static-black-alpha-600) 0%, var(--seed-color-palette-static-black-alpha-600) 100%",
+          "stops": [
+            {
+              "color": "var(--seed-color-palette-static-black-alpha-600)",
+              "position": 0
+            },
+            {
+              "color": "var(--seed-color-palette-static-black-alpha-600)",
+              "position": 1
+            }
+          ]
+        },
         "size": "var(--seed-dimension-x6)",
         "shadow": "0px 2px 4px 0px #00000026"
       },
@@ -17,7 +29,19 @@ export const vars = {
     },
     "selected": {
       "fillIcon": {
-        "gradient": "#FF9A56 0%, #FF6600 100%"
+        "gradient": {
+          "serialized": "#FF9A56 0%, #FF6600 100%",
+          "stops": [
+            {
+              "color": "#FF9A56",
+              "position": 0
+            },
+            {
+              "color": "#FF6600",
+              "position": 1
+            }
+          ]
+        }
       },
       "lineIcon": {
         "color": "var(--seed-color-bg-transparent)"

--- a/packages/lynx-css/vars/component/page-banner.d.ts
+++ b/packages/lynx-css/vars/component/page-banner.d.ts
@@ -353,7 +353,9 @@ export declare const vars: {
   "toneMagicVariantWeak": {
     "enabled": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic)"
+        }
       },
       /** 아이콘은 Fill 타입 사용을 권장합니다. */
       "prefixIcon": {
@@ -374,7 +376,9 @@ export declare const vars: {
     },
     "pressed": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic-pressed)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic-pressed)"
+        }
       }
     }
   }

--- a/packages/lynx-css/vars/component/page-banner.mjs
+++ b/packages/lynx-css/vars/component/page-banner.mjs
@@ -308,7 +308,9 @@ export const vars = {
   "toneMagicVariantWeak": {
     "enabled": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic)"
+        }
       },
       "prefixIcon": {
         "color": "var(--seed-color-fg-neutral)"
@@ -328,7 +330,9 @@ export const vars = {
     },
     "pressed": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic-pressed)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic-pressed)"
+        }
       }
     }
   }

--- a/packages/lynx-css/vars/component/skeleton.d.ts
+++ b/packages/lynx-css/vars/component/skeleton.d.ts
@@ -56,7 +56,9 @@ export declare const vars: {
         "color": "var(--seed-color-palette-gray-200)"
       },
       "shimmer": {
-        "gradient": "var(--seed-gradient-shimmer-neutral)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-shimmer-neutral)"
+        }
       }
     }
   },
@@ -69,7 +71,9 @@ export declare const vars: {
         "color": "var(--seed-color-bg-magic-weak)"
       },
       "shimmer": {
-        "gradient": "var(--seed-gradient-shimmer-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-shimmer-magic)"
+        }
       }
     }
   }

--- a/packages/lynx-css/vars/component/skeleton.mjs
+++ b/packages/lynx-css/vars/component/skeleton.mjs
@@ -41,7 +41,9 @@ export const vars = {
         "color": "var(--seed-color-palette-gray-200)"
       },
       "shimmer": {
-        "gradient": "var(--seed-gradient-shimmer-neutral)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-shimmer-neutral)"
+        }
       }
     }
   },
@@ -51,7 +53,9 @@ export const vars = {
         "color": "var(--seed-color-bg-magic-weak)"
       },
       "shimmer": {
-        "gradient": "var(--seed-gradient-shimmer-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-shimmer-magic)"
+        }
       }
     }
   }

--- a/packages/lynx-css/vars/component/top-navigation.d.ts
+++ b/packages/lynx-css/vars/component/top-navigation.d.ts
@@ -58,7 +58,19 @@ export declare const vars: {
   "toneTransparentGradientTrue": {
     "enabled": {
       "root": {
-        "gradient": "#00000059 0%, #00000000 100%",
+        "gradient": {
+          "serialized": "#00000059 0%, #00000000 100%",
+          "stops": [
+            {
+              "color": "#00000059",
+              "position": 0
+            },
+            {
+              "color": "#00000000",
+              "position": 1
+            }
+          ]
+        },
         /** gradient가 표시될 때 하단 아래로 gradient가 확장되는 길이입니다. */
         "bleedBottom": "var(--seed-dimension-x5)"
       }

--- a/packages/lynx-css/vars/component/top-navigation.mjs
+++ b/packages/lynx-css/vars/component/top-navigation.mjs
@@ -51,7 +51,19 @@ export const vars = {
   "toneTransparentGradientTrue": {
     "enabled": {
       "root": {
-        "gradient": "#00000059 0%, #00000000 100%",
+        "gradient": {
+          "serialized": "#00000059 0%, #00000000 100%",
+          "stops": [
+            {
+              "color": "#00000059",
+              "position": 0
+            },
+            {
+              "color": "#00000000",
+              "position": 1
+            }
+          ]
+        },
         "bleedBottom": "var(--seed-dimension-x5)"
       }
     }

--- a/packages/lynx-qvism-preset/src/recipes/callout.ts
+++ b/packages/lynx-qvism-preset/src/recipes/callout.ts
@@ -134,7 +134,7 @@ const callout = defineSlotRecipe({
       },
       magic: {
         root: {
-          backgroundImage: `linear-gradient(88deg, ${vars.toneMagic.enabled.root.gradient})`,
+          backgroundImage: `linear-gradient(88deg, ${vars.toneMagic.enabled.root.gradient.serialized})`,
         },
         title: { color: vars.toneMagic.enabled.title.color },
         description: { color: vars.toneMagic.enabled.description.color },
@@ -182,7 +182,7 @@ const callout = defineSlotRecipe({
       pressed: true,
       css: {
         root: {
-          backgroundImage: `linear-gradient(88deg, ${vars.toneMagic.pressed.root.gradient})`,
+          backgroundImage: `linear-gradient(88deg, ${vars.toneMagic.pressed.root.gradient.serialized})`,
         },
       },
     },

--- a/packages/lynx-qvism-preset/src/recipes/page-banner.ts
+++ b/packages/lynx-qvism-preset/src/recipes/page-banner.ts
@@ -272,7 +272,7 @@ const pageBanner = defineSlotRecipe({
       variant: "weak",
       css: {
         root: {
-          backgroundImage: `linear-gradient(88deg, ${vars.toneMagicVariantWeak.enabled.root.gradient})`,
+          backgroundImage: `linear-gradient(88deg, ${vars.toneMagicVariantWeak.enabled.root.gradient.serialized})`,
         },
         title: { color: vars.toneMagicVariantWeak.enabled.title.color },
         description: { color: vars.toneMagicVariantWeak.enabled.description.color },
@@ -348,7 +348,7 @@ const pageBanner = defineSlotRecipe({
       pressed: true,
       css: {
         root: {
-          backgroundImage: `linear-gradient(88deg, ${vars.toneMagicVariantWeak.pressed.root.gradient})`,
+          backgroundImage: `linear-gradient(88deg, ${vars.toneMagicVariantWeak.pressed.root.gradient.serialized})`,
         },
       },
     },

--- a/packages/lynx-qvism-preset/src/vars/component/callout.d.ts
+++ b/packages/lynx-qvism-preset/src/vars/component/callout.d.ts
@@ -199,7 +199,9 @@ export declare const vars: {
   "toneMagic": {
     "enabled": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic)"
+        }
       },
       /** 아이콘은 Fill 타입 사용을 권장합니다. */
       "prefixIcon": {
@@ -221,7 +223,9 @@ export declare const vars: {
     },
     "pressed": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic-pressed)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic-pressed)"
+        }
       }
     }
   }

--- a/packages/lynx-qvism-preset/src/vars/component/callout.mjs
+++ b/packages/lynx-qvism-preset/src/vars/component/callout.mjs
@@ -169,7 +169,9 @@ export const vars = {
   "toneMagic": {
     "enabled": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic)"
+        }
       },
       "prefixIcon": {
         "color": "var(--seed-color-fg-neutral)"
@@ -189,7 +191,9 @@ export const vars = {
     },
     "pressed": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic-pressed)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic-pressed)"
+        }
       }
     }
   }

--- a/packages/lynx-qvism-preset/src/vars/component/image-frame-reaction-button.d.ts
+++ b/packages/lynx-qvism-preset/src/vars/component/image-frame-reaction-button.d.ts
@@ -10,7 +10,19 @@ export declare const vars: {
       },
       /** lineIcon 아래에 내려가는 하트 아이콘입니다. */
       "fillIcon": {
-        "gradient": "var(--seed-color-palette-static-black-alpha-600) 0%, var(--seed-color-palette-static-black-alpha-600) 100%",
+        "gradient": {
+          "serialized": "var(--seed-color-palette-static-black-alpha-600) 0%, var(--seed-color-palette-static-black-alpha-600) 100%",
+          "stops": [
+            {
+              "color": "var(--seed-color-palette-static-black-alpha-600)",
+              "position": 0
+            },
+            {
+              "color": "var(--seed-color-palette-static-black-alpha-600)",
+              "position": 1
+            }
+          ]
+        },
         /** 보이는 버튼 크기입니다. */
         "size": "var(--seed-dimension-x6)",
         "shadow": "0px 2px 4px 0px #00000026"
@@ -25,7 +37,19 @@ export declare const vars: {
     "selected": {
       /** lineIcon 아래에 내려가는 하트 아이콘입니다. */
       "fillIcon": {
-        "gradient": "#FF9A56 0%, #FF6600 100%"
+        "gradient": {
+          "serialized": "#FF9A56 0%, #FF6600 100%",
+          "stops": [
+            {
+              "color": "#FF9A56",
+              "position": 0
+            },
+            {
+              "color": "#FF6600",
+              "position": 1
+            }
+          ]
+        }
       },
       /** fillIcon 위로 올라가는 하트 아이콘입니다. */
       "lineIcon": {

--- a/packages/lynx-qvism-preset/src/vars/component/image-frame-reaction-button.mjs
+++ b/packages/lynx-qvism-preset/src/vars/component/image-frame-reaction-button.mjs
@@ -6,7 +6,19 @@ export const vars = {
         "targetSize": "var(--seed-dimension-x10)"
       },
       "fillIcon": {
-        "gradient": "var(--seed-color-palette-static-black-alpha-600) 0%, var(--seed-color-palette-static-black-alpha-600) 100%",
+        "gradient": {
+          "serialized": "var(--seed-color-palette-static-black-alpha-600) 0%, var(--seed-color-palette-static-black-alpha-600) 100%",
+          "stops": [
+            {
+              "color": "var(--seed-color-palette-static-black-alpha-600)",
+              "position": 0
+            },
+            {
+              "color": "var(--seed-color-palette-static-black-alpha-600)",
+              "position": 1
+            }
+          ]
+        },
         "size": "var(--seed-dimension-x6)",
         "shadow": "0px 2px 4px 0px #00000026"
       },
@@ -17,7 +29,19 @@ export const vars = {
     },
     "selected": {
       "fillIcon": {
-        "gradient": "#FF9A56 0%, #FF6600 100%"
+        "gradient": {
+          "serialized": "#FF9A56 0%, #FF6600 100%",
+          "stops": [
+            {
+              "color": "#FF9A56",
+              "position": 0
+            },
+            {
+              "color": "#FF6600",
+              "position": 1
+            }
+          ]
+        }
       },
       "lineIcon": {
         "color": "var(--seed-color-bg-transparent)"

--- a/packages/lynx-qvism-preset/src/vars/component/page-banner.d.ts
+++ b/packages/lynx-qvism-preset/src/vars/component/page-banner.d.ts
@@ -353,7 +353,9 @@ export declare const vars: {
   "toneMagicVariantWeak": {
     "enabled": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic)"
+        }
       },
       /** 아이콘은 Fill 타입 사용을 권장합니다. */
       "prefixIcon": {
@@ -374,7 +376,9 @@ export declare const vars: {
     },
     "pressed": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic-pressed)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic-pressed)"
+        }
       }
     }
   }

--- a/packages/lynx-qvism-preset/src/vars/component/page-banner.mjs
+++ b/packages/lynx-qvism-preset/src/vars/component/page-banner.mjs
@@ -308,7 +308,9 @@ export const vars = {
   "toneMagicVariantWeak": {
     "enabled": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic)"
+        }
       },
       "prefixIcon": {
         "color": "var(--seed-color-fg-neutral)"
@@ -328,7 +330,9 @@ export const vars = {
     },
     "pressed": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic-pressed)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic-pressed)"
+        }
       }
     }
   }

--- a/packages/lynx-qvism-preset/src/vars/component/skeleton.d.ts
+++ b/packages/lynx-qvism-preset/src/vars/component/skeleton.d.ts
@@ -56,7 +56,9 @@ export declare const vars: {
         "color": "var(--seed-color-palette-gray-200)"
       },
       "shimmer": {
-        "gradient": "var(--seed-gradient-shimmer-neutral)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-shimmer-neutral)"
+        }
       }
     }
   },
@@ -69,7 +71,9 @@ export declare const vars: {
         "color": "var(--seed-color-bg-magic-weak)"
       },
       "shimmer": {
-        "gradient": "var(--seed-gradient-shimmer-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-shimmer-magic)"
+        }
       }
     }
   }

--- a/packages/lynx-qvism-preset/src/vars/component/skeleton.mjs
+++ b/packages/lynx-qvism-preset/src/vars/component/skeleton.mjs
@@ -41,7 +41,9 @@ export const vars = {
         "color": "var(--seed-color-palette-gray-200)"
       },
       "shimmer": {
-        "gradient": "var(--seed-gradient-shimmer-neutral)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-shimmer-neutral)"
+        }
       }
     }
   },
@@ -51,7 +53,9 @@ export const vars = {
         "color": "var(--seed-color-bg-magic-weak)"
       },
       "shimmer": {
-        "gradient": "var(--seed-gradient-shimmer-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-shimmer-magic)"
+        }
       }
     }
   }

--- a/packages/lynx-qvism-preset/src/vars/component/top-navigation.d.ts
+++ b/packages/lynx-qvism-preset/src/vars/component/top-navigation.d.ts
@@ -58,7 +58,19 @@ export declare const vars: {
   "toneTransparentGradientTrue": {
     "enabled": {
       "root": {
-        "gradient": "#00000059 0%, #00000000 100%",
+        "gradient": {
+          "serialized": "#00000059 0%, #00000000 100%",
+          "stops": [
+            {
+              "color": "#00000059",
+              "position": 0
+            },
+            {
+              "color": "#00000000",
+              "position": 1
+            }
+          ]
+        },
         /** gradient가 표시될 때 하단 아래로 gradient가 확장되는 길이입니다. */
         "bleedBottom": "var(--seed-dimension-x5)"
       }

--- a/packages/lynx-qvism-preset/src/vars/component/top-navigation.mjs
+++ b/packages/lynx-qvism-preset/src/vars/component/top-navigation.mjs
@@ -51,7 +51,19 @@ export const vars = {
   "toneTransparentGradientTrue": {
     "enabled": {
       "root": {
-        "gradient": "#00000059 0%, #00000000 100%",
+        "gradient": {
+          "serialized": "#00000059 0%, #00000000 100%",
+          "stops": [
+            {
+              "color": "#00000059",
+              "position": 0
+            },
+            {
+              "color": "#00000000",
+              "position": 1
+            }
+          ]
+        },
         "bleedBottom": "var(--seed-dimension-x5)"
       }
     }

--- a/packages/qvism-preset/src/recipes/callout.ts
+++ b/packages/qvism-preset/src/recipes/callout.ts
@@ -286,7 +286,7 @@ const callout = defineSlotRecipe({
       },
       magic: {
         root: {
-          backgroundImage: `linear-gradient(88deg, ${vars.toneMagic.enabled.root.gradient})`,
+          backgroundImage: `linear-gradient(88deg, ${vars.toneMagic.enabled.root.gradient.serialized})`,
 
           ...prefixIcon({
             color: vars.toneMagic.enabled.prefixIcon.color,
@@ -296,7 +296,7 @@ const callout = defineSlotRecipe({
           }),
 
           [pseudo(":is(button, a)", engaged)]: {
-            backgroundImage: `linear-gradient(88deg, ${vars.toneMagic.pressed.root.gradient})`,
+            backgroundImage: `linear-gradient(88deg, ${vars.toneMagic.pressed.root.gradient.serialized})`,
           },
         },
         title: {

--- a/packages/qvism-preset/src/recipes/page-banner.ts
+++ b/packages/qvism-preset/src/recipes/page-banner.ts
@@ -497,7 +497,7 @@ const pageBanner = defineSlotRecipe({
       variant: "weak",
       css: {
         root: {
-          backgroundImage: `linear-gradient(88deg, ${vars.toneMagicVariantWeak.enabled.root.gradient})`,
+          backgroundImage: `linear-gradient(88deg, ${vars.toneMagicVariantWeak.enabled.root.gradient.serialized})`,
 
           ...prefixIcon({
             color: vars.toneMagicVariantWeak.enabled.prefixIcon.color,
@@ -507,7 +507,7 @@ const pageBanner = defineSlotRecipe({
           }),
 
           [pseudo(":is(button)", engaged)]: {
-            backgroundImage: `linear-gradient(88deg, ${vars.toneMagicVariantWeak.pressed.root.gradient})`,
+            backgroundImage: `linear-gradient(88deg, ${vars.toneMagicVariantWeak.pressed.root.gradient.serialized})`,
           },
         },
         title: {

--- a/packages/qvism-preset/src/recipes/skeleton.ts
+++ b/packages/qvism-preset/src/recipes/skeleton.ts
@@ -50,14 +50,14 @@ const skeleton = defineRecipe({
         background: vars.toneNeutral.enabled.root.color,
 
         "&::after": {
-          backgroundImage: `linear-gradient(90deg, ${vars.toneNeutral.enabled.shimmer.gradient})`,
+          backgroundImage: `linear-gradient(90deg, ${vars.toneNeutral.enabled.shimmer.gradient.serialized})`,
         },
       },
       magic: {
         background: vars.toneMagic.enabled.root.color,
 
         "&::after": {
-          backgroundImage: `linear-gradient(90deg, ${vars.toneMagic.enabled.shimmer.gradient})`,
+          backgroundImage: `linear-gradient(90deg, ${vars.toneMagic.enabled.shimmer.gradient.serialized})`,
         },
       },
     },

--- a/packages/qvism-preset/src/vars/component/callout.d.ts
+++ b/packages/qvism-preset/src/vars/component/callout.d.ts
@@ -199,7 +199,9 @@ export declare const vars: {
   "toneMagic": {
     "enabled": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic)"
+        }
       },
       /** 아이콘은 Fill 타입 사용을 권장합니다. */
       "prefixIcon": {
@@ -221,7 +223,9 @@ export declare const vars: {
     },
     "pressed": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic-pressed)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic-pressed)"
+        }
       }
     }
   }

--- a/packages/qvism-preset/src/vars/component/callout.mjs
+++ b/packages/qvism-preset/src/vars/component/callout.mjs
@@ -169,7 +169,9 @@ export const vars = {
   "toneMagic": {
     "enabled": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic)"
+        }
       },
       "prefixIcon": {
         "color": "var(--seed-color-fg-neutral)"
@@ -189,7 +191,9 @@ export const vars = {
     },
     "pressed": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic-pressed)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic-pressed)"
+        }
       }
     }
   }

--- a/packages/qvism-preset/src/vars/component/image-frame-reaction-button.d.ts
+++ b/packages/qvism-preset/src/vars/component/image-frame-reaction-button.d.ts
@@ -10,7 +10,19 @@ export declare const vars: {
       },
       /** lineIcon 아래에 내려가는 하트 아이콘입니다. */
       "fillIcon": {
-        "gradient": "var(--seed-color-palette-static-black-alpha-600) 0%, var(--seed-color-palette-static-black-alpha-600) 100%",
+        "gradient": {
+          "serialized": "var(--seed-color-palette-static-black-alpha-600) 0%, var(--seed-color-palette-static-black-alpha-600) 100%",
+          "stops": [
+            {
+              "color": "var(--seed-color-palette-static-black-alpha-600)",
+              "position": 0
+            },
+            {
+              "color": "var(--seed-color-palette-static-black-alpha-600)",
+              "position": 1
+            }
+          ]
+        },
         /** 보이는 버튼 크기입니다. */
         "size": "var(--seed-dimension-x6)",
         "shadow": "0px 2px 4px 0px #00000026"
@@ -25,7 +37,19 @@ export declare const vars: {
     "selected": {
       /** lineIcon 아래에 내려가는 하트 아이콘입니다. */
       "fillIcon": {
-        "gradient": "#FF9A56 0%, #FF6600 100%"
+        "gradient": {
+          "serialized": "#FF9A56 0%, #FF6600 100%",
+          "stops": [
+            {
+              "color": "#FF9A56",
+              "position": 0
+            },
+            {
+              "color": "#FF6600",
+              "position": 1
+            }
+          ]
+        }
       },
       /** fillIcon 위로 올라가는 하트 아이콘입니다. */
       "lineIcon": {

--- a/packages/qvism-preset/src/vars/component/image-frame-reaction-button.mjs
+++ b/packages/qvism-preset/src/vars/component/image-frame-reaction-button.mjs
@@ -6,7 +6,19 @@ export const vars = {
         "targetSize": "var(--seed-dimension-x10)"
       },
       "fillIcon": {
-        "gradient": "var(--seed-color-palette-static-black-alpha-600) 0%, var(--seed-color-palette-static-black-alpha-600) 100%",
+        "gradient": {
+          "serialized": "var(--seed-color-palette-static-black-alpha-600) 0%, var(--seed-color-palette-static-black-alpha-600) 100%",
+          "stops": [
+            {
+              "color": "var(--seed-color-palette-static-black-alpha-600)",
+              "position": 0
+            },
+            {
+              "color": "var(--seed-color-palette-static-black-alpha-600)",
+              "position": 1
+            }
+          ]
+        },
         "size": "var(--seed-dimension-x6)",
         "shadow": "0px 2px 4px 0px #00000026"
       },
@@ -17,7 +29,19 @@ export const vars = {
     },
     "selected": {
       "fillIcon": {
-        "gradient": "#FF9A56 0%, #FF6600 100%"
+        "gradient": {
+          "serialized": "#FF9A56 0%, #FF6600 100%",
+          "stops": [
+            {
+              "color": "#FF9A56",
+              "position": 0
+            },
+            {
+              "color": "#FF6600",
+              "position": 1
+            }
+          ]
+        }
       },
       "lineIcon": {
         "color": "var(--seed-color-bg-transparent)"

--- a/packages/qvism-preset/src/vars/component/page-banner.d.ts
+++ b/packages/qvism-preset/src/vars/component/page-banner.d.ts
@@ -353,7 +353,9 @@ export declare const vars: {
   "toneMagicVariantWeak": {
     "enabled": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic)"
+        }
       },
       /** 아이콘은 Fill 타입 사용을 권장합니다. */
       "prefixIcon": {
@@ -374,7 +376,9 @@ export declare const vars: {
     },
     "pressed": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic-pressed)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic-pressed)"
+        }
       }
     }
   }

--- a/packages/qvism-preset/src/vars/component/page-banner.mjs
+++ b/packages/qvism-preset/src/vars/component/page-banner.mjs
@@ -308,7 +308,9 @@ export const vars = {
   "toneMagicVariantWeak": {
     "enabled": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic)"
+        }
       },
       "prefixIcon": {
         "color": "var(--seed-color-fg-neutral)"
@@ -328,7 +330,9 @@ export const vars = {
     },
     "pressed": {
       "root": {
-        "gradient": "var(--seed-gradient-glow-magic-pressed)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-glow-magic-pressed)"
+        }
       }
     }
   }

--- a/packages/qvism-preset/src/vars/component/skeleton.d.ts
+++ b/packages/qvism-preset/src/vars/component/skeleton.d.ts
@@ -56,7 +56,9 @@ export declare const vars: {
         "color": "var(--seed-color-palette-gray-200)"
       },
       "shimmer": {
-        "gradient": "var(--seed-gradient-shimmer-neutral)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-shimmer-neutral)"
+        }
       }
     }
   },
@@ -69,7 +71,9 @@ export declare const vars: {
         "color": "var(--seed-color-bg-magic-weak)"
       },
       "shimmer": {
-        "gradient": "var(--seed-gradient-shimmer-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-shimmer-magic)"
+        }
       }
     }
   }

--- a/packages/qvism-preset/src/vars/component/skeleton.mjs
+++ b/packages/qvism-preset/src/vars/component/skeleton.mjs
@@ -41,7 +41,9 @@ export const vars = {
         "color": "var(--seed-color-palette-gray-200)"
       },
       "shimmer": {
-        "gradient": "var(--seed-gradient-shimmer-neutral)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-shimmer-neutral)"
+        }
       }
     }
   },
@@ -51,7 +53,9 @@ export const vars = {
         "color": "var(--seed-color-bg-magic-weak)"
       },
       "shimmer": {
-        "gradient": "var(--seed-gradient-shimmer-magic)"
+        "gradient": {
+          "serialized": "var(--seed-gradient-shimmer-magic)"
+        }
       }
     }
   }

--- a/packages/qvism-preset/src/vars/component/top-navigation.d.ts
+++ b/packages/qvism-preset/src/vars/component/top-navigation.d.ts
@@ -58,7 +58,19 @@ export declare const vars: {
   "toneTransparentGradientTrue": {
     "enabled": {
       "root": {
-        "gradient": "#00000059 0%, #00000000 100%",
+        "gradient": {
+          "serialized": "#00000059 0%, #00000000 100%",
+          "stops": [
+            {
+              "color": "#00000059",
+              "position": 0
+            },
+            {
+              "color": "#00000000",
+              "position": 1
+            }
+          ]
+        },
         /** gradient가 표시될 때 하단 아래로 gradient가 확장되는 길이입니다. */
         "bleedBottom": "var(--seed-dimension-x5)"
       }

--- a/packages/qvism-preset/src/vars/component/top-navigation.mjs
+++ b/packages/qvism-preset/src/vars/component/top-navigation.mjs
@@ -51,7 +51,19 @@ export const vars = {
   "toneTransparentGradientTrue": {
     "enabled": {
       "root": {
-        "gradient": "#00000059 0%, #00000000 100%",
+        "gradient": {
+          "serialized": "#00000059 0%, #00000000 100%",
+          "stops": [
+            {
+              "color": "#00000059",
+              "position": 0
+            },
+            {
+              "color": "#00000000",
+              "position": 1
+            }
+          ]
+        },
         "bleedBottom": "var(--seed-dimension-x5)"
       }
     }


### PR DESCRIPTION
> 🔗 #1760의 기반이 되는 stacked PR입니다. 이 PR이 gradient 값을 표현·해상하는 기반을 만들고, #1760이 ScrollFog에서 실제로 소비합니다.

## 무엇을 바꾸나

컴포넌트 vars의 gradient property를 문자열 대신 `{ serialized, stops? }` 객체로 생성합니다.

- `serialized`: 기존과 동일한 CSS gradient 문자열입니다.
- `stops`: `{ color, position }` 배열입니다. `position`은 0~1 원본 값이라 stop별 `calc()` 보간 같은 동적 연산에 사용할 수 있습니다.

inline gradient와 token reference gradient는 모두 같은 object shape을 유지합니다. 다만 token이 mode별로 다른 gradient 값을 가지면 하나의 stops 배열로 표현할 수 없으므로 `{ serialized }`만 제공합니다.

이 PR에서 component vars의 `.mjs`/`.d.ts`는 의도대로 바뀌지만, 생성되는 CSS stylesheet의 값은 이전과 동일합니다.

## 왜 필요한가

#1760의 ScrollFog는 4방향 fog mask를 만들면서 각 stop의 원본 position을 `calc()`에 넣어야 합니다. 기존 vars는 gradient를 하나의 CSS 문자열로 평탄화했기 때문에 rootage에 stop 데이터가 있어도 recipe에서 다시 사용할 수 없었습니다.

이번 변경은 stringifier가 gradient의 직렬화 결과와 구조화된 stops를 함께 제공하게 만들어 rootage를 단일 출처로 사용할 수 있게 합니다.

## 설계

### AST kind로 property type을 판별합니다

처음 구현은 `ValueLit`만 받아 값의 kind를 검사하고, token reference는 CLI의 gradient 전용 hook으로 다시 판별했습니다. 최종 구현은 `PropertyDeclaration` 전체를 받아 `GradientPropertyDeclaration`인지 확인합니다.

```diff
- stringifyProperty(expr: ValueLit | TokenLit)
+ stringifyProperty(decl: PropertyDeclaration)

- resolveGradientToken?: (token) => { stops?: GradientStopVars[] } | undefined
+ resolveTokenValues?: (token) => ValueLit[] | undefined
```

gradient 정책은 TypeScript stringifier가 소유합니다.

- inline gradient의 stop을 `{ color, position }`으로 변환
- token reference의 mode별 값을 조회
- 모든 mode의 stops가 같을 때만 `stops` 제공
- mode별 값이 다르거나 해상할 수 없으면 `serialized`만 제공

CLI는 gradient를 해석하지 않고 analyzer가 제공하는 capability를 stringifier에 주입합니다.

### `createTokenValuesResolver`는 core analyzer에 있습니다

`resolveToken`은 이미 존재하던 primitive로, token 하나를 주어진 mode map에서 해상합니다. 하지만 “해당 token collection에 선언된 모든 mode를 순회해 해상된 값들을 얻는” API는 없었습니다.

`createTokenValuesResolver(ctx)`는 기존 `resolveToken`을 조합해 그 빈 역할을 담당합니다.

```ts
const resolveTokenValues = createTokenValuesResolver(ctx);
const values = resolveTokenValues(token);
```

- analyzer가 `RootageCtx`, collection, mode 순서, token dependency graph를 소유합니다.
- language stringifier는 `RootageCtx`를 알지 않고 `(token) => ValueLit[] | undefined` capability만 받습니다.
- CLI는 analyzer와 language를 연결만 합니다.

함수가 resolver closure를 생성하므로 `createTokenValuesResolver`라는 이름을 사용합니다. `resolveTokenValuesByMode`처럼 즉시 값을 반환하는 함수와 구분됩니다.

### 확장 범위

이 capability는 gradient 전용이 아닙니다. 이후 shadow layer처럼 token의 mode별 해상 값이 필요한 structured property가 생기면 동일한 `resolveTokenValues`를 재사용하고, 각 property의 표현 정책은 해당 language layer에 둘 수 있습니다.

다만 현재 계약은 “collection 선언 순서의 값 배열”과 “해상 불가 시 `undefined`”까지만 제공합니다. 소비자가 mode id 자체를 알아야 하거나 오류를 구분해야 하는 요구가 생기면 `{ mode, value }[]` 같은 더 명시적인 결과로 확장하는 편이 맞습니다. 이번 PR에서는 mode 불변성 판정만 필요해 현재 계약으로 제한했습니다.

## 함께 수정한 부분

- gradient 문자열을 사용하던 Web/Lynx recipe가 `.serialized`를 사용하도록 변경했습니다.
- gradient 내부의 `color`/`position` key에 property JSDoc이 잘못 삽입되지 않도록 JSON indentation depth에 맞춰 치환을 anchoring했습니다.
- enum-only property/slot 제거와 기존 stringifier 동작은 유지합니다.

## 리뷰 포인트

1. **Analyzed declaration 전제**: CLI는 `getComponentSpecDeclarations(ctx)`를 통해 `transformResolvedType`이 적용된 declaration만 전달합니다. 다만 core의 `getComponentSpecMjs` 타입은 아직 parser가 만든 unresolved declaration도 받을 수 있어, 이 전제를 타입으로 명확히 표현할지는 후속 검토가 필요합니다.
2. **Mode invariance**: 현재는 고정 구조의 작은 stops 배열을 `JSON.stringify`로 비교합니다.
3. **Shape 안정성**: resolver가 없어도 gradient는 문자열로 돌아가지 않고 `{ serialized }`를 유지합니다.
4. **JSDoc anchoring**: vars JSON의 고정 depth에 의존하므로 전체 출력 테스트로 구조를 잠그는 것이 필요합니다.

## 마이그레이션

gradient 문자열을 보간하던 내부 recipe(`callout`, `page-banner`, `skeleton`)는 `.serialized`를 사용합니다.

`@seed-design/css/vars/component/*`를 직접 사용하는 경우 gradient property 접근을 다음처럼 바꿔야 합니다.

```diff
- vars.toneMagic.enabled.root.gradient
+ vars.toneMagic.enabled.root.gradient.serialized
```

## 검증

- `bun generate:all`
- `bun rootage:test` — 119 pass
- `bun packages:build`
- `bun test:all`
- `git diff --check`
- 현재 PR head의 원격 CI 통과

## 버전

`@seed-design/css`와 `@seed-design/lynx-css`는 patch입니다. 생성 CSS는 동일하고, typography를 제외한 `@seed-design/css/vars/component/*`는 현재 정책상 SemVer 보장 대상이 아닙니다.
