### PR TITLE
docs(changeset): document component vars as internal plumbing

### DIFF
--- a/skills/changeset/SKILL.md
+++ b/skills/changeset/SKILL.md
@@ -7,6 +7,8 @@ description: bun changeset CLI가 감지한 변경 패키지를 기반으로 cha
 
 `bun changeset`이 감지한 변경 패키지를 후보로 삼아, 패키지별 bump를 사용자에게 확정받고, 확인 후 `.changeset/*.md` 파일을 작성한다.
 
+> SEED는 **2.0부터 strict semver**를 따른다 (breaking change는 major에서만). bump 결정은 `references/version-matrix.md`의 전파 매트릭스를 단일 기준으로 삼는다 — 한 패키지의 변경이 그것을 의존하는 패키지로 어떻게 전파되는지가 핵심이다.
+
 ## 실행 절차
 
 ### Phase 1: 변경 패키지 감지 (후보 목록)
@@ -33,27 +35,29 @@ perl -pe 's/\e\[[0-9;?]*[a-zA-Z]//g' /tmp/changeset-detect.txt \
 
 ### Phase 2: 패키지별 bump 확정 (AskUserQuestion)
 
-후보의 **각 패키지마다** 실제 변경 내용을 확인하고(`git diff <패키지_경로>` 또는 커밋 로그), `references/patterns.md`의 분류 기준으로 추천 bump를 정한 뒤, **AskUserQuestion으로 사용자에게 패키지별 bump를 확정받는다.**
+후보의 **각 패키지마다** 실제 변경 내용을 확인하고(`git diff <패키지_경로>` 또는 커밋 로그), `references/version-matrix.md`의 전파 매트릭스로 추천 bump를 정한 뒤, **AskUserQuestion으로 사용자에게 패키지별 bump를 확정받는다.**
 
-3. 패키지 1개당 질문 1개. 옵션은 `major` / `minor` / `patch` / `안함(제외)` 4개.
-   - 모델이 분석한 추천 타입을 **첫 번째 옵션으로 두고 라벨에 `(추천)`**을 붙인다. 판단 근거는 옵션 description에 적는다.
+3. **전파 후보 확장**: 한 패키지를 bump하면 그것을 의존하는 패키지도 매트릭스대로 함께 후보에 올린다. css가 오르면 `react`(css를 peer로 소비), headless가 오르면 `react`(dependency로 소비), react가 major면 `figma`(major 정렬). `bun changeset`이 stacked 등으로 못 잡은 dependent도 여기서 직접 추가한다.
+4. 패키지 1개당 질문 1개. 옵션은 `major` / `minor` / `patch` / `안함(제외)` 4개.
+   - 모델이 분석한 추천 타입을 **첫 번째 옵션으로 두고 라벨에 `(추천)`**을 붙인다. 판단 근거(매트릭스의 어느 행인지)는 옵션 description에 적는다.
    - `안함(제외)`은 그 패키지를 changeset에서 빼는 선택지다. stacked로 딸려온 무관 패키지나 changeset이 불필요한 패키지에 사용한다.
-4. AskUserQuestion은 호출당 질문 4개까지 가능하므로, 후보가 5개 이상이면 4개씩 나눠 여러 번 호출한다.
-5. `안함`으로 답한 패키지는 제외하고, 나머지를 **확정 목록**으로 삼는다.
-   - **주의**: breaking change는 `major`가 아니라 `minor`로 답하게 하고, 메시지에 `(BREAKING CHANGE: ...)` 접두사를 붙여 표현한다 — `references/patterns.md` 참조. major는 패키지 전체 구조 변경 같은 대격변에만.
+5. AskUserQuestion은 호출당 질문 4개까지 가능하므로, 후보가 5개 이상이면 4개씩 나눠 여러 번 호출한다.
+6. `안함`으로 답한 패키지는 제외하고, 나머지를 **확정 목록**으로 삼는다.
+   - **주의 (2.0)**: 공개 표면을 깨는 변경(공개 prop/API·recipe·slot·variant·토큰·공개 data-attr 이름변경·삭제, headless breaking을 extend 등)은 **`major`**다. 1.x처럼 minor로 답하지 않는다. 반대로 내부 plumbing(styling 전용 `data-*`) 이동·삭제는 비공개라 breaking이 아니다(`patch`/`minor`). 판단이 헷갈리면 `references/version-matrix.md`로 확인한다.
 
 ### Phase 3: 메시지 작성
 
-6. `references/patterns.md`를 읽고 메시지 패턴을 참조한다.
-7. 확정 목록의 변경 내용을 바탕으로 **디자인 시스템 소비자(개발자)** 관점의 한국어 메시지를 작성한다.
+7. `references/patterns.md`를 읽고 메시지 패턴을 참조한다.
+8. 확정 목록의 변경 내용을 바탕으로 **디자인 시스템 소비자(개발자)** 관점의 한국어 메시지를 작성한다.
    - 내부 리팩토링이 아닌 **사용자에게 보이는 변경**에 초점을 맞춘다.
    - 타입별 구조를 따른다 (patch: 1줄+불릿, minor: 제목+설명+코드예제, major: 제목+설명+마이그레이션).
-   - breaking change가 포함된 경우 `(BREAKING CHANGE: {마이그레이션 액션})` 접두사를 메시지 첫 줄에 붙인다.
-8. 독립적인 변경이 여러 개면 별도 changeset 파일로 분리를 권장한다.
+   - `(BREAKING CHANGE: {마이그레이션 액션})` 접두사는 **major에만** 첫 줄에 붙인다. minor/patch엔 붙이지 않는다.
+   - snippet 변경은 "재설치 안 하면 기존 코드가 깨지나?"로 가른다 — 안 깨지면 `minor`(접두사 없음), 깨지면 `major`. (`references/patterns.md`의 "snippet 변경 분류")
+9. 독립적인 변경이 여러 개면 별도 changeset 파일로 분리를 권장한다. 단 전파로 함께 오르는 패키지(css+react 등)는 한 파일에 묶는다.
 
 ### Phase 4: 메시지 확인
 
-9. bump는 Phase 2에서 확정됐으므로, 여기서는 **메시지 미리보기**를 보여주고 확인받는다:
+10. bump는 Phase 2에서 확정됐으므로, 여기서는 **메시지 미리보기**를 보여주고 확인받는다:
 
 ```text
 ## Changeset 초안
@@ -67,12 +71,20 @@ perl -pe 's/\e\[[0-9;?]*[a-zA-Z]//g' /tmp/changeset-detect.txt \
 (changeset 파일 전체 내용을 코드블록으로)
 ```
 
-10. 사용자에게 메시지 확인/수정을 요청한다. 수정 요청이 있으면 반영 후 다시 보여준다.
+11. 사용자에게 메시지 확인/수정을 요청한다. 수정 요청이 있으면 반영 후 다시 보여준다.
 
-### Phase 5: 파일 생성
+### Phase 5: peer floor 수동 bump 체크
 
-11. 사용자가 승인하면 `.changeset/` 디렉토리에 Write 도구로 파일을 생성한다.
-12. 파일명은 영어 소문자 `형용사-명사-동사.md` 형태의 랜덤 3단어 조합을 사용한다.
+12. 확정 목록에 **css 또는 headless의 `minor`**가 있으면, 그걸 새로 소비하는 dependent(주로 `react`)의 peer/dep floor를 올려야 하는지 `references/version-matrix.md`로 확인한다.
+    - `.changeset/config.json`의 `onlyUpdatePeerDependentsWhenOutOfRange: true` 때문에, floor가 새 버전 범위 **안**이면 changeset이 dependent를 자동으로 안 올린다. 안 올리면 `react@new + css@old` 조합이 허용되어 **런타임 silent 실패**가 난다.
+    - 필요하면 dependent의 `package.json`에서 해당 floor를 `^N.M.0`로 직접 수정해 같은 PR에 포함한다 (패키지 설치가 아니라 **버전 정책 edit**이라 직접 수정이 정당하다). ceiling(`<N+1`)은 건드리지 않는다.
+    - **`major` bump는 changeset이 자동 전파**하므로 이 단계는 **minor 전파에만** 해당한다.
+13. floor 수정이 필요하면 사용자에게 어떤 `package.json`을 어떻게 바꿀지 알리고 진행한다.
+
+### Phase 6: 파일 생성
+
+14. 사용자가 승인하면 `.changeset/` 디렉토리에 Write 도구로 파일을 생성한다.
+15. 파일명은 영어 소문자 `형용사-명사-동사.md` 형태의 랜덤 3단어 조합을 사용한다.
     - 기존 `.changeset/*.md` 파일명과 충돌하지 않도록 확인한다.
 
 ---
