### PR TITLE
fix(dialog): render Title and Description with dialog primitives for a11y

### DIFF
--- a/.changeset/thirty-bats-juggle.md
+++ b/.changeset/thirty-bats-juggle.md
@@ -2,4 +2,4 @@
 "@seed-design/react": patch
 ---
 
-`DialogTitle`/`DialogDescription`이 시맨틱 요소(`h2`/`p`)로 렌더되고, 렌더된 경우 dialog에 `aria-labelledby`/`aria-describedby`로 연결되도록 수정합니다.
+`DialogTitle`/`DialogDescription`을 시맨틱 요소(`h2`/`p`)로 렌더하고, 렌더된 경우 `DialogContent`에 `aria-labelledby`/`aria-describedby`로 연결되도록 수정합니다.

--- a/.changeset/thirty-bats-juggle.md
+++ b/.changeset/thirty-bats-juggle.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react": patch
+---
+
+`DialogTitle`/`DialogDescription`이 시맨틱 요소(`h2`/`p`)로 렌더되고, 렌더된 경우 dialog에 `aria-labelledby`/`aria-describedby`로 연결되도록 수정합니다.

--- a/packages/react/src/components/Dialog/Dialog.tsx
+++ b/packages/react/src/components/Dialog/Dialog.tsx
@@ -1,11 +1,9 @@
-import { Dialog as DialogPrimitive, useDialogContext } from "@seed-design/react-dialog";
+import { Dialog as DialogPrimitive } from "@seed-design/react-dialog";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";
 import { dialog, type DialogVariantProps } from "@seed-design/css/recipes/dialog";
 import { createSlotRecipeContext } from "../../utils/createSlotRecipeContext";
-import { createWithStateProps } from "../../utils/createWithStateProps";
 
 const { withRootProvider, withContext } = createSlotRecipeContext(dialog);
-const withStateProps = createWithStateProps([useDialogContext]);
 
 ////////////////////////////////////////////////////////////////////////////////////
 
@@ -68,25 +66,19 @@ export const DialogHeader = withContext<HTMLDivElement, DialogHeaderProps>(Primi
 
 ////////////////////////////////////////////////////////////////////////////////////
 
-// NOTE: uses DialogPrimitive.TitleProps,
-// but actual rendered component is a Primitive.span rather than a DialogPrimitive.Title
-// find out why later; misses h2 and some a11y features
 export interface DialogTitleProps extends DialogPrimitive.TitleProps {}
 
 export const DialogTitle = withContext<HTMLHeadingElement, DialogTitleProps>(
-  withStateProps(Primitive.span),
+  DialogPrimitive.Title,
   "title",
 );
 
 ////////////////////////////////////////////////////////////////////////////////////
 
-// NOTE: uses DialogPrimitive.DescriptionProps,
-// but actual rendered component is a Primitive.div rather than a DialogPrimitive.Description
-// find out why later; misses p and some a11y features
 export interface DialogDescriptionProps extends DialogPrimitive.DescriptionProps {}
 
 export const DialogDescription = withContext<HTMLParagraphElement, DialogDescriptionProps>(
-  withStateProps(Primitive.div),
+  DialogPrimitive.Description,
   "description",
 );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **접근성 개선**
  * 대화상자의 제목과 설명이 다이얼로그 전용 시맨틱 요소로 렌더링되도록 개선했습니다.
  * 제목과 설명이 제공된 경우, 다이얼로그에 `aria-labelledby`/`aria-describedby`가 연결되어 스크린리더 내 읽기 순서와 의미 전달이 더 일관되게 동작합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->