### PR TITLE
fix(docs): repair dead ai-integration redirects and slim down llms.txt

### DIFF
--- a/docs/app/ai-integration/llms.txt/route.ts
+++ b/docs/app/ai-integration/llms.txt/route.ts
@@ -58,13 +58,5 @@ AI 도구 연동 가이드 문서입니다.
 ## Categories
 
 ${categoryList}
-
-## Usage
-
-개별 페이지는 /llms/ai-integration/{path}.txt 형태로 접근할 수 있습니다.
-
-예시:
-- ${new URL("/llms/ai-integration/docs-mcp.txt", baseUrl)}
-- ${new URL("/llms/ai-integration/figma-mcp.txt", baseUrl)}
 `);
 }

--- a/docs/app/breeze/ai-integration/llms-txt/page.tsx
+++ b/docs/app/breeze/ai-integration/llms-txt/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from "next/navigation";
-
-export default function () {
-  return redirect("/ai-integration/llms-txt");
-}

--- a/docs/app/breeze/llms.txt/route.ts
+++ b/docs/app/breeze/llms.txt/route.ts
@@ -27,13 +27,6 @@ export async function GET() {
 
 ${pageList}
 
-## Usage
-
-개별 페이지는 /llms/breeze/{path}.txt 형태로 접근할 수 있습니다.
-
-예시:
-- ${new URL("/llms/breeze/components/animate-number.txt", baseUrl)}
-
 ## Related Sections
 
 - [React Library](${new URL("/react/llms.txt", baseUrl)}): React 컴포넌트 라이브러리

--- a/docs/app/docs/ai-integration/llms-txt/page.tsx
+++ b/docs/app/docs/ai-integration/llms-txt/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from "next/navigation";
-
-export default function () {
-  return redirect("/ai-integration/llms-txt");
-}

--- a/docs/app/docs/llms.txt/route.ts
+++ b/docs/app/docs/llms.txt/route.ts
@@ -66,13 +66,5 @@ ${pageList}`;
 ## Categories
 
 ${categoryList}
-
-## Usage
-
-개별 페이지는 /llms/docs/{path}.txt 형태로 접근할 수 있습니다.
-
-예시:
-- ${new URL("/llms/components/button.txt", baseUrl)}
-- ${new URL("/llms/foundations/color.txt", baseUrl)}
 `);
 }

--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -6,17 +6,8 @@ export async function GET() {
   return new Response(`# SEED Design System - Documentation for LLMs
 
 SEED는 당근의 디자인 시스템입니다.
-이 문서는 대규모 언어 모델(LLM)이 SEED를 쉽게 이해할 수 있도록 구조화되어 있습니다.
-
-## Requirements
-
-- **절대 경로를 추론하지 마세요**
-- **해당 문서에 있는 모든 섹션들의 요소는 [요소](링크)로 되어있으니 일찍이 경로를 추론하지 마세요**
-- **섹션의 요소를 정확하게 찾고 링크를 참조하세요**
 
 ## Documentation Sections
-
-각 섹션별로 llms.txt 진입점과 llms-full.txt 전체 문서를 제공합니다.
 
 | 섹션 | 진입점 | 전체 문서 | 설명 |
 |------|--------|-----------|------|
@@ -26,18 +17,5 @@ SEED는 당근의 디자인 시스템입니다.
 | Lynx | [llms.txt](${new URL("/lynx/llms.txt", baseUrl)}) | [llms-full.txt](${new URL("/lynx/llms-full.txt", baseUrl)}) | Lynx 프레임워크 |
 | AI Integration | [llms.txt](${new URL("/ai-integration/llms.txt", baseUrl)}) | [llms-full.txt](${new URL("/ai-integration/llms-full.txt", baseUrl)}) | AI 도구 연동 가이드 |
 | Changelog | [llms.txt](${new URL("/llms/react/updates/changelog.txt", baseUrl)}) | - | 패키지별/버전별 변경 이력 |