@@ -88,7 +100,9 @@ perl -pe 's/\e\[[0-9;?]*[a-zA-Z]//g' /tmp/changeset-detect.txt \
 
 - changeset 메시지는 **CHANGELOG에 그대로 들어가는 유저향 텍스트**다. 내부 구현 디테일이 아닌 사용자 영향을 서술한다.
 - frontmatter의 패키지명은 반드시 쌍따옴표(`"`)로 감싼다.
+- bump는 "내가 무엇을 바꿨나"의 **observable contract**로 정한다. 의존성이 올랐다는 이유만으로 올리지 않는다 (`references/version-matrix.md` 원칙 1).
 
 ## 참조 파일
 
+- `references/version-matrix.md` — 패키지 간 버전 전파 매트릭스 + bump 결정 기준 (**먼저 참조**)
 - `references/patterns.md` — 메시지 작성 패턴 가이드

--- a/skills/changeset/SKILL.md
+++ b/skills/changeset/SKILL.md
@@ -37,27 +37,27 @@ perl -pe 's/\e\[[0-9;?]*[a-zA-Z]//g' /tmp/changeset-detect.txt \
 
 후보의 **각 패키지마다** 실제 변경 내용을 확인하고(`git diff <패키지_경로>` 또는 커밋 로그), `references/version-matrix.md`의 전파 매트릭스로 추천 bump를 정한 뒤, **AskUserQuestion으로 사용자에게 패키지별 bump를 확정받는다.**
 
-3. **전파 후보 확장**: 한 패키지를 bump하면 그것을 의존하는 패키지도 매트릭스대로 함께 후보에 올린다. css가 오르면 `react`(css를 peer로 소비), headless가 오르면 `react`(dependency로 소비), react가 major면 `figma`(major 정렬). `bun changeset`이 stacked 등으로 못 잡은 dependent도 여기서 직접 추가한다.
-4. 패키지 1개당 질문 1개. 옵션은 `major` / `minor` / `patch` / `안함(제외)` 4개.
+1. **전파 후보 확장**: 한 패키지를 bump하면 그것을 의존하는 패키지도 매트릭스대로 함께 후보에 올린다. css가 오르면 `react`(css를 peer로 소비), headless가 오르면 `react`(dependency로 소비), react가 major면 `figma`(major 정렬). `bun changeset`이 stacked 등으로 못 잡은 dependent도 여기서 직접 추가한다.
+2. 패키지 1개당 질문 1개. 옵션은 `major` / `minor` / `patch` / `안함(제외)` 4개.
    - 모델이 분석한 추천 타입을 **첫 번째 옵션으로 두고 라벨에 `(추천)`**을 붙인다. 판단 근거(매트릭스의 어느 행인지)는 옵션 description에 적는다.
    - `안함(제외)`은 그 패키지를 changeset에서 빼는 선택지다. stacked로 딸려온 무관 패키지나 changeset이 불필요한 패키지에 사용한다.
-5. AskUserQuestion은 호출당 질문 4개까지 가능하므로, 후보가 5개 이상이면 4개씩 나눠 여러 번 호출한다.
-6. `안함`으로 답한 패키지는 제외하고, 나머지를 **확정 목록**으로 삼는다.
-   - **주의 (2.0)**: 공개 표면을 깨는 변경(공개 prop/API·recipe·slot·variant·토큰·공개 data-attr 이름변경·삭제, headless breaking을 extend 등)은 **`major`**다. 1.x처럼 minor로 답하지 않는다. 반대로 내부 plumbing(styling 전용 `data-*`) 이동·삭제는 비공개라 breaking이 아니다(`patch`/`minor`). 판단이 헷갈리면 `references/version-matrix.md`로 확인한다.
+3. AskUserQuestion은 호출당 질문 4개까지 가능하므로, 후보가 5개 이상이면 4개씩 나눠 여러 번 호출한다.
+4. `안함`으로 답한 패키지는 제외하고, 나머지를 **확정 목록**으로 삼는다.
+   - **주의 (2.0)**: 공개 표면을 깨는 변경(공개 prop/API·recipe·slot·variant·토큰·공개 data attr 이름변경·삭제, headless breaking을 extend 등)은 **`major`**다. 1.x처럼 minor로 답하지 않는다. 반대로 내부 배선(styling 전용 `data-*`) 이동·삭제는 비공개라 breaking이 아니다(`patch`/`minor`). 판단이 헷갈리면 `references/version-matrix.md`로 확인한다.
 
 ### Phase 3: 메시지 작성
 
-7. `references/patterns.md`를 읽고 메시지 패턴을 참조한다.
-8. 확정 목록의 변경 내용을 바탕으로 **디자인 시스템 소비자(개발자)** 관점의 한국어 메시지를 작성한다.
+1. `references/patterns.md`를 읽고 메시지 패턴을 참조한다.
+2. 확정 목록의 변경 내용을 바탕으로 **디자인 시스템 소비자(개발자)** 관점의 한국어 메시지를 작성한다.
    - 내부 리팩토링이 아닌 **사용자에게 보이는 변경**에 초점을 맞춘다.
    - 타입별 구조를 따른다 (patch: 1줄+불릿, minor: 제목+설명+코드예제, major: 제목+설명+마이그레이션).
    - `(BREAKING CHANGE: {마이그레이션 액션})` 접두사는 **major에만** 첫 줄에 붙인다. minor/patch엔 붙이지 않는다.
    - snippet 변경은 "재설치 안 하면 기존 코드가 깨지나?"로 가른다 — 안 깨지면 `minor`(접두사 없음), 깨지면 `major`. (`references/patterns.md`의 "snippet 변경 분류")
-9. 독립적인 변경이 여러 개면 별도 changeset 파일로 분리를 권장한다. 단 전파로 함께 오르는 패키지(css+react 등)는 한 파일에 묶는다.
+3. 독립적인 변경이 여러 개면 별도 changeset 파일로 분리를 권장한다. 단 전파로 함께 오르는 패키지(css+react 등)는 한 파일에 묶는다.
 
 ### Phase 4: 메시지 확인
 
-10. bump는 Phase 2에서 확정됐으므로, 여기서는 **메시지 미리보기**를 보여주고 확인받는다:
+1. bump는 Phase 2에서 확정됐으므로, 여기서는 **메시지 미리보기**를 보여주고 확인받는다:
 
 ```text
 ## Changeset 초안
@@ -71,36 +71,30 @@ perl -pe 's/\e\[[0-9;?]*[a-zA-Z]//g' /tmp/changeset-detect.txt \
 (changeset 파일 전체 내용을 코드블록으로)
 ```
 
-11. 사용자에게 메시지 확인/수정을 요청한다. 수정 요청이 있으면 반영 후 다시 보여준다.
+2. 사용자에게 메시지 확인/수정을 요청한다. 수정 요청이 있으면 반영 후 다시 보여준다.
 
 ### Phase 5: peer floor 수동 bump 체크
 
-12. 확정 목록에 **css 또는 headless의 `minor`**가 있으면, 그걸 새로 소비하는 dependent(주로 `react`)의 peer/dep floor를 올려야 하는지 `references/version-matrix.md`로 확인한다.
-    - `.changeset/config.json`의 `onlyUpdatePeerDependentsWhenOutOfRange: true` 때문에, floor가 새 버전 범위 **안**이면 changeset이 dependent를 자동으로 안 올린다. 안 올리면 `react@new + css@old` 조합이 허용되어 **런타임 silent 실패**가 난다.
-    - 필요하면 dependent의 `package.json`에서 해당 floor를 `^N.M.0`로 직접 수정해 같은 PR에 포함한다 (패키지 설치가 아니라 **버전 정책 edit**이라 직접 수정이 정당하다). ceiling(`<N+1`)은 건드리지 않는다.
-    - **`major` bump는 changeset이 자동 전파**하므로 이 단계는 **minor 전파에만** 해당한다.
-13. floor 수정이 필요하면 사용자에게 어떤 `package.json`을 어떻게 바꿀지 알리고 진행한다.
+1. 확정 목록에 **css 또는 headless의 `minor`**가 있으면, 그걸 새로 소비하는 dependent(주로 `react`)의 peer/dep floor를 올려야 하는지 `references/version-matrix.md`로 확인한다.
+   - `.changeset/config.json`의 `onlyUpdatePeerDependentsWhenOutOfRange`가 켜져 있어, floor가 새 버전 범위 **안**이면 changeset이 dependent를 자동으로 안 올린다. 안 올리면 `react@new + css@old` 조합이 허용되어 **런타임 silent 실패**가 난다.
+   - 필요하면 dependent의 `package.json`에서 해당 floor를 `^N.M.0`로 직접 수정해 같은 PR에 포함한다 (패키지 설치가 아니라 **버전 정책 edit**이라 직접 수정이 정당하다). ceiling(`<N+1`)은 건드리지 않는다.
+   - **`major` bump는 changeset이 자동 전파**하므로 이 단계는 **minor 전파에만** 해당한다.
+2. floor 수정이 필요하면 사용자에게 어떤 `package.json`을 어떻게 바꿀지 알리고 진행한다.
 
 ### Phase 6: 파일 생성
 
