### PR TITLE
fix(navigation-menu, dialog): avoid dangling aria references when parts are not rendered

### DIFF
--- a/.changeset/brave-poems-relate.md
+++ b/.changeset/brave-poems-relate.md
@@ -1,0 +1,8 @@
+---
+"@seed-design/react-navigation-menu": major
+---
+
+Navigation Menu Group이 `NavigationMenuGroupLabel`이 실제로 렌더된 경우에만 `aria-labelledby`를 노출하도록 수정합니다.
+
+- 기존에는 `NavigationMenuGroupLabel` 없이 `NavigationMenuGroup`만 사용해도 group root의 `aria-labelledby`가 존재하지 않는 id를 가리켜 dangling 참조가 되는 접근성 문제가 있었습니다. 이제 `NavigationMenuGroupLabel`이 렌더된 동안에만 `aria-labelledby`가 부여됩니다.
+- `useNavigationMenuRoot()`에서 `getGroupProps`, `getGroupLabelProps`를 제거합니다. group 접근성 배선은 `NavigationMenuGroup`, `NavigationMenuGroupLabel` 컴포넌트가 담당하므로, 커스텀 구현에서 이 두 함수를 사용하고 있었다면 컴포넌트로 교체하세요.

--- a/.changeset/brave-poems-relate.md
+++ b/.changeset/brave-poems-relate.md
@@ -2,7 +2,4 @@
 "@seed-design/react-navigation-menu": major
 ---
 
-Navigation Menu Group이 `NavigationMenuGroupLabel`이 실제로 렌더된 경우에만 `aria-labelledby`를 노출하도록 수정합니다.
-
-- 기존에는 `NavigationMenuGroupLabel` 없이 `NavigationMenuGroup`만 사용해도 group root의 `aria-labelledby`가 존재하지 않는 id를 가리켜 dangling 참조가 되는 접근성 문제가 있었습니다. 이제 `NavigationMenuGroupLabel`이 렌더된 동안에만 `aria-labelledby`가 부여됩니다.
-- `useNavigationMenuRoot()`에서 `getGroupProps`, `getGroupLabelProps`를 제거합니다. group 접근성 배선은 `NavigationMenuGroup`, `NavigationMenuGroupLabel` 컴포넌트가 담당하므로, 커스텀 구현에서 이 두 함수를 사용하고 있었다면 컴포넌트로 교체하세요.
+`NavigationMenuGroupLabel`이 실제로 렌더된 경우에만 `NavigationMenuGroup`이 `aria-labelledby`를 노출하도록 수정합니다.

--- a/.changeset/gentle-dialogs-heal.md
+++ b/.changeset/gentle-dialogs-heal.md
@@ -2,6 +2,4 @@
 "@seed-design/react-dialog": patch
 ---
 
-Dialog Content가 `DialogTitle`/`DialogDescription`이 실제로 렌더된 경우에만 각각 `aria-labelledby`/`aria-describedby`를 노출하도록 수정합니다.
-
-- 기존에는 `DialogTitle` 또는 `DialogDescription` 없이 Dialog를 사용해도 content가 존재하지 않는 id를 가리켜 dangling 참조가 되는 접근성 문제가 있었습니다. 이제 해당 파트가 렌더된 동안에만 대응하는 aria 속성이 부여됩니다.
+`DialogTitle`/`DialogDescription`이 실제로 렌더된 경우에만 `DialogContent`가 각각 `aria-labelledby`/`aria-describedby`를 노출하도록 수정합니다.

--- a/.changeset/gentle-dialogs-heal.md
+++ b/.changeset/gentle-dialogs-heal.md
@@ -1,0 +1,7 @@
+---
+"@seed-design/react-dialog": patch
+---
+
+Dialog Content가 `DialogTitle`/`DialogDescription`이 실제로 렌더된 경우에만 각각 `aria-labelledby`/`aria-describedby`를 노출하도록 수정합니다.
+
+- 기존에는 `DialogTitle` 또는 `DialogDescription` 없이 Dialog를 사용해도 content가 존재하지 않는 id를 가리켜 dangling 참조가 되는 접근성 문제가 있었습니다. 이제 해당 파트가 렌더된 동안에만 대응하는 aria 속성이 부여됩니다.

