### PR TITLE
fix(stackflow): focus AppScreen layer without scrolling on enter

### DIFF
--- a/.changeset/calm-otters-focus.md
+++ b/.changeset/calm-otters-focus.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/stackflow": patch
+---
+
+`AppScreen`이 화면 진입 애니메이션 완료 후 포커스를 이동할 때 `preventScroll`을 적용해, 스크롤 가능한 컨테이너(예: iframe)에 임베드된 경우 발생하던 원치 않는 스크롤 점프를 방지합니다.

--- a/packages/stackflow/src/primitive/AppScreen/AppScreen.tsx
+++ b/packages/stackflow/src/primitive/AppScreen/AppScreen.tsx
@@ -40,7 +40,10 @@ export const AppScreenRoot = forwardRef<HTMLDivElement, AppScreenRootProps>((pro
   // transitionState, so the effect won't re-fire.
   useEffect(() => {
     if (api.activity?.transitionState === "enter-done") {
-      api.layerRef.current?.focus();
+      // `preventScroll` so moving focus never scrolls an ancestor. The layer already fills
+      // the viewport, so the browser's default scroll-into-view is at best a no-op — and at
+      // worst a jarring jump when the app is embedded in a scrollable host (e.g. an iframe).
+      api.layerRef.current?.focus({ preventScroll: true });
     }
   }, [api.activity?.transitionState, api.layerRef]);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 화면 전환 애니메이션이 완료된 후 포커스를 이동할 때 불필요한 스크롤 점프가 발생하지 않도록 개선했습니다.
  * 스크롤 가능한 컨테이너나 iframe에 앱이 포함된 경우에도 현재 스크롤 위치를 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->