-14. 사용자가 승인하면 `.changeset/` 디렉토리에 Write 도구로 파일을 생성한다.
-15. 파일명은 영어 소문자 `형용사-명사-동사.md` 형태의 랜덤 3단어 조합을 사용한다.
-    - 기존 `.changeset/*.md` 파일명과 충돌하지 않도록 확인한다.
+1. 사용자가 승인하면 `.changeset/` 디렉토리에 Write 도구로 파일을 생성한다.
+2. 파일명은 영어 소문자 `형용사-명사-동사.md` 형태의 랜덤 3단어 조합을 사용한다.
+   - 기존 `.changeset/*.md` 파일명과 충돌하지 않도록 확인한다.
 
 ---
-
-## Linked 패키지 그룹
-
-`.changeset/config.json`의 `linked` 배열에 정의된 패키지들은 릴리스 시 동일 버전으로 자동 처리된다. changeset에는 변경된 패키지만 포함하면 된다.
-
-- `[@seed-design/figma, @seed-design/mcp]`
-- `[@seed-design/codemod, @seed-design/migration-index]`
 
 ## 주의사항
 
 - changeset 메시지는 **CHANGELOG에 그대로 들어가는 유저향 텍스트**다. 내부 구현 디테일이 아닌 사용자 영향을 서술한다.
 - frontmatter의 패키지명은 반드시 쌍따옴표(`"`)로 감싼다.
-- bump는 "내가 무엇을 바꿨나"의 **observable contract**로 정한다. 의존성이 올랐다는 이유만으로 올리지 않는다 (`references/version-matrix.md` 원칙 1).
+- bump는 내 **공개 표면**이 무엇이 바뀌었나로 정한다. 의존성이 올랐다는 이유만으로 올리지 않는다 (`references/version-matrix.md`의 "기준은 내 공개 표면").
+- `.changeset/config.json`의 `linked`에 묶인 패키지들은 릴리스 시 같은 버전으로 자동 정렬되므로, changeset에는 실제로 변경된 패키지만 넣으면 된다.
 
 ## 참조 파일
 

--- a/skills/changeset/SKILL.md
+++ b/skills/changeset/SKILL.md
@@ -43,7 +43,7 @@ perl -pe 's/\e\[[0-9;?]*[a-zA-Z]//g' /tmp/changeset-detect.txt \
    - `안함(제외)`은 그 패키지를 changeset에서 빼는 선택지다. stacked로 딸려온 무관 패키지나 changeset이 불필요한 패키지에 사용한다.
 3. AskUserQuestion은 호출당 질문 4개까지 가능하므로, 후보가 5개 이상이면 4개씩 나눠 여러 번 호출한다.
 4. `안함`으로 답한 패키지는 제외하고, 나머지를 **확정 목록**으로 삼는다.
-   - **주의 (2.0)**: 공개 표면을 깨는 변경(공개 prop/API·recipe·slot·variant·토큰·공개 data attr 이름변경·삭제, headless breaking을 extend 등)은 **`major`**다. 1.x처럼 minor로 답하지 않는다. 반대로 내부 배선(styling 전용 `data-*`) 이동·삭제는 비공개라 breaking이 아니다(`patch`/`minor`). 판단이 헷갈리면 `references/version-matrix.md`로 확인한다.
+   - **주의 (2.0)**: 공개 표면을 깨는 변경(공개 prop/API·recipe·slot·variant·토큰·공개 data attr 이름변경·삭제, headless breaking을 extend 등)은 **`major`**다. 1.x처럼 minor로 답하지 않는다. 반대로 내부 배선(styling 전용 `data-*`, `typography`를 제외한 `vars/component/*`) 이동·삭제는 비공개라 breaking이 아니다(`patch`/`minor`). 판단이 헷갈리면 `references/version-matrix.md`로 확인한다.
 
 ### Phase 3: 메시지 작성
 

--- a/skills/changeset/references/patterns.md
+++ b/skills/changeset/references/patterns.md
@@ -23,10 +23,9 @@ SEED는 **2.0부터 strict semver**를 따른다. breaking change는 **major에�
 - 버그 수정 (기존 동작이 의도와 달랐던 것을 바로잡음)
 - 스타일/레이아웃 미세 조정 (padding, margin, font-weight 등) — 단 **의도된 시각적 디자인 변경**이면 `minor`
 - 기존 컴포넌트에 variant **값** 추가 (새 API가 아닌 기존 옵션의 확장)
-- 의존성 floor 갱신 / peer 범위 정리 (공개 표면 변화 없음)
+- 의존성 floor 갱신 / peer 범위 정리 — 의존 패키지가 올랐어도 **내 코드·출력이 그대로**면 patch
 - 내부 리팩토링 (공개 표면·DOM 출력 변화 없음)
 - 성능 개선 / 접근성 개선 (기존 동작 유지)
-- 의존하는 headless가 minor 올랐지만 **내 코드·출력은 그대로**인 경우 (exact pin 재배포만 필요)
 
 ### minor (additive — 기존 소비자를 깨지 않음)
 
@@ -51,7 +50,7 @@ SEED는 **2.0부터 strict semver**를 따른다. breaking change는 **major에�
 - 기존 snippet이 새 npm 패키지와 함께 더 이상 동작하지 않는 경우 (재설치 강제)
 - 패키지 전체 구조 변경, 런타임/프레임워크 요구사항 변경 (예: React 버전 요구 변경)
 
-> **예외 — 내부 plumbing은 breaking이 아니다.** SEED의 styling 전용 `data-*`(css ↔ styled react 사이의 비공개 배선)는 옮기거나 지워도 공개 표면이 아니므로 `patch`/`minor`다. 지원 표면은 **컴포넌트 + props + recipe 클래스**다. (`version-matrix.md` 원칙 1·4)
+> **예외 — 내부 배선은 breaking이 아니다.** SEED의 styling 전용 `data-*`(css와 styled react를 잇는 비공개 연결)는 옮기거나 지워도 공개 표면이 아니므로 `patch`/`minor`다. 지원 표면은 **컴포넌트 + props + recipe 클래스**다. (`version-matrix.md`의 "`data-*`는 내부 배선")
 
 ## BREAKING CHANGE 접두사
 
@@ -88,7 +87,7 @@ SEED는 **2.0부터 strict semver**를 따른다. breaking change는 **major에�
 
 ## snippet 변경 분류
 
-snippet은 사용자가 자기 코드베이스로 **복사해간 코드**라 npm 공개 표면이 아니다. snippet 자체엔 버전이 없고, snippet이 `dependencies`로 가리키는 `@seed-design/react`·`@seed-design/css`의 changeset으로 추적된다. 분류는 observable-contract 원칙(`version-matrix.md` 원칙 1)을 따른다.
+snippet은 사용자가 자기 코드베이스로 **복사해간 코드**라 npm 공개 표면이 아니다. snippet 자체엔 버전이 없고, snippet이 `dependencies`로 가리키는 npm 패키지(`@seed-design/react`·`@seed-design/css`)의 changeset으로 추적된다. 분류는 `version-matrix.md`의 "기준은 내 공개 표면"을 따른다.
 
 판단 기준 한 줄: **"재설치 안 하면 기존 코드가 깨지나?"**
 

--- a/skills/changeset/references/patterns.md
+++ b/skills/changeset/references/patterns.md
@@ -2,6 +2,8 @@
 
 SEED Design CHANGELOG 분석에서 추출한 메시지 작성 규칙과 예시.
 
