### PR TITLE
fix(menu): avoid dangling group aria-labelledby when no label is rendered

### DIFF
--- a/.changeset/lazy-groups-listen.md
+++ b/.changeset/lazy-groups-listen.md
@@ -2,7 +2,4 @@
 "@seed-design/react-menu": major
 ---
 
-Menu Group이 `MenuGroupLabel`이 실제로 렌더된 경우에만 `aria-labelledby`를 노출하도록 수정합니다.
-
-- 기존에는 `MenuGroupLabel` 없이 `MenuGroup`만 사용해도 group root의 `aria-labelledby`가 존재하지 않는 id를 가리켜 dangling 참조가 되는 접근성 문제가 있었습니다. 이제 `MenuGroupLabel`이 렌더된 동안에만 `aria-labelledby`가 부여됩니다.
-- `useMenu()`/`useMenuContext()`에서 `getGroupProps`, `getGroupLabelProps`를 제거합니다. group 접근성 배선은 `MenuGroup`, `MenuGroupLabel` 컴포넌트가 담당하므로, 커스텀 구현에서 이 두 함수를 사용하고 있었다면 `MenuGroup`/`MenuGroupLabel` 컴포넌트로 교체하세요.
+`MenuGroupLabel`이 실제로 렌더된 경우에만 `MenuGroup`이 `aria-labelledby`를 노출하도록 수정합니다.

--- a/.changeset/lazy-groups-listen.md
+++ b/.changeset/lazy-groups-listen.md
@@ -1,0 +1,8 @@
+---
+"@seed-design/react-menu": major
+---
+
+Menu Group이 `MenuGroupLabel`이 실제로 렌더된 경우에만 `aria-labelledby`를 노출하도록 수정합니다.
+
+- 기존에는 `MenuGroupLabel` 없이 `MenuGroup`만 사용해도 group root의 `aria-labelledby`가 존재하지 않는 id를 가리켜 dangling 참조가 되는 접근성 문제가 있었습니다. 이제 `MenuGroupLabel`이 렌더된 동안에만 `aria-labelledby`가 부여됩니다.
+- `useMenu()`/`useMenuContext()`에서 `getGroupProps`, `getGroupLabelProps`를 제거합니다. group 접근성 배선은 `MenuGroup`, `MenuGroupLabel` 컴포넌트가 담당하므로, 커스텀 구현에서 이 두 함수를 사용하고 있었다면 `MenuGroup`/`MenuGroupLabel` 컴포넌트로 교체하세요.

--- a/packages/react-headless/menu/src/Menu.tsx
+++ b/packages/react-headless/menu/src/Menu.tsx
@@ -12,11 +12,17 @@ import { DismissibleLayer } from "@seed-design/react-dismissible-layer";
 import { mergeProps } from "@seed-design/dom-utils";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";
 import React, { forwardRef, createContext } from "react";
-import { useMenu, type UseMenuItemProps, type UseMenuProps } from "./useMenu";
+import {
+  useMenu,
+  useMenuGroup,
+  type UseMenuGroupReturn,
+  type UseMenuItemProps,
+  type UseMenuProps,
+} from "./useMenu";
 import { MenuProvider, useMenuContext } from "./useMenuContext";
 import { MenuItemProvider } from "./useMenuItemContext";
 
