### PR TITLE
fix(dialog): make DialogActionProps reflect DialogAction's actual props

### DIFF
--- a/.changeset/brave-doors-shave.md
+++ b/.changeset/brave-doors-shave.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react": patch
+---
+
+`DialogActionProps`가 `DialogAction`이 실제로 받는 props를 나타내도록 수정합니다. `type`, `disabled`, `form`, `value` 등 button 전용 속성이 포함됩니다.

--- a/packages/react/src/components/Dialog/Dialog.tsx
+++ b/packages/react/src/components/Dialog/Dialog.tsx
@@ -90,8 +90,6 @@ export const DialogFooter = withContext<HTMLDivElement, DialogFooterProps>(Primi
 
 ////////////////////////////////////////////////////////////////////////////////////
 
-export interface DialogActionProps
-  extends PrimitiveProps,
-    React.HTMLAttributes<HTMLButtonElement> {}
+export interface DialogActionProps extends DialogPrimitive.CloseButtonProps {}
 
 export const DialogAction = DialogPrimitive.CloseButton;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * `Dialog.Action`에서 실제로 렌더되는 닫기 버튼에 맞게 props 타입을 정교하게 조정했습니다.
  * `type`, `disabled`, `form`, `value` 등 버튼 전용 속성 사용 시의 타입 불일치를 해결했습니다.
  * 런타임 동작은 변경되지 않았습니다.

* **문서**
  * 이번 변경 사항을 패치 릴리스로 기록했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->