+> bump 타입(major/minor/patch)을 정하기 전에 **먼저 `version-matrix.md`의 전파 매트릭스**로 "이 패키지와 그것을 의존하는 패키지들이 각각 어떤 bump를 받아야 하는지"를 확인한다. 이 문서는 그렇게 정한 타입에 맞는 **메시지를 어떻게 쓰는지**를 다룬다.
+
 ## 언어 규칙
 
 - **언어**: 한국어 (기술 용어, 컴포넌트명, prop명, CSS 속성명은 영어 유지)
@@ -12,39 +14,48 @@ SEED Design CHANGELOG 분석에서 추출한 메시지 작성 규칙과 예시.
 
 ## 타입 분류 기준
 
+SEED는 **2.0부터 strict semver**를 따른다. breaking change는 **major에서만** 낸다 (1.x처럼 minor에 breaking을 싣지 않는다).
+
 ### patch
 
+기존 소비자에게 보이는 표면이 그대로인 변경.
+
 - 버그 수정 (기존 동작이 의도와 달랐던 것을 바로잡음)
-- 스타일/레이아웃 미세 조정 (padding, margin, font-weight 등)
-- 기존 컴포넌트에 variant 값 추가 (새 API가 아닌 기존 옵션의 확장)
-- 의존성 업데이트 (peerDependencies 범위 확장 등)
-- 내부 리팩토링 (사용자 API 변경 없음)
-- 성능 개선 (API 변경 없음)
-- 접근성 개선 (기존 동작 유지)
+- 스타일/레이아웃 미세 조정 (padding, margin, font-weight 등) — 단 **의도된 시각적 디자인 변경**이면 `minor`
+- 기존 컴포넌트에 variant **값** 추가 (새 API가 아닌 기존 옵션의 확장)
+- 의존성 floor 갱신 / peer 범위 정리 (공개 표면 변화 없음)
+- 내부 리팩토링 (공개 표면·DOM 출력 변화 없음)
+- 성능 개선 / 접근성 개선 (기존 동작 유지)
+- 의존하는 headless가 minor 올랐지만 **내 코드·출력은 그대로**인 경우 (exact pin 재배포만 필요)
 
-### minor
+### minor (additive — 기존 소비자를 깨지 않음)
 
-- 새 컴포넌트 추가
-- 새 기능/훅 추가
-- 기존 컴포넌트에 새 prop/API 추가 (기존 API 하위 호환 유지)
-- 새 CSS recipe 추가
-- snippet 업데이트가 필요한 내부 구조 변경 (하위 호환은 됨)
-- 기존 prop/API 제거 또는 이름 변경 (**breaking change** — BREAKING CHANGE 접두사 사용)
-- 기존 동작의 breaking change (**breaking change** — BREAKING CHANGE 접두사 사용)
-- 컴포넌트 이름 변경 (**breaking change** — BREAKING CHANGE 접두사 사용)
-- snippet 재설치가 필요한 변경 (**breaking change** — BREAKING CHANGE 접두사 사용)
+- 새 컴포넌트 / 서브컴포넌트 추가
+- 새 기능 / 훅 추가
+- 기존 컴포넌트에 새 prop/API 추가 (하위 호환 유지)
+- 새 CSS recipe / variant 추가
+- 새 data attribute 기반 스타일링 추가 (기존 selector는 유지)
+- headless non-breaking 추가기능, 그리고 그것을 채택한 react/스타일 업데이트
+- **snippet에 새 기능/스타일 추가** — 기존 코드는 안 깨지고 새 걸 쓰려면 재설치만 하면 되는 경우 (→ "snippet 변경 분류" 참조)
 
-### major
+### major (breaking — 공개 표면을 깨는 변경)
 
-거의 사용하지 않는다. 판단이 어려우면 사용자에게 확인한다.
+1.x에선 minor로 냈지만 **2.0부터는 major**다.
 
-- 패키지 전체 구조 변경 (예: 패키지 분리/통합)
-- 전체 API 표면의 근본적 재설계
-- 런타임/프레임워크 요구사항 변경 (예: React 버전 요구 변경)
+- 공개 API / prop 제거 또는 이름 변경
+- 컴포넌트 이름 변경
+- recipe / slot / variant **이름** 변경·삭제
+- 토큰 / css variable 이름 변경·삭제
+- **공개 contract** data attribute(소비자가 자기 CSS로 타겟하는 것) 이름 변경·삭제
+- headless 인터페이스 breaking을 react가 그대로 extend
+- 기존 snippet이 새 npm 패키지와 함께 더 이상 동작하지 않는 경우 (재설치 강제)
+- 패키지 전체 구조 변경, 런타임/프레임워크 요구사항 변경 (예: React 버전 요구 변경)
+
+> **예외 — 내부 plumbing은 breaking이 아니다.** SEED의 styling 전용 `data-*`(css ↔ styled react 사이의 비공개 배선)는 옮기거나 지워도 공개 표면이 아니므로 `patch`/`minor`다. 지원 표면은 **컴포넌트 + props + recipe 클래스**다. (`version-matrix.md` 원칙 1·4)
 
 ## BREAKING CHANGE 접두사
 
-minor에 breaking change가 포함될 때, 메시지 첫 줄 앞에 `(BREAKING CHANGE: {사용자가 해야 할 마이그레이션 액션})` 접두사를 붙인다.
+`(BREAKING CHANGE: {사용자가 해야 할 마이그레이션 액션})`은 **major changeset의 첫 줄에만** 붙인다. CHANGELOG에서 소비자가 무엇을 해야 하는지 바로 보이게 하기 위함이다. **minor/patch에는 붙이지 않는다.**
 
 ### 형식
 
@@ -55,33 +66,35 @@ minor에 breaking change가 포함될 때, 메시지 첫 줄 앞에 `(BREAKING C
 ### 예시
 
 ```text
-(BREAKING CHANGE: BottomSheet snippet을 다시 설치해야 합니다.) BottomSheet에 드래그를 통해 닫는 기능을 추가합니다.
+(BREAKING CHANGE: `PageBanner.TextContent`를 `PageBanner.Content`로 변경해야 합니다.) Page Banner의 슬롯 구조를 정리합니다.
 
-  - vaul headless 코드 기반으로 seed에 맞게 커스텀하여 구현했습니다.
-  - vaul과 동일한 인터페이스를 가지고 있습니다. (snap-points, fade-from-index, etc.)
-  - `npx @seed-design/cli@latest add ui:bottom-sheet`로 snippet을 최신화하세요.
-```
-
-```text
-(BREAKING CHANGE: TextField snippet을 다시 설치해야 합니다.) Text Field 관련 컴포넌트를 업데이트합니다.
-
-  - 스타일 업데이트
-  - size 통일 및 variant (underline) 추가
-  - 내부적으로 Field 컴포넌트를 사용하도록 변경하여 스타일 일관성 향상
-```
-
-```text
-(BREAKING CHANGE: PageBanner snippet을 다시 설치해야 합니다.) Page Banner 스니펫을 업데이트합니다.
-
-  - Box를 사용하여 스타일링하던 부분을 `PageBanner.Body`로 교체합니다.
   - `PageBanner.TextContent`를 `PageBanner.Content`로 이름 변경합니다.
+  - Box로 스타일링하던 부분을 `PageBanner.Body`로 교체합니다.
+  - `npx @seed-design/cli@latest add ui:page-banner`로 snippet을 다시 설치한 뒤 사용처를 수정하세요.
+```
+
+```text
+(BREAKING CHANGE: `size` 토큰 이름이 바뀌어 의존 패키지를 함께 올려야 합니다.) Color/Size 토큰 일부를 재명명합니다.
+
+  - `$color.legacy.*` 토큰을 제거합니다.
+  - css 소비 패키지는 peer/deps를 `^N+1`로 올려야 합니다.
 ```
 
 ### 규칙
 
-- 접두사의 마이그레이션 액션은 사용자가 **무엇을 해야 하는지** 명시한다 (예: "snippet을 다시 설치해야 합니다", "`prop명`을 `새이름`으로 변경해야 합니다")
+- 접두사의 마이그레이션 액션은 사용자가 **무엇을 해야 하는지** 명시한다 (예: "`prop명`을 `새이름`으로 변경해야 합니다", "snippet을 다시 설치해야 합니다")
 - 접두사 뒤의 설명은 **무엇이 바뀌었는지** 서술한다
 - 불릿 리스트로 세부 변경사항과 마이그레이션 방법을 안내한다
+
+## snippet 변경 분류
+
+snippet은 사용자가 자기 코드베이스로 **복사해간 코드**라 npm 공개 표면이 아니다. snippet 자체엔 버전이 없고, snippet이 `dependencies`로 가리키는 `@seed-design/react`·`@seed-design/css`의 changeset으로 추적된다. 분류는 observable-contract 원칙(`version-matrix.md` 원칙 1)을 따른다.
+
+판단 기준 한 줄: **"재설치 안 하면 기존 코드가 깨지나?"**
+
+- **안 깨짐** (새 기능/스타일을 받으려면 재설치만 하면 됨) → **`minor`**, 접두사 **없음**.
+  - "`npx @seed-design/cli@latest add ui:x`로 최신화하면 ~를 사용할 수 있습니다." 톤.
+- **깨짐** (재설치 강제, 사용처 수정 필요) → **`major`**, `(BREAKING CHANGE: x snippet을 다시 설치해야 합니다.)` 접두사.
 
 ## 메시지 구조
 
@@ -110,7 +123,6 @@ ImageFrame 컴포넌트 개선
 
 - `fallback` prop이 이미지 로딩 실패 시 대체 콘텐츠를 올바르게 표시하도록 개선합니다.
 - Reaction Button이 iOS에서 렌더링되지 않는 문제를 수정합니다.
-- Reaction Button uncontrolled 상태에서 클릭 시 상태가 변경되지 않는 문제를 수정합니다.
 ```
 
 ### patch — 사용자 영향 없음
