### PR TITLE
test(stackflow-spa): add browser E2E coverage

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,44 @@
+name: Test E2E
+
+on:
+  push:
+    paths:
+      - "examples/stackflow-spa/**"
+      - "docs/registry/react/**"
+      - "packages/stackflow/**"
+      - "packages/react/**"
+      - "packages/react-headless/**"
+      - "packages/css/**"
+      - "packages/stylesheet/**"
+      - ".github/workflows/e2e-test.yml"
+      - ".github/actions/setup/action.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup
+        with:
+          build-packages: true
+
+      - name: Install browsers
+        run: bunx playwright install --with-deps chromium webkit
+        working-directory: examples/stackflow-spa
+
+      - name: Run tests
+        run: bun run e2e
+        working-directory: examples/stackflow-spa
+
+      - name: Upload report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: examples/stackflow-spa/playwright-report
+          retention-days: 7

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ lib
 docs/.next
 docs/.source
 docs/out
+examples/stackflow-spa/test-results
+examples/stackflow-spa/playwright-report
 docs/public/__lynx__
 
 scripts/data

--- a/bun.lock
+++ b/bun.lock
@@ -333,8 +333,8 @@
         "@karrotmarket/react-multicolor-icon": "^1.17.0",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-use-callback-ref": "^1.1.1",
-        "@seed-design/css": "2.5.0",
-        "@seed-design/react": "2.3.0",
+        "@seed-design/css": "2.6.1",
+        "@seed-design/react": "2.4.1",
         "@seed-design/react-pagination": "workspace:*",
         "@seed-design/rootage-artifacts": "workspace:*",
         "@seed-design/stackflow": "2.0.3",
