### PR TITLE
fix(drawer): coalesce undefined active snap point to null

### DIFF
--- a/.changeset/quiet-drawers-heal.md
+++ b/.changeset/quiet-drawers-heal.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react-drawer": patch
+---
+
+Drawer의 active snap point가 특정 상황에서 `undefined`로 설정되던 문제를 수정합니다.

--- a/packages/react-headless/drawer/src/use-snap-points.ts
+++ b/packages/react-headless/drawer/src/use-snap-points.ts
@@ -165,7 +165,7 @@ export function useSnapPoints({
         });
       }
 
-      setActiveSnapPoint(snapPoints?.[Math.max(newSnapPointIndex, 0)]);
+      setActiveSnapPoint(snapPoints?.[Math.max(newSnapPointIndex, 0)] ?? null);
     },
     [
       drawerRef,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Drawer에서 특정 상황에 `active snap point`가 `undefined`로 남던 문제를 수정했습니다.
  * 스냅 포인트가 없을 때 상태가 `null`로 정리되도록 개선해, 더 안정적으로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->