### PR TITLE
fix(react): preserve defaults for undefined props

### DIFF
--- a/.changeset/young-years-knock.md
+++ b/.changeset/young-years-knock.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react": patch
+---
+
+`DialogRoot` 등 컴포넌트에 `undefined` prop을 전달했을 때 각 컴포넌트의 기본값이 적용되지 않는 문제를 수정합니다.

--- a/packages/lynx-react/src/utils/create-slot-recipe-context.test.tsx
+++ b/packages/lynx-react/src/utils/create-slot-recipe-context.test.tsx
@@ -29,6 +29,7 @@ const mockSlotRecipe = Object.assign(
 type MockProps = {
   children?: unknown;
   className?: string;
+  active?: boolean;
 };
 
 type MockReceived = { props?: MockProps };
@@ -92,5 +93,55 @@ describe("createSlotRecipeContext", () => {
 
     expect(rootReceived.props?.className).toBe("root-a extra");
     expect(childReceived.props?.className).toBe("label-a child-extra");
+  });
+
+  it("restores root default props overwritten with undefined", () => {
+    const { Mock: Root, received } = createMock("Root");
+    const { withRootProvider } = createSlotRecipeContext(mockSlotRecipe);
+    const StyledRoot = withRootProvider<MockVariantProps & MockProps>(Root, {
+      defaultProps: { active: true },
+    });
+
+    render(<StyledRoot active={undefined} />);
+
+    expect(received.props?.active).toBe(true);
+  });
+
+  it("restores provider default props overwritten with undefined", () => {
+    const { Mock: Root, received } = createMock("Root");
+    const { withProvider } = createSlotRecipeContext(mockSlotRecipe);
+    const StyledRoot = withProvider<{ tag: "mock" }, MockVariantProps & MockProps>(Root, "root", {
+      defaultProps: { active: true },
+    });
+
+    render(<StyledRoot active={undefined} />);
+
+    expect(received.props?.active).toBe(true);
+  });
+
+  it("restores context default props overwritten with undefined and preserves false", () => {
+    const { Mock: Root } = createMock("Root");
+    const { Mock: Child, received } = createMock("Child");
+    const { withRootProvider, withContext } = createSlotRecipeContext(mockSlotRecipe);
+    const StyledRoot = withRootProvider<MockVariantProps & MockProps>(Root);
+    const StyledChild = withContext<{ tag: "mock" }, MockProps>(Child, "label", {
+      defaultProps: { active: true },
+    });
+
+    const { rerender } = render(
+      <StyledRoot>
+        <StyledChild active={undefined} />
+      </StyledRoot>,
+    );
+
+    expect(received.props?.active).toBe(true);
+
+    rerender(
+      <StyledRoot>
+        <StyledChild active={false} />
+      </StyledRoot>,
+    );
+
+    expect(received.props?.active).toBe(false);
   });
 });

--- a/packages/lynx-react/src/utils/create-slot-recipe-context.tsx
+++ b/packages/lynx-react/src/utils/create-slot-recipe-context.tsx
@@ -24,6 +24,20 @@ function assertNotIntrinsicComponent(Component: ElementType<any>, caller: string
   );
 }
 
+function restoreDefaultProps<P>(
+  props: Record<string, unknown>,
+  defaultProps: Partial<P> | undefined,
+) {
+  if (!defaultProps) return;
+
+  // Explicit `undefined` should not override component-level defaults.
+  for (const key of Object.keys(defaultProps)) {
+    if (props[key] === undefined) {
+      props[key] = defaultProps[key as keyof P];
+    }
+  }
+}
+
 export function createSlotRecipeContext<
   Props extends Record<string, string | boolean | undefined>,
   Classnames extends Record<string, string>,
