### PR TITLE
fix(docs): stop the landing hero from flashing on load

### DIFF
--- a/docs/components/landing/components/hero-video.tsx
+++ b/docs/components/landing/components/hero-video.tsx
@@ -62,7 +62,7 @@ export function HeroVideo({
     <>
       <ManagedVideo
         playbackEnabled={playbackEnabled}
-        poster={poster}
+        poster={resolved && prefersReducedMotion ? poster : undefined}
         src={src}
         sources={sources}
         wrapperClassName={wrapperClassName}

--- a/docs/components/landing/components/managed-video.tsx
+++ b/docs/components/landing/components/managed-video.tsx
@@ -24,7 +24,7 @@ interface ManagedVideoProps
   > {
   onFirstLoop?: () => void;
   playbackEnabled: boolean;
-  poster: string;
+  poster?: string;
   sources?: ManagedVideoSource[];
   src?: string;
   wrapperClassName?: string;
@@ -156,10 +156,12 @@ export function ManagedVideo({
         overflow: "hidden",
         lineHeight: 0,
         transform: "translateZ(0)",
-        backgroundImage: `url(${JSON.stringify(poster)})`,
-        backgroundPosition: "center",
-        backgroundRepeat: "no-repeat",
-        backgroundSize: "cover",
+        ...(poster && {
+          backgroundImage: `url(${JSON.stringify(poster)})`,
+          backgroundPosition: "center",
+          backgroundRepeat: "no-repeat",
+          backgroundSize: "cover",
+        }),
         ...wrapperStyle,
       }}
     >

--- a/docs/components/landing/landing-responsive-sections.tsx
+++ b/docs/components/landing/landing-responsive-sections.tsx
@@ -20,35 +20,35 @@ export function LandingResponsiveSections({
 }: LandingResponsiveSectionsProps) {
   const lottieMotionEnabled = environmentResolved && !prefersReducedMotion;
 
-  if (layout === "mobile") {
-    return (
-      <SectionBento
-        lottieEnabled={environmentResolved}
-        lottieMotionEnabled={lottieMotionEnabled}
-        mode="compact"
-        mp4PlaybackEnabled={lottieMotionEnabled}
-        prefersReducedMotion={prefersReducedMotion}
-      />
-    );
-  }
-
   return (
     <>
       <SectionHero prefersReducedMotion={prefersReducedMotion} resolved={environmentResolved} />
-      {layout === "tablet" && <h1 className="sr-only">{INTRO_TITLE.replace(/\n/g, " ")}</h1>}
-      <SectionBento
-        lottieEnabled={environmentResolved}
-        lottieMotionEnabled={lottieMotionEnabled}
-        mode="desktop"
-        mp4PlaybackEnabled={lottieMotionEnabled}
-        prefersReducedMotion={prefersReducedMotion}
-      />
-      {layout === "desktop" && (
-        <SectionLottieIntro
+      {layout === "mobile" ? (
+        <SectionBento
           lottieEnabled={environmentResolved}
           lottieMotionEnabled={lottieMotionEnabled}
-          onLottieReady={onLottieReady}
+          mode="compact"
+          mp4PlaybackEnabled={lottieMotionEnabled}
+          prefersReducedMotion={prefersReducedMotion}
         />
+      ) : (
+        <>
+          {layout === "tablet" && <h1 className="sr-only">{INTRO_TITLE.replace(/\n/g, " ")}</h1>}
+          <SectionBento
+            lottieEnabled={environmentResolved}
+            lottieMotionEnabled={lottieMotionEnabled}
+            mode="desktop"
+            mp4PlaybackEnabled={lottieMotionEnabled}
+            prefersReducedMotion={prefersReducedMotion}
+          />
+          {layout === "desktop" && (
+            <SectionLottieIntro
+              lottieEnabled={environmentResolved}
+              lottieMotionEnabled={lottieMotionEnabled}
+              onLottieReady={onLottieReady}
+            />
+          )}
+        </>
       )}
     </>
   );

--- a/docs/components/landing/sections/section-bento.tsx
+++ b/docs/components/landing/sections/section-bento.tsx
@@ -78,7 +78,7 @@ function CompactBento({
           resolved={lottieEnabled}
           src={HERO_VIDEO_MOBILE}
           poster={HERO_POSTER_MOBILE}
-          wrapperClassName="aspect-[1074/1344] w-full"
+          wrapperClassName="aspect-[1074/1344] w-full bg-[#f3f3f3]"
           videoClassName="size-full scale-[1.002] object-cover"
           buttonClassName="bottom-3 right-3"
         />

--- a/docs/components/landing/sections/section-bento.tsx
+++ b/docs/components/landing/sections/section-bento.tsx
@@ -232,6 +232,7 @@ export function SectionBento({
       mobileStack
       forceStacked={mode === "compact"}
       pinFrom="lg"
+      sectionClassName={mode === "compact" ? "md:hidden" : undefined}
       panelClassName="flex flex-col justify-start rounded-b-[20px] bg-white"
       behindClassName="bg-[#121212]"
     >

--- a/docs/components/landing/sections/section-hero.tsx
+++ b/docs/components/landing/sections/section-hero.tsx
@@ -23,7 +23,13 @@ export function SectionHero({
   resolved: boolean;
 }) {
   return (
-    <SectionLayer id="hero" z={Z.hero} regionVh={REGIONS.hero} panelClassName="bg-white">
+    <SectionLayer
+      id="hero"
+      z={Z.hero}
+      regionVh={REGIONS.hero}
+      sectionClassName="hidden md:block"
+      panelClassName="bg-white"
+    >
       <div data-hero-frame className="box-border size-full">
         <div data-hero-video className="relative size-full overflow-hidden">
           <HeroVideo

--- a/docs/components/landing/sections/section-hero.tsx
+++ b/docs/components/landing/sections/section-hero.tsx
@@ -37,7 +37,7 @@ export function SectionHero({
             resolved={resolved}
             src={HERO_VIDEO}
             poster={HERO_POSTER}
-            wrapperClassName="size-full"
+            wrapperClassName="size-full bg-[#f3f3f3]"
             videoClassName="size-full object-cover"
             buttonClassName="bottom-4 right-4"
           />


### PR DESCRIPTION
랜딩 홈을 새로고침할 때마다 주황 화면이 번쩍인 뒤 레이아웃이 밀리는 문제를 고칩니다. 데스크톱·모바일 양쪽에서 재현됐습니다.

## 원인

원인이 두 개 겹쳐 있었습니다.

**1. layout 분기가 JS라서 SSR이 항상 모바일**

`SERVER_ENVIRONMENT.layout`이 항상 `"mobile"`이라 SSR은 compact bento 셸을 그리고, hydration 후 데스크톱 hero로 교체됩니다. 그래서 **데스크톱 사용자도 모바일 트리를 — 주황 poster를 포함해 — 한 프레임 보게 됩니다.**

서버는 뷰포트를 모르므로 초기값을 `"desktop"`으로 바꿔도 반대편이 틀릴 뿐입니다. `useState` 초기값이 문제가 아니라 분기를 JS로 한다는 게 문제입니다.

**2. 모바일 poster가 영상 엔딩 프레임에서 추출됨**

ffmpeg 실측:

| 에셋 | poster | 영상 t=0 |
|---|---|---|
| `intro-poster.webp` (데스크톱) | 흰 배경 `#f3f3f3` + 텍스트 (영상 t≈1s) | 균일 `#f3f3f3` |
| `intro-mobile-poster.webp` (모바일) | **주황 `#ee5603` + SEED 락업 (영상 t≈8s, 엔딩)** | `#f5f5f5` |

모바일 poster만 엔딩 프레임에서 뽑혀 있어 poster→영상 전환이 하드 컷이었습니다.

## 변경

- **hero를 CSS로 게이팅** — `SectionHero`를 항상 렌더하고 `hidden md:block`을 겁니다. compact 셸에는 `md:hidden`을 줘서 데스크톱 첫 페인트에 둘이 겹치지 않게 했습니다. `md`(768px)는 `WIDE_LAYOUT_QUERY`와 1:1로 맞습니다.
- **poster는 reduced-motion 전용** — 그 경우 `playbackEnabled`가 계속 false라 `<video>`가 마운트되지 않아 poster가 유일한 hero 콘텐츠입니다. 일반 사용자에게는 아예 렌더하지 않습니다.
  - `resolved` 가드가 필요한 이유: `useReducedMotion`의 서버 스냅샷이 `true`라서 `prefersReducedMotion` 단독으로는 SSR 셸에서 poster가 그대로 나옵니다.

## 범위를 hero로 제한한 이유

bento 내부, `#intro`, `resolved` 게이트는 **의도적으로** JS 분기를 유지했습니다. 두 트리를 동시에 DOM에 두면:

- `id="bento"`가 중복되고 `scenes.ts`의 `querySelector`가 첫 매칭만 잡아 **한쪽 벤토 애니메이션이 에러 없이 조용히 죽습니다**
- `[data-bento-mobile-*]`가 `REVEAL_SELECTOR` / `repairStaleReveals` 커버리지 밖이라 `autoAlpha: 0`을 되돌릴 주체가 없어 영구 invisible이 될 수 있습니다
- Lottie가 4개 동시 로드되고 숨은 채로 계속 loop 재생됩니다

`#hero`는 독립 `SectionLayer` 형제라 id 중복이 없고, `createHeroToBento`가 `mm.add({ isWide })` 안에서만 등록되므로 이 위험들을 전부 비껴갑니다.

## 검증

SSR HTML을 직접 떠서 확인했습니다.

- `id="hero"` 존재 → 데스크톱 첫 페인트부터 hero가 자리를 잡음
- hero: `class="relative w-full  hidden md:block "`
- compact bento: `class="relative w-full bg-[#121212] md:hidden h-auto"`
- **poster 참조 0개** — 주황 이미지가 HTML에 아예 없으니 깜빡일 수가 없습니다

그 외 `biome check` 무수정 통과, 변경 파일 타입 에러 0, `bun docs:test` 통과.

## 남겨둔 것

- **모바일 poster가 엔딩 프레임인 건 그대로 뒀습니다.** reduced-motion 사용자에게 보일 대표 이미지로는 브랜드 락업이 오히려 적절합니다.
- **로딩 플레이스홀더는 넣지 않았습니다.** 흰색과 영상 t=0(`#f3f3f3`)의 WCAG 대비율이 **1.110**이라(1.0 = 구분 불가) 색 전환을 넣어도 육안으로 안 보이고, 빠른 네트워크에서는 오히려 새로운 깜빡임이 됩니다. 프로덕션에서 실제로 느린지 확인한 뒤 판단하는 게 맞다고 봅니다.
- **레이아웃 시프트가 완전히 사라진 건 아닙니다.** 첫 화면(`#hero`)은 SSR부터 정확하지만, 그 아래 bento 내부는 여전히 hydration 후 확정됩니다. 데스크톱에서 hero 아래라 첫 화면 밖이고 hydration이 스크롤보다 빠르지만, 전면 해결은 위 "범위를 제한한 이유"의 작업이 선행돼야 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 모션/환경에 따라 영상 포스터를 올바르게 적용하고, 포스터가 없을 때는 불필요한 배경 스타일이 표시되지 않도록 개선했습니다.
* **개선 사항**
  * 반응형 랜딩의 섹션 렌더링 로직을 정리해 모바일/태블릿/데스크톱에서 Hero와 Bento 노출 규칙이 화면 크기에 맞게 더 안정적으로 동작합니다.
  * 데스크톱에서 추가 소개 콘텐츠 노출이 의도대로 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->