### PR TITLE
test(menu): migrate tests from vitest to bun test

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -892,10 +892,8 @@
       },
       "devDependencies": {
         "@types/react": "^19.1.6",
-        "jsdom": "^29.0.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "vitest": "^4.1.3",
       },
       "peerDependencies": {
         "react": ">=18.0.0",
@@ -5231,8 +5229,6 @@
 
     "obuf": ["obuf@1.1.2", "", {}, "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="],
 
-    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
-
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
@@ -6873,8 +6869,6 @@
 
     "@seed-design/react-file-upload/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
 
-    "@seed-design/react-menu/vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
-
     "@seed-design/react-scrollable/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
 
     "@seed-design/rsbuild-plugin-lynx-icon/@rsbuild/core": ["@rsbuild/core@1.7.3", "", { "dependencies": { "@rspack/core": "~1.7.5", "@rspack/lite-tapable": "~1.1.0", "@swc/helpers": "^0.5.18", "core-js": "~3.47.0", "jiti": "^2.6.1" }, "bin": { "rsbuild": "bin/rsbuild.js" } }, "sha512-kI1oQvCXbQYxUvQPnDLdjSX4gFsbrFNpuUj6jXEJ7IcJ74Q+n4oeFj74/8tKerhxhe0L90m/ZQfzLeN5ORGA9w=="],
@@ -8027,32 +8021,6 @@
 
     "@sanity/ui/motion/framer-motion": ["framer-motion@12.23.24", "", { "dependencies": { "motion-dom": "^12.23.23", "motion-utils": "^12.23.6", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-HMi5HRoRCTou+3fb3h9oTLyJGBxHfW+HnNE25tAXOvVx/IvwMHK0cx7IR4a2ZU6sh3IX1Z+4ts32PcYBOqka8w=="],
 
-    "@seed-design/react-menu/vitest/@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
-
-    "@seed-design/react-menu/vitest/@vitest/mocker": ["@vitest/mocker@4.1.9", "", { "dependencies": { "@vitest/spy": "4.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw=="],
-
-    "@seed-design/react-menu/vitest/@vitest/pretty-format": ["@vitest/pretty-format@4.1.9", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A=="],
-
-    "@seed-design/react-menu/vitest/@vitest/runner": ["@vitest/runner@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "pathe": "^2.0.3" } }, "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg=="],
-
-    "@seed-design/react-menu/vitest/@vitest/snapshot": ["@vitest/snapshot@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA=="],
-
-    "@seed-design/react-menu/vitest/@vitest/spy": ["@vitest/spy@4.1.9", "", {}, "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA=="],
-
-    "@seed-design/react-menu/vitest/@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
-
-    "@seed-design/react-menu/vitest/es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
-
-    "@seed-design/react-menu/vitest/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
-
-    "@seed-design/react-menu/vitest/std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
-
-    "@seed-design/react-menu/vitest/tinyexec": ["tinyexec@1.1.1", "", {}, "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg=="],
-
-    "@seed-design/react-menu/vitest/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
-
-    "@seed-design/react-menu/vitest/tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
-
     "@seed-design/rsbuild-plugin-lynx-icon/@rsbuild/core/@rspack/core": ["@rspack/core@1.7.11", "", { "dependencies": { "@module-federation/runtime-tools": "0.22.0", "@rspack/binding": "1.7.11", "@rspack/lite-tapable": "1.1.0" }, "peerDependencies": { "@swc/helpers": ">=0.5.1" }, "optionalPeers": ["@swc/helpers"] }, "sha512-rsD9b+Khmot5DwCMiB3cqTQo53ioPG3M/A7BySu8+0+RS7GCxKm+Z+mtsjtG/vsu4Tn2tcqCdZtA3pgLoJB+ew=="],
 
     "@seed-design/rsbuild-plugin-lynx-icon/@rsbuild/core/@swc/helpers": ["@swc/helpers@0.5.21", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg=="],
@@ -9076,10 +9044,6 @@
     "@sanity/ui/motion/framer-motion/motion-dom": ["motion-dom@12.23.23", "", { "dependencies": { "motion-utils": "^12.23.6" } }, "sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA=="],
 
     "@sanity/ui/motion/framer-motion/motion-utils": ["motion-utils@12.23.6", "", {}, "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ=="],
-
-    "@seed-design/react-menu/vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
-
-    "@seed-design/react-menu/vitest/@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "@seed-design/rsbuild-plugin-lynx-icon/@rsbuild/core/@rspack/core/@module-federation/runtime-tools": ["@module-federation/runtime-tools@0.22.0", "", { "dependencies": { "@module-federation/runtime": "0.22.0", "@module-federation/webpack-bundler-runtime": "0.22.0" } }, "sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA=="],
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "qvism:generate:watch": "watchlist ecosystem/qvism/core ecosystem/qvism/cli packages/qvism-preset packages/lynx-qvism-preset -- bun qvism:generate",
     "cli:watch": "watchlist packages/cli -- bun --filter @seed-design/cli dev",
     "headless:build": "ultra -r --filter 'packages/react-headless/*' build",
-    "headless:test": "bash -c 'bun test packages/react-headless; a=$?; bun --filter @seed-design/react-menu test; b=$?; exit $((a || b))'",
+    "headless:test": "bun test packages/react-headless",
     "headless:test:watch": "bun test --watch packages/react-headless",
     "react:test": "bun test packages/react",
     "react:test:watch": "bun test --watch packages/react",

--- a/packages/react-headless/menu/package.json
+++ b/packages/react-headless/menu/package.json
@@ -24,8 +24,7 @@
   "scripts": {
     "clean": "rm -rf lib",
     "build": "bunchee",
-    "lint:publish": "bun publint",
-    "test": "vitest run"
+    "lint:publish": "bun publint"
   },
   "dependencies": {
     "@floating-ui/react": "^0.27.0",
@@ -38,10 +37,8 @@
   },
   "devDependencies": {
     "@types/react": "^19.1.6",
-    "jsdom": "^29.0.2",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "vitest": "^4.1.3"
+    "react-dom": "^19.1.0"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/react-headless/menu/src/useMenu.test.tsx
+++ b/packages/react-headless/menu/src/useMenu.test.tsx
@@ -1,17 +1,6 @@
-// this file is .vitest.tsx, not .test.tsx — so bun test won't pick it up.
-//
-// @floating-ui/react defers focus via requestAnimationFrame (enqueueFocus).
-// bun test preloads happydom, which doesn't fire rAF the way we need.
-// vitest + jsdom (pretendToBeVisual) gives us a real rAF that ticks at ~16ms,
-// letting waitForFocus() actually flush the deferred .focus() calls.
-//
-// see vitest.config.ts for the jsdom environment setup.
-
-/// <reference types="@testing-library/jest-dom/vitest" />
-
 import { render, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, jest } from "bun:test";
 
 import * as React from "react";
 
@@ -33,8 +22,8 @@ type UseMenuProps = MenuRootProps;
 const waitForPositioning = () => act(async () => {});
 
 // Flush rAF-deferred focus from FloatingFocusManager / useListNavigation.
-// jsdom (pretendToBeVisual) fires rAF callbacks every ~16 ms via setInterval,
-// so a short timer is needed for enqueueFocus() in @floating-ui/react to land.
+// happy-dom mocks rAF with setImmediate, so a short timer is needed for
+// enqueueFocus() in @floating-ui/react to land.
 const waitForFocus = () =>
   act(async () => {
     await new Promise((resolve) => setTimeout(resolve, 50));
@@ -247,7 +236,7 @@ describe("useMenu", () => {
 
     it("supports controlled open state", async () => {
       const user = userEvent.setup();
-      const onOpenChange = vi.fn();
+      const onOpenChange = jest.fn();
       const { getByText } = render(<ControlledMenu onOpenChange={onOpenChange} />);
       await waitForPositioning();
       await user.click(getByText("Open Menu"));
@@ -262,7 +251,7 @@ describe("useMenu", () => {
 
     it("calls onOpenChange when toggled", async () => {
       const user = userEvent.setup();
-      const onOpenChange = vi.fn();
+      const onOpenChange = jest.fn();
       const { getByText } = render(<BasicMenu onOpenChange={onOpenChange} />);
       await waitForPositioning();
       await user.click(getByText("Open Menu"));
@@ -274,7 +263,7 @@ describe("useMenu", () => {
 
     it("reports reason 'escapeKeyDown' when closed by Escape", async () => {
       const user = userEvent.setup();
-      const onOpenChange = vi.fn();
+      const onOpenChange = jest.fn();
       const { getByText } = render(<BasicMenu onOpenChange={onOpenChange} />);
       await waitForPositioning();
       await user.click(getByText("Open Menu"));
@@ -288,7 +277,7 @@ describe("useMenu", () => {
 
     it("reports reason 'interactOutside' when closed by outside click", async () => {
       const user = userEvent.setup();
-      const onOpenChange = vi.fn();
+      const onOpenChange = jest.fn();
       const { getByText } = render(
         <div>
           <BasicMenu onOpenChange={onOpenChange} />
@@ -307,7 +296,7 @@ describe("useMenu", () => {
 
     it("reports reason 'itemClick' when closed by item selection", async () => {
       const user = userEvent.setup();
-      const onOpenChange = vi.fn();
+      const onOpenChange = jest.fn();
       const { getByText } = render(<BasicMenu onOpenChange={onOpenChange} />);
       await waitForPositioning();
       await user.click(getByText("Open Menu"));
@@ -554,7 +543,7 @@ describe("useMenu", () => {
   describe("item interaction", () => {
     it("calls onClick on item when clicked", async () => {
       const user = userEvent.setup();
-      const onClick = vi.fn();
+      const onClick = jest.fn();
       const { getByText } = render(
         <Menu>
           <MenuTrigger>Open Menu</MenuTrigger>
@@ -591,7 +580,7 @@ describe("useMenu", () => {
 
     it("activates focused item on Enter key", async () => {
       const user = userEvent.setup();
-      const onClick = vi.fn();
+      const onClick = jest.fn();
       const { getByText } = render(
         <Menu>
           <MenuTrigger>Open Menu</MenuTrigger>
@@ -604,14 +593,14 @@ describe("useMenu", () => {
       );
       await waitForPositioning();
       await user.click(getByText("Open Menu"));
-      getByText("Activatable").focus();
+      act(() => getByText("Activatable").focus());
       await user.keyboard("{Enter}");
       expect(onClick).toHaveBeenCalledTimes(1);
     });
 
     it("activates focused item on Space key", async () => {
       const user = userEvent.setup();
-      const onClick = vi.fn();
+      const onClick = jest.fn();
       const { getByText } = render(
         <Menu>
           <MenuTrigger>Open Menu</MenuTrigger>
@@ -624,14 +613,14 @@ describe("useMenu", () => {
       );
       await waitForPositioning();
       await user.click(getByText("Open Menu"));
-      getByText("Activatable").focus();
+      act(() => getByText("Activatable").focus());
       await user.keyboard(" ");
       expect(onClick).toHaveBeenCalledTimes(1);
     });
 
     it("does not activate disabled item on click or keyboard", async () => {
       const user = userEvent.setup();
-      const onClick = vi.fn();
+      const onClick = jest.fn();
       const { getByText } = render(
         <Menu>
           <MenuTrigger>Open Menu</MenuTrigger>
@@ -761,7 +750,7 @@ describe("useMenu", () => {
 
     it("does not cascade-dismiss Menu B when Menu A's layer is removed", async () => {
       const user = userEvent.setup();
-      const onMenuBOpenChange = vi.fn();
+      const onMenuBOpenChange = jest.fn();
       const { getByText } = render(<TwoSiblingMenus onMenuBOpenChange={onMenuBOpenChange} />);
       await waitForPositioning();
 
@@ -810,7 +799,7 @@ describe("useMenu", () => {
 
     it("does not cascade-dismiss Menu B on touch switch (touch)", async () => {
       const user = userEvent.setup();
-      const onMenuBOpenChange = vi.fn();
+      const onMenuBOpenChange = jest.fn();
       const { getByText } = render(<TwoSiblingMenus onMenuBOpenChange={onMenuBOpenChange} />);
       await waitForPositioning();
 
@@ -838,7 +827,7 @@ describe("useMenu", () => {
 
     it("keeps Menu B open and interactive after switching from Menu A", async () => {
       const user = userEvent.setup();
-      const onClick = vi.fn();
+      const onClick = jest.fn();
       const { getByText } = render(
         <div>
           <Menu>
@@ -873,7 +862,7 @@ describe("useMenu", () => {
 
   describe("mouse interaction", () => {
     it("activates item on mouse-up after drag from trigger", async () => {
-      const onClick = vi.fn();
+      const onClick = jest.fn();
       const { getByText } = render(
         <Menu>
           <MenuTrigger>Open Menu</MenuTrigger>

--- a/packages/react-headless/menu/vitest.config.ts
+++ b/packages/react-headless/menu/vitest.config.ts
@@ -1,9 +1,0 @@
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-  test: {
-    environment: "jsdom",
-    setupFiles: ["./vitest.setup.ts"],
-    include: ["src/**/*.vitest.{ts,tsx}"],
-  },
-});

--- a/packages/react-headless/menu/vitest.setup.ts
+++ b/packages/react-headless/menu/vitest.setup.ts
@@ -1,9 +1,0 @@
-import { cleanup } from "@testing-library/react";
-import * as matchers from "@testing-library/jest-dom/matchers";
-import { afterEach, expect } from "vitest";
-
-expect.extend(matchers);
-
-afterEach(() => {
-  cleanup();
-});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 메뉴 관련 테스트를 Bun 테스트 러너 환경에 맞게 전환했습니다.
  * 포커스 전환 및 메뉴 아이템 활성화 동작 검증을 더 안정적으로 조정했습니다(이벤트 플러시 타이밍 반영).
  * `onOpenChange`/클릭 관련 콜백 모킹 방식을 일관되게 정리하고, 닫힘 사유 검증을 유지했습니다.

* **Chores**
  * 기존 Vitest 설정/테스트 설정 코드를 제거해 테스트 구성 단계를 간소화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->