-
-## Individual Page Access
-
-개별 페이지는 /llms/{section}/{path} 형태로 접근할 수 있습니다.
-
-예시:
-- ${new URL("/llms/react/components/action-button.txt", baseUrl)} - Action Button 컴포넌트 문서
-- ${new URL("/llms/foundations/color/palette.txt", baseUrl)} - Color Palette 문서
-- ${new URL("/llms/ai-integration/figma-mcp.txt", baseUrl)} - Figma MCP 문서
-
-## Notes
-
-- 모든 문서는 seed-design.io의 공식 문서와 동기화됩니다.
-- llms-full.txt는 해당 섹션의 모든 문서를 하나의 파일로 제공합니다.`);
+`);
 }

--- a/docs/app/lynx/llms.txt/route.ts
+++ b/docs/app/lynx/llms.txt/route.ts
@@ -27,13 +27,6 @@ Lynx 프레임워크 문서입니다.
 
 ${pageList}
 
-## Usage
-
-개별 페이지는 /llms/lynx/{path}.txt 형태로 접근할 수 있습니다.
-
-예시:
-- ${new URL("/llms/lynx/icon.txt", baseUrl)}
-
 ## Related Sections
 
 - [React Library](${new URL("/react/llms.txt", baseUrl)}): React 컴포넌트 라이브러리

--- a/docs/app/react/ai-integration/llms-txt/page.tsx
+++ b/docs/app/react/ai-integration/llms-txt/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from "next/navigation";
-
-export default function () {
-  return redirect("/ai-integration/llms-txt");
-}

--- a/docs/app/react/ai-integration/mcp/page.tsx
+++ b/docs/app/react/ai-integration/mcp/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from "next/navigation";
-
-export default function () {
-  return redirect("/ai-integration/figma-mcp");
-}

--- a/docs/app/react/llms.txt/route.ts
+++ b/docs/app/react/llms.txt/route.ts
@@ -73,13 +73,5 @@ React 컴포넌트 라이브러리 문서입니다.
 ## Categories
 
 ${categoryList}
-
-## Usage
-
-개별 페이지는 /llms/react/{path}.txt 형태로 접근할 수 있습니다.
-
-예시:
-- ${new URL("/llms/react/components/button.txt", baseUrl)}
-- ${new URL("/llms/react/getting-started/installation.txt", baseUrl)}
 `);
 }

--- a/docs/content/react/developer-tools/figma-integration/codegen.mdx
+++ b/docs/content/react/developer-tools/figma-integration/codegen.mdx
@@ -15,7 +15,7 @@ Figma 디자인을 열고, Dev mode에서 코드 생성을 원하는 디자인 �
 
 Codegen 플러그인은 작은 단위의 코드 생성 및 작업에 적합합니다.
 
-복잡한 작업은 [MCP](/react/ai-integration/mcp)를 활용하는 것을 권장합니다.
+복잡한 작업은 [MCP](/ai-integration/figma-mcp)를 활용하는 것을 권장합니다.
 
 ## 관련 문서
 

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -20,3 +20,10 @@
 /foundations/design-token-reference /foundations/design-token/reference 301
 /foundations/iconography/overview /foundations/iconography 301
 /foundations/typography/overview /foundations/typography 301
+
+# AI Integration 통합: react/docs/breeze 아래 있던 문서를 `/ai-integration`으로 옮겼다.
+# `llms-txt` 페이지는 삭제되고 `/llms.txt` 라우트로 대체됐다.
+/react/ai-integration/llms-txt /llms.txt 301
+/docs/ai-integration/llms-txt /llms.txt 301
+/breeze/ai-integration/llms-txt /llms.txt 301
+/react/ai-integration/mcp /ai-integration/figma-mcp 301


### PR DESCRIPTION
## 1. Three redirects pointed at a 404

`/ai-integration/llms-txt` returns 404 in production, but three shim pages redirected to it:

```
curl -o /dev/null -w '%{http_code}' https://seed-design.io/ai-integration/llms-txt   # 404
```

`/react/ai-integration/llms-txt` and `/docs/ai-integration/llms-txt` return 200 only because they *are* the shims.

**How it broke** — three commits:

1. `2dc1e3a67` (#1137) unified the AI Integration section, deleting `content/{react,docs,breeze}/ai-integration/llms-txt.mdx` and renaming `react/ai-integration/mcp.mdx` → `ai-integration/figma-mcp.mdx`. The old paths were covered by `:path*` wildcards in `next.config.mjs`.
2. `ae4af0585` noticed those wildcards silently die under `output: "export"` and replaced them with four hard-coded `page.tsx` shims.
3. `131853fdb` (#1306) then deleted the *unified* `ai-integration/llms-txt.mdx` too, swapping the sidebar to `external:[llms.txt](/llms.txt)` — but nobody updated the shims.

**Fix** — moved all four into `public/_redirects`, the mechanism this repo actually deploys (Cloudflare Pages, real `301`). A `page.tsx` shim renders an HTML page instead of emitting a redirect status, so it carries no SEO signal.

```
/react/ai-integration/llms-txt  /llms.txt 301
/docs/ai-integration/llms-txt   /llms.txt 301
/breeze/ai-integration/llms-txt /llms.txt 301
/react/ai-integration/mcp /ai-integration/figma-mcp 301
```

`/llms.txt` as the target matches what the sidebar already concluded in #1306.

`react/ai-integration/mcp`'s **target was fine** (`(mcp)` is a route group, stripped from the URL) — it moved along for consistency. One in-content link in `codegen.mdx` still pointed at the pre-move URL; now canonical.

## 2. llms.txt told the model not to do what the next section taught it to do

The root `llms.txt` opened with:

```markdown
## Requirements

