### PR TITLE
feat(rootage): add excludeFromExchange token flag; exclude bg/neutral-solid-muted(-pressed)

### DIFF
--- a/ecosystem/rootage/core/src/analyzer/resolver.ts
+++ b/ecosystem/rootage/core/src/analyzer/resolver.ts
@@ -110,7 +110,13 @@ export function transformResolvedType<T extends AST.Node | AST.Node[]>(
         }
       }) as AST.TokenDeclaration["values"];
 
-      return factory.createTokenDeclaration(node.collection, node.token, values, node.description);
+      return factory.createTokenDeclaration(
+        node.collection,
+        node.token,
+        values,
+        node.description,
+        node.excludeFromExchange,
+      );
     }
 
     if (node.kind === "UnresolvedPropertyDeclaration") {

--- a/ecosystem/rootage/core/src/languages/exchange/index.ts
+++ b/ecosystem/rootage/core/src/languages/exchange/index.ts
@@ -125,6 +125,8 @@ export function getTokensModel(ast: AST.TokensDocument): Exchange.TokensModel {
   }
 
   for (const decl of ast.data) {
+    if (decl.excludeFromExchange) continue;
+
     const tokenRef = decl.token.identifier;
     const description = decl.description;
     const valueMap = buildValues(decl);

--- a/ecosystem/rootage/core/src/languages/exchange/tokens.test.ts
+++ b/ecosystem/rootage/core/src/languages/exchange/tokens.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from "bun:test";
+
+import YAML from "yaml";
+import { getTokensModel } from "./index";
+import { type AST, Authoring } from "../../parser";
+import { buildContext, getSourceFiles } from "../../analyzer";
+
+const parse = (yaml: string) => getTokensModel(Authoring.parseTokensDocument(YAML.parse(yaml)));
+
+describe("getTokensModel", () => {
+  it("should transform literal and alias color values", () => {
+    const transformed = parse(`
+kind: Tokens
+metadata:
+  id: test
+  name: Test
+  lastUpdated: 26-01-01
+data:
+  collection: color
+  tokens:
+    $color.palette.gray-00:
+      values:
+        light: "#ffffff"
+        dark: "#000000"
+    $color.bg.layer-1:
+      values:
+        light: "#f7f8f9"
+        dark: $color.palette.gray-00
+`);
+
+    expect(transformed).toEqual({
+      kind: "Tokens",
+      metadata: {
+        id: "test",
+        name: "Test",
+        lastUpdated: "26-01-01",
+      },
+      data: {
+        collection: "color",
+        tokens: {
+          "$color.palette.gray-00": {
+            values: {
+              light: { type: "color", value: "#ffffff" },
+              dark: { type: "color", value: "#000000" },
+            },
+          },
+          "$color.bg.layer-1": {
+            values: {
+              light: { type: "color", value: "#f7f8f9" },
+              dark: { type: "color", value: "$color.palette.gray-00" },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("should pass token descriptions through", () => {
+    const transformed = parse(`
+kind: Tokens
+metadata:
+  id: test
+  name: Test
+data:
+  collection: color
+  tokens:
+    $color.bg.a:
+      description: 배경 색상입니다.
+      values:
+        light: "#ffffff"
+`);
+
+    expect(transformed.data.tokens["$color.bg.a"]!.description).toBe("배경 색상입니다.");
+  });
+
+  it("should transform dimension, number, and duration values", () => {
+    const transformed = parse(`
+kind: Tokens
+metadata:
+  id: test
+  name: Test
+data:
+  collection: global
+  tokens:
+    $dimension.x1:
+      values:
+        default: 4px
+    $scale.s95:
+      values:
+        default: 0.95
+    $duration.t1:
+      values:
+        default: 300ms
+`);
+
+    expect(transformed.data.tokens).toEqual({
+      "$dimension.x1": {
+        values: { default: { type: "dimension", value: { value: 4, unit: "px" } } },
+      },
+      "$scale.s95": {
+        values: { default: { type: "number", value: 0.95 } },
+      },
+      "$duration.t1": {
+        values: { default: { type: "duration", value: { value: 300, unit: "ms" } } },
+      },
+    });
+  });
+
+  it("should transform cubicBezier values", () => {
+    const transformed = parse(`
+kind: Tokens
+metadata:
+  id: test
+  name: Test
+data:
+  collection: global
+  tokens:
+    $timing-function.easing:
+      values:
+        default:
+          type: cubicBezier
+          value: [0.25, 0.1, 0.25, 1]
+`);
+
+    expect(transformed.data.tokens["$timing-function.easing"]!.values).toEqual({
+      default: { type: "cubicBezier", value: [0.25, 0.1, 0.25, 1] },
+    });
+  });
+
+  it("should transform shadow values", () => {
+    const transformed = parse(`
+kind: Tokens
+metadata:
+  id: test
+  name: Test
+data:
+  collection: color
+  tokens:
+    $shadow.s1:
+      values:
+        light:
+          type: shadow
+          value:
+            - color: "#000000"
+              offsetX: 0px
+              offsetY: 1px
+              blur: 4px
+              spread: 0px
+`);
+
+    expect(transformed.data.tokens["$shadow.s1"]!.values).toEqual({
+      light: {
+        type: "shadow",
+        value: [
+          {
+            color: "#000000",
+            offsetX: { value: 0, unit: "px" },
+            offsetY: { value: 1, unit: "px" },
+            blur: { value: 4, unit: "px" },
+            spread: { value: 0, unit: "px" },
+          },
+        ],
+      },
+    });
+  });
+
+  it("should transform gradient values", () => {
+    const transformed = parse(`
+kind: Tokens
+metadata:
+  id: test
+  name: Test
+data:
+  collection: color
+  tokens:
+    $gradient.g1:
+      values:
+        light:
+          type: gradient
+          value:
+            - color: "#ff0000"
+              position: 0
+            - color: "#00ff00"
+              position: 1
+`);
+
+    expect(transformed.data.tokens["$gradient.g1"]!.values).toEqual({
+      light: {
+        type: "gradient",
+        value: [
+          { color: "#ff0000", position: 0 },
+          { color: "#00ff00", position: 1 },
+        ],
+      },
+    });
+  });
+
+  it("should throw for unresolved token declarations", () => {
+    // 모든 모드 값이 참조인 토큰은 파스 시점에 타입이 정해지지 않으므로,
+    // getSourceFiles/getTokenDeclarations로 resolve하지 않고 직접 넘기면 던진다.
+    expect(() =>
+      parse(`
+kind: Tokens
+metadata:
+  id: test
+  name: Test
+data:
+  collection: color
+  tokens:
+    $color.bg.a:
+      values:
+        light: $color.palette.gray-00
+`),
+    ).toThrow("Cannot convert unresolved token declaration");
+  });
+
+  it("should exclude tokens marked excludeFromExchange", () => {
+    const transformed = parse(`
+kind: Tokens
+metadata:
+  id: test
+  name: Test
+data:
+  collection: color
+  tokens:
+    $color.bg.a:
+      values:
+        light: "#ffffff"
+    $color.bg.b:
+      description: kept for compatibility
+      excludeFromExchange: true
+      values:
+        light: "#000000"
+`);
+
+    expect(Object.keys(transformed.data.tokens)).toEqual(["$color.bg.a"]);
+  });
+
+  it("should preserve excludeFromExchange through reference resolution", () => {
+    const collectionsYaml = `
+kind: TokenCollections
+metadata:
+  id: collections
+  name: collections
+data:
+  - name: color
+    modes:
+      - id: light
+`;
+    const tokensYaml = `
+kind: Tokens
+metadata:
+  id: test
+  name: test
+data:
+  collection: color
+  tokens:
+    $color.palette.gray-00:
+      values:
+        light: "#ffffff"
+    $color.bg.a:
+      values:
+        light: $color.palette.gray-00
+    $color.bg.b:
+      excludeFromExchange: true
+      values:
+        light: $color.palette.gray-00
+`;
+
+    const ctx = buildContext([
+      {
+        fileName: "collections.yaml",
+        ast: Authoring.fromObject(YAML.parse(collectionsYaml)),
+      },
+      {
+        fileName: "tokens.yaml",
+        ast: Authoring.fromObject(YAML.parse(tokensYaml)),
+      },
+    ]);
+
+    const tokensAst = getSourceFiles(ctx)
+      .map((file) => file.ast)
+      .find((ast): ast is AST.TokensDocument => ast.kind === "TokensDocument");
+    if (!tokensAst) throw new Error("tokens document not found");
+
+    const transformed = getTokensModel(tokensAst);
+
+    expect(Object.keys(transformed.data.tokens)).toEqual(["$color.palette.gray-00", "$color.bg.a"]);
+  });
+});

--- a/ecosystem/rootage/core/src/parser/ast.ts
+++ b/ecosystem/rootage/core/src/parser/ast.ts
@@ -88,6 +88,7 @@ export interface ColorTokenDeclaration {
   token: TokenLit;
   values: ColorTokenValueDeclaration[];
   description?: string;
+  excludeFromExchange?: boolean;
 }
 
 export interface ColorTokenValueDeclaration {
@@ -102,6 +103,7 @@ export interface DimensionTokenDeclaration {
   token: TokenLit;
   values: DimensionTokenValueDeclaration[];
   description?: string;
+  excludeFromExchange?: boolean;
 }
 
 export interface DimensionTokenValueDeclaration {
@@ -116,6 +118,7 @@ export interface NumberTokenDeclaration {
   token: TokenLit;
   values: NumberTokenValueDeclaration[];
   description?: string;
+  excludeFromExchange?: boolean;
 }
 
 export interface NumberTokenValueDeclaration {
@@ -130,6 +133,7 @@ export interface DurationTokenDeclaration {
   token: TokenLit;
   values: DurationTokenValueDeclaration[];
   description?: string;
+  excludeFromExchange?: boolean;
 }
 
 export interface DurationTokenValueDeclaration {
@@ -144,6 +148,7 @@ export interface CubicBezierTokenDeclaration {
   token: TokenLit;
   values: CubicBezierTokenValueDeclaration[];
   description?: string;
+  excludeFromExchange?: boolean;
 }
 
 export interface CubicBezierTokenValueDeclaration {
@@ -158,6 +163,7 @@ export interface ShadowTokenDeclaration {
   token: TokenLit;
   values: ShadowTokenValueDeclaration[];
   description?: string;
+  excludeFromExchange?: boolean;
 }
 
 export interface ShadowTokenValueDeclaration {
@@ -172,6 +178,7 @@ export interface GradientTokenDeclaration {
   token: TokenLit;
   values: GradientTokenValueDeclaration[];
   description?: string;
+  excludeFromExchange?: boolean;
 }
 
 export interface GradientTokenValueDeclaration {
@@ -188,6 +195,7 @@ export interface UnresolvedTokenDeclaration {
   token: TokenLit;
   values: UnresolvedTokenValueDeclaration[];
   description?: string;
+  excludeFromExchange?: boolean;
 }
 
 export interface UnresolvedTokenValueDeclaration {

--- a/ecosystem/rootage/core/src/parser/authoring/tokens.ts
+++ b/ecosystem/rootage/core/src/parser/authoring/tokens.ts
@@ -48,6 +48,7 @@ export function parseTokenDeclarations(data: Document.TokensData): TokenDeclarat
               factory.createColorTokenValueDeclaration(mode, value as ColorHexLit | TokenLit),
             ),
             tokenData.description,
+            tokenData.excludeFromExchange,
           ),
         );
         break;
@@ -60,6 +61,7 @@ export function parseTokenDeclarations(data: Document.TokensData): TokenDeclarat
               factory.createDimensionTokenValueDeclaration(mode, value as DimensionLit | TokenLit),
             ),
             tokenData.description,
+            tokenData.excludeFromExchange,
           ),
         );
         break;
@@ -72,6 +74,7 @@ export function parseTokenDeclarations(data: Document.TokensData): TokenDeclarat
               factory.createNumberTokenValueDeclaration(mode, value as NumberLit | TokenLit),
             ),
             tokenData.description,
+            tokenData.excludeFromExchange,
           ),
         );
         break;
@@ -84,6 +87,7 @@ export function parseTokenDeclarations(data: Document.TokensData): TokenDeclarat
               factory.createDurationTokenValueDeclaration(mode, value as DurationLit | TokenLit),
             ),
             tokenData.description,
+            tokenData.excludeFromExchange,
           ),
         );
         break;
@@ -99,6 +103,7 @@ export function parseTokenDeclarations(data: Document.TokensData): TokenDeclarat
               ),
             ),
             tokenData.description,
+            tokenData.excludeFromExchange,
           ),
         );
         break;
@@ -111,6 +116,7 @@ export function parseTokenDeclarations(data: Document.TokensData): TokenDeclarat
               factory.createShadowTokenValueDeclaration(mode, value as ShadowLit | TokenLit),
             ),
             tokenData.description,
+            tokenData.excludeFromExchange,
           ),
         );
         break;
