### PR TITLE
fix(docs): resolve rootage from authoring yaml; link spec json in llms.txt

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -95,6 +95,7 @@
         "tailwind-merge": "^3.5.0",
         "unified": "^11.0.5",
         "unist-util-visit": "^5.0.0",
+        "yaml": "^2.9.0",
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^4.1.3",
@@ -6853,6 +6854,8 @@
 
     "@sanity/uuid/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
+    "@seed-design/docs/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
     "@seed-design/docs/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@seed-design/docs-mcp/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
@@ -6870,6 +6873,8 @@
     "@seed-design/react-file-upload/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
 
     "@seed-design/react-scrollable/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
+
+    "@seed-design/rootage-core/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "@seed-design/rsbuild-plugin-lynx-icon/@rsbuild/core": ["@rsbuild/core@1.7.3", "", { "dependencies": { "@rspack/core": "~1.7.5", "@rspack/lite-tapable": "~1.1.0", "@swc/helpers": "^0.5.18", "core-js": "~3.47.0", "jiti": "^2.6.1" }, "bin": { "rsbuild": "bin/rsbuild.js" } }, "sha512-kI1oQvCXbQYxUvQPnDLdjSX4gFsbrFNpuUj6jXEJ7IcJ74Q+n4oeFj74/8tKerhxhe0L90m/ZQfzLeN5ORGA9w=="],
 

--- a/docs/app/_llms/AGENTS.md
+++ b/docs/app/_llms/AGENTS.md
@@ -17,12 +17,12 @@ alwaysApply: true
 - 룰은 `match`(대상 식별)와 `transform`(노드 변환)을 분리한다.
 - 변환 실패 시 예외를 전파하지 말고 원본 노드를 반환해 안전하게 실패한다.
 - 문자열 정규식 후처리보다 AST 변환을 우선한다.
-- 테스트 단언은 `contains`가 아니라 fixture 전체 일치로 작성한다.
+- 테스트 단언은 `contains`가 아니라 전체 일치(파이프라인은 fixture, 룰 단위는 inline snapshot 허용)로 작성한다.
 
 ## 필수 작업 절차
 
 1. 룰 추가/변경 시 `rules/`에 독립 모듈로 구현한다.
-2. `__fixtures__`에 `*.input.mdx` / `*.output.mdx`를 추가한다.
+2. 룰 단위 검증은 inline snapshot으로 충분하다. 파이프라인 fixture(`__fixtures__/pipeline`)에 케이스를 추가한다.
 3. 룰 단위 테스트와 파이프라인 테스트를 모두 갱신한다.
 4. 아래 검증을 통과시킨다.
    - `cd docs && bun test app/_llms`

--- a/docs/app/_llms/__fixtures__/pipeline/combined.input.mdx
+++ b/docs/app/_llms/__fixtures__/pipeline/combined.input.mdx
@@ -26,3 +26,5 @@
 <TypeTable
   type={{"id":"test","name":"TestProps","entries":[{"name":"variant","description":"","tags":[],"type":"string","simplifiedType":"string","required":false,"deprecated":false}]}}
 />
+
+<ComponentSpecBlock id="action-button" variants={["variant=brandSolid"]} />