@@ -352,7 +352,8 @@
         "react-dom": "^19.2.3",
       },
       "devDependencies": {
-        "@seed-design/cli": "1.6.1",
+        "@playwright/test": "^1.61.1",
+        "@seed-design/cli": "1.7.0",
         "@seed-design/vite-plugin": "^2.1.0",
         "@types/node": "^25.0.0",
         "@types/react": "^19.2.7",
@@ -602,7 +603,7 @@
         "@seed-design/react-pull-to-refresh": "^2.1.0",
         "@seed-design/react-quantity-picker": "^1.0.0",
         "@seed-design/react-radio-group": "^2.0.1",
-        "@seed-design/react-scale-feedback": "^0.0.0",
+        "@seed-design/react-scale-feedback": "^1.0.0",
         "@seed-design/react-segmented-control": "^2.0.2",
         "@seed-design/react-select": "^1.0.1",
         "@seed-design/react-side-navigation": "^1.0.1",
@@ -2810,6 +2811,8 @@
     "@oxc-transform/binding-win32-x64-msvc": ["@oxc-transform/binding-win32-x64-msvc@0.138.0", "", { "os": "win32", "cpu": "x64" }, "sha512-b3HcocQafzqrG2+TXgDUm4gYDZDjEIlJ98MqwkxTJnSGi0h4jI+7bmecRcFmrvZOOq7Et2O/fRs2jFCp0+Aw4w=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@playwright/test": ["@playwright/test@1.62.1", "", { "dependencies": { "playwright": "1.62.1" }, "bin": { "playwright": "cli.js" } }, "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ=="],
 
     "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
 
@@ -5515,6 +5518,10 @@
 
     "player.style": ["player.style@0.1.10", "", { "dependencies": { "media-chrome": "~4.11.0" } }, "sha512-Jxv7tlaQ3SFCddsN35jzoGnCHB3/xMTbJOgn4zcsmF0lcZvRPq5UkRRAD5tZm8CvzKndUvtoDlG6GSPL/N/SrA=="],
 
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
+
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
+
     "pluralize-esm": ["pluralize-esm@9.0.5", "", {}, "sha512-Kb2dcpMsIutFw2hYrN0EhsAXOUJTd6FVMIxvNAkZCMQLVt9NGZqQczvGpYDxNWCZeCWLHUPxQIBudWzt1h7VVA=="],
 
     "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
@@ -7254,6 +7261,8 @@
     "peek-stream/through2": ["through2@2.0.5", "", { "dependencies": { "readable-stream": "~2.3.6", "xtend": "~4.0.1" } }, "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ=="],
 
     "pkg-dir/find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "posthog-js/dompurify": ["dompurify@3.4.0", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg=="],
 

--- a/examples/stackflow-spa/e2e/AGENTS.md
+++ b/examples/stackflow-spa/e2e/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md
+
+## 디렉토리 개요
+
+`stackflow-spa`를 실제 모바일 브라우저 환경에서 검증하는 Playwright E2E 테스트를 둔다. 테스트 전용 UI는 `src/activities`에 두고 공개 패키지 API는 변경하지 않는다.
+
+## 파일 작성 컨벤션
+
+- 논리 테스트 파일은 `*.e2e.ts`로 작성한다.
+- 테스트 전용 route는 `/e2e/*` 아래에 두며 홈 화면에 링크하지 않는다.
+- barrel file은 만들지 않고 필요한 도우미를 파일에서 직접 import한다.
+
+## 코드 작성 컨벤션
+
+- locator는 접근성 role이나 `data-testid`를 사용하고 CSS class 및 인라인 style 문자열에 의존하지 않는다.
+- 이미지의 공개 loading 상태, 실제 레이아웃, hit-test 결과처럼 사용자에게 관측되는 값을 검증한다.
+- screenshot이나 AppScreen의 transition 내부 상태를 단언하지 않는다.

--- a/examples/stackflow-spa/e2e/image-behavior.e2e.ts
+++ b/examples/stackflow-spa/e2e/image-behavior.e2e.ts
@@ -1,0 +1,109 @@
+import { type Locator, expect, test } from "@playwright/test";
+
+const HELD_IMAGE_URL = "http://e2e.invalid/held.png";
+const LAZY_IMAGE_URL = "http://e2e.invalid/lazy.png";
+const PNG_1X1 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+
+async function expectOnTop(overlay: Locator) {
+  await overlay.scrollIntoViewIfNeeded();
+  const box = await overlay.boundingBox();
+  if (!box) throw new Error("overlay의 레이아웃이 필요합니다.");
+
+  const isOnTop = await overlay.evaluate((element, bounds) => {
+    const hit = element.ownerDocument.elementFromPoint(
+      bounds.x + bounds.width / 2,
+      bounds.y + bounds.height / 2,
+    );
+    return hit !== null && element.contains(hit);
+  }, box);
+
+  expect(isOnTop).toBe(true);
+}
+
+test.describe("ImageFrame 이미지 동작", () => {
+  test("lazy 이미지는 뷰포트 밖 레이아웃을 유지하고 진입 후 로드된다", async ({ page }) => {
+    await page.route(LAZY_IMAGE_URL, (route) =>
+      route.fulfill({ contentType: "image/png", body: Buffer.from(PNG_1X1, "base64") }),
+    );
+    await page.goto("/e2e/image-behavior");
+
+    const image = page
+      .getByTestId("lazy-image-frame")
+      .getByRole("img", { name: "Lazy E2E fixture" });
+    await expect(image).toBeAttached();
+    await expect(image).toHaveAttribute("data-loading-state", "loading");
+    await expect(image).not.toHaveAttribute("hidden", /.*/);
+    await expect(image).toHaveCSS("display", "block");
+    expect(await image.evaluate((element: HTMLImageElement) => element.complete)).toBe(false);
+
+    await image.scrollIntoViewIfNeeded();
+
+    await expect
+      .poll(() => image.evaluate((element: HTMLImageElement) => element.naturalWidth))
+      .toBeGreaterThan(0);
+    await expect(image).toHaveAttribute("data-loading-state", "loaded");
+  });
+
+  test("보류된 이미지는 fallback과 겹친 레이아웃을 유지하고 interaction을 가로채지 않는다", async ({
+    page,
+  }) => {
+    await page.route(HELD_IMAGE_URL, () => {});
+    const heldImageRequest = page.waitForRequest(HELD_IMAGE_URL);
+    await page.goto("/e2e/image-behavior", { waitUntil: "domcontentloaded" });
+    await heldImageRequest;
+
+    const root = page.getByTestId("held-image-frame");
+    const image = root.getByRole("img", { name: "Held E2E fixture" });
+    const fallback = root.getByTestId("held-image-fallback");
+
+    await expect(image).toHaveAttribute("data-loading-state", "loading");
+    await expect(image).not.toHaveAttribute("hidden", /.*/);
+    await expect(image).toHaveCSS("display", "block");
+
+    const imageBox = await image.boundingBox();
+    const fallbackBox = await fallback.boundingBox();
+    if (!imageBox || !fallbackBox) throw new Error("이미지와 fallback의 레이아웃이 필요합니다.");
+    expect(Math.abs(imageBox.x - fallbackBox.x)).toBeLessThan(1);
+    expect(Math.abs(imageBox.y - fallbackBox.y)).toBeLessThan(1);
+    expect(Math.abs(imageBox.width - fallbackBox.width)).toBeLessThan(1);
+    expect(Math.abs(imageBox.height - fallbackBox.height)).toBeLessThan(1);
+
+    await expectOnTop(fallback);
+    await fallback.click();
+    await expect(fallback).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("이미지 요청 실패 시 이미지는 숨고 fallback이 프레임을 채운다", async ({ page }) => {
+    await page.route(HELD_IMAGE_URL, (route) => route.abort());
+    await page.goto("/e2e/image-behavior");
+
+    const root = page.getByTestId("held-image-frame");
+    const image = root.getByRole("img", { name: "Held E2E fixture", includeHidden: true });
+    const fallback = root.getByTestId("held-image-fallback");
+
+    await expect(image).toHaveAttribute("data-loading-state", "error");
+    await expect(image).toHaveAttribute("hidden", /.*/);
+    await expect(image).toHaveCSS("display", "none");
+    await expect(fallback).toBeVisible();
+
+    const fallbackBox = await fallback.boundingBox();
+    if (!fallbackBox) throw new Error("fallback의 레이아웃이 필요합니다.");
+    expect(fallbackBox.width).toBeGreaterThan(0);
+    expect(fallbackBox.height).toBeGreaterThan(0);
+  });
+
+  test("ImageFrame overlay는 로드된 이미지 위에서 hit-test된다", async ({ page }) => {
+    await page.goto("/e2e/image-behavior");
+
+    const overlays = ["badge", "icon", "indicator", "reaction"];
+    for (const overlay of overlays) {
+      const root = page.getByTestId(`overlay-${overlay}-frame`);
+      await expect(root.getByRole("img", { name: `${overlay} overlay fixture` })).toHaveAttribute(
+        "data-loading-state",
+        "loaded",
+      );
+      await expectOnTop(root.getByTestId(`overlay-${overlay}`));
+    }
+  });
+});

--- a/examples/stackflow-spa/package.json
+++ b/examples/stackflow-spa/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite --host 0.0.0.0",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
     "serve": "vite preview"
   },
   "dependencies": {
@@ -34,6 +36,7 @@
     "react-dom": "^19.2.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@seed-design/cli": "1.7.0",
     "@seed-design/vite-plugin": "^2.1.0",
     "@types/node": "^25.0.0",

--- a/examples/stackflow-spa/playwright.config.ts
+++ b/examples/stackflow-spa/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "**/*.e2e.ts",
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  reporter: "html",
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "bun run dev -- --host 127.0.0.1 --port 4173 --strictPort",
+    url: "http://127.0.0.1:4173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 300_000,
+  },
+  projects: [
+    {
+      name: "Pixel 10 / Chromium",
+      use: { ...devices["Pixel 10"] },
+    },
+    {
+      name: "iPhone 17 / WebKit",
+      use: { ...devices["iPhone 17"] },
+    },
+  ],
+});

