### PR TITLE
docs: add Quantity Picker component guideline

### DIFF
--- a/docs/content/components/quantity-picker.mdx
+++ b/docs/content/components/quantity-picker.mdx
@@ -6,7 +6,7 @@ description: 버튼으로 수치 값을 한 단계씩 늘리거나 줄일 수 �
 ## Anatomy
 
 <FigmaImage
-  id="2145:19511"
+  id="2170:11199"
   alt="Quantity Picker의 Anatomy 이미지. Decrement Button, Value Display, Increment Button으로 구성됩니다."
 />
 

--- a/docs/content/components/quantity-picker.mdx
+++ b/docs/content/components/quantity-picker.mdx
@@ -1,0 +1,101 @@
+---
+title: Quantity Picker
+description: 버튼으로 수치 값을 한 단계씩 늘리거나 줄일 수 있는 입력 컴포넌트입니다.
+---
+
+## Anatomy
+
+<FigmaImage
+  id="2145:19511"
+  alt="Quantity Picker의 Anatomy 이미지. Decrement Button, Value Display, Increment Button으로 구성됩니다."
+/>
+
+Quantity Picker는 값을 한 단계 늘리는 Increment Button, 한 단계 줄이는 Decrement Button, 현재 값을 표시하는 Value Display 영역으로 구성됩니다.
+
+## Properties
+
+### Size
+
+<FigmaImage id="2145:19529" alt="Quantity Picker의 Size Property - Small, Medium, Large" />
+
+Small, Medium, Large 세 가지 사이즈를 제공합니다. [Action Button](/components/action-button), [Text Input](/components/text-input) 등 다른 입력 요소와 함께 배치할 때는 사이즈를 맞춰 일관성을 유지합니다.
+
+### Value State
+
+<FigmaImage id="2145:19550" alt="Quantity Picker의 Value State - Min, InRange, Max" />
+
+입력 가능한 값의 범위를 prop으로 제한하여 범위를 벗어난 값을 입력하지 않도록 합니다.
+
+- **Min**: 최소값에 도달해 Decrement가 불가능한 상태
+- **InRange**: Increment / Decrement 모두 가능한 상태
+- **Max**: 최대값에 도달해 Increment가 불가능한 상태
+
+### State
+
+<FigmaImage id="2145:19568" alt="Quantity Picker의 State - Enabled, Disabled, Error" />
+
+Quantity Picker는 Enabled, Disabled, Error 상태를 가집니다.
+
+- **Enabled**: 값 변경이 가능한 기본 상태
+- **Disabled**: 값 변경이 불가능한 상태
+- **Error**: 입력된 값이 허용 범위를 벗어난 상태
+
+### Button State
+
+<FigmaImage
+  id="2145:19587"
+  alt="Quantity Picker의 Button State - Enabled, Hover/Pressed, Loading, Focused, Disabled"
+/>
+
+Decrement Button과 Increment Button은 각각 Enabled, Hover/Pressed, Loading, Focused, Disabled 다섯 가지 상태를 가집니다.
+
+- **Enabled**: 선택 가능한 기본 상태
+- **Hover/Pressed**: 마우스 오버, 클릭/터치 시 옅은 배경색 강조
+- **Loading**: 수량 변경 요청에 대한 서버 응답을 기다리는 상태
+- **Focused**: 키보드 포커스 시 포커스링 표시
+- **Disabled**: 선택이 불가능한 상태
+
+### Removable Property
+
+<FigmaImage id="2145:19621" alt="Quantity Picker의 Removable Property - Removable OFF, Removable ON" />
+
+Removable 옵션을 활성화한 경우, 입력된 값이 최소값에 도달했을 때 Decrement 버튼을 Remove 버튼으로 교체합니다.
+
+## Guidelines
+
+### Quantity Picker 기본 사용하기
+
+<FigmaImage
+  id="2145:19638"
+  alt="장바구니 화면에서 Value Min과 Max 상태로 사용된 Quantity Picker 예시"
+/>
+
+Quantity Picker는 장바구니, 상품 상세, 주문서 등 수량을 변경해야 하는 화면에서 사용합니다.
+
+Quantity Picker는 Min·Max prop으로 입력 가능한 값의 범위를 제한합니다. 경계에 도달한 버튼은 자동으로 비활성화되어, 잘못된 값이 입력되는 것을 사전에 막습니다.
+
+### Removable 활성화하기
+
+<FigmaImage
+  id="2145:19719"
+  alt="장바구니 화면에서 Removable OFF와 Removable ON을 비교한 Quantity Picker 예시"
+/>
+
+Removable은 값이 최소값에 도달했을 때 Decrement 버튼을 Remove 버튼으로 교체하는 기능입니다. 값을 더 줄이는 동작이 곧 항목 삭제를 의미하는 맥락에서 사용합니다.
+
+### Size 선택하기
+
+<Grid>
+
+<FigmaImage id="2145:20030" alt="Small 사이즈 Quantity Picker를 사용한 예시" />
+<FigmaImage id="2145:20047" alt="Medium 사이즈 Quantity Picker를 사용한 예시" />
+
+</Grid>
+
+[Action Button](/components/action-button), [Text Input](/components/text-input) 등 다른 입력 요소와 함께 배치할 때는 사이즈를 맞춰 일관성을 유지합니다.
+
+### Quantity Picker 터치 영역
+
+<FigmaImage id="2145:20072" alt="Increment·Decrement 버튼에만 터치 영역이 적용된 Quantity Picker 예시" />
+
+Quantity Picker의 터치 영역은 양쪽 Increment·Decrement 버튼에 한정됩니다. Value Display는 터치에 반응하지 않습니다.


### PR DESCRIPTION
## Summary

Figma SEED-Docs(node `2145-19501`)에서 추출한 **Quantity Picker** 컴포넌트 가이드 문서를 추가합니다.

`docs/content/components/quantity-picker.mdx`

## 구성

- **Anatomy** — Increment Button, Decrement Button, Value Display
- **Properties**
  - Size (Small / Medium / Large)
  - Value State (Min / InRange / Max)
  - State (Enabled / Disabled / Error)
  - Button State (Enabled / Hover·Pressed / Loading / Focused / Disabled)
  - Removable Property
- **Guidelines**
  - Quantity Picker 기본 사용하기
  - Removable 활성화하기
  - Size 선택하기
  - Quantity Picker 터치 영역

이미지 11개는 모두 Figma 노드를 `FigmaImage`로 참조합니다.

## 검증

- ✅ fumadocs-mdx source 생성 통과 (MDX 파싱 / frontmatter 스키마 OK)
- ✅ 사용 컴포넌트(`FigmaImage`, `Grid`) mdx-components 등록 확인
- ⚠️ 로컬 dev 서버 렌더는 환경 의존성 이슈(누락된 deps)로 확인 미완 — CI/프리뷰에서 확인 필요
- ℹ️ `quantity-picker` rootage 스펙이 아직 없어 `Specification`(ComponentSpecBlock) 섹션은 제외했습니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * Quantity Picker 컴포넌트의 구조(증가/감소/값 표시)와 주요 속성(Size, 값 상태, 상태, 버튼 상태, 제거 가능)를 설명하는 가이드를 추가했습니다.
  * 기본 사용, 제거 가능 옵션 의미, 크기 선택 시 유의사항, 터치 영역 범위를 안내합니다.
  * Figma 이미지 예시와 관련 컴포넌트 링크를 포함했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->