### PR TITLE
fix(docs): 랜딩 Showcase의 깨진 Color 링크 수정

### DIFF
--- a/docs/components/landing/lib/landing-content.ts
+++ b/docs/components/landing/lib/landing-content.ts
@@ -136,7 +136,7 @@ export const SHOWCASE_ROW_TOP: ShowcaseItem[] = [
   {
     title: "Color",
     image: "/landing/showcase/color.webp",
-    href: "/foundations/color/color-system",
+    href: "/foundations/color",
   },
   {
     title: "Iconography",


### PR DESCRIPTION
## 배경
랜딩페이지 Showcase 섹션(`SEED의 기반`)의 **Color** 카드가 존재하지 않는 slug `/foundations/color/color-system`을 가리켜 404가 발생했습니다. (Slack 제보 건)

## 전수조사 결과
`docs/components/landing/lib/landing-content.ts`의 `SHOWCASE_ROW_TOP`(7개) + `SHOWCASE_ROW_BOTTOM`(8개) 총 **15개 Foundations 링크**를 실제 문서 파일(`docs/content/foundations/**`) 및 라우팅(`foundationsSource`, `meta.json`)과 대조했습니다.

| 링크 | 판정 |
|---|---|
| `/foundations/color/color-system` | ❌ 깨짐 → `/foundations/color`로 수정 |
| 나머지 14개 (layout, voice-and-tone, iconography, elevation, gradient, design-token, writing, radius, spacing, state, motion, international-design, inclusive-design, typography) | ✅ 정상 |

## 변경
- Color 카드 href: `/foundations/color/color-system` → `/foundations/color`
  - `color/`는 `layout: "tabs"` 폴더이고 실제 slug는 `/foundations/color`(Overview index), `/color/color-role`, `/color/palette` 뿐입니다. `color-system`은 `/public` 하위 이미지 에셋 폴더명으로만 남아있던 잔재이며, 리다이렉트 설정도 없어 이 링크만 404였습니다.
  - Color 문서의 정식 진입점인 Overview 탭(`/foundations/color`)으로 연결하도록 수정했습니다.

## 참고
- `@seed-design/docs`는 `private` 패키지(version 0.0.0)라 changeset 대상이 아닙니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 랜딩 페이지의 Color 항목 링크를 올바른 색상 가이드 페이지로 연결하도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->