### PR TITLE
build(react): drop unresolvable "node" from tsconfig types

### DIFF
--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -6,7 +6,7 @@
     "moduleResolution": "Bundler",
     "verbatimModuleSyntax": true,
     "typeRoots": ["../../node_modules/@types", "../../types"],
-    "types": ["bun", "bun-jest-dom", "node"],
+    "types": ["bun", "bun-jest-dom"],
 
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * React 패키지의 타입 설정이 정리되어, Bun 관련 타입만 사용하도록 변경되었습니다.
  * 불필요한 Node 타입 항목이 제거되어 설정이 더 간결해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->