### PR TITLE
fix(lynx-react): stop BottomSheet gestures from scrolling background on Android

### DIFF
--- a/.changeset/lucky-moons-repeat.md
+++ b/.changeset/lucky-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/lynx-react": patch
+---
+
+Android에서 `BottomSheet` 내부를 스크롤하거나 드래그할 때 시트 뒤의 `list`/`scroll-view`가 함께 스크롤되던 문제를 수정합니다. 본문은 nested scroll에서 제외하고, 핸들·헤더·푸터·backdrop 위의 스와이프는 플랫폼 제스처로 전달되지 않도록 막습니다. 시트 드래그와 본문 스크롤 동작은 그대로입니다.

--- a/docs/content/lynx/components/bottom-sheet.mdx
+++ b/docs/content/lynx/components/bottom-sheet.mdx
@@ -118,6 +118,20 @@ Lynx `BottomSheet`는 React `BottomSheet`와 다음과 같은 차이가 있습�
 | `snapPoints` | 없음 | 지원 (`(number \| string)[]`, 기본값 `["fit"]`) |
 | `BottomSheetTrigger`의 `asChild` | 지원 | **미지원** (기본 `<view>`로만 렌더링) |
 | imperative ref API | — | `BottomSheetRootRef.{open, close, snapTo, expand, collapse}` |
+| 배경 스크롤 차단 | 브라우저가 처리 | 컴포넌트가 Lynx 네이티브 속성으로 직접 차단 (아래 참고) |
+
+### Android 스크롤 격리
+
+Lynx Android는 터치를 Lynx 이벤트 시스템과 플랫폼(네이티브) 디스패치 양쪽으로 흘립니다. 아무 처리도 하지 않으면 시트가 드래그를 처리해도 네이티브 이벤트가 그대로 흘러 시트 뒤의 `list`/`scroll-view`가 함께 스크롤됩니다. `BottomSheet`는 이를 막기 위해 다음 속성을 내장하고 있어, 별도 설정 없이 배경이 멈춥니다.
+
+| 슬롯 | 속성 | 역할 |
+|---|---|---|
+| `BottomSheetBody` | `enable-nested-scroll={false}` | 본문이 스크롤 끝에 닿았을 때 남은 스크롤이 조상 스크롤 컨테이너로 넘어가지 않게 합니다 |
+| Handle · Header · Footer | `consume-slide-event` (세로) | 시트를 드래그하는 세로 스와이프가 배경으로 새지 않게 합니다 |
+| Backdrop | `consume-slide-event` (전 방향) | dim 영역 위 스와이프가 배경에 닿지 않게 합니다 |
+| `BottomSheetContent` | `block-native-event` | Lynx 화면을 감싸는 바깥 네이티브 스크롤 컨테이너로 제스처가 새지 않게 합니다 |
+
+`consume-slide-event`는 플랫폼 제스처만 막고 Lynx 터치 이벤트에는 영향을 주지 않으므로, 시트 드래그와 본문 스크롤은 그대로 동작합니다. 커스텀 슬롯을 직접 만들어 시트 안에 배치하는 경우, 그 위의 세로 스와이프는 격리되지 않으니 같은 속성을 직접 넣어야 합니다.
 
 ## Lynx 미지원 기능
 