@@ -93,6 +107,9 @@ export function createSlotRecipeContext<
     const StyledComponent = (innerProps: any) => {
       const props = { ...(defaultProps ?? {}), ...useProps(), ...innerProps } as Props &
         Record<string, unknown>;
+
+      restoreDefaultProps(props, defaultProps);
+
       const [variantProps, otherProps] = recipe.splitVariantProps(props);
       const classNames = recipe(variantProps);
 
@@ -123,6 +140,9 @@ export function createSlotRecipeContext<
 
     const StyledComponent = forwardRef<any, any>((innerProps, ref) => {
       const props: any = { ...(defaultProps ?? {}), ...useProps(), ...innerProps };
+
+      restoreDefaultProps(props, defaultProps);
+
       const [variantProps, otherProps] = recipe.splitVariantProps(props as Props);
       const classNames = recipe(variantProps);
       const slotClassName: string | undefined = classNames[slot];
@@ -158,6 +178,9 @@ export function createSlotRecipeContext<
 
     const StyledComponent = forwardRef<any, any>((innerProps, ref) => {
       const props: any = { ...(defaultProps ?? {}), ...innerProps };
+
+      restoreDefaultProps(props, defaultProps);
+
       const classNames = useClassNames();
       const slotClassName: string | undefined = slot ? classNames[slot] : undefined;
       const userClassName: string | undefined = props["className"];

--- a/packages/react/src/utils/createRecipeContext.test.tsx
+++ b/packages/react/src/utils/createRecipeContext.test.tsx
@@ -1,0 +1,52 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "bun:test";
+import { createRecipeContext } from "./createRecipeContext";
+
+type TestRecipeProps = {
+  active?: boolean;
+};
+
+let receivedProps: TestRecipeProps | undefined;
+
+const testRecipe = Object.assign(
+  (props?: TestRecipeProps) => {
+    receivedProps = props;
+    return "root";
+  },
+  {
+    splitVariantProps: <T extends TestRecipeProps>(props: T) =>
+      [props, {} as Omit<T, keyof TestRecipeProps>] as [
+        TestRecipeProps,
+        Omit<T, keyof TestRecipeProps>,
+      ],
+  },
+);
+
+const { PropsProvider, withContext } = createRecipeContext(testRecipe);
+const Root = withContext<unknown, TestRecipeProps>(() => null, {
+  defaultProps: { active: true },
+});
+
+describe("createRecipeContext", () => {
+  it("restores default props overwritten with undefined", () => {
+    render(<Root active={undefined} />);
+
+    expect(receivedProps).toMatchObject({ active: true });
+  });
+
+  it("restores default props overwritten with undefined context props", () => {
+    render(
+      <PropsProvider value={{ active: undefined }}>
+        <Root />
+      </PropsProvider>,
+    );
+
+    expect(receivedProps).toMatchObject({ active: true });
+  });
+
+  it("preserves explicitly provided false values", () => {
+    render(<Root active={false} />);
+
+    expect(receivedProps).toMatchObject({ active: false });
+  });
+});

--- a/packages/react/src/utils/createRecipeContext.tsx
+++ b/packages/react/src/utils/createRecipeContext.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 import { createContext, forwardRef, useContext } from "react";
+import { restoreDefaultProps } from "./restoreDefaultProps";
 
 type Recipe<Props extends Record<string, string | boolean | undefined>> = ((
   props?: Props,
@@ -31,6 +32,9 @@ export function createRecipeContext<Props extends Record<string, string | boolea
     const StyledComponent = forwardRef<any, any>((innerProps, ref) => {
       const props = { ...(defaultProps ?? {}), ...useProps(), ...innerProps } as Props &
         React.HTMLAttributes<HTMLElement>;
+
+      restoreDefaultProps(props as Record<string, unknown>, defaultProps);
+
       const [variantProps, otherProps] = recipe.splitVariantProps(props);
       const className = recipe(variantProps); // TODO: should we memoize this?
 

--- a/packages/react/src/utils/createSlotRecipeContext.test.tsx
+++ b/packages/react/src/utils/createSlotRecipeContext.test.tsx
@@ -27,8 +27,14 @@ const testRecipe = Object.assign(
   },
 );
 
-const { PropsProvider, withRootProvider } = createSlotRecipeContext(testRecipe);
+const { PropsProvider, withProvider, withRootProvider } = createSlotRecipeContext(testRecipe);
 const Root = withRootProvider<TestRecipeProps>(() => null, {
+  defaultProps: {
+    lazyMount: true,
+    unmountOnExit: true,
+  },
+});
+const Slot = withProvider<unknown, TestRecipeProps>(() => null, "root", {
   defaultProps: {
     lazyMount: true,
     unmountOnExit: true,
@@ -65,6 +71,21 @@ describe("createSlotRecipeContext", () => {
       expect(receivedProps).toMatchObject({
         lazyMount: false,
         unmountOnExit: false,
+      });
+    });
+  });
+
+  describe("withProvider", () => {
+    it("restores default props overwritten with undefined context props", () => {
+      render(
+        <PropsProvider value={{ lazyMount: undefined, unmountOnExit: undefined }}>
+          <Slot />
+        </PropsProvider>,
+      );
+
+      expect(receivedProps).toMatchObject({
+        lazyMount: true,
+        unmountOnExit: true,
       });
     });
   });

--- a/packages/react/src/utils/createSlotRecipeContext.test.tsx
+++ b/packages/react/src/utils/createSlotRecipeContext.test.tsx
@@ -1,0 +1,71 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "bun:test";
+import { createSlotRecipeContext } from "./createSlotRecipeContext";
+
+type TestRecipeProps = {
+  lazyMount?: boolean;
+  unmountOnExit?: boolean;
+};
+
+type TestClassNames = {
+  root: string;
+};
+
+let receivedProps: TestRecipeProps | undefined;
+
+const testRecipe = Object.assign(
+  (props?: TestRecipeProps): TestClassNames => {
+    receivedProps = props;
+    return { root: "root" };
+  },
+  {
+    splitVariantProps: <T extends TestRecipeProps>(props: T) =>
+      [props, {} as Omit<T, keyof TestRecipeProps>] as [
+        TestRecipeProps,
+        Omit<T, keyof TestRecipeProps>,
+      ],
+  },
+);
+
+const { PropsProvider, withRootProvider } = createSlotRecipeContext(testRecipe);
+const Root = withRootProvider<TestRecipeProps>(() => null, {
+  defaultProps: {
+    lazyMount: true,
+    unmountOnExit: true,
+  },
+});
+
+describe("createSlotRecipeContext", () => {
+  describe("withRootProvider", () => {
+    it("restores default props overwritten with undefined", () => {
+      render(<Root lazyMount={undefined} unmountOnExit={undefined} />);
+
+      expect(receivedProps).toMatchObject({
+        lazyMount: true,
+        unmountOnExit: true,
+      });
+    });
+
+    it("restores default props overwritten with undefined context props", () => {
+      render(
+        <PropsProvider value={{ lazyMount: undefined, unmountOnExit: undefined }}>
+          <Root />
+        </PropsProvider>,
+      );
+
+      expect(receivedProps).toMatchObject({
+        lazyMount: true,
+        unmountOnExit: true,
+      });
+    });
+
+    it("preserves explicitly provided false values", () => {
+      render(<Root lazyMount={false} unmountOnExit={false} />);
+
+      expect(receivedProps).toMatchObject({
+        lazyMount: false,
+        unmountOnExit: false,
+      });
+    });
+  });
+});

--- a/packages/react/src/utils/createSlotRecipeContext.tsx
+++ b/packages/react/src/utils/createSlotRecipeContext.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 import { createContext, forwardRef, useContext } from "react";
+import { restoreDefaultProps } from "./restoreDefaultProps";
 
 type SlotRecipe<
   Props extends Record<string, string | boolean | undefined>,
@@ -56,16 +57,7 @@ export function createSlotRecipeContext<
       const props = { ...(defaultProps ?? {}), ...useProps(), ...innerProps } as Props &
         React.HTMLAttributes<HTMLElement>;
 
-      // Explicit `undefined` should not override component-level defaults.
-      if (defaultProps) {
-        const propsWithDefaults = props as Record<string, unknown>;
-
-        for (const key of Object.keys(defaultProps)) {
-          if (propsWithDefaults[key] === undefined) {
-            propsWithDefaults[key] = defaultProps[key as keyof P];
-          }
-        }
-      }
+      restoreDefaultProps(props as Record<string, unknown>, defaultProps);
 
       const [variantProps, otherProps] = recipe.splitVariantProps(props);
       const classNames = recipe(variantProps); // TODO: should we memoize this?
@@ -95,6 +87,9 @@ export function createSlotRecipeContext<
     const StyledComponent = forwardRef<any, any>((innerProps, ref) => {
       const props = { ...(defaultProps ?? {}), ...useProps(), ...innerProps } as Props &
         React.HTMLAttributes<HTMLElement>;
+
+      restoreDefaultProps(props as Record<string, unknown>, defaultProps);
+
       const [variantProps, otherProps] = recipe.splitVariantProps(props);
       const classNames = recipe(variantProps); // TODO: should we memoize this?
       const className = classNames[slot as keyof typeof classNames];

--- a/packages/react/src/utils/createSlotRecipeContext.tsx
+++ b/packages/react/src/utils/createSlotRecipeContext.tsx
@@ -55,6 +55,18 @@ export function createSlotRecipeContext<
     const StyledComponent = (innerProps: any) => {
       const props = { ...(defaultProps ?? {}), ...useProps(), ...innerProps } as Props &
         React.HTMLAttributes<HTMLElement>;
+
+      // Explicit `undefined` should not override component-level defaults.
+      if (defaultProps) {
+        const propsWithDefaults = props as Record<string, unknown>;
+
+        for (const key of Object.keys(defaultProps)) {
+          if (propsWithDefaults[key] === undefined) {
+            propsWithDefaults[key] = defaultProps[key as keyof P];
+          }
+        }
+      }
+
       const [variantProps, otherProps] = recipe.splitVariantProps(props);
       const classNames = recipe(variantProps); // TODO: should we memoize this?
 

--- a/packages/react/src/utils/restoreDefaultProps.ts
+++ b/packages/react/src/utils/restoreDefaultProps.ts
@@ -1,0 +1,13 @@
+/** Restores defaults overwritten by explicitly passed undefined values. */
+export function restoreDefaultProps<P>(
+  props: Record<string, unknown>,
+  defaultProps: Partial<P> | undefined,
+) {
+  if (!defaultProps) return;
+
+  for (const key of Object.keys(defaultProps)) {
+    if (props[key] === undefined) {
+      props[key] = defaultProps[key as keyof P];
+    }
+  }
+}

--- a/packages/stackflow/src/utils/createStyleContext.test.tsx
+++ b/packages/stackflow/src/utils/createStyleContext.test.tsx
@@ -1,0 +1,59 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "bun:test";
+import { createStyleContext } from "./createStyleContext";
+
+type TestRecipeProps = {
+  active?: boolean;
+};
+
+type TestClassNames = {
+  root: string;
+};
+
+let receivedProps: TestRecipeProps | undefined;
+
+const testRecipe = Object.assign(
+  (props?: TestRecipeProps): TestClassNames => {
+    receivedProps = props;
+    return { root: "root" };
+  },
+  {
+    splitVariantProps: <T extends TestRecipeProps>(props: T) =>
+      [props, {} as Omit<T, keyof TestRecipeProps>] as [
+        TestRecipeProps,
+        Omit<T, keyof TestRecipeProps>,
+      ],
+  },
+);
+
+const { PropsProvider, withProvider, withRootProvider } = createStyleContext(testRecipe);
+const Root = withRootProvider<TestRecipeProps>(() => null, {
+  defaultProps: { active: true },
+});
+const Slot = withProvider<unknown, TestRecipeProps>(() => null, "root", {
+  defaultProps: { active: true },
+});
+
+describe("createStyleContext", () => {
+  it("restores default props overwritten with undefined", () => {
+    render(<Root active={undefined} />);
+
+    expect(receivedProps).toMatchObject({ active: true });
+  });
+
+  it("restores default props overwritten with undefined context props", () => {
+    render(
+      <PropsProvider value={{ active: undefined }}>
+        <Slot />
+      </PropsProvider>,
+    );
+
+    expect(receivedProps).toMatchObject({ active: true });
+  });
+
+  it("preserves explicitly provided false values", () => {
+    render(<Root active={false} />);
+
+    expect(receivedProps).toMatchObject({ active: false });
+  });
+});

--- a/packages/stackflow/src/utils/createStyleContext.test.tsx
+++ b/packages/stackflow/src/utils/createStyleContext.test.tsx
@@ -51,6 +51,22 @@ describe("createStyleContext", () => {
     expect(receivedProps).toMatchObject({ active: true });
   });
 
+  it("restores default props overwritten with undefined slot props", () => {
+    render(<Slot active={undefined} />);
+
+    expect(receivedProps).toMatchObject({ active: true });
+  });
+
+  it("preserves explicitly provided false context props", () => {
+    render(
+      <PropsProvider value={{ active: false }}>
+        <Slot />
+      </PropsProvider>,
+    );
+
+    expect(receivedProps).toMatchObject({ active: false });
+  });
+
   it("preserves explicitly provided false values", () => {
     render(<Root active={false} />);
 

--- a/packages/stackflow/src/utils/createStyleContext.tsx
+++ b/packages/stackflow/src/utils/createStyleContext.tsx
@@ -8,6 +8,20 @@ type Recipe<
   splitVariantProps: <T extends Props>(props: T) => [Props, Omit<T, keyof Props>];
 };
 
+function restoreDefaultProps<P>(
+  props: Record<string, unknown>,
+  defaultProps: Partial<P> | undefined,
+) {
+  if (!defaultProps) return;
+
+  // Explicit `undefined` should not override component-level defaults.
+  for (const key of Object.keys(defaultProps)) {
+    if (props[key] === undefined) {
+      props[key] = defaultProps[key as keyof P];
+    }
+  }
+}
+
 export function createStyleContext<
   Props extends Record<string, string | boolean | undefined>,
   Classnames extends Record<string, string>,
@@ -55,6 +69,9 @@ export function createStyleContext<
     const StyledComponent = (innerProps: any) => {
       const props = { ...(defaultProps ?? {}), ...useProps(), ...innerProps } as Props &
         React.HTMLAttributes<HTMLElement>;
+
+      restoreDefaultProps(props as Record<string, unknown>, defaultProps);
+
       const [variantProps, otherProps] = recipe.splitVariantProps(props);
       const classNames = recipe(variantProps); // TODO: should we memoize this?
 
@@ -83,6 +100,9 @@ export function createStyleContext<
     const StyledComponent = forwardRef<any, any>((innerProps, ref) => {
       const props = { ...(defaultProps ?? {}), ...useProps(), ...innerProps } as Props &
         React.HTMLAttributes<HTMLElement>;
+
+      restoreDefaultProps(props as Record<string, unknown>, defaultProps);
+
       const [variantProps, otherProps] = recipe.splitVariantProps(props);
       const classNames = recipe(variantProps); // TODO: should we memoize this?
       const className = classNames[slot as keyof typeof classNames];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 기본 속성이 명시적인 `undefined` 전달로 덮어써지던 문제를 수정했습니다. 이제 `Root`/컨텍스트/슬롯 등 각 경로에서 기본값이 정상적으로 복원되며, `false`처럼 명시된 값은 그대로 유지됩니다.
* **테스트**
  * 루트/프로바이더/컨텍스트 및 슬롯/스타일 관련 경로에서 `undefined` 복원 및 `false` 보존 동작을 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->