### PR TITLE
feat(docs): add per-section llms.txt indexes and fix stale skill URLs

### DIFF
--- a/docs/app/components/llms.txt/route.ts
+++ b/docs/app/components/llms.txt/route.ts
@@ -1,0 +1,39 @@
+import { getLLMMarkdownUrl, sectionConfigs, shouldIncludeInFullText } from "@/app/_llms/config";
+import { getDisplayTitle } from "@/app/_llms/utils";
+import { baseUrl } from "@/app/metadata";
+import { componentsSource } from "@/app/source";
+
+export const revalidate = false;
+
+export async function GET() {
+  // 섹션 인덱스와 progress-board는 sectionConfigs.excludePaths가 이미 걸러준다.
+  // `(deprecated)`는 라우트 그룹이라 slug에 안 들어간다 — frontmatter로만 구분된다.
+  const pages = componentsSource
+    .getPages()
+    .filter((page) => shouldIncludeInFullText("components", page.path));
+
+  const pageList = pages
+    .sort((a, b) => a.slugs.join("/").localeCompare(b.slugs.join("/")))
+    .map((page) => {
+      const displayTitle = getDisplayTitle(page, pages);
+      const llmsUrl = new URL(getLLMMarkdownUrl("components", page.slugs), baseUrl);
+      const deprecatedLabel = page.data.deprecated ? " (Deprecated)" : "";
+      const description = page.data.description ? `: ${page.data.description}` : "";
+      return `- [${displayTitle}](${llmsUrl})${deprecatedLabel}${description}`;
+    })
+    .join("\n");
+
+  return new Response(`# SEED Components - LLM Reference
+
+${sectionConfigs.components.description}
+
+## Components
+
+${pageList}
+
+## Related Sections
+
+- [Foundations](${new URL("/foundations/llms.txt", baseUrl)}): 색상, 타이포그래피 등 디자인 파운데이션
+- [React Library](${new URL("/react/llms.txt", baseUrl)}): React 컴포넌트 구현 및 API 레퍼런스
+`);
+}

--- a/docs/app/docs/llms.txt/route.ts
+++ b/docs/app/docs/llms.txt/route.ts
@@ -5,16 +5,12 @@ import { docsSource } from "@/app/source";
 
 export const revalidate = false;
 