--- a/examples/stackflow-spa/src/activities/ActivityE2EImageBehavior.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityE2EImageBehavior.tsx
@@ -1,0 +1,132 @@
+import { IconCarrotFill, IconHouseLine } from "@karrotmarket/react-monochrome-icon";
+import {
+  Flex,
+  ImageFrame,
+  ImageFrameBadge,
+  ImageFrameFloater,
+  ImageFrameIcon,
+  ImageFrameIndicator,
+  ImageFrameReactionButton,
+  VStack,
+} from "@seed-design/react";
+import { useFlow, type StaticActivityComponentType } from "@stackflow/react/future";
+import { useState } from "react";
+import {
+  AppBar,
+  AppBarBackButton,
+  AppBarIconButton,
+  AppBarLeft,
+  AppBarMain,
+  AppBarRight,
+} from "seed-design/ui/app-bar";
+import { AppScreen, AppScreenContent } from "seed-design/ui/app-screen";
+
+declare module "@stackflow/config" {
+  interface Register {
+    ActivityE2EImageBehavior: {};
+  }
+}
+
+const HELD_IMAGE_URL = "http://e2e.invalid/held.png";
+const LAZY_IMAGE_URL = "http://e2e.invalid/lazy.png";
+const SAMPLE_IMAGE = `data:image/svg+xml,${encodeURIComponent(
+  "<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><rect width='200' height='200' fill='#6ba6ff'/></svg>",
+)}`;
+
+type OverlayKind = "badge" | "icon" | "indicator" | "reaction";
+
+function OverlayFrame({ kind }: { kind: OverlayKind }) {
+  const [pressed, setPressed] = useState(false);
+  const overlay = {
+    badge: (
+      <ImageFrameBadge data-testid="overlay-badge" tone="brand" variant="solid">
+        NEW
+      </ImageFrameBadge>
+    ),
+    icon: <ImageFrameIcon data-testid="overlay-icon" svg={<IconCarrotFill />} />,
+    indicator: <ImageFrameIndicator data-testid="overlay-indicator">+9</ImageFrameIndicator>,
+    reaction: (
+      <ImageFrameReactionButton
+        data-testid="overlay-reaction"
+        pressed={pressed}
+        onPressedChange={setPressed}
+        aria-label="Like"
+      />
+    ),
+  }[kind];
+
+  return (
+    <ImageFrame
+      data-testid={`overlay-${kind}-frame`}
+      ratio={1}
+      src={SAMPLE_IMAGE}
+      alt={`${kind} overlay fixture`}
+      style={{ width: 120 }}
+      stroke
+    >
+      <ImageFrameFloater placement="bottom-end">{overlay}</ImageFrameFloater>
+    </ImageFrame>
+  );
+}
+
+const ActivityE2EImageBehavior: StaticActivityComponentType<"ActivityE2EImageBehavior"> = () => {
+  const { push } = useFlow();
+  const [fallbackPressed, setFallbackPressed] = useState(false);
+
+  return (
+    <AppScreen>
+      <AppBar>
+        <AppBarLeft>
+          <AppBarBackButton />
+        </AppBarLeft>
+        <AppBarMain>E2E Image Behavior</AppBarMain>
+        <AppBarRight>
+          <AppBarIconButton aria-label="Home" onClick={() => push("ActivityHome", {})}>
+            <IconHouseLine />
+          </AppBarIconButton>
+        </AppBarRight>
+      </AppBar>
+      <AppScreenContent>
+        <VStack gap="x6" p="x5">
+          <ImageFrame
+            data-testid="held-image-frame"
+            src={HELD_IMAGE_URL}
+            alt="Held E2E fixture"
+            ratio={4 / 3}
+            style={{ width: 300 }}
+            fallback={
+              <button
+                type="button"
+                data-testid="held-image-fallback"
+                aria-pressed={fallbackPressed}
+                onClick={() => setFallbackPressed((value) => !value)}
+                style={{ width: "100%", height: "100%", border: 0 }}
+              >
+                fallback
+              </button>
+            }
+          />
+
+          <Flex gap="x3" wrap="wrap">
+            {(["badge", "icon", "indicator", "reaction"] as const).map((kind) => (
+              <OverlayFrame key={kind} kind={kind} />
+            ))}
+          </Flex>
+
+          <div style={{ height: 12000 }} />
+
+          <ImageFrame
+            data-testid="lazy-image-frame"
+            src={LAZY_IMAGE_URL}
+            alt="Lazy E2E fixture"
+            loading="lazy"
+            ratio={4 / 3}
+            style={{ width: 300 }}
+          />
+        </VStack>
+      </AppScreenContent>
+    </AppScreen>
+  );
+};
+
+export default ActivityE2EImageBehavior;

