### PR TITLE
fix(hooks): run cli tests with bun test in post-edit hook

### DIFF
--- a/.claude/hooks/post-edit-tasks.sh
+++ b/.claude/hooks/post-edit-tasks.sh
@@ -53,7 +53,7 @@ elif [[ "$FILE_PATH" == *"packages/figma/"* ]]; then
 
 elif [[ "$FILE_PATH" == *"packages/cli/"* ]]; then
   run_with_feedback bun --filter @seed-design/cli build
-  run_with_feedback bun --filter @seed-design/cli test --dots
+  run_with_feedback bun test packages/cli --dots
   
 elif [[ "$FILE_PATH" == *"packages/stackflow/"* ]]; then
   run_with_feedback bun --filter @seed-design/stackflow build


### PR DESCRIPTION
## 문제

`.claude/hooks/post-edit-tasks.sh`가 `packages/cli/` 편집 시 `bun --filter @seed-design/cli test --dots`를 실행하는데, `@seed-design/cli`에는 `test` 스크립트가 없어서(`build`/`dev`/`lint:publish`만 존재) bun이 항상 `error: No packages matched the filter`(exit 1)로 실패했습니다. CLI 파일을 편집할 때마다 훅이 깨지는 상태였습니다.

## 해결

CI(`cli-test.yml`)와 동일하게 `bun test packages/cli`를 직접 실행하도록 교체했습니다. 같은 스크립트의 qvism 라인(`bun test ecosystem/qvism --dots`)과 같은 패턴입니다.

```diff
-  run_with_feedback bun --filter @seed-design/cli test --dots
+  run_with_feedback bun test packages/cli --dots
```

## 검증

- `packages/cli/src/index.ts` touch 후 훅을 실제 호출 방식 그대로(stdin JSON) 실행 → `✓ All tasks completed successfully` (build + test 모두 통과)
- `bun test packages/cli --dots` 단독 실행: **31 pass / 0 fail** (6개 파일, CI와 동일 결과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * CLI 패키지 테스트 실행 방식이 개선되어, 지정된 패키지 경로를 직접 기준으로 테스트를 수행합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->