### PR TITLE
docs: drop the architecture diagram from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,6 @@ SEED는 당근 제품을 위한 통합된 디자인 언어입니다. 하나의 �
 
 [문서 사이트](https://seed-design.io)
 
-## 아키텍처
-
-SEED는 **디자인 토큰 → 스타일 → 컴포넌트** 파이프라인을 따릅니다.
-
-```text
-rootage (토큰·스키마 정의, YAML)
-   ↓
-qvism-preset (레시피)  +  css (토큰·CSS)
-   ↓
-react (컴포넌트)  ←  react-headless (로직)
-```
-
 ## 패키지
 
 **Definitions** — 토큰·레시피 소스


### PR DESCRIPTION
README에서 아키텍처 섹션(파이프라인 다이어그램)을 뺍니다.

[#1784](https://github.com/daangn/seed-design/pull/1784)에서 들어갔던 부분인데, README에 두기엔 과한 내용이라 제거합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * README에서 아키텍처 설명과 토큰·스타일·컴포넌트 파이프라인 다이어그램을 제거했습니다.
  * 소개 문구 다음에 패키지 목록이 바로 표시되도록 문서 구성을 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->