### PR TITLE
docs: reword landing page meta description

### DIFF
--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -27,6 +27,6 @@ export default function HomePage() {
 export function generateMetadata(): Metadata {
   return buildSeoMetadata({
     title: "SEED Design System",
-    description: "SEED는 당근 제품을 위한 통합된 디자인 언어입니다.",
+    description: "SEED는 당근 제품을 위해 통합된 디자인 언어입니다.",
   });
 }


### PR DESCRIPTION
랜딩 페이지(`/`)의 meta description 한 문장을 수정합니다.

```diff
- SEED는 당근 제품을 위한 통합된 디자인 언어입니다.
+ SEED는 당근 제품을 위해 통합된 디자인 언어입니다.
```

`<meta name="description">`, `og:description`, `twitter:description`에 반영됩니다. 그 외 title / OG 이미지 / 하위 문서 페이지는 변경 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 앱 페이지의 SEO 설명 문구를 업데이트했습니다.
  * 당근 제품을 위한 통합된 디자인 언어를 더 명확하게 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->