--- a/docs/app/_llms/__fixtures__/pipeline/combined.output.mdx
+++ b/docs/app/_llms/__fixtures__/pipeline/combined.output.mdx
@@ -15,3 +15,5 @@ export default function ActionButtonPreview() {
 
 * `variant`
   - type: `string`
+
+Component spec (JSON): /rootage/components/action-button.json

--- a/docs/app/_llms/rules/component-spec-block-rule.test.ts
+++ b/docs/app/_llms/rules/component-spec-block-rule.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeLLMBodyWithRules } from "../normalize-llm-body";
+import { normalizeForAssert } from "../test-utils";
+import { componentSpecBlockRule } from "./component-spec-block-rule";
+
+const normalize = (input: string) =>
+  normalizeForAssert(normalizeLLMBodyWithRules(input, [componentSpecBlockRule]));
+
+describe("componentSpecBlockRule", () => {
+  it("replaces spec block with rootage json url", () => {
+    expect(
+      normalize(`# Control Chip
+
+<ComponentSpecBlock id="control-chip" />`),
+    ).toMatchInlineSnapshot(`
+      "# Control Chip
+
+      Component spec (JSON): /rootage/components/control-chip.json"
+    `);
+  });
+
+  it("ignores variants prop", () => {
+    expect(
+      normalize(`# Action Button
+
+<ComponentSpecBlock id="action-button" variants={["variant=brandSolid", "size=medium"]} />`),
+    ).toMatchInlineSnapshot(`
+      "# Action Button
+
+      Component spec (JSON): /rootage/components/action-button.json"
+    `);
+  });
+
+  it("keeps original node for unknown spec id", () => {
+    expect(
+      normalize(`# Unknown
+
+<ComponentSpecBlock id="does-not-exist" />`),
+    ).toMatchInlineSnapshot(`
+      "# Unknown
+
+      <ComponentSpecBlock id="does-not-exist" />"
+    `);
+  });
+});

--- a/docs/app/_llms/rules/component-spec-block-rule.ts
+++ b/docs/app/_llms/rules/component-spec-block-rule.ts
@@ -1,173 +1,30 @@
-import { readFileSync } from "node:fs";
-import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
-import type {
-  MdxJsxAttribute,
-  MdxJsxAttributeValueExpression,
-  MdxJsxFlowElement,
-} from "mdast-util-mdx-jsx";
-import type { Exchange } from "@seed-design/rootage-core";
+import type { MdxJsxFlowElement } from "mdast-util-mdx-jsx";
 import index from "@seed-design/rootage-artifacts/index.json";
-import type { Rule, RuleNode } from "./types";
-import {
-  type ArrayExpressionNode,
-  type ExpressionStatementNode,
-  type LiteralNode,
-  isProgramNode,
-  isStringLiteral,
-} from "./estree-utils";
+import type { Rule } from "./types";
 
 /*
-  <ComponentSpecBlock id="action-button" variants={["variant=brandSolid"]} /> 에서
-  variants 배열을 파싱합니다.
+  마크다운 테이블을 생성하는 대신 rootage exchange JSON URL을 안내합니다.
+  테이블 생성은 번들된 빌드에서 조용히 실패했고(스펙 JSON fs 접근 불가),
+  스펙 전문은 JSON이 소스 오브 트루스이므로 URL 참조가 더 정확합니다.
+  variants prop은 llms.txt 출력에서는 무시합니다.
 */