--- a/examples/stackflow-spa/src/stackflow/Stack.tsx
+++ b/examples/stackflow-spa/src/stackflow/Stack.tsx
@@ -68,6 +68,7 @@ export const { Stack, actions, stepActions } = stackflow({
     ActivityCodegenTest: lazy(() => import("../activities/ActivityCodegenTest")),
     ActivityDetail: lazy(() => import("../activities/ActivityDetail")),
     ActivityDialog: lazy(() => import("../activities/ActivityDialog")),
+    ActivityE2EImageBehavior: lazy(() => import("../activities/ActivityE2EImageBehavior")),
     ActivityErrorState: lazy(() => import("../activities/ActivityErrorState")),
     ActivityFontMultiplierLayout: lazy(() => import("../activities/ActivityFontMultiplierLayout")),
     ActivityHelpBubble: lazy(() => import("../activities/ActivityHelpBubble")),

--- a/examples/stackflow-spa/src/stackflow/stackflow.config.ts
+++ b/examples/stackflow-spa/src/stackflow/stackflow.config.ts
@@ -36,6 +36,7 @@ export const config = defineConfig({
     { route: "/codegen-test", name: "ActivityCodegenTest" },
     { route: "/detail", name: "ActivityDetail" },
     { route: "/dialog", name: "ActivityDialog" },
+    { route: "/e2e/image-behavior", name: "ActivityE2EImageBehavior" },
     { route: "/error-state", name: "ActivityErrorState" },
     { route: "/font-multiplier-layout", name: "ActivityFontMultiplierLayout" },
     { route: "/result-section", name: "ActivityResultSection" },


### PR DESCRIPTION
## 요약

- Playwright E2E 소유권을 docs Storybook에서 examples/stackflow-spa로 이동했습니다.
- 기존 ImageFrame/Avatar 계약 5개와 Stackflow 핵심 계약 8개를 실제 SPA에서 검증합니다.
- Pixel 7 Chromium과 iPhone 13 WebKit에서 13개 논리 테스트를 각각 실행합니다.

## 주요 변경

- stackflow-spa에 Playwright 설정, e2e/e2e:ui 스크립트, 공통 helper와 테스트를 추가했습니다.
- 홈에 노출되지 않는 /e2e/image-behavior Activity에서 lazy/loading/error/overlay 상태를 통제합니다.
- 기존 PopTest, AnimateFalseTest, TransitionStyle Activity에는 action용 data-testid만 추가했습니다.
- 정착 상태는 top activity 1개, enter-done, 실제 x=0, AppBar opacity=1, swipe idle로 판정합니다.
- swipe는 Chromium CDP 없이 touchstart/touchmove/touchend dispatch로 두 브라우저에서 실행합니다.
- docs의 E2E fixture, 조건부 Storybook glob, Playwright 설정과 스크립트를 제거했습니다. 일반 Storybook/Chromatic 스토리는 유지합니다.
- CI는 Chromium과 WebKit을 설치하고 SPA E2E를 실행하며, 실패 시 trace가 포함된 HTML report를 업로드합니다.

## 테스트 범위

### 이미지 계약 5개

1. 뷰포트 밖 lazy 이미지의 로딩 상태와 레이아웃 유지 및 스크롤 후 로드
2. 보류 이미지와 fallback의 겹침 및 fallback interaction
3. 요청 실패 시 이미지 숨김과 fallback 채움
4. ImageFrame badge/icon/indicator/reaction overlay hit-test
5. Avatar badge hit-test

### Stackflow 계약 8개

1. URL, browser back/forward, 404 route 복원
2. 세 transition style의 push/pop 정착
3. pop(2)와 동시 pop(); pop();의 정확한 착지
4. animated push 후 pop({ animate: false }) 정착
5. 임계값 미만 swipe 취소와 callback
6. 임계값 이상 swipe pop과 callback
7. preventSwipeBack의 edge 제거와 stack 보존
8. top layer focus 및 iframe 부모 scroll 보존

## 검증

- bun generate:all: 예상 밖 generated diff 없음
- bun test:all: unit 1,314개 + Lynx 63개 통과
- bun --filter @seed-design/stackflow-spa build: 통과
- SPA E2E: 13개 x 2개 브라우저 = 26/26 통과
- git diff --check: 통과
- negative control:
  - 로딩 중 이미지를 다시 숨기면 ImageFrame 테스트 실패
  - Stackflow 정착 safety-net 제거 시 animate:false의 x 오프셋과 동시 pop의 AppBar opacity 잔여값을 각각 검출

## 범위

공개 패키지 API 변경은 없습니다. 테스트 전용 route와 예제 앱의 data-testid만 추가했으며, 기존 수동 QA Activity는 홈에서 계속 접근할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 이미지 지연 로딩, 실패 시 대체 화면, 오버레이와 배지 동작을 확인할 수 있는 테스트 화면을 추가했습니다.
  - 이미지 동작과 화면 전환, 뒤로가기, 스와이프 동작을 자동으로 검증하는 E2E 테스트를 추가했습니다.

- **테스트**
  - Chromium 및 WebKit 환경에서 E2E 테스트를 실행하고, 실패 시 테스트 리포트를 보관합니다.
  - 화면 전환, 중첩 화면 닫기, 애니메이션 없는 전환, 스와이프 취소·차단 및 역방향 스와이프 동작 검증을 강화했습니다.
  - iframe 포커스와 부모 스크롤 상태 보존을 검증합니다.

- **문서**
  - E2E 테스트 작성 및 검증 기준을 문서화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->