### PR TITLE
fix(docs): honor not-prose in the prose heading weight rule

### DIFF
--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -105,7 +105,7 @@ html {
    font-medium / t*-medium directly; this rule matches in-content prose headings to the
    page title (fumadocs defaults them to 600, which would otherwise outweigh the title).
    :is() lifts specificity over fumadocs' :where() typography. */
-.prose :is(h1, h2, h3, h4, h5, h6) {
+.prose :is(h1, h2, h3, h4, h5, h6):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   font-weight: 500;
 }
 


### PR DESCRIPTION
## 문제

[`seed-design.io/react/components/swipeable-menu-sheet`](https://seed-design.io/react/components/swipeable-menu-sheet) 예시에서 메뉴시트 타이틀이 recipe가 지정한 `font-weight: 700`이 아니라 **500**으로 렌더됩니다.

## 원인

포탈 여부와 무관한 **docs 전역 CSS 버그**입니다.

1. [`docs/app/global.css:108`](https://github.com/daangn/seed-design/blob/dev/docs/app/global.css#L108)의 `.prose :is(h1..h6) { font-weight: 500 }`이 **언레이어드**로 선언돼 있습니다.
2. docs는 [`next.config.mjs:27`](https://github.com/daangn/seed-design/blob/dev/docs/next.config.mjs#L27)에서 `conditionNames = ["seed-layered", "..."]`를 켜므로 SEED recipe CSS가 `@layer seed-components`로 들어갑니다.
3. **언레이어드 규칙은 모든 `@layer`를 무조건 이깁니다** → `.seed-menu-sheet__title`의 `font-weight: var(--seed-font-weight-bold)`(=700)가 집니다. `SwipeableMenuSheet.Title`은 `Drawer.Title` → `Primitive.h2`라 이 규칙에 걸립니다.
4. `ComponentPreview`는 이미 `not-prose`로 감싸져 있지만([`component-preview.tsx:35`](https://github.com/daangn/seed-design/blob/dev/docs/components/component-preview.tsx#L35)), `not-prose`는 tailwind-typography가 **자기가 생성하는 `:where()` 규칙에만** `:not(:where([class~="not-prose"], [class~="not-prose"] *))` 가드를 붙여주는 장치입니다. 손으로 쓴 `.prose :is(...)`엔 그 가드가 없어 `not-prose` 섬 안까지 새어 들어갑니다.

## 변경

셀렉터 한 줄. 그 전역 규칙이 tailwind-typography와 **같은 `not-prose` 계약**을 지키게 합니다.

```css
.prose :is(h1, h2, h3, h4, h5, h6):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
  font-weight: 500;
}
```

`:not()`은 인자 중 가장 높은 specificity를 자기 값으로 가져오는데, `:where()`는 항상 0입니다. 덕분에 규칙 무게가 **`(0,1,1)`로 수정 전과 완전히 동일**합니다 — 매치 대상만 줄고 우선순위 관계는 하나도 안 건드립니다. (`:where()` 없이 쓰면 `(0,2,1)`로 무거워져 Updates의 `prose-h2:*` 유틸·`updates-article.css` 여백 규칙과의 승패가 뒤집힐 수 있습니다.)

셀렉터 형태는 `@fumadocs/tailwind` typography 플러그인이 생성하는 것과 동일하게 맞췄습니다.

SwipeableMenuSheet뿐 아니라 **모든 컴포넌트 예시가 한 번에 정상화**됩니다.

## 검토하고 버린 대안

- **`.prose > :is(h1..h6)`로 직계 자식 한정** — 안 됩니다. `<Steps>`/`<Accordion>` 안에 중첩된 MDX 소제목이 `lynx/getting-started/installation.mdx`, `ai-integration/(mcp)/figma-mcp.mdx`, `react/getting-started/installation/manual.mdx` 등 10곳 이상 있어 전부 500을 잃습니다.
- **오버레이 포탈** — 증상은 가려지지만 원인이 남습니다. registry 스니펫은 사용자가 복사해 가는 공개 코드라 changeset + stackflow 액티비티 스코프 렌더링 검토가 붙는 별도 안건이고, heading은 오버레이 전용도 아니라(`ListHeader`의 `as="h1".."h6"`, `Text`의 `as`) 포탈로는 원천 차단이 안 됩니다.

## 검증 (dev 서버 computed style 실측)

| 확인 지점 | 결과 |
|---|---|
| SwipeableMenuSheet 타이틀 (`.seed-menu-sheet__title`, `<h2>`) | **500 → 700** ✅ |
| MenuSheet 타이틀 (같은 recipe, 다른 페이지) | **700** ✅ 함께 고쳐짐 |
| 같은 페이지 MDX 소제목 22개 | 전부 **500** 유지 ✅ |
| `<Steps>` 중첩 소제목 8개 (`/react/getting-started/installation/manual`, depth 3~7) | 전부 **500** 유지 ✅ |
| DocsCard `<h3>` (`t5-medium`) | **500**, 변화 없음 ✅ |
| Updates 아티클 (`/updates/how-seed-evolved`) | h2 28px/mt 96px/500, h3 24px/mt 64px/500 — `updates-article.css` 여백 규칙과 충돌 없음 ✅ |
| `bun --filter @seed-design/docs build` (static export) | **exit 0** ✅ |

셀렉터 매치 수로도 확인됩니다: 옛 셀렉터 24개 → 새 셀렉터 22개, 줄어든 2개가 정확히 예시 영역 안의 heading입니다.

**회귀 없음**: `.prose` 안 `not-prose` 영역에서 heading을 렌더하는 지점을 전부 훑었고 500에 기대는 곳이 없습니다. DocsCard h3는 `t5-medium`(=500)을, Accordion은 `<h3>` 래퍼가 아니라 그 안의 `<span class="seed-accordion__title">`(recipe medium=500)이 실제 제목이라 둘 다 무영향입니다.

## 참고

`docs`는 `private: true`라 changeset은 불필요합니다.

같은 성격의 언레이어드 전역 누수로 [`global.css:116`](https://github.com/daangn/seed-design/blob/dev/docs/app/global.css#L116)의 `strong { font-weight: 600 }`도 있지만, `docs/examples`·`docs/registry` 어디에도 `<strong>` 사용처가 없어 지금은 증상이 없습니다. 나중에 예시에서 굵은 텍스트가 깨지면 같은 방식으로 가드를 붙이면 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 문서 본문에서 `not-prose`로 감싼 구역의 제목이 의도와 다르게 기본 문서 제목 스타일로 덮어써지던 문제를 수정했습니다.
  * 일반 문서 제목은 동일한 글꼴 두께를 유지하되, 예제 및 별도 스타일이 필요한 컴포넌트 영역은 원래 스타일이 보존됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->