--- a/packages/lynx-react/src/components/BottomSheet/BottomSheet.test.tsx
+++ b/packages/lynx-react/src/components/BottomSheet/BottomSheet.test.tsx
@@ -40,26 +40,29 @@ vi.mock("@lynx-js/lynx-ui-sheet", async () => {
     unknown,
     Record<string, unknown> & { children?: React.ReactNode }
   >((props) => {
-    const children = props["children"] as React.ReactNode;
+    const { children, className, style, ...rest } = props;
 
+    // 실물 SheetHandle과 동일하게 rest props를 native view로 흘려보낸다.
     return (
-      <view className={props["className"] as string} style={props["style"] as never}>
-        {children}
+      <view className={className as string} style={style as never} {...rest}>
+        {children as React.ReactNode}
       </view>
     );
   });
   SheetHandle.displayName = "MockSheetHandle";
 
-  const passthrough = (displayName: string) => {
-    const Component = React.forwardRef<unknown, { children?: React.ReactNode }>((props) => {
-      return <>{props.children}</>;
-    });
-    Component.displayName = displayName;
-    return Component;
-  };
+  const SheetBackdrop = React.forwardRef<
+    unknown,
+    Record<string, unknown> & { children?: React.ReactNode }
+  >((props) => {
+    return (
+      <view className={props["className"] as string}>{props["children"] as React.ReactNode}</view>
+    );
+  });
+  SheetBackdrop.displayName = "MockSheetBackdrop";
 
   return {
-    SheetBackdrop: passthrough("MockSheetBackdrop"),
+    SheetBackdrop,
     SheetContent,
     SheetHandle,
     SheetRoot,
@@ -108,6 +111,79 @@ describe("BottomSheet", () => {
 
     expect(body).not.toBeNull();
     expect(body?.hasAttribute("scroll-y")).toBe(true);
+  });
+
+  // Android는 터치를 Lynx와 플랫폼 디스패치 양쪽으로 흘려서, 아래 속성이 빠지면
+  // 시트 위 제스처가 배경 list/scroll-view까지 스크롤시킨다.
+  describe("Android 스크롤 격리", () => {
+    it("opts Body out of nested scroll so it does not chain to ancestors", () => {
+      const { container } = render(
+        <BottomSheet.Root>
+          <BottomSheet.Body>
+            <text>Scrollable content</text>
+          </BottomSheet.Body>
+        </BottomSheet.Root>,
+      );
+
+      expect(container.querySelector("scroll-view")?.getAttribute("enable-nested-scroll")).toBe(
+        "false",
+      );
+    });
+
+    it("claims vertical slides on the drag handle", () => {
+      const { container } = render(
+        <BottomSheet.Root>
+          <BottomSheet.Handle />
+        </BottomSheet.Root>,
+      );
+
+      const touchArea = container.querySelector(".seed-bottom-sheet-handle__touchArea");
+
+      expect(touchArea?.hasAttribute("consume-slide-event")).toBe(true);
+    });
+
+    it("claims vertical slides on Header and Footer", () => {
+      const { container } = render(
+        <BottomSheet.Root>
+          <BottomSheet.Header>
+            <text>Header</text>
+          </BottomSheet.Header>
+          <BottomSheet.Footer>
+            <text>Footer</text>
+          </BottomSheet.Footer>
+        </BottomSheet.Root>,
+      );
+
+      for (const slot of ["header", "footer"]) {
+        const element = container.querySelector(`.seed-bottom-sheet__${slot}`);
+
+        expect(element?.hasAttribute("consume-slide-event")).toBe(true);
+      }
+    });
+
+    it("claims slides on the Backdrop through a full-size child view", () => {
+      const { container } = render(
+        <BottomSheet.Root>
+          <BottomSheet.Backdrop />
+        </BottomSheet.Root>,
+      );
+
+      const backdrop = container.querySelector(".seed-bottom-sheet__backdrop");
+
+      expect(backdrop?.querySelector("view")?.hasAttribute("consume-slide-event")).toBe(true);
+    });
+
+    it("blocks native gestures outside Lynx on Content", () => {
+      render(
+        <BottomSheet.Root>
+          <BottomSheet.Content />
+        </BottomSheet.Root>,
+      );
+
+      expect(sheetMocks.contentProps.at(-1)).toMatchObject({
+        "block-native-event": true,
+      });
+    });
   });
 
   it("renders Handle with a target-size touch area around the visual handle", () => {

--- a/packages/lynx-react/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/lynx-react/src/components/BottomSheet/BottomSheet.tsx
@@ -87,6 +87,27 @@ const SEED_EXIT_ANIMATION: SheetTransition = {
   damping: 40,
 };
 
+////////////////////////////////////////////////////////////////////////////////////
+// Android 스크롤 격리
+//
+// Lynx Android는 터치를 Lynx 이벤트 시스템과 플랫폼(네이티브) 디스패치 양쪽으로 흘린다.
+// 시트가 Lynx 쪽에서 드래그를 처리해도 네이티브 이벤트는 그대로 흘러 뒤의 list/scroll-view가
+// 같이 스크롤된다. `consume-slide-event`는 지정한 각도의 스와이프에서 플랫폼 제스처만 막고
+// Lynx 터치 이벤트는 건드리지 않으므로, 시트 드래그를 유지한 채 배경만 멈춘다.
+//
+// 주의: Body(`<scroll-view>`)의 조상에는 넣지 않는다. Body 스크롤은 네이티브 스크롤이라
+// 플랫폼 제스처가 막히면 같이 죽는다. Body는 대신 `enable-nested-scroll`로 격리한다.
+////////////////////////////////////////////////////////////////////////////////////
+
+/** 세로 스와이프 각도. 시트 드래그 방향이며, 배경 리스트가 스크롤되는 방향이기도 하다. */
+const VERTICAL_SLIDE_ANGLES: Array<[number, number]> = [
+  [46, 134],
+  [-134, -46],
+];
+
+/** 전 방향. dim 영역 위에서는 어떤 방향 스와이프도 배경에 닿으면 안 된다. */
+const ALL_SLIDE_ANGLES: Array<[number, number]> = [[-180, 180]];
+
 /**
  * Trigger와 Content가 Root의 imperative API와 동작 옵션을 공유하는 내부 컨텍스트.
  */
@@ -271,8 +292,29 @@ BottomSheetPositioner.displayName = "BottomSheetPositioner";
 
 export interface BottomSheetBackdropProps extends SheetBackdropProps {}
 
+/**
+ * @remarks
+ * `SheetBackdrop`은 rest props를 native `<view>`에 전달하지 않아 스크롤 격리 속성을
+ * 직접 넘길 수 없다. 대신 dim 영역을 채우는 자식 `<view>`를 두어 거기에 적용한다.
+ * tap은 자식에서 backdrop으로 버블되므로 `clickToClose`는 그대로 동작한다.
+ */
 export const BottomSheetBackdrop: LynxForwardRefComponent<unknown, BottomSheetBackdropProps> =
-  withContext<unknown, BottomSheetBackdropProps>(SheetBackdrop, "backdrop");
+  forwardRef<unknown, BottomSheetBackdropProps>((props, ref) => {
+    const { children, className, ...restProps } = props;
+    const classNames = useClassNames();
+
+    return (
+      <SheetBackdrop
+        {...(ref ? ({ ref } as Record<string, unknown>) : {})}
+        {...restProps}
+        className={clsx(classNames.backdrop, className)}
+      >
+        <view style={{ width: "100%", height: "100%" }} consume-slide-event={ALL_SLIDE_ANGLES}>
+          {children}
+        </view>
+      </SheetBackdrop>
+    );
+  });
 BottomSheetBackdrop.displayName = "BottomSheetBackdrop";
 
 export interface BottomSheetContentProps extends SheetContentProps {}
@@ -291,6 +333,9 @@ export const BottomSheetContent: LynxForwardRefComponent<unknown, BottomSheetCon
       <SheetContent
         {...(ref ? { ref } : {})}
         {...restProps}
+        // LynxView 바깥의 네이티브 조상(Lynx 화면을 감싸는 네이티브 스크롤 컨테이너)으로
+        // 제스처가 새는 것을 막는다. Lynx 내부 디스패치는 그대로라 Body 스크롤에 영향이 없다.
+        {...({ "block-native-event": true } as Record<string, unknown>)}
         className={clsx(classNames.content, className)}
         innerStyle={{
           display: "flex",
@@ -324,7 +369,11 @@ export function BottomSheetHandle(props: BottomSheetHandleProps): ReactElement {
   const classNames = bottomSheetHandle();
 
   return (
-    <SheetHandle className={classNames.touchArea} {...rest}>
+    <SheetHandle
+      className={classNames.touchArea}
+      {...rest}
+      {...({ "consume-slide-event": VERTICAL_SLIDE_ANGLES } as Record<string, unknown>)}
+    >
       <view className={clsx(classNames.root, className)} style={style as never}>
         {children}
       </view>
@@ -355,6 +404,7 @@ function createViewSlot(
     return (
       <view
         {...(ref ? ({ ref: ref as LynxViewRef } as Record<string, unknown>) : {})}
+        consume-slide-event={VERTICAL_SLIDE_ANGLES}
         className={clsx(classNames[slotName], className)}
         style={style as never}
       >
@@ -400,6 +450,9 @@ export const BottomSheetBody: LynxForwardRefComponent<unknown, BottomSheetBodyPr
   return (
     <scroll-view
       {...(ref ? ({ ref: ref as LynxViewRef } as Record<string, unknown>) : {})}
+      // Android는 nested scroll이 기본 켜짐이라, body가 스크롤 끝에 닿으면 남은 스크롤이
+      // 조상 스크롤 컨테이너로 넘어간다. `<scroll-view>` 타입에 없는 속성이라 spread로 넘긴다.
+      {...({ "enable-nested-scroll": false } as Record<string, unknown>)}
       scroll-y
       className={clsx(classNames.body, className)}
       style={style as never}


### PR DESCRIPTION
## 문제

안드로이드에서 `BottomSheet` 내부를 스크롤하면 시트 뒤의 list가 같이 스크롤됩니다. iOS는 정상입니다.

## 원인

Lynx Android는 터치를 **두 경로로 동시에** 흘립니다.

1. **이중 디스패치 누수** — Lynx 이벤트 시스템(시트 드래그는 main-thread 핸들러로 여기서 동작)과 별개로, `LynxView.dispatchTouchEvent`가 `consume-slide-event`가 걸린 노드를 responder chain에서 찾지 못하면 `super.dispatchTouchEvent`로 네이티브 디스패치를 계속 진행합니다. 시트가 제스처를 처리해도 배경이 같이 움직이는 이유입니다.
2. **nested scroll 체이닝** — Android는 `enable-nested-scroll`이 기본 켜짐이라(`lynx-ui-scroll-view`가 소스에서 명시적으로 `SystemInfo.platform === 'Android' ? true`로 두고 있습니다), 시트 본문 `<scroll-view>`가 스크롤 끝에 닿으면 남은 스크롤이 조상 스크롤 컨테이너로 넘어갑니다.

iOS에는 두 메커니즘이 모두 없어 이 증상이 나타나지 않습니다.

`lynx-ui`의 slider·swiper는 `consume-slide-event`/`block-native-event`를 쓰는데 **sheet만 빠져 있습니다**(최신 3.134.0에도 없음). 다만 `SheetContent`/`SheetHandle`이 rest props를 native view로 흘려주기 때문에, 포크 없이 래퍼에서 속성을 주입할 수 있었습니다.

## 변경

`packages/lynx-react/src/components/BottomSheet/BottomSheet.tsx` 한 파일입니다.

| 슬롯 | 속성 | 역할 |
|---|---|---|
| `Body` | `enable-nested-scroll={false}` | 조상 스크롤 컨테이너로의 체이닝 차단 |
| Handle · Header · Footer | `consume-slide-event` (세로) | 시트 드래그 제스처가 네이티브로 새지 않게 함 |
| Backdrop | `consume-slide-event` (전 방향) | dim 영역 스와이프 차단 |
| `Content` | `block-native-event` | LynxView 바깥 네이티브 조상으로의 누수 차단 |

`consume-slide-event`는 플랫폼 제스처만 막고 Lynx 터치 이벤트는 건드리지 않아 시트 드래그가 그대로 동작합니다. **Body의 조상에는 의도적으로 넣지 않았습니다** — Body 스크롤은 네이티브 스크롤이라 플랫폼 제스처가 막히면 같이 죽습니다.

`SheetBackdrop`만 rest props를 전달하지 않아, dim 영역을 채우는 자식 `<view>`를 두는 방식으로 처리했습니다. tap은 자식에서 버블되므로 `clickToClose`는 그대로입니다.

## 검증

- `bun generate:all`, `bun test:all`, `bun packages:build`, `bun --filter lynx-spa build`, `bun docs:test` 통과
- 추가한 5개 테스트는 소스를 되돌리면 전부 실패하는 것을 확인했습니다(회귀를 실제로 잡음)
- **실기기 확인 필요**: `examples/lynx-spa` BottomSheetPage의 "Scrollable body over list" 섹션이 재현 환경입니다. 본문 스크롤 시 배경 정지 / 본문 스크롤 자체는 정상 동작 / 시트 드래그·스냅·드래그로 닫기 정상 / iOS 회귀 없음을 확인해주세요.

속성으로 격리되지 않는다면 원인이 엔진 디스패치 레벨이라는 뜻이고, 그때는 라이브러리를 vendoring해도 같은 속성을 쓰는 것이라 해결되지 않습니다. `SheetView`에 `container`를 넘겨 별도 overlay window로 띄우는 구조 대안을 검토하게 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Android에서 BottomSheet를 스크롤하거나 드래그할 때 배경의 목록과 스크롤 영역이 함께 움직이던 문제를 수정했습니다.
  * 시트 본문 스크롤, 드래그 핸들, 헤더, 푸터 및 백드롭의 제스처 동작을 안정화했습니다.

* **문서**
  * Android 스크롤 격리 동작과 커스텀 슬롯 사용 시 필요한 설정을 문서에 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->