@@ -128,63 +140,55 @@ Breakpoint 기반 반응형 스타일링을 지원합니다.
 
 - Box, Flex, Grid, VStack 등 유틸리티 컴포넌트의 레이아웃 관련 프로퍼티에 breakpoint 기반 반응형 객체를 사용할 수 있습니다.
 
-```tsx
+​```tsx
 <Box padding={{ base: "x3", md: "x6" }} />
 <Grid columns={{ base: 1, md: 2, lg: 4 }} gap="x4" />
+​```
 ```
-```text
 
+### minor — snippet 새 기능 (additive, 접두사 없음)
+
+기존 snippet은 안 깨지고, 새 기능을 쓰려면 최신화만 하면 되는 경우:
+
+```text
+BottomSheet에 드래그를 통해 닫는 기능을 추가합니다.
+
+- vaul headless 코드 기반으로 seed에 맞게 커스텀하여 구현했습니다.
+- snap-points, fade-from-index 등 vaul과 동일한 인터페이스를 제공합니다.
+- `npx @seed-design/cli@latest add ui:bottom-sheet`로 최신화하면 사용할 수 있습니다.
 ```
-Content Placeholder 컴포넌트를 추가합니다.
-```text
-
-```
-Footer Block을 추가합니다.
-
-- `Footer.LinkText`: 푸터에서 사용하는 링크 텍스트 컴포넌트
-- 4가지 푸터 블록 예제와 소셜 미디어 아이콘 컴포넌트 포함
-```text
 
 ### major — 제목 + 설명 + 마이그레이션 가이드
 
-```
-`AlertDialogRoot`, `MenuSheetRoot` 및 `BottomSheetRoot`의 `onOpenChange` 두 번째 인자로 `details`를 제공합니다. `details.reason`과 `details.event`를 사용할 수 있습니다.
-
-`DialogAction`을 `DialogPrimitive.CloseButton`으로 교체합니다. `AlertDialogAction` `onClick` 핸들러에서 `event.preventDefault()`를 호출하여 닫기 동작을 방지할 수 있습니다.
 ```text
+(BREAKING CHANGE: `DialogAction`을 `DialogPrimitive.CloseButton`으로 교체해야 합니다.) Dialog 닫기 동작 제어 방식을 변경합니다.
 
-```
-**`add` 명령어 사용 방식을 변경합니다.**
-
-- 항목 추가
-
-```sh
-seed-design add ui:action-button breeze:animate-number
-```text
-
-- 기존 `seed-design add action-button` 형식은 더 이상 지원되지 않습니다.
-- `seed-design add-all ui lib breeze`로 레지스트리별 일괄 추가가 가능합니다.
+- `AlertDialogRoot`, `MenuSheetRoot`, `BottomSheetRoot`의 `onOpenChange` 두 번째 인자로 `details`(`details.reason`, `details.event`)를 제공합니다.
+- `AlertDialogAction` `onClick`에서 `event.preventDefault()`를 호출해 닫기를 막을 수 있습니다.
 ```
 
 ## 다수 패키지 포함
 
-하나의 changeset에 여러 패키지를 포함할 수 있다.
+하나의 changeset에 여러 패키지를 포함할 수 있다. 어떤 패키지를 함께 올려야 하는지는 `version-matrix.md`의 전파 매트릭스로 정한다.
 
-### 동일 맥락 — 하나의 changeset으로 통합
+### 전파에 따른 동반 bump — 하나의 changeset으로 통합
+
+예: 새 컴포넌트를 추가하면 css(recipe 추가)와 react(컴포넌트 추가)가 함께 minor.
 
 ```text
 ---
-"@seed-design/react": patch
-"@seed-design/css": patch
-"@seed-design/rootage-artifacts": patch
+"@seed-design/css": minor
+"@seed-design/react": minor
 ---
 
-IdentityPlaceholder의 스타일과 글리프를 업데이트하고, `identity="business"` variant를 추가합니다.
+Content Placeholder 컴포넌트를 추가합니다.
 ```
+
+> ⚠️ 위처럼 css가 minor 오를 때 **react의 css peer floor(`^N.M.0`)는 changeset이 자동으로 안 올린다** (`onlyUpdatePeerDependentsWhenOutOfRange`). 같은 PR에서 `react/package.json`을 손수 올려야 한다 — `version-matrix.md`의 "peer floor 수동 bump 함정" 참조.
 
 ### 독립적 변경 — 별도 changeset으로 분리
 
-패키지 A의 버그 수정과 패키지 B의 새 기능 추가처럼 맥락이 다르면 별도 파일로 분리한다.
+패키지 A의 버그 수정과 패키지 B의 새 기능처럼 맥락이 다르면 별도 파일로 분리한다.
 
 ### 패키지별 다른 타입
 