-const MenuGroupLabelIdContext = createContext<string | null>(null);
+const MenuGroupContext = createContext<UseMenuGroupReturn | null>(null);
 
 export interface MenuRootProps extends UseMenuProps {
   children?: React.ReactNode;
@@ -198,13 +204,12 @@ MenuItem.displayName = "MenuItem";
 export interface MenuGroupProps extends PrimitiveProps, React.HTMLAttributes<HTMLDivElement> {}
 
 export const MenuGroup = forwardRef<HTMLDivElement, MenuGroupProps>((props, ref) => {
-  const { getGroupProps } = useMenuContext();
-  const { labelId, rootProps } = getGroupProps();
+  const group = useMenuGroup();
 
   return (
-    <MenuGroupLabelIdContext.Provider value={labelId}>
-      <Primitive.div ref={ref} {...mergeProps(rootProps, props)} />
-    </MenuGroupLabelIdContext.Provider>
+    <MenuGroupContext.Provider value={group}>
+      <Primitive.div ref={ref} {...mergeProps(group.rootProps, props)} />
+    </MenuGroupContext.Provider>
   );
 });
 MenuGroup.displayName = "MenuGroup";
@@ -212,10 +217,16 @@ MenuGroup.displayName = "MenuGroup";
 export interface MenuGroupLabelProps extends PrimitiveProps, React.HTMLAttributes<HTMLDivElement> {}
 
 export const MenuGroupLabel = forwardRef<HTMLDivElement, MenuGroupLabelProps>((props, ref) => {
-  const { getGroupLabelProps } = useMenuContext();
-  const labelId = React.useContext(MenuGroupLabelIdContext);
-  if (!labelId) throw new Error("MenuGroupLabel must be used within a MenuGroup");
+  const group = React.useContext(MenuGroupContext);
+  if (!group) throw new Error("MenuGroupLabel must be used within a MenuGroup");
 
-  return <Primitive.div ref={ref} {...mergeProps(getGroupLabelProps(labelId), props)} />;
+  // Compose the group's label ref so the group advertises aria-labelledby only
+  // while this label is actually rendered (see useMenuGroup).
+  return (
+    <Primitive.div
+      ref={composeRefs(group.refs.label, ref)}
+      {...mergeProps(group.labelProps, props)}
+    />
+  );
 });
 MenuGroupLabel.displayName = "MenuGroupLabel";

--- a/packages/react-headless/menu/src/useMenu.ts
+++ b/packages/react-headless/menu/src/useMenu.ts
@@ -142,11 +142,6 @@ function useMenuState(props: UseMenuStateProps) {
   const labelsRef = useRef<(string | null)[]>([]);
   const triggerRef = useRef<Element | null>(null);
 
-  const groupIndexCounter = useRef(0);
-  groupIndexCounter.current = 0;
-
-  const menuId = useId();
-
   return {
     open,
     setOpenState,
@@ -155,23 +150,12 @@ function useMenuState(props: UseMenuStateProps) {
     elementsRef,
     labelsRef,
     triggerRef,
-    groupIndexCounter,
-    menuId,
   };
 }
 
 export function useMenu(props: UseMenuProps) {
-  const {
-    open,
-    setOpenState,
-    activeIndex,
-    setActiveIndex,
-    elementsRef,
-    labelsRef,
-    triggerRef,
-    groupIndexCounter,
-    menuId,
-  } = useMenuState(props);
+  const { open, setOpenState, activeIndex, setActiveIndex, elementsRef, labelsRef, triggerRef } =
+    useMenuState(props);
 
   const {
     disabled = false,
@@ -443,24 +427,39 @@ export function useMenu(props: UseMenuProps) {
     //     }),
     //   };
     // },
+  };
+}
 
-    getGroupProps: () => {
-      const groupIndex = groupIndexCounter.current++;
-      const labelId = `menu:${menuId}:group-${groupIndex}:label`;
-      return {
-        labelId,
-        rootProps: elementProps({
-          role: "group",
-          "aria-labelledby": labelId,
-        }),
-      };
+export type UseMenuGroupReturn = ReturnType<typeof useMenuGroup>;
+
+// A group advertises aria-labelledby only while its label is actually rendered.
+// Mirrors useFieldset: a callback ref flips a boolean synchronously at commit, so
+// the attribute is present on first paint and never points at a missing id — no
+// menu-global registry or render-order ids needed. Each group owns its own id and
+// presence flag, so conditionally rendering or reordering groups can never make one
+// group inherit another's label reference.
+export function useMenuGroup() {
+  const id = useId();
+  const labelId = `menu-group:${id}:label`;
+
+  const [isLabelRendered, setIsLabelRendered] = useState(false);
+  const labelRef = useCallback((node: HTMLDivElement | null) => {
+    setIsLabelRendered(!!node);
+  }, []);
+
+  return {
+    refs: {
+      label: labelRef,
     },
 
-    getGroupLabelProps: (labelId: string) => {
-      return elementProps({
-        role: "presentation",
-        id: labelId,
-      });
-    },
+    rootProps: elementProps({
+      role: "group",
+      ...(isLabelRendered && { "aria-labelledby": labelId }),
+    }),
+
+    labelProps: elementProps({
+      role: "presentation",
+      id: labelId,
+    }),
   };
 }

--- a/packages/react-headless/menu/src/useMenu.vitest.tsx
+++ b/packages/react-headless/menu/src/useMenu.vitest.tsx
@@ -198,6 +198,31 @@ describe("useMenu", () => {
       const label = getByText("Group 1");
       expect(label).toHaveAttribute("id", labelledBy);
     });
+
+    it("does not set a dangling aria-labelledby on a group without a label", async () => {
+      function MenuWithUnlabeledGroup() {
+        return (
+          <Menu>
+            <MenuTrigger>Open Menu</MenuTrigger>
+            <MenuPositioner>
+              <MenuContent>
+                <MenuGroup>
+                  <MenuItem>Item A</MenuItem>
+                  <MenuItem>Item B</MenuItem>
+                </MenuGroup>
+              </MenuContent>
+            </MenuPositioner>
+          </Menu>
+        );
+      }
+
+      const user = userEvent.setup();
+      const { getAllByRole, getByText } = render(<MenuWithUnlabeledGroup />);
+      await waitForPositioning();
+      await user.click(getByText("Open Menu"));
+      const group = getAllByRole("group")[0];
+      expect(group).not.toHaveAttribute("aria-labelledby");
+    });
   });
 
   describe("open/close state", () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 메뉴 그룹을 위한 `useMenuGroup` 훅이 추가되어 그룹 라벨 관련 동작 구성을 더 유연하게 지원합니다.
* **Bug Fixes**
  * 라벨이 실제로 렌더될 때만 `aria-labelledby`가 적용되도록 개선하여, 라벨 없는 메뉴 그룹에 불필요한 속성이 남지 않게 수정했습니다.
  * `MenuGroupLabel`이 그룹 외부에서 사용될 때 오류 처리가 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->