--- a/packages/react-headless/dialog/src/Dialog.tsx
+++ b/packages/react-headless/dialog/src/Dialog.tsx
@@ -125,7 +125,9 @@ export interface DialogTitleProps
 
 export const DialogTitle = forwardRef<HTMLHeadingElement, DialogTitleProps>((props, ref) => {
   const api = useDialogContext();
-  return <Primitive.h2 ref={ref} {...mergeProps(api.titleProps, props)} />;
+  return (
+    <Primitive.h2 ref={composeRefs(api.refs.title, ref)} {...mergeProps(api.titleProps, props)} />
+  );
 });
 
 export interface DialogDescriptionProps
@@ -135,7 +137,12 @@ export interface DialogDescriptionProps
 export const DialogDescription = forwardRef<HTMLParagraphElement, DialogDescriptionProps>(
   (props, ref) => {
     const api = useDialogContext();
-    return <Primitive.p ref={ref} {...mergeProps(api.descriptionProps, props)} />;
+    return (
+      <Primitive.p
+        ref={composeRefs(api.refs.description, ref)}
+        {...mergeProps(api.descriptionProps, props)}
+      />
+    );
   },
 );
 

--- a/packages/react-headless/dialog/src/useDialog.test.tsx
+++ b/packages/react-headless/dialog/src/useDialog.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "bun:test";
+import { DialogContent, DialogDescription, DialogRoot, DialogTitle } from "./index";
+
+describe("useDialog (title/description aria wiring)", () => {
+  it("references title and description ids only when they are rendered", () => {
+    render(
+      <DialogRoot defaultOpen>
+        <DialogContent>
+          <DialogTitle>Dialog Title</DialogTitle>
+          <DialogDescription>Dialog Description</DialogDescription>
+        </DialogContent>
+      </DialogRoot>,
+    );
+
+    const content = document.querySelector('[role="dialog"]');
+    expect(content).not.toBeNull();
+
+    const labelledBy = content?.getAttribute("aria-labelledby");
+    const describedBy = content?.getAttribute("aria-describedby");
+    expect(document.getElementById(labelledBy ?? "")?.textContent).toBe("Dialog Title");
+    expect(document.getElementById(describedBy ?? "")?.textContent).toBe("Dialog Description");
+  });
+
+  it("does not set dangling aria-labelledby/describedby when title/description are absent", () => {
+    render(
+      <DialogRoot defaultOpen>
+        <DialogContent>
+          <div>No title, no description</div>
+        </DialogContent>
+      </DialogRoot>,
+    );
+
+    const content = document.querySelector('[role="dialog"]');
+    expect(content).not.toBeNull();
+    expect(content).not.toHaveAttribute("aria-labelledby");
+    expect(content).not.toHaveAttribute("aria-describedby");
+  });
+});

--- a/packages/react-headless/dialog/src/useDialog.ts
+++ b/packages/react-headless/dialog/src/useDialog.ts
@@ -1,6 +1,6 @@
 import { useControllableState } from "@seed-design/react-use-controllable-state";
 import { buttonProps, dataAttr, elementProps } from "@seed-design/dom-utils";
