### PR TITLE
refactor(rootage): drop unused side panel close button pressed icon color

### DIFF
--- a/.changeset/olive-pandas-wonder.md
+++ b/.changeset/olive-pandas-wonder.md
@@ -1,0 +1,7 @@
+---
+"@seed-design/css": patch
+"@seed-design/lynx-css": patch
+"@seed-design/rootage-artifacts": patch
+---
+
+(사용자 변경사항 없음) Side Panel 닫기 버튼 spec에서 사용되지 않던 pressed 상태의 icon 색상 정의를 제거합니다.

--- a/packages/css/vars/component/side-panel-close-button.d.ts
+++ b/packages/css/vars/component/side-panel-close-button.d.ts
@@ -18,9 +18,6 @@ export declare const vars: {
     "pressed": {
       "root": {
         "color": "var(--seed-color-bg-transparent-pressed)"
-      },
-      "icon": {
-        "color": "var(--seed-color-fg-neutral)"
       }
     }
   }

--- a/packages/css/vars/component/side-panel-close-button.mjs
+++ b/packages/css/vars/component/side-panel-close-button.mjs
@@ -18,9 +18,6 @@ export const vars = {
     "pressed": {
       "root": {
         "color": "var(--seed-color-bg-transparent-pressed)"
-      },
-      "icon": {
-        "color": "var(--seed-color-fg-neutral)"
       }
     }
   }

--- a/packages/lynx-css/vars/component/side-panel-close-button.d.ts
+++ b/packages/lynx-css/vars/component/side-panel-close-button.d.ts
@@ -18,9 +18,6 @@ export declare const vars: {
     "pressed": {
       "root": {
         "color": "var(--seed-color-bg-transparent-pressed)"
-      },
-      "icon": {
-        "color": "var(--seed-color-fg-neutral)"
       }
     }
   }

--- a/packages/lynx-css/vars/component/side-panel-close-button.mjs
+++ b/packages/lynx-css/vars/component/side-panel-close-button.mjs
@@ -18,9 +18,6 @@ export const vars = {
     "pressed": {
       "root": {
         "color": "var(--seed-color-bg-transparent-pressed)"
-      },
-      "icon": {
-        "color": "var(--seed-color-fg-neutral)"
       }
     }
   }

--- a/packages/lynx-qvism-preset/src/vars/component/side-panel-close-button.d.ts
+++ b/packages/lynx-qvism-preset/src/vars/component/side-panel-close-button.d.ts
@@ -18,9 +18,6 @@ export declare const vars: {
     "pressed": {
       "root": {
         "color": "var(--seed-color-bg-transparent-pressed)"
-      },
-      "icon": {
-        "color": "var(--seed-color-fg-neutral)"
       }
     }
   }

--- a/packages/lynx-qvism-preset/src/vars/component/side-panel-close-button.mjs
+++ b/packages/lynx-qvism-preset/src/vars/component/side-panel-close-button.mjs
@@ -18,9 +18,6 @@ export const vars = {
     "pressed": {
       "root": {
         "color": "var(--seed-color-bg-transparent-pressed)"
-      },
-      "icon": {
-        "color": "var(--seed-color-fg-neutral)"
       }
     }
   }

--- a/packages/qvism-preset/src/vars/component/side-panel-close-button.d.ts
+++ b/packages/qvism-preset/src/vars/component/side-panel-close-button.d.ts
@@ -18,9 +18,6 @@ export declare const vars: {
     "pressed": {
       "root": {
         "color": "var(--seed-color-bg-transparent-pressed)"
-      },
-      "icon": {
-        "color": "var(--seed-color-fg-neutral)"
       }
     }
   }

--- a/packages/qvism-preset/src/vars/component/side-panel-close-button.mjs
+++ b/packages/qvism-preset/src/vars/component/side-panel-close-button.mjs
@@ -18,9 +18,6 @@ export const vars = {
     "pressed": {
       "root": {
         "color": "var(--seed-color-bg-transparent-pressed)"
-      },
-      "icon": {
-        "color": "var(--seed-color-fg-neutral)"
       }
     }
   }

--- a/packages/rootage/__generated__/components/side-panel-close-button.json
+++ b/packages/rootage/__generated__/components/side-panel-close-button.json
@@ -114,12 +114,6 @@
                   "type": "color",
                   "value": "$color.bg.transparent-pressed"
                 }
-              },
-              "icon": {
-                "color": {
-                  "type": "color",
-                  "value": "$color.fg.neutral"
-                }
               }
             }
           }

--- a/packages/rootage/components/side-panel-close-button.yaml
+++ b/packages/rootage/components/side-panel-close-button.yaml
@@ -45,5 +45,3 @@ data:
       pressed:
         root:
           color: $color.bg.transparent-pressed
-        icon:
-          color: $color.fg.neutral


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 사이드 패널 닫기 버튼을 눌렀을 때 아이콘 색상이 불필요하게 변경되지 않도록 개선했습니다.
  * 눌림 상태에서는 버튼 배경색만 적용되고 아이콘 컬러 설정은 제외됩니다.

* **문서**
  * 사이드 패널 닫기 버튼의 상태별 스타일 문구를 업데이트해, 눌림 상태의 아이콘 색상 정의가 제거된 점을 반영했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->