### PR TITLE
chore(lynx-react): bump @lynx-js/lynx-ui-sheet to 3.134.0

### DIFF
--- a/.changeset/gentle-pianos-invite.md
+++ b/.changeset/gentle-pianos-invite.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/lynx-react": patch
+---
+
+`@lynx-js/lynx-ui-sheet`를 3.134.0으로 올려, `BottomSheet`를 빠르게 연속으로 여닫을 때 전환 애니메이션이 중단되면 열림/닫힘 상태가 어긋나던 문제를 개선합니다.

--- a/bun.lock
+++ b/bun.lock
@@ -254,7 +254,7 @@
         "@karrotmarket/icon-data": "^1.34.0",
         "@karrotmarket/lynx-monochrome-icon": "1.10.0",
         "@karrotmarket/lynx-multicolor-icon": "1.13.0",
-        "@lynx-js/lynx-ui-sheet": "^3.130.1",
+        "@lynx-js/lynx-ui-sheet": "^3.134.0",
         "@lynx-js/react": "^0.117.0",
         "@seed-design/lynx-css": "0.5.0",
         "@seed-design/lynx-react": "0.3.0",
@@ -483,7 +483,7 @@
       "version": "0.3.0",
       "dependencies": {
         "@lynx-js/lynx-ui-common": "^3.130.0",
-        "@lynx-js/lynx-ui-sheet": "^3.130.1",
+        "@lynx-js/lynx-ui-sheet": "^3.134.0",
         "clsx": "^2.1.1",
       },
       "devDependencies": {
@@ -2298,13 +2298,13 @@
 
     "@lynx-js/lynx-ui-common": ["@lynx-js/lynx-ui-common@3.133.1", "", { "dependencies": { "@lynx-js/gesture-runtime": "2.1.1", "@lynx-js/react-use": "0.1.3" }, "peerDependencies": { "@lynx-js/react": ">=0.100.0", "@lynx-js/types": "*", "@types/react": "^18" } }, "sha512-xV+GoixE/FK4DvjqYNJxZBeF+Jk1lCrUwvj7rd9cTzQV+xXiPDcP6BNnAu8q4jYDE5WKD/hgfHn9quUTcWvccQ=="],
 
-    "@lynx-js/lynx-ui-dialog": ["@lynx-js/lynx-ui-dialog@3.133.1", "", { "dependencies": { "@lynx-js/lynx-ui-button": "3.133.1", "@lynx-js/lynx-ui-common": "3.133.1", "@lynx-js/lynx-ui-overlay": "3.133.1", "@lynx-js/lynx-ui-presence": "3.133.1", "clsx": "^2.1.1" }, "peerDependencies": { "@lynx-js/react": ">=0.100.0", "@lynx-js/types": "*", "@types/react": "^18" } }, "sha512-UrTKEePoA9KFyU4D15wFePxNswnU1RcPGgqShzYeDGJ2Cq/ua9Ddz+Bo5mPcIXTVAPNkSVs2DaEcbsNtZoULHQ=="],
+    "@lynx-js/lynx-ui-dialog": ["@lynx-js/lynx-ui-dialog@3.134.0", "", { "dependencies": { "@lynx-js/lynx-ui-button": "3.133.1", "@lynx-js/lynx-ui-common": "3.133.1", "@lynx-js/lynx-ui-overlay": "3.133.1", "@lynx-js/lynx-ui-presence": "3.134.0", "clsx": "^2.1.1" }, "peerDependencies": { "@lynx-js/react": ">=0.100.0", "@lynx-js/types": "*", "@types/react": "^18" } }, "sha512-n7i9DSZw4xMFFOE28N+pTL0nLg254hGIpBYHuNR3mVbH8gd/ZG4o7TU5PwZHr3TbOZEworSOj9nDQ1VC6ZkJaw=="],
 
     "@lynx-js/lynx-ui-overlay": ["@lynx-js/lynx-ui-overlay@3.133.1", "", { "dependencies": { "@lynx-js/lynx-ui-common": "3.133.1" }, "peerDependencies": { "@lynx-js/react": ">=0.100.0", "@lynx-js/types": "*", "@types/react": "^18" } }, "sha512-PCfjmAUheL5USYCaJUZQVf8M+g6we0h7yOdi0Z0+5RJgjzn0WNuAQU6oNisId+H4W0tGmTlRvtXs1gZJ4+KcoQ=="],
 
-    "@lynx-js/lynx-ui-presence": ["@lynx-js/lynx-ui-presence@3.133.1", "", { "dependencies": { "@lynx-js/lynx-ui-common": "3.133.1", "clsx": "^2.1.1" }, "peerDependencies": { "@lynx-js/react": ">=0.100.0", "@lynx-js/types": "*", "@types/react": "^18" } }, "sha512-SjDLZPBmnAuFUekAMA8xl0y1iDlzc2JNP+wQcOJ+JyEdNy7V5v2apomPqLXNVtGoZ7eSIOTjxuzeO1e/kRYqSg=="],
+    "@lynx-js/lynx-ui-presence": ["@lynx-js/lynx-ui-presence@3.134.0", "", { "dependencies": { "@lynx-js/lynx-ui-common": "3.133.1", "clsx": "^2.1.1" }, "peerDependencies": { "@lynx-js/react": ">=0.100.0", "@lynx-js/types": "*", "@types/react": "^18" } }, "sha512-fJgP7QAKTGhF8lynY/ZdVdvQd4R9lLMyouRUq8dVdxo/NOhEZGhfR7r9eIsDD0QuZPzzP8BtH/In9aIMarD0iQ=="],
 
-    "@lynx-js/lynx-ui-sheet": ["@lynx-js/lynx-ui-sheet@3.133.1", "", { "dependencies": { "@lynx-js/lynx-ui-common": "3.133.1", "@lynx-js/lynx-ui-dialog": "3.133.1", "@lynx-js/lynx-ui-overlay": "3.133.1", "@lynx-js/lynx-ui-presence": "3.133.1", "@lynx-js/motion": "0.0.3", "clsx": "^2.1.1" }, "peerDependencies": { "@lynx-js/react": ">=0.100.0", "@lynx-js/types": "*", "@types/react": "^18" } }, "sha512-mw5h6aD5cj72U+nQl6cCMPf+ZK9TkPQSAGIuiYwcMDRWabNF+nCBYgywaFh2ZGTDf0nspWTaYr9lDzzJyqmQ9g=="],
+    "@lynx-js/lynx-ui-sheet": ["@lynx-js/lynx-ui-sheet@3.134.0", "", { "dependencies": { "@lynx-js/lynx-ui-common": "3.133.1", "@lynx-js/lynx-ui-dialog": "3.134.0", "@lynx-js/lynx-ui-overlay": "3.133.1", "@lynx-js/lynx-ui-presence": "3.134.0", "@lynx-js/motion": "0.0.3", "clsx": "^2.1.1" }, "peerDependencies": { "@lynx-js/react": ">=0.100.0", "@lynx-js/types": "*", "@types/react": "^18" } }, "sha512-uqa+aR8oAMlIPZzSR920HBtx9grXWkIDzyTAlIe8Ts6XBQPYyLsDLvefgXXRF5PgDh4yjjpdzBGCFWBKsnj3RA=="],
 
     "@lynx-js/motion": ["@lynx-js/motion@0.0.3", "", { "dependencies": { "framer-motion": "12.34.1", "motion-dom": "12.23.12", "motion-utils": "12.23.6" }, "peerDependencies": { "@lynx-js/react": "*", "@lynx-js/types": "*" }, "optionalPeers": ["@lynx-js/types"] }, "sha512-Kujwj1grxFTPjwr3IEO4Qca5YRsoJCeTctsEaUcVFYC5Ekb52LuUavJicMqUuswzW/HrARpJw9npLSiTjfcwYQ=="],
 

--- a/examples/lynx-spa/package.json
+++ b/examples/lynx-spa/package.json
@@ -13,7 +13,7 @@
     "@karrotmarket/icon-data": "^1.34.0",
     "@karrotmarket/lynx-monochrome-icon": "1.10.0",
     "@karrotmarket/lynx-multicolor-icon": "1.13.0",
-    "@lynx-js/lynx-ui-sheet": "^3.130.1",
+    "@lynx-js/lynx-ui-sheet": "^3.134.0",
     "@lynx-js/react": "^0.117.0",
     "@seed-design/lynx-css": "0.5.0",
     "@seed-design/lynx-react": "0.3.0",

--- a/packages/lynx-react/package.json
+++ b/packages/lynx-react/package.json
@@ -47,8 +47,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@lynx-js/lynx-ui-sheet": "^3.130.1",
     "@lynx-js/lynx-ui-common": "^3.130.0",
+    "@lynx-js/lynx-ui-sheet": "^3.134.0",
     "clsx": "^2.1.1"
   }
 }