@@ -123,6 +129,7 @@ export function parseTokenDeclarations(data: Document.TokensData): TokenDeclarat
               factory.createGradientTokenValueDeclaration(mode, value as GradientLit | TokenLit),
             ),
             tokenData.description,
+            tokenData.excludeFromExchange,
           ),
         );
         break;
@@ -135,6 +142,7 @@ export function parseTokenDeclarations(data: Document.TokensData): TokenDeclarat
               factory.createUnresolvedTokenValueDeclaration(mode, value as TokenLit),
             ),
             tokenData.description,
+            tokenData.excludeFromExchange,
           ),
         );
     }

--- a/ecosystem/rootage/core/src/parser/authoring/types.ts
+++ b/ecosystem/rootage/core/src/parser/authoring/types.ts
@@ -69,6 +69,7 @@ export interface TokensData {
         [mode: string]: Value;
       };
       description?: string;
+      excludeFromExchange?: boolean;
     };
   };
 }

--- a/ecosystem/rootage/core/src/parser/factory.ts
+++ b/ecosystem/rootage/core/src/parser/factory.ts
@@ -495,6 +495,7 @@ export function createColorTokenDeclaration(
   token: TokenLit,
   values: ColorTokenValueDeclaration[],
   description?: string,
+  excludeFromExchange?: boolean,
 ): ColorTokenDeclaration {
   return {
     kind: "ColorTokenDeclaration",
@@ -502,6 +503,7 @@ export function createColorTokenDeclaration(
     token,
     values,
     description,
+    excludeFromExchange,
   };
 }
 
@@ -513,6 +515,7 @@ export function createDimensionTokenDeclaration(
   token: TokenLit,
   values: DimensionTokenValueDeclaration[],
   description?: string,
+  excludeFromExchange?: boolean,
 ): DimensionTokenDeclaration {
   return {
     kind: "DimensionTokenDeclaration",
@@ -520,6 +523,7 @@ export function createDimensionTokenDeclaration(
     token,
     values,
     description,
+    excludeFromExchange,
   };
 }
 
@@ -531,6 +535,7 @@ export function createNumberTokenDeclaration(
   token: TokenLit,
   values: NumberTokenValueDeclaration[],
   description?: string,
+  excludeFromExchange?: boolean,
 ): NumberTokenDeclaration {
   return {
     kind: "NumberTokenDeclaration",
@@ -538,6 +543,7 @@ export function createNumberTokenDeclaration(
     token,
     values,
     description,
+    excludeFromExchange,
   };
 }
 
@@ -549,6 +555,7 @@ export function createDurationTokenDeclaration(
   token: TokenLit,
   values: DurationTokenValueDeclaration[],
   description?: string,
+  excludeFromExchange?: boolean,
 ): DurationTokenDeclaration {
   return {
     kind: "DurationTokenDeclaration",
@@ -556,6 +563,7 @@ export function createDurationTokenDeclaration(
     token,
     values,
     description,
+    excludeFromExchange,
   };
 }
 
@@ -567,6 +575,7 @@ export function createCubicBezierTokenDeclaration(
   token: TokenLit,
   values: CubicBezierTokenValueDeclaration[],
   description?: string,
+  excludeFromExchange?: boolean,
 ): CubicBezierTokenDeclaration {
   return {
     kind: "CubicBezierTokenDeclaration",
@@ -574,6 +583,7 @@ export function createCubicBezierTokenDeclaration(
     token,
     values,
     description,
+    excludeFromExchange,
   };
 }
 
@@ -585,6 +595,7 @@ export function createShadowTokenDeclaration(
   token: TokenLit,
   values: ShadowTokenValueDeclaration[],
   description?: string,
+  excludeFromExchange?: boolean,
 ): ShadowTokenDeclaration {
   return {
     kind: "ShadowTokenDeclaration",
@@ -592,6 +603,7 @@ export function createShadowTokenDeclaration(
     token,
     values,
     description,
+    excludeFromExchange,
   };
 }
 
@@ -603,6 +615,7 @@ export function createGradientTokenDeclaration(
   token: TokenLit,
   values: GradientTokenValueDeclaration[],
   description?: string,
+  excludeFromExchange?: boolean,
 ): GradientTokenDeclaration {
   return {
     kind: "GradientTokenDeclaration",
@@ -610,6 +623,7 @@ export function createGradientTokenDeclaration(
     token,
     values,
     description,
+    excludeFromExchange,
   };
 }
 
@@ -621,6 +635,7 @@ export function createUnresolvedTokenDeclaration(
   token: TokenLit,
   values: UnresolvedTokenValueDeclaration[],
   description?: string,
+  excludeFromExchange?: boolean,
 ): UnresolvedTokenDeclaration {
   return {
     kind: "UnresolvedTokenDeclaration",
@@ -628,6 +643,7 @@ export function createUnresolvedTokenDeclaration(
     token,
     values,
     description,
+    excludeFromExchange,
   };
 }
 
@@ -647,6 +663,7 @@ export function createTokenDeclaration(
     | GradientTokenValueDeclaration[]
     | UnresolvedTokenValueDeclaration[],
   description?: string,
+  excludeFromExchange?: boolean,
 ): TokenDeclaration {
   switch (values[0]!.kind) {
     case "ColorTokenValueDeclaration":
@@ -655,6 +672,7 @@ export function createTokenDeclaration(
         token,
         values as ColorTokenValueDeclaration[],
         description,
+        excludeFromExchange,
       );
     case "DimensionTokenValueDeclaration":
       return createDimensionTokenDeclaration(
@@ -662,6 +680,7 @@ export function createTokenDeclaration(
         token,
         values as DimensionTokenValueDeclaration[],
         description,
+        excludeFromExchange,
       );
     case "NumberTokenValueDeclaration":
       return createNumberTokenDeclaration(
@@ -669,6 +688,7 @@ export function createTokenDeclaration(
         token,
         values as NumberTokenValueDeclaration[],
         description,
+        excludeFromExchange,
       );
     case "DurationTokenValueDeclaration":
       return createDurationTokenDeclaration(
@@ -676,6 +696,7 @@ export function createTokenDeclaration(
         token,
         values as DurationTokenValueDeclaration[],
         description,
+        excludeFromExchange,
       );
     case "CubicBezierTokenValueDeclaration":
       return createCubicBezierTokenDeclaration(
@@ -683,6 +704,7 @@ export function createTokenDeclaration(
         token,
         values as CubicBezierTokenValueDeclaration[],
         description,
+        excludeFromExchange,
       );
     case "ShadowTokenValueDeclaration":
       return createShadowTokenDeclaration(
@@ -690,6 +712,7 @@ export function createTokenDeclaration(
         token,
         values as ShadowTokenValueDeclaration[],
         description,
+        excludeFromExchange,
       );
     case "GradientTokenValueDeclaration":
       return createGradientTokenDeclaration(
@@ -697,6 +720,7 @@ export function createTokenDeclaration(
         token,
         values as GradientTokenValueDeclaration[],
         description,
+        excludeFromExchange,
       );
     case "UnresolvedTokenValueDeclaration":
       return createUnresolvedTokenDeclaration(
@@ -704,6 +728,7 @@ export function createTokenDeclaration(
         token,
         values as UnresolvedTokenValueDeclaration[],
         description,
+        excludeFromExchange,
       );
   }
 }

--- a/packages/rootage/__generated__/color.json
+++ b/packages/rootage/__generated__/color.json
@@ -1639,32 +1639,6 @@
         },
         "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (solid)"
       },
-      "$color.bg.neutral-solid-muted": {
-        "values": {
-          "theme-light": {
-            "type": "color",
-            "value": "$color.palette.gray-800"
-          },
-          "theme-dark": {
-            "type": "color",
-            "value": "$color.palette.gray-400"
-          }
-        },
-        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (solid-muted)"
-      },
-      "$color.bg.neutral-solid-muted-pressed": {
-        "values": {
-          "theme-light": {
-            "type": "color",
-            "value": "$color.palette.gray-900"
-          },
-          "theme-dark": {
-            "type": "color",
-            "value": "$color.palette.gray-500"
-          }
-        },
-        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (solid-muted-pressed)"
-      },
       "$color.bg.neutral-weak": {
         "values": {
           "theme-light": {

--- a/packages/rootage/color.yaml
+++ b/packages/rootage/color.yaml
@@ -575,11 +575,13 @@ data:
         theme-dark: $color.palette.gray-300
     $color.bg.neutral-solid-muted:
       description: 일반적인 콘텐츠에 사용되는 기본 색상입니다. (solid-muted)
+      excludeFromExchange: true
       values:
         theme-light: $color.palette.gray-800
         theme-dark: $color.palette.gray-400
     $color.bg.neutral-solid-muted-pressed:
       description: 일반적인 콘텐츠에 사용되는 기본 색상입니다. (solid-muted-pressed)
+      excludeFromExchange: true
       values:
         theme-light: $color.palette.gray-900
         theme-dark: $color.palette.gray-500


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 토큰에 `excludeFromExchange` 옵션을 추가해 Exchange 변환 대상에서 선택적으로 제외할 수 있습니다.
  * 제외 설정이 토큰 파싱 및 참조 해석 과정에서도 유지됩니다.
  * 특정 중립 배경 토큰이 Exchange 결과에서 제외되도록 설정되었습니다.

* **테스트**
  * 색상, 치수, 그림자, 그라디언트 등 다양한 토큰 변환과 제외 옵션을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->