### PR TITLE
style(docs): set get-started/updates h1 to 40px

### DIFF
--- a/docs/components/layout/prose-page.tsx
+++ b/docs/components/layout/prose-page.tsx
@@ -25,8 +25,8 @@ export function ProsePage({ title, description, hero, children, footer = true }:
       {hero ? <div className="mb-10 w-full md:mb-14">{hero}</div> : null}
       <div className="mx-auto w-full max-w-[1100px]">
         <header className="not-prose mb-10 md:mb-14">
-          {/* Unified doc-page title scale (see OverviewLayout): SemiBold 600, text-3xl→md:text-4xl. */}
-          <h1 className="text-fd-foreground text-3xl font-medium tracking-tight text-balance md:text-4xl">
+          {/* get-started/updates 제목 스케일: text-3xl→md:text-[40px] (데스크탑 40px 고정). */}
+          <h1 className="text-fd-foreground text-3xl font-medium tracking-tight text-balance md:text-[40px]">
             {title}
           </h1>
           {description ? (


### PR DESCRIPTION
## Summary

`/get-started`와 `/updates` 페이지의 h1 텍스트 사이즈를 **40px**로 조정합니다.

두 페이지는 모두 사이드바 없는 1컬럼 셸인 `ProsePage`(`docs/components/layout/prose-page.tsx`)의 h1을 공유합니다. 해당 h1 하나만 변경했습니다.

## Change

`docs/components/layout/prose-page.tsx`
- h1: `md:text-4xl` (36px) → `md:text-[40px]` (40px)
- 모바일 기본값 `text-3xl`(30px)은 유지

## Scope

- `ProsePage`는 `/get-started`, `/updates` **두 페이지에서만** 사용됩니다. (다른 문서 페이지의 h1은 `docs-page-renderer`가 별도로 렌더하므로 영향 없음)

## Verify

- ⚠️ 로컬 dev 서버 렌더는 환경 이슈로 확인 미완 — CI 빌드 / alpha 프리뷰에서 40px 확인 필요
- ℹ️ 데스크탑(md+) 기준 40px. 모바일은 30px 유지 — 모바일도 40px로 통일이 필요하면 알려주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 데스크톱 환경에서 문서 페이지 최상단 제목이 40px 크기로 일관되게 표시되도록 조정했습니다.
  * 시작하기 및 업데이트 페이지의 제목 크기 표현을 통일했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->