### PR DESCRIPTION
## 배경

`@lynx-js/lynx-ui-sheet` 선언 버전이 `^3.130.1`로 오래돼 있어, 최신 릴리스까지의 변경사항을 훑고 우리에게 유효한 것을 반영합니다.

## 3.133.1 → 3.134.0 변경사항 리뷰

lock이 이미 3.133.1로 해석되고 있어서, 실질적으로 새로 들어오는 건 **`lynx-ui-presence`의 수정 두 건**입니다.

| PR | 내용 | 우리에게 미치는 영향 |
|---|---|---|
| [lynx-family/lynx-ui#204](https://github.com/lynx-family/lynx-ui/pull/204) | 전환 도중 인터럽트된 visibility 처리 | `BottomSheet`는 `SheetBackdrop`을 통해 presence를 구동하므로, 시트를 빠르게 여닫을 때 열림/닫힘 상태가 어긋나던 경로가 개선됩니다 |
| [lynx-family/lynx-ui#213](https://github.com/lynx-family/lynx-ui/pull/213) | 빠른 토글 시 enter 타이밍 보존 | 위와 동일 경로 |

`lynx-ui-sheet` 3.134.0 자체는 presence 의존성 bump만 있고 소스 변경은 없습니다. `lynx-ui-common`/`overlay`는 upstream에서도 3.133.1 그대로라 선언을 유지했습니다. 나머지 커밋(sortable, swiper, input, ui-list)은 우리가 쓰지 않는 패키지입니다.

**스크롤 전파 관련 sheet 수정은 upstream에 없습니다** — Android 배경 스크롤 이슈는 별도 PR에서 다룹니다.

## 검증

- `bun test:all` (lynx-react 65 tests), `bun packages:build`, `bun --filter lynx-spa build` 통과
- lynx-spa BottomSheetPage에서 시트 연속 여닫기 스모크는 실기기 확인이 필요합니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 바텀 시트를 빠르게 연속으로 열고 닫을 때 전환 애니메이션이 중단되어 열림/닫힘 상태가 어긋나는 문제를 개선했습니다.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->