-function getVariantsFromNode(node: RuleNode): string[] {
-  const attr = node.attributes.find(
-    (a): a is MdxJsxAttribute => a.type === "mdxJsxAttribute" && a.name === "variants",
-  );
-  if (!attr || typeof attr.value !== "object" || !attr.value) return [];
-
-  const attrValue = attr.value as MdxJsxAttributeValueExpression;
-  const estree = attrValue.data?.estree;
-  if (!isProgramNode(estree)) return [];
-
-  const stmt = estree.body[0];
-  if (!stmt || stmt.type !== "ExpressionStatement") return [];
-
-  const expr = (stmt as ExpressionStatementNode).expression;
-  if (expr.type !== "ArrayExpression") return [];
-
-  return (expr as ArrayExpressionNode).elements
-    .filter((el): el is LiteralNode & { value: string } => isStringLiteral(el))
-    .map((el) => el.value);
-}
-
-/*
-  MDX의 variants prop ["variant=brandSolid"] 형식과
-  JSON의 variants 객체 { "variant": "brandSolid" }를 비교합니다.
-*/
-function matchesVariantFilter(
-  defVariants: Record<string, string>,
-  filterVariants: string[],
-): boolean {
-  if (filterVariants.length === 0) return true;
-
-  const filterMap: Record<string, string> = {};
-  for (const f of filterVariants) {
-    const eqIdx = f.indexOf("=");
-    if (eqIdx < 0) continue;
-    filterMap[f.slice(0, eqIdx)] = f.slice(eqIdx + 1);
-  }
-
-  // filterMap의 모든 키/값이 defVariants와 일치해야 함
-  for (const [k, v] of Object.entries(filterMap)) {
-    if (defVariants[k] !== v) return false;
-  }
-  return true;
-}
-
-function stringifyVariants(variants: Record<string, string>): string {
-  const entries = Object.entries(variants);
-  if (entries.length === 0) return "Base";
-  return entries.map(([k, v]) => `${k}=${v}`).join(", ");
-}
-
-function formatPropertyValue(prop: Exchange.Value): string {
-  // 토큰 참조 ($color.bg.brand-solid 등)는 그대로 표시
-  if (typeof prop.value === "string") return prop.value;
-  return JSON.stringify(prop.value);
-}
-
-/*
-  ComponentSpec 데이터를 마크다운 테이블로 변환합니다.
-  filterVariants가 비어있으면 모든 definition을 포함합니다.
-*/
-function generateMarkdown(spec: Exchange.ComponentSpecModel, filterVariants: string[]): string {
-  const sections: string[] = [];
-
-  for (const defEntry of spec.data.definitions) {
-    if (!matchesVariantFilter(defEntry.variants, filterVariants)) continue;
-
-    const variantLabel = stringifyVariants(defEntry.variants);
-    const rows: string[] = [];
-
-    for (const stateDef of defEntry.definitions) {
-      const stateStr = stateDef.states.join(", ");
-      for (const [slotName, slotProps] of Object.entries(stateDef.slots)) {
-        for (const [propName, propValue] of Object.entries(slotProps)) {
-          rows.push(
-            `| ${stateStr} | ${slotName} | ${propName} | ${formatPropertyValue(propValue)} |`,
-          );
-        }
-      }
-    }
-
-    if (rows.length === 0) continue;
-
-    const table = [
-      "| State | Slot | Property | Value |",
-      "| --- | --- | --- | --- |",
-      ...rows,
-    ].join("\n");
-
-    sections.push(`### ${variantLabel}\n\n${table}`);
-  }
-
-  return sections.join("\n\n");
-}
-
-/*
-  rootage component spec 파일을 id를 키로 캐싱합니다.
-*/
-let specDataCache: Map<string, Exchange.ComponentSpecModel> | null = null;
-
-function loadComponentSpecData(): Map<string, Exchange.ComponentSpecModel> {
-  if (specDataCache) return specDataCache;
-
-  specDataCache = new Map();
-  const rootageDir = join(
-    dirname(createRequire(import.meta.url).resolve("@seed-design/rootage-artifacts/package.json")),
-    "__generated__",
-  );
-
-  for (const resource of index.resources) {
-    const { path } = resource;
-    if (!path.startsWith("/components/")) continue;
-
-    try {
-      const content = readFileSync(join(rootageDir, path.slice(1)), "utf-8");
-      const data = JSON.parse(content) as Exchange.ComponentSpecModel;
-      const id = data.metadata?.id ?? path.replace("/components/", "").replace(".json", "");
-      specDataCache.set(id, data);
-    } catch {
-      // 읽지 못한 파일은 건너뜀
-    }
-  }
-
-  return specDataCache;
-}
-
 export const componentSpecBlockRule: Rule = {
   name: "ComponentSpecBlock",
   match: (node): node is MdxJsxFlowElement =>
     node.type === "mdxJsxFlowElement" && node.name === "ComponentSpecBlock",
   transform: (node, context) => {
-    try {
-      const id = context.getStringAttribute(node, "id");
-      if (!id) throw new Error("ComponentSpecBlock: id prop is required");
-
-      const filterVariants = getVariantsFromNode(node);
-      const specData = loadComponentSpecData();
-      const spec = specData.get(id);
-      if (!spec) throw new Error(`ComponentSpecBlock: spec not found for id="${id}"`);
-
-      const markdown = generateMarkdown(spec, filterVariants);
-      if (!markdown) throw new Error(`ComponentSpecBlock: no definitions for id="${id}"`);
-
-      return [{ type: "html", value: markdown }];
-    } catch (e) {
-      console.warn(`[ComponentSpecBlock] 변환 실패, 노드 스킵: ${e}`);
-      return [];
+    const id = context.getStringAttribute(node, "id");
+    if (!id) {
+      console.warn("[ComponentSpecBlock] id prop이 없어 원본 노드를 유지합니다.");
+      return [node];
     }
+
+    const resourcePath = `/components/${id}.json`;
+    if (!index.resources.some((resource) => resource.path === resourcePath)) {
+      console.warn(`[ComponentSpecBlock] id="${id}"의 스펙 리소스가 없어 원본 노드를 유지합니다.`);
+      return [node];
+    }
+
+    return [{ type: "html", value: `Component spec (JSON): /rootage${resourcePath}` }];
   },
 };

--- a/docs/lib/rootage.ts
+++ b/docs/lib/rootage.ts
@@ -1,24 +1,29 @@
 import "server-only";
 
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { cache } from "react";
-import { buildContext, Exchange } from "@seed-design/rootage-core";
-import index from "@seed-design/rootage-artifacts/index.json";
+import { Authoring, buildContext } from "@seed-design/rootage-core";
+import YAML from "yaml";
 
 // `process.cwd()` is `docs/` during Next.js build/runtime.
 // `@seed-design/rootage-artifacts` is the workspace package at `packages/rootage`.
-const ROOTAGE_DATA = join(process.cwd(), "..", "packages", "rootage", "__generated__");
+// Authoring YAML을 소스로 쓴다 — exchange JSON(__generated__)은 excludeFromExchange 토큰이
+// 빠져 있어, 아직 산출물에 남아 그 토큰을 참조하는 컴포넌트 스펙(예: control-chip)의 해석이
+// 실패한다. 문서는 저장소 내부 소비자이므로 authoring 소스를 기준으로 렌더링한다.
+const ROOTAGE_SOURCE = join(process.cwd(), "..", "packages", "rootage");
 
 export const getRootage = cache(async () => {
+  const paths = (await readdir(ROOTAGE_SOURCE, { recursive: true })).filter((path) =>
+    path.endsWith(".yaml"),
+  );
   const sourceFiles = await Promise.all(
-    index.resources.map(async (resource) => {
-      const content = await readFile(join(ROOTAGE_DATA, resource.path), "utf-8");
-      return {
-        fileName: resource.path,
-        ast: Exchange.fromObject(JSON.parse(content) as Exchange.Model),
-      };
-    }),
+    paths.map(async (path) => ({
+      fileName: path,
+      ast: Authoring.fromObject(
+        YAML.parse(await readFile(join(ROOTAGE_SOURCE, path), "utf-8")) as Authoring.Model,
+      ),
+    })),
   );
   return buildContext(sourceFiles);
 });

--- a/docs/package.json
+++ b/docs/package.json
@@ -81,7 +81,8 @@
     "styled-components": "6",
     "tailwind-merge": "^3.5.0",
     "unified": "^11.0.5",
-    "unist-util-visit": "^5.0.0"
+    "unist-util-visit": "^5.0.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.3",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 컴포넌트 스펙 블록이 관련 JSON 리소스 경로로 표시됩니다.
  - 지정된 variants 정보가 함께 제공됩니다.
  - 존재하지 않는 컴포넌트 ID는 원본 블록을 유지합니다.
  - 다양한 MDX 입력 형식의 variants를 안정적으로 처리합니다.

- **문서**
  - Control Chip, Action Button 및 알 수 없는 컴포넌트 ID에 대한 예시가 추가되었습니다.

- **테스트**
  - 스펙 경로 변환, variants 처리, 잘못된 ID 처리 동작을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->