-const excludedCategories = new Set(["progress-board"]);
-
-const categoryOrder = ["foundation", "components", "guidelines", "migration", "resources"];
+// IA 개편으로 foundation/components/guidelines/resources는 각자 최상위 섹션으로 빠져나갔고
+// (`/foundations`, `/components`, `/patterns`) `/docs`에는 migration만 남았다.
+const categoryOrder = ["migration"];
 
 const categoryDescriptions: Record<string, string> = {
-  components: "컴포넌트 디자인 가이드라인",
-  foundation: "색상, 타이포그래피, 간격 등 기초 토큰",
-  guidelines: "디자인 가이드라인 및 원칙",
   migration: "마이그레이션 가이드",
-  resources: "디자인 리소스",
 };
 
 export async function GET() {
@@ -24,7 +20,6 @@ export async function GET() {
   for (const page of pages) {
     if (page.slugs.length === 0) continue;
     const category = page.slugs[0];
-    if (excludedCategories.has(category)) continue;
     if (!categories.has(category)) {
       categories.set(category, []);
     }
@@ -57,14 +52,19 @@ ${pageList}`;
 
   return new Response(`# SEED Guidelines - LLM Reference
 
-디자인 가이드라인 문서입니다.
+마이그레이션 등 디자인 참고 문서입니다.
 
 ## Quick Access
 
-- [전체 문서 (llms-full.txt)](${new URL("/docs/llms-full.txt", baseUrl)}): 모든 디자인 문서를 하나의 파일로
+- [전체 문서 (llms-full.txt)](${new URL("/docs/llms-full.txt", baseUrl)}): 모든 참고 문서를 하나의 파일로
 
 ## Categories
 
 ${categoryList}
+
+## Related Sections
+
+- [Foundations](${new URL("/foundations/llms.txt", baseUrl)}): 색상, 타이포그래피 등 디자인 파운데이션
+- [Components](${new URL("/components/llms.txt", baseUrl)}): 컴포넌트 디자인 스펙
 `);
 }

--- a/docs/app/foundations/llms.txt/route.ts
+++ b/docs/app/foundations/llms.txt/route.ts
@@ -1,0 +1,40 @@
+import { getLLMMarkdownUrl, sectionConfigs, shouldIncludeInFullText } from "@/app/_llms/config";
+import { getDisplayTitle } from "@/app/_llms/utils";
+import { baseUrl } from "@/app/metadata";
+import { foundationsSource } from "@/app/source";
+
+export const revalidate = false;
+
+export async function GET() {
+  // 섹션 인덱스는 sectionConfigs.excludePaths가 이미 걸러준다.
+  const pages = foundationsSource
+    .getPages()
+    .filter((page) => shouldIncludeInFullText("foundations", page.path));
+
+  // color/iconography/design-token 탭 그룹의 index는 모두 title이 "Overview"라
+  // 그대로 나열하면 구분이 안 된다. getDisplayTitle이 slug로 꼬리표를 붙여준다.
+  // 정렬은 title이 아니라 slug 기준 — 그래야 탭 그룹의 하위 문서가 부모 옆에 붙는다.
+  const pageList = pages
+    .sort((a, b) => a.slugs.join("/").localeCompare(b.slugs.join("/")))
+    .map((page) => {
+      const displayTitle = getDisplayTitle(page, pages);
+      const llmsUrl = new URL(getLLMMarkdownUrl("foundations", page.slugs), baseUrl);
+      const description = page.data.description ? `: ${page.data.description}` : "";
+      return `- [${displayTitle}](${llmsUrl})${description}`;
+    })
+    .join("\n");
+
+  return new Response(`# SEED Foundations - LLM Reference
+
+${sectionConfigs.foundations.description}
+
+## Documents
+
+${pageList}
+
+## Related Sections
+
+- [Components](${new URL("/components/llms.txt", baseUrl)}): 컴포넌트 디자인 스펙
+- [React Library](${new URL("/react/llms.txt", baseUrl)}): React 컴포넌트 라이브러리
+`);
+}

--- a/docs/app/get-started/llms.txt/route.ts
+++ b/docs/app/get-started/llms.txt/route.ts
@@ -1,0 +1,20 @@
+import { getLLMText } from "@/app/_llms/get-llm-text";
+import { getStartedSource } from "@/app/source";
+import { notFound } from "next/navigation";
+
+export const revalidate = false;
+
+// 다른 섹션의 llms.txt는 하위 문서 목록이지만 get-started는 index.mdx 한 장이 전부다.
+// 자기 자신만 담긴 목록을 내보내봐야 쓸모가 없어서 본문을 그대로 내보낸다.
+// (`/llms/get-started/*` 라우트가 없는 것도 같은 이유 — 하위 문서가 없다.)
+export async function GET() {
+  const page = getStartedSource.getPage([]);
+
+  if (!page) notFound();
+
+  return new Response(await getLLMText(page, "get-started"), {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+}

--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -11,13 +11,16 @@ SEED는 당근의 디자인 시스템입니다.
 
 | 섹션 | 진입점 | 전체 문서 | 설명 |
 |------|--------|-----------|------|
+| Get Started | [llms.txt](${new URL("/get-started/llms.txt", baseUrl)}) | - | SEED가 무엇이고 어디서부터 보면 되는지 (본문 1장) |
 | Foundations | [llms.txt](${new URL("/foundations/llms.txt", baseUrl)}) | - | 색상, 타이포그래피, 간격 등 디자인 파운데이션 |
 | Components | [llms.txt](${new URL("/components/llms.txt", baseUrl)}) | - | 컴포넌트 디자인 스펙 (Anatomy, Properties, Guidelines) |
+| Patterns | [llms.txt](${new URL("/patterns/llms.txt", baseUrl)}) | - | 디자인 패턴 및 가이드라인 |
 | Design Guidelines | [llms.txt](${new URL("/docs/llms.txt", baseUrl)}) | [llms-full.txt](${new URL("/docs/llms-full.txt", baseUrl)}) | 마이그레이션 등 디자인 참고 문서 |
 | React Library | [llms.txt](${new URL("/react/llms.txt", baseUrl)}) | [llms-full.txt](${new URL("/react/llms-full.txt", baseUrl)}) | React 컴포넌트 라이브러리, API 레퍼런스 |
 | Breeze Utilities | [llms.txt](${new URL("/breeze/llms.txt", baseUrl)}) | [llms-full.txt](${new URL("/breeze/llms-full.txt", baseUrl)}) | 유틸리티 UI 컴포넌트 |
 | Lynx | [llms.txt](${new URL("/lynx/llms.txt", baseUrl)}) | [llms-full.txt](${new URL("/lynx/llms-full.txt", baseUrl)}) | Lynx 프레임워크 |
 | AI Integration | [llms.txt](${new URL("/ai-integration/llms.txt", baseUrl)}) | [llms-full.txt](${new URL("/ai-integration/llms-full.txt", baseUrl)}) | AI 도구 연동 가이드 |
+| Updates | [llms.txt](${new URL("/updates/llms.txt", baseUrl)}) | - | SEED 업데이트 소식과 릴리스 노트 |
 | Changelog | [llms.txt](${new URL("/llms/react/updates/changelog.txt", baseUrl)}) | - | 패키지별/버전별 변경 이력 |
 `);
 }

--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -11,7 +11,9 @@ SEED는 당근의 디자인 시스템입니다.
 
 | 섹션 | 진입점 | 전체 문서 | 설명 |
 |------|--------|-----------|------|
-| Design Guidelines | [llms.txt](${new URL("/docs/llms.txt", baseUrl)}) | [llms-full.txt](${new URL("/docs/llms-full.txt", baseUrl)}) | 컴포넌트 디자인 가이드라인, Foundation |
+| Foundations | [llms.txt](${new URL("/foundations/llms.txt", baseUrl)}) | - | 색상, 타이포그래피, 간격 등 디자인 파운데이션 |
+| Components | [llms.txt](${new URL("/components/llms.txt", baseUrl)}) | - | 컴포넌트 디자인 스펙 (Anatomy, Properties, Guidelines) |
+| Design Guidelines | [llms.txt](${new URL("/docs/llms.txt", baseUrl)}) | [llms-full.txt](${new URL("/docs/llms-full.txt", baseUrl)}) | 마이그레이션 등 디자인 참고 문서 |
 | React Library | [llms.txt](${new URL("/react/llms.txt", baseUrl)}) | [llms-full.txt](${new URL("/react/llms-full.txt", baseUrl)}) | React 컴포넌트 라이브러리, API 레퍼런스 |
 | Breeze Utilities | [llms.txt](${new URL("/breeze/llms.txt", baseUrl)}) | [llms-full.txt](${new URL("/breeze/llms-full.txt", baseUrl)}) | 유틸리티 UI 컴포넌트 |
 | Lynx | [llms.txt](${new URL("/lynx/llms.txt", baseUrl)}) | [llms-full.txt](${new URL("/lynx/llms-full.txt", baseUrl)}) | Lynx 프레임워크 |

--- a/docs/app/patterns/llms.txt/route.ts
+++ b/docs/app/patterns/llms.txt/route.ts
@@ -1,0 +1,37 @@
+import { getLLMMarkdownUrl, sectionConfigs, shouldIncludeInFullText } from "@/app/_llms/config";
+import { getDisplayTitle } from "@/app/_llms/utils";
+import { baseUrl } from "@/app/metadata";
+import { patternsSource } from "@/app/source";
+
+export const revalidate = false;
+
+export async function GET() {
+  // 섹션 인덱스는 sectionConfigs.excludePaths가 이미 걸러준다.
+  const pages = patternsSource
+    .getPages()
+    .filter((page) => shouldIncludeInFullText("patterns", page.path));
+
+  const pageList = pages
+    .sort((a, b) => a.slugs.join("/").localeCompare(b.slugs.join("/")))
+    .map((page) => {
+      const displayTitle = getDisplayTitle(page, pages);
+      const llmsUrl = new URL(getLLMMarkdownUrl("patterns", page.slugs), baseUrl);
+      const description = page.data.description ? `: ${page.data.description}` : "";
+      return `- [${displayTitle}](${llmsUrl})${description}`;
+    })
+    .join("\n");
+
+  return new Response(`# SEED Patterns - LLM Reference
+
+${sectionConfigs.patterns.description}
+
+## Documents
+
+${pageList}
+
+## Related Sections
+
+- [Components](${new URL("/components/llms.txt", baseUrl)}): 컴포넌트 디자인 스펙
+- [Foundations](${new URL("/foundations/llms.txt", baseUrl)}): 색상, 타이포그래피 등 디자인 파운데이션
+`);
+}

--- a/docs/app/updates/llms.txt/route.ts
+++ b/docs/app/updates/llms.txt/route.ts
@@ -1,0 +1,43 @@
+import { getLLMMarkdownUrl, sectionConfigs, shouldIncludeInFullText } from "@/app/_llms/config";
+import { getDisplayTitle } from "@/app/_llms/utils";
+import { baseUrl } from "@/app/metadata";
+import { updatesSource } from "@/app/source";
+
+export const revalidate = false;
+
+/** 정렬 전용. publishedAt은 프론트매터 파싱에 따라 문자열/Date 양쪽으로 온다. */
+function publishedTime(page: { data: { publishedAt?: string | Date } }): number {
+  return page.data.publishedAt ? new Date(page.data.publishedAt).getTime() : 0;
+}
+
+export async function GET() {
+  // updates는 섹션 인덱스 mdx가 없어 excludePaths도 비어있다(랜딩은 app/updates/page.tsx).
+  const pages = updatesSource
+    .getPages()
+    .filter((page) => shouldIncludeInFullText("updates", page.path));
+
+  // 글 목록이라 slug 알파벳순은 의미가 없다. 발행일 최신순으로 세운다.
+  const pageList = pages
+    .sort((a, b) => publishedTime(b) - publishedTime(a))
+    .map((page) => {
+      const displayTitle = getDisplayTitle(page, pages);
+      const llmsUrl = new URL(getLLMMarkdownUrl("updates", page.slugs), baseUrl);
+      const description = page.data.description ? `: ${page.data.description}` : "";
+      return `- [${displayTitle}](${llmsUrl})${description}`;
+    })
+    .join("\n");
+
+  return new Response(`# SEED Updates - LLM Reference
+
+${sectionConfigs.updates.description}
+
+## Posts
+
+${pageList}
+
+## Related Sections
+
+- [Changelog](${new URL("/llms/react/updates/changelog.txt", baseUrl)}): 패키지별/버전별 변경 이력
+- [React Library](${new URL("/react/llms.txt", baseUrl)}): React 컴포넌트 라이브러리
+`);
+}

--- a/skills/seed-design/SKILL.md
+++ b/skills/seed-design/SKILL.md
@@ -77,7 +77,7 @@ SEED Design의 모든 문서에는 llms.txt 형태의 LLM 최적화 문서가 �
 
 ```text
 https://seed-design.io/llms/react/components/{component-name}.txt
-https://seed-design.io/llms/docs/foundation/color/color-system.txt
+https://seed-design.io/llms/foundations/color.txt
 ```
 
 ### CLI docs 명령어

--- a/skills/seed-design/SKILL.md
+++ b/skills/seed-design/SKILL.md
@@ -71,7 +71,8 @@ SEED Design의 모든 문서에는 llms.txt 형태의 LLM 최적화 문서가 �
 | 영역 | 인덱스 URL | 용도 |
 |------|-----------|------|
 | React | https://seed-design.io/react/llms.txt | 컴포넌트 목록, 설치/스타일링 가이드 |
-| Design | https://seed-design.io/docs/llms.txt | 파운데이션(색상, 타이포, 스페이싱 등) |
+| Foundations | https://seed-design.io/foundations/llms.txt | 파운데이션(색상, 타이포, 스페이싱 등) |
+| Components | https://seed-design.io/components/llms.txt | 컴포넌트 디자인 스펙(Anatomy, Properties, Guidelines) |
 
 ### 개별 문서 조회
 

--- a/skills/seed-design/references/foundation.md
+++ b/skills/seed-design/references/foundation.md
@@ -18,9 +18,9 @@ https://seed-design.io/docs/llms.txt
 
 | 토픽 | URL |
 |------|-----|
-| 색상 시스템 개요 | https://seed-design.io/llms/docs/foundation/color/color-system.txt |
-| 역할 기반 색상 | https://seed-design.io/llms/docs/foundation/color/color-role.txt |
-| 팔레트 | https://seed-design.io/llms/docs/foundation/color/palette.txt |
+| 색상 시스템 개요 | https://seed-design.io/llms/foundations/color.txt |
+| 역할 기반 색상 | https://seed-design.io/llms/foundations/color/color-role.txt |
+| 팔레트 | https://seed-design.io/llms/foundations/color/palette.txt |
 
 핵심 원칙: 역할 기반 색상(`--seed-color-fg-*`, `--seed-color-bg-*`, `--seed-color-stroke-*`)을 우선 사용합니다. 팔레트 색상(`--seed-color-palette-*`)은 역할 기반으로 커버되지 않는 예외 상황에만 사용합니다.
 
@@ -28,7 +28,7 @@ https://seed-design.io/docs/llms.txt
 
 | 토픽 | URL |
 |------|-----|
-| 타이포그래피 개요 | https://seed-design.io/llms/docs/foundation/typography/overview.txt |
+| 타이포그래피 개요 | https://seed-design.io/llms/foundations/typography.txt |
 
 핵심 원칙: 스케일은 t1(가장 작음)부터 t10(가장 큼). CSS 변수 `--seed-font-size-t{n}`, `--seed-line-height-t{n}`, `--seed-font-weight-*`로 사용합니다.
 
@@ -36,18 +36,18 @@ https://seed-design.io/docs/llms.txt
 
 | 토픽 | URL |
 |------|-----|
-| Overview | https://seed-design.io/llms/docs/foundation/iconography/overview.txt |
-| Usage | https://seed-design.io/llms/docs/foundation/iconography/usage.txt |
-| Library | https://seed-design.io/llms/docs/foundation/iconography/library.txt |
+| Overview | https://seed-design.io/llms/foundations/iconography.txt |
+| Usage | https://seed-design.io/llms/foundations/iconography/usage.txt |
+| Library | https://seed-design.io/llms/foundations/iconography/library.txt |
 
 ### 스페이싱, 테마, 기타
 
 | 토픽 | URL |
 |------|-----|
-| 스페이싱 | https://seed-design.io/llms/docs/foundation/spacing.txt |
+| 스페이싱 | https://seed-design.io/llms/foundations/spacing.txt |
 | 테마 | https://seed-design.io/llms/react/getting-started/styling/theming.txt |
 | Tailwind CSS 연동 | https://seed-design.io/llms/react/getting-started/styling/tailwind-css.txt |
-| Elevation (그림자) | https://seed-design.io/llms/docs/foundation/elevation.txt |
-| Radius (모서리) | https://seed-design.io/llms/docs/foundation/radius.txt |
-| Motion (애니메이션) | https://seed-design.io/llms/docs/foundation/motion.txt |
-| Gradient | https://seed-design.io/llms/docs/foundation/gradient.txt |
+| Elevation (그림자) | https://seed-design.io/llms/foundations/elevation.txt |
+| Radius (모서리) | https://seed-design.io/llms/foundations/radius.txt |
+| Motion (애니메이션) | https://seed-design.io/llms/foundations/motion.txt |
+| Gradient | https://seed-design.io/llms/foundations/gradient.txt |

--- a/skills/seed-design/references/foundation.md
+++ b/skills/seed-design/references/foundation.md
@@ -7,7 +7,7 @@ SEED Design의 파운데이션 — 색상, 타이포그래피, 스페이싱, 테
 디자인 가이드라인의 전체 목록은 llms.txt에서 확인할 수 있습니다:
 
 ```text
-https://seed-design.io/docs/llms.txt
+https://seed-design.io/foundations/llms.txt
 ```
 
 ## 주요 토픽별 llms.txt


### PR DESCRIPTION
## Why

The foundations/components IA restructure moved content out of `docs/content/docs/` into top-level sections, but the llms.txt layer never followed.

Two consequences, both verified against production:

1. **The `seed-design` skill's foundation URLs all 404.** `docs/public/_redirects` rewrites page routes (`/docs/foundation/* → /foundations/:splat`) but `/llms/*` is served by its own route handlers, so nothing redirects there. All 13 URLs in `skills/seed-design/` were dead.
2. **Five sections had no llms.txt index.** `getLLMMarkdownUrl` points every section root at `/{section}/llms.txt`, but only 5 of 10 sections had that route. `/foundations/llms.txt`, `/components/llms.txt` and `/patterns/llms.txt` 404'd — and the patterns landing page passed that 404 straight into its `markdownUrl` prop. Meanwhile `/docs/llms.txt` was left listing migration docs only, so no index reached foundations or components at all.

## What

**Skill URLs** — repointed to the new paths. `color-system`, `typography/overview` and `iconography/overview` were merged into their section index pages, so they map to `/llms/foundations/{color,typography,iconography}.txt` rather than 1:1.

**New indexes** — `foundations`, `components`, `patterns`, `updates`, `get-started`. Every section now has an entry point. They filter through the existing `shouldIncludeInFullText`, so `progress-board.mdx` and section index pages stay out for free, and sort by slug so tabbed folders (color, iconography, design-token) keep their children next to the parent overview.

Two deviate for a reason:

- `updates` sorts by `publishedAt` descending — it is a post list, so alphabetical order carries no meaning. Its static `llms.txt` segment resolves ahead of the sibling `[slug]` route.
- `get-started` serves the page body via `getLLMText` instead of a list. It is a single `index.mdx` with no `/llms/get-started/*` routes under it, so an index would contain nothing but a link to itself.

**Cleanup** — dropped the dead `foundation`/`components`/`guidelines`/`resources` categories from the `/docs` index (only `migration` still lives there), and registered every section in the root `/llms.txt` table, whose `Design Guidelines` row still claimed to cover Foundation.

## Verification

- All 5 new routes exercised against a local dev server; tab-group adjacency, `progress-board` exclusion and `updates` date ordering confirmed in the output.
- `bun docs:test` — 92 pass / 0 fail. Biome clean. No new `tsc` errors.
- Note: page routes 500 in a fresh worktree because `@seed-design/react` is unbuilt there. That is baseline, unrelated to this change, and the llms routes do not import it.

## Follow-ups (not in this PR)

- `docs/app/_llms/rules/component-grid-rule.ts` still resolves `content/docs/<section>` (gone) and builds `/llms/docs/*` URLs (404). It is currently unreachable — `<CatalogGrid>` only appears in the three section `index.mdx` files, which every llms route excludes — so it fails silently rather than emitting garbage.
- `sanity.config.ts:43` previews to `/docs/components/<slug>`; the 301 catches it.
- `<Cards>`/`<Card>` has no normalize rule, so the JSX passes through raw in the get-started output. Legible, but not clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - Foundations, Components, Patterns, Updates, Get Started 영역별 LLM용 마크다운 문서를 제공합니다.
  - 문서 목록, 설명, 관련 섹션 링크를 포함한 구조화된 참조 콘텐츠를 제공합니다.

- **개선 사항**
  - 통합 문서 색인에 주요 문서 영역과 Updates 항목을 추가했습니다.
  - LLM 문서 링크와 개별 Foundation 문서 링크를 최신 경로로 정리했습니다.
  - Updates 문서는 최신 발행순으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->