- **절대 경로를 추론하지 마세요**
- **해당 문서에 있는 모든 섹션들의 요소는 [요소](링크)로 되어있으니 일찍이 경로를 추론하지 마세요**
- **섹션의 요소를 정확하게 찾고 링크를 참조하세요**
```

...while every section file carried a `## Usage` block explaining exactly how to infer paths. Both are redundant anyway: the link lists already emit full URLs, e.g. `- [Action Button](https://seed-design.io/llms/react/components/action-button.txt)`.

Worse, 4 of the 6 hand-written `예시:` URLs had rotted into 404s — `/llms/react/components/button.txt`, `.../getting-started/installation.txt`, `/llms/components/button.txt`, `/llms/lynx/icon.txt`. Dead examples actively misdirect.

**Removed**: `## Requirements`, `## Usage` + `예시:` (all 6 files), and the root's self-describing preamble + `## Notes`.
**Kept**: section blurbs, `Quick Access`, `Related Sections`, and the changelog's `— changes since this version` — real links, or glosses that disambiguate.

Net: **-82 / +9**.

## Verification

- All 6 llms.txt routes rendered against a dev server: 200, no leftover instruction prose.
- `_redirects`: 19/19 rules well-formed.
- `bun docs:test`: 92 pass, 0 fail.
- `biome check` clean on the 6 edited routes; `baseUrl` still used in each (no dead imports).

Two caveats, stated plainly:

- MDX page routes 500 in this worktree because the workspace packages aren't built (`Can't resolve '@seed-design/react'`) — pre-existing, unrelated to this diff. Page existence was confirmed instead via `/ai-integration/llms.txt`, which is generated from `aiIntegrationSource.getPages()` and lists exactly `figma-mcp`, `docs-mcp`, `skill` — no `llms-txt`.
- The actual `301` behaviour is Cloudflare-side and only observable on a deploy. **Worth clicking through on the preview.**

## Not in scope

- `content/ai-integration/meta.json` lists a `"lynx-tools"` page that has never existed. Fumadocs silently drops it. Left alone.
- The three unrelated shims (`radio-select-box`, `check-select-box`, `theming`) have valid targets. Moving them would be churn, not a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)