### PR TITLE
fix(segmented-control): type SegmentedControlItem with its declared props interface

### DIFF
--- a/.changeset/witty-labels-accept.md
+++ b/.changeset/witty-labels-accept.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react-segmented-control": patch
+---
+
+`SegmentedControlItem`에 `className`, `asChild` 등 DOM 속성 전달 시 발생하던 타입 에러를 수정합니다.

--- a/packages/react-headless/segmented-control/src/SegmentedControl.tsx
+++ b/packages/react-headless/segmented-control/src/SegmentedControl.tsx
@@ -48,21 +48,20 @@ export interface SegmentedControlItemProps
     PrimitiveProps,
     Omit<React.InputHTMLAttributes<HTMLLabelElement>, "value"> {}
 
-export const SegmentedControlItem = React.forwardRef<
-  HTMLLabelElement,
-  UseSegmentedControlItemProps
->((props, ref) => {
-  const { value, invalid, disabled, ...otherProps } = props;
-  const { getItemProps } = useSegmentedControlContext();
-  const itemProps = getItemProps({ value, disabled, invalid });
-  const mergedProps = mergeProps(itemProps.rootProps, otherProps);
+export const SegmentedControlItem = React.forwardRef<HTMLLabelElement, SegmentedControlItemProps>(
+  (props, ref) => {
+    const { value, invalid, disabled, ...otherProps } = props;
+    const { getItemProps } = useSegmentedControlContext();
+    const itemProps = getItemProps({ value, disabled, invalid });
+    const mergedProps = mergeProps(itemProps.rootProps, otherProps);
 
-  return (
-    <SegmentedControlItemProvider value={itemProps}>
-      <Primitive.label ref={ref} {...mergedProps} />
-    </SegmentedControlItemProvider>
-  );
-});
+    return (
+      <SegmentedControlItemProvider value={itemProps}>
+        <Primitive.label ref={ref} {...mergedProps} />
+      </SegmentedControlItemProvider>
+    );
+  },
+);
 SegmentedControlItem.displayName = "SegmentedControlItem";
 
 export interface SegmentedControlItemHiddenInputProps


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 세그먼트 컨트롤 항목 컴포넌트의 공개 타입 정의를 정리하여 `className`, `asChild` 등 DOM 속성 전달 시 발생하던 타입 에러를 수정했습니다.
  * 기존 렌더링 및 동작은 변경되지 않았습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->