@@ -215,7 +219,9 @@ IdentityPlaceholder의 스타일과 글리프를 업데이트하고, `identity="
 
 ## 안티패턴
 
-- 내부 구현 디테일을 나열하지 않는다 (예: "파일명 변경", "import 경로 수정" 등)
-- 커밋 메시지를 그대로 복사하지 않는다 — changeset은 CHANGELOG용 유저향 텍스트다
-- 영어로 작성하지 않는다 (기술 용어 제외)
-- `~해요` 체와 `~합니다` 체를 하나의 changeset 내에서 섞지 않는다
+- **breaking change를 minor로 내지 않는다** (2.0부터 공개 표면 breaking은 `major`).
+- **의존성이 올랐다는 이유만으로 버전을 올리지 않는다** — 그 변경이 내 공개 표면으로 새어나갈 때만 전파한다 (observable contract).
+- 내부 구현 디테일을 나열하지 않는다 (예: "파일명 변경", "import 경로 수정").
+- 커밋 메시지를 그대로 복사하지 않는다 — changeset은 CHANGELOG용 유저향 텍스트다.
+- 영어로 작성하지 않는다 (기술 용어 제외).
+- `~해요` 체와 `~합니다` 체를 하나의 changeset 내에서 섞지 않는다.

--- a/skills/changeset/references/patterns.md
+++ b/skills/changeset/references/patterns.md
@@ -49,7 +49,7 @@ SEED는 **2.0부터 strict semver**를 따른다. breaking change는 **major에�
 - 기존 snippet이 새 npm 패키지와 함께 더 이상 동작하지 않는 경우 (재설치 강제)
 - 패키지 전체 구조 변경, 런타임/프레임워크 요구사항 변경 (예: React 버전 요구 변경)
 
-> **예외 — 내부 배선은 breaking이 아니다.** SEED의 styling 전용 `data-*`(css와 styled react를 잇는 비공개 연결)는 옮기거나 지워도 공개 표면이 아니므로 `patch`/`minor`다. 지원 표면은 **컴포넌트 + props + recipe 클래스**다. (`version-matrix.md`의 "`data-*`는 내부 배선")
+> **예외 — 내부 배선은 breaking이 아니다.** SEED의 styling 전용 `data-*`(css와 styled react를 잇는 비공개 연결)와 `typography`를 제외한 `vars/component/*`(rootage spec에서 생성되는 recipe 구현용 값)는 옮기거나 지워도 공개 표면이 아니므로 `patch`/`minor`다. 지원 표면은 **컴포넌트 + props + recipe 클래스**다. (`version-matrix.md`의 "`data-*`는 내부 배선", "컴포넌트 vars도 내부 배선")
 
 ## BREAKING CHANGE 접두사
 

--- a/skills/changeset/references/patterns.md
+++ b/skills/changeset/references/patterns.md
@@ -22,7 +22,6 @@ SEED는 **2.0부터 strict semver**를 따른다. breaking change는 **major에�
 
 - 버그 수정 (기존 동작이 의도와 달랐던 것을 바로잡음)
 - 스타일/레이아웃 미세 조정 (padding, margin, font-weight 등) — 단 **의도된 시각적 디자인 변경**이면 `minor`
-- 기존 컴포넌트에 variant **값** 추가 (새 API가 아닌 기존 옵션의 확장)
 - 의존성 floor 갱신 / peer 범위 정리 — 의존 패키지가 올랐어도 **내 코드·출력이 그대로**면 patch
 - 내부 리팩토링 (공개 표면·DOM 출력 변화 없음)
 - 성능 개선 / 접근성 개선 (기존 동작 유지)
@@ -32,7 +31,7 @@ SEED는 **2.0부터 strict semver**를 따른다. breaking change는 **major에�
 - 새 컴포넌트 / 서브컴포넌트 추가
 - 새 기능 / 훅 추가
 - 기존 컴포넌트에 새 prop/API 추가 (하위 호환 유지)
-- 새 CSS recipe / variant 추가
+- 새 CSS recipe / variant 추가 — 기존 variant에 **값**만 더하는 것도 포함 (css 산출물이 늘고 prop 타입이 넓어지는 additive 변경)
 - 새 data attribute 기반 스타일링 추가 (기존 selector는 유지)
 - headless non-breaking 추가기능, 그리고 그것을 채택한 react/스타일 업데이트
 - **snippet에 새 기능/스타일 추가** — 기존 코드는 안 깨지고 새 걸 쓰려면 재설치만 하면 되는 경우 (→ "snippet 변경 분류" 참조)
@@ -107,10 +106,6 @@ BottomSheet title 영역의 padding을 수정합니다.
 
 ```text
 iOS의 폰트 스케일링 max limit을 135%에서 160%로 늘립니다.
-```
-
-```text
-Avatar 및 Avatar Stack의 `size=56` variant를 추가합니다.
 ```
 
 ### patch — 1줄 제목 + 불릿 리스트

--- a/skills/changeset/references/version-matrix.md
+++ b/skills/changeset/references/version-matrix.md
@@ -65,6 +65,12 @@ css가 깨지면 react가 깨지지만, 그 역은 없다 (react는 css를 소�
 
 SEED의 `data-*`는 css와 styled react를 잇는 비공개 연결이고, 지원 표면은 **컴포넌트 + props + recipe 클래스**다. 그래서 styling 전용 data attr는 옮기거나 지워도 안 깨진다 (major 아님). 단 소비자가 자기 CSS로 타겟해도 되는 **공개 contract** data attr라면 제거·이름변경은 major다.
 
+### 컴포넌트 vars도 내부 배선
+
+`@seed-design/css/vars/component/*`(및 `lynx-css`)는 rootage component spec에서 생성되는 recipe 구현용 값이라 지원 표면이 아니다. spec이 바뀌어 이름·구조가 달라져도 `patch`/`minor`다.
+
+단 **`typography`는 예외**다. 값 객체를 CSS-in-JS에 그대로 펼쳐 쓰는 용도가 있고 마이그레이션 가이드가 직접 import를 안내해왔으므로 SemVer를 지킨다. (사용자 대상 안내는 `packages/css/README.md`의 Stability 절과 Upgrade Guides에 있다.)
+
 ## peer floor 수동 bump 함정 ⚠️
 
 `.changeset/config.json`에 `onlyUpdatePeerDependentsWhenOutOfRange: true`가 켜져 있다. 결과:

--- a/skills/changeset/references/version-matrix.md
+++ b/skills/changeset/references/version-matrix.md
@@ -28,6 +28,8 @@ css가 깨지면 react가 깨지지만, 그 역은 없다 (react는 css를 소�
 |---|---|---|---|---|
 | 스타일만 변경 (css 산출물 추가 X) | `patch` ¹ | – | – | – (`^`로 커버됨) |
 | 새 (서브)컴포넌트 (recipe/vars 동반) | `minor` | `minor` | 신규=`1.0.0`/`0.x`, 서브컴포넌트 추가=`minor` | css peer floor ↑ + headless dep floor ↑/신규 추가 |
+| 기존 variant에 **값** 추가 (recipe 산출물 동반) | `minor` | `minor` ² | – | css peer floor ↑ |
+| 새 토큰 추가 (컴포넌트와 무관) | `minor` | – | – | – (`^`로 커버됨) |
 | headless non-breaking 추가기능 | – | `minor` ² | `minor` | headless dep floor ↑ |
 | headless 추가기능 + 스타일링 | `minor` | `minor` | `minor` | css peer floor ↑ + headless dep floor ↑ |
 | React 로직 추가 기반 스타일 업데이트 | `minor` | `minor` | – | css peer floor ↑ |
@@ -37,7 +39,7 @@ css가 깨지면 react가 깨지지만, 그 역은 없다 (react는 css를 소�
 | 스타일링용 **data attr 이름변경·삭제** | **`major`** ⁴ | **`major`** | 변경한 게 headless면 `major` | css 소비 전 패키지 `^N+1` (+headless 새 major 재선언) |
 
 ¹ 단순 버그/미세 조정은 `patch`. 단 **의도된 시각적 기능**(디자인 의도가 있는 변경)이면 `minor`.
-² react가 그 추가기능을 **채택(사용)하거나 인터페이스로 제공**할 때만 react가 오른다. 안 쓰면 react는 변화 없음.
+² react가 그것을 **채택(사용)하거나 인터페이스로 제공**할 때만 react가 오른다. 안 쓰면 react는 변화 없음. variant 값의 경우 그 값을 prop 타입으로 노출하면 react도 `minor`, css 산출물만 늘고 react 타입이 그대로면 react는 변화 없음.
 ³ 토큰은 단독으로 보면 major가 아닐 것 같지만, 컴포넌트 스타일과 결합돼 있어 css/react가 함께 major.
 ⁴ selector가 바뀌므로 css major. headless major로 data attr 계약이 깨졌거나 react 자체가 제공하던 data attr 값이 바뀐 것이므로 react도 major.
 

--- a/skills/changeset/references/version-matrix.md
+++ b/skills/changeset/references/version-matrix.md
@@ -1,0 +1,79 @@
+# 버전 전파 매트릭스 (SEED 2.0)
+
+SEED는 **2.0을 분기점으로 strict semver**를 따른다. breaking change는 **major에서만** 낸다 (1.x처럼 minor에서 내지 않는다).
+
+이 문서는 "어떤 패키지를 어떻게 바꾸면, 그 패키지와 그것을 의존하는 패키지들이 각각 어떤 bump를 받아야 하는지"를 정한다. changeset의 bump 추천(SKILL.md Phase 2)과 peer floor 체크(Phase 4.5)는 이 매트릭스를 따른다.
+
+## 패키지 트랙
+
+### npm 트랙 (changeset 대상, strict semver)
+
+`@seed-design/` 접두사 생략:
+
+- **토큰/스타일**: `css`, `rootage-artifacts`, `tailwind3-plugin`, `tailwind4-theme`
+- **번들러 플러그인**: `vite-plugin`, `webpack-plugin`, `rsbuild-plugin`
+- **React**: `react`(umbrella), `stackflow`, react-headless 개별 패키지 약 37개(`react-*`, `dom-utils`)
+- **도구**: `figma`, `mcp`(figma와 linked), `cli`, `codemod`+`migration-index`(linked)
+
+### changeset 제외 (private / 자체 버저닝)
+
+`qvism-preset`, `qvism-core`, `qvism-cli`, `rootage-core`, `rootage-cli`, `postcss-*`, `figma-codegen` 및 figma 위젯들, `lynx-*`, `docs`, 예제 패키지. → `bun changeset`이 자동으로 제외하므로 후보에 뜨지 않는다.
+
+### 결합 방향 (단방향)
+
+```text
+css (leaf, deps 없음)
+  ↑ peerDependency
+react (umbrella)  ←  react-headless/* (react가 dependency로 소비: exact pin 또는 workspace:^)
+  ↑ major 정렬
+figma (css/react를 직접 의존하진 않지만 codegen 출력이 특정 react 세대 전용)
+```
+
+css가 깨지면 react가 깨지지만, 그 역은 없다 (react는 css를 소비할 뿐).
+
+## 전파 매트릭스
+
+세로축은 "내가 일으킨 변경", 가로축은 "그래서 각 패키지가 받는 bump"다.
+
+| 변경 상황 | css | react | 해당 headless | react의 peer/deps 조치 |
+|---|---|---|---|---|
+| 스타일만 변경 (css 산출물 추가 X) | `patch` ¹ | – | – | – (`^`로 커버됨) |
+| 새 (서브)컴포넌트 (recipe/vars 동반) | `minor` | `minor` | 신규=`1.0.0`/`0.x`, 서브컴포넌트 추가=`minor` | css peer floor ↑ + headless dep floor ↑/신규 추가 |
+| headless non-breaking 추가기능 | – | `minor` ² | `minor` | headless dep floor ↑ |
+| headless 추가기능 + 스타일링 | `minor` | `minor` | `minor` | css peer floor ↑ + headless dep floor ↑ |
+| React 로직 추가 기반 스타일 업데이트 | `minor` | `minor` | – | css peer floor ↑ |
+| data attr 기반 스타일링 추가 | `minor` | `minor` | 제공 시 `minor` | css peer floor ↑ (+headless dep floor ↑) |
+| headless 인터페이스 **breaking** | – | 안 씀=– / 흡수=`patch` / extend=`major` | **`major`** | 흡수·extend 시 headless를 새 major로 재선언 (`^N+1`) |
+| 토큰·css variable·**recipe/slot/variant 이름변경·삭제** | **`major`** | **`major`** ³ | – | css 소비 전 패키지 peer/deps `^N+1` |
+| 스타일링용 **data attr 이름변경·삭제** | **`major`** ⁴ | **`major`** | 변경한 게 headless면 `major` | css 소비 전 패키지 `^N+1` (+headless 새 major 재선언) |
+
+¹ 단순 버그/미세 조정은 `patch`. 단 **의도된 시각적 기능**(디자인 의도가 있는 변경)이면 `minor`.
+² react가 그 추가기능을 **채택(사용)하거나 인터페이스로 제공**할 때만 react가 오른다. 안 쓰면 react는 변화 없음.
+³ 토큰은 단독으로 보면 major가 아닐 것 같지만, 컴포넌트 스타일과 결합돼 있어 css/react가 함께 major.
+⁴ selector가 바뀌므로 css major. headless major로 data attr 계약이 깨졌거나 react 자체가 제공하던 data attr 값이 바뀐 것이므로 react도 major.
+
+## 핵심 원칙
+
+1. **버전은 "의존성 버전"이 아니라 "내 observable contract"로 정해진다.** 의존성을 bump했다는 사실만으로 내 버전이 오르지 않는다 — 그 변경이 **내 공개 표면(컴포넌트·props·recipe 클래스)으로 새어나갈 때만** 전파된다. 예) 내부 추적 코드를 제거해도 출력(DOM)이 보존되면 breaking이 아니다.
+
+2. **react major ≥ 다른 모든 패키지 major.** 모든 css major에는 react도 major가 따라온다(css는 react의 런타임 substrate). 그래서 react 패키지의 major가 항상 가장 높거나 같다. `figma`는 major를 react에 정렬한다(codegen이 특정 react 세대 전용이므로). 문서 버저닝에도 react 버전을 기준으로 쓸 수 있다.
+
+3. **floor와 ceiling은 비대칭.** `^N.M.0`이 맞고 `~`는 틀리다.
+   - **floor**(하한) = 내가 import하는 걸 다 담은 가장 낮은 버전. 새 기능을 채택할 때마다 **ratchet up**(올리기만).
+   - **ceiling**(상한) = 다음 major `<N+1`. minor는 additive superset이라 높은 버전이 낮은 소비자를 깨지 않으므로 ceiling은 안 내려간다.
+   - `~`(예: `~2.0.0`)는 "react 2.0.0은 css 2.1.0과 못 쓴다"는 거짓 선언이 되어, css 2.1.0이 나오는 순간 전원 강제 lockstep 업그레이드를 유발한다.
+
+4. **SEED의 `data-*`는 내부 plumbing이다.** css ↔ styled react 사이의 비공개 배선이고, 지원 표면은 **컴포넌트 + props + recipe 클래스**다. 그래서 styling 전용 data attr는 옮기거나 지워도 비공개라 안 깨진다(major 아님). 단 소비자가 자기 CSS로 타겟해도 되는 **공개 contract** data-*라면 제거·이름변경 = major.
+
+## peer floor 수동 bump 함정 ⚠️
+
+`.changeset/config.json`에 `onlyUpdatePeerDependentsWhenOutOfRange: true`가 켜져 있다. 결과:
+
+- **css/headless를 `minor`로 올릴 때**: dependent(주로 `react`)의 기존 floor가 새 버전 범위 **안**이면(예: css `2.0→2.1`, react peer `^2.0.0`) changesets가 dependent를 **자동으로 안 올린다**.
+  - 그러면 `react@2.1.0 + css@2.0.0` 조합이 허용되어, 새 컴포넌트가 require하는 `css@2.1.0` recipe가 없어 **런타임 silent 실패**가 난다.
+  - → **그 기능 PR에서 dependent의 peer/dep floor를 `^N.M.0`로 손수 올려 같은 커밋에 포함**한다. 이는 패키지 설치(`bun add`)가 아니라 **버전 정책 edit**이므로 `package.json` 직접 수정이 정당하다 (AGENTS.md의 "`bun add`로 설치" 룰의 예외).
+  - 예: 새 컴포넌트 추가로 css가 `2.1.0`이 되면 → `react`의 `peerDependencies["@seed-design/css"]`를 `^2.0.0 → ^2.1.0`로 직접 수정. ceiling(`<3`)은 그대로 둔다.
+
+- **css/headless를 `major`로 올릴 때**: floor가 범위 **밖**이 되므로 changesets가 dependent를 자동으로 major bump한다. → **수동 불필요**.
+
+요약: **minor 전파 = 손수, major 전파 = 자동.**

--- a/skills/changeset/references/version-matrix.md
+++ b/skills/changeset/references/version-matrix.md
@@ -2,34 +2,23 @@
 
 SEED는 **2.0을 분기점으로 strict semver**를 따른다. breaking change는 **major에서만** 낸다 (1.x처럼 minor에서 내지 않는다).
 
-이 문서는 "어떤 패키지를 어떻게 바꾸면, 그 패키지와 그것을 의존하는 패키지들이 각각 어떤 bump를 받아야 하는지"를 정한다. changeset의 bump 추천(SKILL.md Phase 2)과 peer floor 체크(Phase 4.5)는 이 매트릭스를 따른다.
+이 문서는 "어떤 패키지를 어떻게 바꾸면, 그 패키지와 그것을 의존하는 패키지들이 각각 어떤 bump를 받아야 하는지"를 정한다. changeset 스킬의 bump 추천과 peer floor 체크는 이 매트릭스를 따른다.
 
 ## 패키지 트랙
 
-### npm 트랙 (changeset 대상, strict semver)
+changeset 후보에 뜨는 건 npm 배포 패키지뿐이다. private / 자체 버저닝 패키지는 `bun changeset`이 자동으로 걸러낸다.
 
-`@seed-design/` 접두사 생략:
-
-- **토큰/스타일**: `css`, `rootage-artifacts`, `tailwind3-plugin`, `tailwind4-theme`
-- **번들러 플러그인**: `vite-plugin`, `webpack-plugin`, `rsbuild-plugin`
-- **React**: `react`(umbrella), `stackflow`, react-headless 개별 패키지 약 37개(`react-*`, `dom-utils`)
-- **도구**: `figma`, `mcp`(figma와 linked), `cli`, `codemod`+`migration-index`(linked)
-
-### changeset 제외 (private / 자체 버저닝)
-
-`qvism-preset`, `qvism-core`, `qvism-cli`, `rootage-core`, `rootage-cli`, `postcss-*`, `figma-codegen` 및 figma 위젯들, `lynx-*`, `docs`, 예제 패키지. → `bun changeset`이 자동으로 제외하므로 후보에 뜨지 않는다.
-
-### 결합 방향 (단방향)
+매트릭스가 다루는 결합은 아래 넷이고, 방향은 단방향이다 (`@seed-design/` 접두사 생략):
 
 ```text
-css (leaf, deps 없음)
-  ↑ peerDependency
-react (umbrella)  ←  react-headless/* (react가 dependency로 소비: exact pin 또는 workspace:^)
+css (토큰·recipe 산출물, deps 없는 leaf)
+  ↑ peerDependency (^N.M.0)
+react (styled 컴포넌트 umbrella)  ←  react-headless/* (`react-*`, `dom-utils`를 `^` 범위 dependency로 소비)
   ↑ major 정렬
-figma (css/react를 직접 의존하진 않지만 codegen 출력이 특정 react 세대 전용)
+figma (react를 의존하진 않지만 codegen 출력이 특정 react 세대 전용)
 ```
 
-css가 깨지면 react가 깨지지만, 그 역은 없다 (react는 css를 소비할 뿐).
+css가 깨지면 react가 깨지지만, 그 역은 없다 (react는 css를 소비할 뿐). 여기 없는 npm 패키지는 이 결합 밖이라 자기 변경만 보고 정한다.
 
 ## 전파 매트릭스
 
@@ -54,16 +43,25 @@ css가 깨지면 react가 깨지지만, 그 역은 없다 (react는 css를 소�
 
 ## 핵심 원칙
 
-1. **버전은 "의존성 버전"이 아니라 "내 observable contract"로 정해진다.** 의존성을 bump했다는 사실만으로 내 버전이 오르지 않는다 — 그 변경이 **내 공개 표면(컴포넌트·props·recipe 클래스)으로 새어나갈 때만** 전파된다. 예) 내부 추적 코드를 제거해도 출력(DOM)이 보존되면 breaking이 아니다.
+### 기준은 "내 공개 표면"
 
-2. **react major ≥ 다른 모든 패키지 major.** 모든 css major에는 react도 major가 따라온다(css는 react의 런타임 substrate). 그래서 react 패키지의 major가 항상 가장 높거나 같다. `figma`는 major를 react에 정렬한다(codegen이 특정 react 세대 전용이므로). 문서 버저닝에도 react 버전을 기준으로 쓸 수 있다.
+버전은 의존성 버전이 아니라 내 공개 표면(컴포넌트·props·recipe 클래스)으로 정해진다. 의존성을 bump했다는 사실만으로 내 버전이 오르지 않는다 — 그 변경이 **공개 표면으로 새어나갈 때만** 전파된다. 예) 내부 추적 코드를 제거해도 출력(DOM)이 그대로면 breaking이 아니다.
 
-3. **floor와 ceiling은 비대칭.** `^N.M.0`이 맞고 `~`는 틀리다.
-   - **floor**(하한) = 내가 import하는 걸 다 담은 가장 낮은 버전. 새 기능을 채택할 때마다 **ratchet up**(올리기만).
-   - **ceiling**(상한) = 다음 major `<N+1`. minor는 additive superset이라 높은 버전이 낮은 소비자를 깨지 않으므로 ceiling은 안 내려간다.
-   - `~`(예: `~2.0.0`)는 "react 2.0.0은 css 2.1.0과 못 쓴다"는 거짓 선언이 되어, css 2.1.0이 나오는 순간 전원 강제 lockstep 업그레이드를 유발한다.
+### react major가 가장 높다
 
-4. **SEED의 `data-*`는 내부 plumbing이다.** css ↔ styled react 사이의 비공개 배선이고, 지원 표면은 **컴포넌트 + props + recipe 클래스**다. 그래서 styling 전용 data attr는 옮기거나 지워도 비공개라 안 깨진다(major 아님). 단 소비자가 자기 CSS로 타겟해도 되는 **공개 contract** data-*라면 제거·이름변경 = major.
+모든 css major에는 react major가 따라온다 (react가 동작하려면 css가 필요하므로). 그래서 react의 major는 항상 가장 높거나 같다. `figma`도 major를 react에 맞춘다 (codegen이 특정 react 세대 전용이므로). 문서 버저닝에도 react 버전을 기준으로 쓸 수 있다.
+
+### floor는 올리고 ceiling은 그대로
+
+`^N.M.0`이 맞고 `~`는 틀리다.
+
+- **floor**(하한) = 내가 import하는 걸 다 담은 가장 낮은 버전. 새 기능을 채택할 때마다 올리기만 하고 내리지 않는다.
+- **ceiling**(상한) = 다음 major `<N+1`. minor는 기능 추가만 하므로 높은 버전이 낮은 소비자를 깨지 않는다. ceiling은 안 내려간다.
+- `~`(예: `~2.0.0`)는 "react 2.0.0은 css 2.1.0과 못 쓴다"는 거짓 선언이 되어, css 2.1.0이 나오는 순간 전원 강제 lockstep 업그레이드를 유발한다.
+
+### `data-*`는 내부 배선
+
+SEED의 `data-*`는 css와 styled react를 잇는 비공개 연결이고, 지원 표면은 **컴포넌트 + props + recipe 클래스**다. 그래서 styling 전용 data attr는 옮기거나 지워도 안 깨진다 (major 아님). 단 소비자가 자기 CSS로 타겟해도 되는 **공개 contract** data attr라면 제거·이름변경은 major다.
 
 ## peer floor 수동 bump 함정 ⚠️
 


### PR DESCRIPTION
> [!NOTE]
> #1708 위에 쌓은 stacked PR입니다. base가 `docs/changeset-seed-2-0`이라 #1708이 먼저 머지돼야 합니다.

## 배경 — 판단 기준에 구멍이 있었습니다

#1708이 정의한 2.0 버전 정책은 내부 plumbing으로 **`data-*`만** 명시하고, `vars/component`는 아예 언급하지 않습니다. 지원 표면 목록(**컴포넌트 + props + recipe 클래스**)에 없으니 소거법으로는 비지원이지만, 명문 근거가 없습니다.

이게 실제로 문제가 됐습니다. #1759에서 컴포넌트 vars의 gradient를 문자열 → `{ serialized, stops? }` 객체로 바꾸면서 bump를 정해야 했는데, 근거가 문서에 없어 "지원 표면 목록에 없으니 아닐 것"이라는 추론에 의존했습니다. 처음엔 `minor` + `BREAKING CHANGE` 접두사로 잡았다가, 두 번 조정한 끝에 `patch`로 내렸습니다. **조항 하나가 있었으면 처음부터 명확했을 일입니다.**

## 왜 #1756과 별개로 필요한가

#1756이 같은 내용을 이미 문서화했지만, **독자가 다릅니다.**

| | #1756 | 이 PR |
|---|---|---|
| 대상 | SEED를 **쓰는 사람** | changeset을 **쓰는 사람**(우리·AI) |
| 위치 | README, Upgrade Guides, Library Authors | changeset 스킬 |
| 답하는 질문 | "이 경로를 써도 되나?" | "이걸 바꿨는데 bump가 뭐지?" |

정책은 하나인데 판단 시점이 달라서, 양쪽에 같은 규칙이 있어야 합니다. 문구는 #1756과 정합시켰습니다.

## 변경 사항

- **`references/version-matrix.md`** — **원칙 5** 신설: 컴포넌트 vars는 내부 plumbing이며 이름·구조가 바뀌어도 `patch`/`minor`. `typography`는 예외로 SemVer 준수.
- **`SKILL.md`, `references/patterns.md`** — 기존 "내부 plumbing(styling 전용 `data-*`)" 표현 옆에 `vars/component/*`를 나란히 추가.

## 리뷰어가 봐주시면 좋을 지점

**1. 원칙 4와 나란히 두는 게 맞는지** — `data-*`와 성격이 같다고 보고 5번으로 뺐습니다. 원칙 4에 하위 항목으로 붙이는 편이 나을 수도 있습니다.

**2. `typography` 예외의 위치** — 예외를 정책 문서에 박아두면 나중에 예외가 늘 때 세 곳을 같이 고쳐야 합니다. 지금은 하나뿐이라 그대로 뒀습니다.

**3. 문구 정합성** — #1756의 사용자 문서와 표현이 어긋나면 나중에 어느 쪽이 맞는지 헷갈립니다. 두 PR을 같이 보시면서 확인해주시면 좋겠습니다.

## 관련

- **#1795** — 같은 정책을 코드 쪽에서 강제합니다. 생성되는 `vars/component/*.d.ts`에 `@internal` 배너를 주입해, 문서를 찾아 읽지 않아도 import 시점에 에디터에서 보이게 합니다. (dev 기준 독립 PR)

정리하면 같은 규칙이 세 층에 놓입니다 — **사용자 문서(#1756) / 판단 기준(이 PR) / 코드(#1795)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