-import { useId, useMemo } from "react";
+import { useCallback, useId, useMemo, useState } from "react";
 
 interface DialogReasonToDetailMap {
   // we might add synthetic events later if needed; currently we aim consistency; DismissibleLayer gives us native events
@@ -90,6 +90,19 @@ export function useDialog(props: UseDialogProps = {}) {
   const titleId = `${id}-title`;
   const descriptionId = `${id}-description`;
 
+  // Presence-aware aria wiring: the content references a title/description id only
+  // when that part is actually rendered, mirroring useField/usePopover — a dialog
+  // without a DialogTitle/DialogDescription must not point aria-labelledby/
+  // aria-describedby at a missing id.
+  const [isTitleRendered, setIsTitleRendered] = useState(false);
+  const titleRef = useCallback((node: HTMLElement | null) => {
+    setIsTitleRendered(!!node);
+  }, []);
+  const [isDescriptionRendered, setIsDescriptionRendered] = useState(false);
+  const descriptionRef = useCallback((node: HTMLElement | null) => {
+    setIsDescriptionRendered(!!node);
+  }, []);
+
   const stateProps = useMemo(
     () =>
       elementProps({
@@ -109,6 +122,10 @@ export function useDialog(props: UseDialogProps = {}) {
       lazyMount: props.lazyMount ?? false,
       unmountOnExit: props.unmountOnExit ?? false,
       stateProps,
+      refs: {
+        title: titleRef,
+        description: descriptionRef,
+      },
       triggerProps: buttonProps({
         "aria-haspopup": "dialog",
         "aria-expanded": open,
@@ -131,8 +148,8 @@ export function useDialog(props: UseDialogProps = {}) {
         ...stateProps,
         role: props.role ?? "dialog",
         "aria-modal": modal,
-        "aria-labelledby": titleId,
-        "aria-describedby": descriptionId,
+        ...(isTitleRendered && { "aria-labelledby": titleId }),
+        ...(isDescriptionRendered && { "aria-describedby": descriptionId }),
       }),
       titleProps: elementProps({
         id: titleId,
@@ -157,6 +174,10 @@ export function useDialog(props: UseDialogProps = {}) {
       stateProps,
       titleId,
       descriptionId,
+      isTitleRendered,
+      isDescriptionRendered,
+      titleRef,
+      descriptionRef,
       props.role,
       props.closeOnInteractOutside,
       props.closeOnEscape,

--- a/packages/react-headless/navigation-menu/src/NavigationMenu.tsx
+++ b/packages/react-headless/navigation-menu/src/NavigationMenu.tsx
@@ -10,7 +10,9 @@ import {
   DEFAULT_CLOSE_DELAY,
   DEFAULT_OPEN_DELAY,
   useNavigationMenu,
+  useNavigationMenuGroup,
   useNavigationMenuRoot,
+  type UseNavigationMenuGroupReturn,
   type UseNavigationMenuProps,
   type UseNavigationMenuRootProps,
 } from "./useNavigationMenu";
@@ -159,7 +161,7 @@ NavigationMenuContent.displayName = "NavigationMenuContent";
 
 ////////////////////////////////////////////////////////////////////////////////////
 
-const NavigationMenuGroupLabelIdContext = createContext<string | null>(null);
+const NavigationMenuGroupContext = createContext<UseNavigationMenuGroupReturn | null>(null);
 
 export interface NavigationMenuGroupProps
   extends PrimitiveProps,
@@ -167,13 +169,12 @@ export interface NavigationMenuGroupProps
 
 export const NavigationMenuGroup = forwardRef<HTMLDivElement, NavigationMenuGroupProps>(
   (props, ref) => {
-    const { getGroupProps } = useNavigationMenuRootContext();
-    const { labelId, rootProps } = getGroupProps();
+    const group = useNavigationMenuGroup();
 
     return (
-      <NavigationMenuGroupLabelIdContext.Provider value={labelId}>
-        <Primitive.div ref={ref} {...mergeProps(rootProps, props)} />
-      </NavigationMenuGroupLabelIdContext.Provider>
+      <NavigationMenuGroupContext.Provider value={group}>
+        <Primitive.div ref={ref} {...mergeProps(group.rootProps, props)} />
+      </NavigationMenuGroupContext.Provider>
     );
   },
 );
@@ -187,13 +188,17 @@ export interface NavigationMenuGroupLabelProps
 
 export const NavigationMenuGroupLabel = forwardRef<HTMLDivElement, NavigationMenuGroupLabelProps>(
   (props, ref) => {
-    const { getGroupLabelProps } = useNavigationMenuRootContext();
-    const labelId = useContext(NavigationMenuGroupLabelIdContext);
-    if (!labelId) {
+    const group = useContext(NavigationMenuGroupContext);
+    if (!group) {
       throw new Error("NavigationMenuGroupLabel must be used within a NavigationMenuGroup");
     }
 
-    return <Primitive.div ref={ref} {...mergeProps(getGroupLabelProps(labelId), props)} />;
+    return (
+      <Primitive.div
+        ref={composeRefs(group.refs.label, ref)}
+        {...mergeProps(group.labelProps, props)}
+      />
+    );
   },
 );
 NavigationMenuGroupLabel.displayName = "NavigationMenuGroupLabel";

--- a/packages/react-headless/navigation-menu/src/useNavigationMenu.test.tsx
+++ b/packages/react-headless/navigation-menu/src/useNavigationMenu.test.tsx
@@ -97,3 +97,45 @@ describe("useNavigationMenu (disclosure semantics)", () => {
     expect(trigger).toHaveAttribute("aria-expanded", "false");
   });
 });
+
+function GroupHarness() {
+  return (
+    <NavigationMenu.Provider>
+      <NavigationMenu.Root value="products">
+        <NavigationMenu.Trigger>Products</NavigationMenu.Trigger>
+        <NavigationMenu.Positioner>
+          <NavigationMenu.Content>
+            <NavigationMenu.Group>
+              <NavigationMenu.GroupLabel>Group One</NavigationMenu.GroupLabel>
+              <NavigationMenu.Item>Item A</NavigationMenu.Item>
+            </NavigationMenu.Group>
+            <NavigationMenu.Group>
+              <NavigationMenu.Item>Item B</NavigationMenu.Item>
+            </NavigationMenu.Group>
+          </NavigationMenu.Content>
+        </NavigationMenu.Positioner>
+      </NavigationMenu.Root>
+    </NavigationMenu.Provider>
+  );
+}
+
+describe("useNavigationMenu (group labelling)", () => {
+  it("labels a group via aria-labelledby resolving to the rendered group label", () => {
+    render(<GroupHarness />);
+
+    const labelledGroup = document.querySelectorAll('[role="group"]')[0];
+    const labelledBy = labelledGroup.getAttribute("aria-labelledby");
+    expect(labelledBy).toBeTruthy();
+
+    const label = document.getElementById(labelledBy ?? "");
+    expect(label).not.toBeNull();
+    expect(label?.textContent).toBe("Group One");
+  });
+
+  it("does not set a dangling aria-labelledby on a group without a label", () => {
+    render(<GroupHarness />);
+
+    const unlabeledGroup = document.querySelectorAll('[role="group"]')[1];
+    expect(unlabeledGroup).not.toHaveAttribute("aria-labelledby");
+  });
+});

--- a/packages/react-headless/navigation-menu/src/useNavigationMenu.ts
+++ b/packages/react-headless/navigation-menu/src/useNavigationMenu.ts
@@ -174,9 +174,6 @@ export function useNavigationMenuRoot(
   const triggerId = `navigation-menu-trigger-${id}`;
   const contentId = `navigation-menu-content-${id}`;
 
-  const groupIndexCounter = useRef(0);
-  groupIndexCounter.current = 0;
-
   const placement: Placement = props.placement ?? rootPlacement;
 
   const onOpenChange = useCallback(
@@ -341,23 +338,39 @@ export function useNavigationMenuRoot(
         }),
       };
     },
+  };
+}
 
-    getGroupProps: () => {
-      const groupIndex = groupIndexCounter.current++;
-      const labelId = `navigation-menu:${id}:group-${groupIndex}:label`;
-      return {
-        labelId,
-        rootProps: elementProps({
-          role: "group",
-          "aria-labelledby": labelId,
-        }),
-      };
+export type UseNavigationMenuGroupReturn = ReturnType<typeof useNavigationMenuGroup>;
+
+// A group advertises aria-labelledby only while its label is actually rendered.
+// Mirrors useFieldset: a callback ref flips a boolean synchronously at commit, so
+// the attribute is present on first paint and never points at a missing id — no
+// render-order ids needed. Each group owns its own id and presence flag, so
+// conditionally rendering or reordering groups can never make one group inherit
+// another's label reference.
+export function useNavigationMenuGroup() {
+  const id = useId();
+  const labelId = `navigation-menu-group:${id}:label`;
+
+  const [isLabelRendered, setIsLabelRendered] = useState(false);
+  const labelRef = useCallback((node: HTMLDivElement | null) => {
+    setIsLabelRendered(!!node);
+  }, []);
+
+  return {
+    refs: {
+      label: labelRef,
     },
 
-    getGroupLabelProps: (labelId: string) =>
-      elementProps({
-        role: "presentation",
-        id: labelId,
-      }),
+    rootProps: elementProps({
+      role: "group",
+      ...(isLabelRendered && { "aria-labelledby": labelId }),
+    }),
+
+    labelProps: elementProps({
+      role: "presentation",
+      id: labelId,
+    }),
   };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 다이얼로그의 제목/설명과 내비게이션 메뉴의 그룹 레이블이 실제로 렌더링될 때만 `aria-labelledby`/`aria-describedby`가 연결되도록 개선했습니다.
  * 표시되지 않는 요소를 참조하는 접근성 속성(“dangling” 참조)이 남지 않게 수정했습니다.
* **Tests**
  * 제목/설명 및 그룹 레이블의 표시 여부에 따라 접근성 속성이 올바르게 적용되는지 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->