### PR TITLE
fix(docs): size the footer seed symbol by width and lock its shrink

### DIFF
--- a/docs/components/landing/sections/section-footer.tsx
+++ b/docs/components/landing/sections/section-footer.tsx
@@ -48,7 +48,7 @@ export function SectionFooter() {
     >
       <div className="mx-auto flex w-full max-w-[1760px] flex-col gap-8 px-spacing-x-global-gutter md:flex-row md:justify-between md:gap-12 md:px-12">
         <div className="flex flex-col gap-3">
-          <SeedSymbol className="h-7 w-auto self-start md:h-8" />
+          <SeedSymbol className="h-auto w-4 shrink-0 self-start md:w-5" />
           <div className="flex flex-col gap-1.5">
             <span className="t12-bold text-[26px] font-bold md:text-[28px]">Rooted in Daangn.</span>
             {/* output: export라 연도는 빌드 시점에 구워진다. 연도 경계에서만 클라이언트와

--- a/docs/components/layout/seed-symbol.tsx
+++ b/docs/components/layout/seed-symbol.tsx
@@ -1,7 +1,7 @@
 /**
  * SEED 심볼 마크 (sprout + seed). footer 브랜드 로고.
  * `currentColor`를 써서 소비처의 text 색을 따른다(docs 라이트/다크, 랜딩 footer).
- * 비율은 viewBox로 보존 — 소비처는 height만 주고 `w-auto`로 쓴다.
+ * 비율은 viewBox로 보존 — 소비처는 width만 주고 `h-auto`로 쓴다(둘 다 주면 비율이 깨진다).
  */
 export function SeedSymbol({ className }: { className?: string }) {
   return (

--- a/docs/components/layout/site-footer.tsx
+++ b/docs/components/layout/site-footer.tsx
@@ -15,7 +15,7 @@ export function SiteFooter() {
   return (
     <footer className="border-fd-border mt-12 flex flex-col gap-10 border-t pt-10 md:flex-row md:justify-between">
       <div className="flex flex-col gap-3">
-        <SeedSymbol className="text-fd-foreground h-7 w-auto self-start md:h-8" />
+        <SeedSymbol className="text-fd-foreground h-auto w-4 shrink-0 self-start md:w-5" />
         <div>
           <p className="text-fd-foreground text-[26px] font-bold tracking-tight lg:text-[28px]">
             {FOOTER_BRAND.tagline}


### PR DESCRIPTION
## Summary

The SEED symbol in both site footers was sized by height (`h-7 w-auto`) — the awkward axis for a portrait mark (viewBox `30 x 52`). It left the logo only ~16px wide and made the dimension anyone actually reasons about implicit.

- Size by width instead: `w-4 md:w-5 h-auto`. The viewBox derives the height.
- Add `shrink-0`. The symbol sits in a **column** flex container, where `flex-shrink` applies to the main axis — the height. `self-start` only prevents cross-axis stretch, so without `shrink-0` the height could be squeezed while the now-fixed width stays put, breaking the aspect ratio. This matters more with the width pinned than it did before.
- Update the `SeedSymbol` doc comment, which told consumers the opposite.

## Files

- `docs/components/layout/seed-symbol.tsx` — doc comment
- `docs/components/layout/site-footer.tsx` — docs footer
- `docs/components/landing/sections/section-footer.tsx` — landing footer

## Verification

Measured in Chrome 148 on both footers, local dev:

| viewport | box | aspect-ratio delta vs viewBox | `flex-shrink` |
| --- | --- | --- | --- |
| 360px (below md) | 16 x 27.73 | 1.4e-4 | 0 |
| 1280px (md and up) | 20 x 34.66 | 4e-5 | 0 |

`bun docs:test` passes.

## Notes

- **No clipping bug was reproduced.** A full-page SVG scan (main document + the 4 block-preview iframes) at 320px and 390px, on both local dev and production `seed-design.io`, found zero aspect-ratio distortions and zero ancestor clips. An A/B/C render (`overflow: hidden` vs `visible` vs a padded viewBox) came out pixel-identical, ruling out `overflow` as a cause. This PR is a correctness guard and an intent cleanup, not a fix for an observed break.
- md and up grows slightly: 32px -> 34.66px tall. `md:w-[18px]` would preserve the old size exactly, but it is off the Tailwind scale, so `md:w-5` was chosen.
- The mark still renders only 16px wide below md, where the sprout and the teardrop tip collapse visually. If that is the real complaint, it needs a size bump, which is a design call and deliberately not made here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 푸터의 브랜드 아이콘 크기와 정렬을 개선했습니다.
  * 다양한 레이아웃에서 아이콘의 비율이 더 안정적으로 유지되며, 높이 눌림 현상이 줄어듭니다.
  * 화면 크기에 따라 아이콘 너비가 자연스럽게 조정되어 일관된 모양을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->