### PR TITLE
fix(docs): keep the tabs sticky-list example inside its container

### DIFF
--- a/docs/examples/react/tabs/sticky-list.tsx
+++ b/docs/examples/react/tabs/sticky-list.tsx
@@ -2,14 +2,10 @@ import { TabsContent, TabsList, TabsRoot, TabsTrigger } from "seed-design/ui/tab
 
 export default function TabsStickyList() {
   return (
-    // 600은 화면 높이라고 가정합니다.
-    <div style={{ width: "360px", height: "600px" }}>
-      <TabsRoot
-        defaultValue="1"
-        size="medium"
-        stickyList
-        style={{ height: "100%" }} // 탭 영역을 전체 화면으로 설정합니다.
-      >
+    // 600은 화면 높이라고 가정합니다. 실제 앱에서는 화면(body)이 스크롤 컨테이너 역할을 하므로
+    // 예제에서는 overflowY로 이를 흉내냅니다. TabsList는 이 컨테이너의 top에 고정됩니다.
+    <div style={{ width: "360px", height: "600px", overflowY: "auto" }}>
+      <TabsRoot defaultValue="1" size="medium" stickyList>
         <TabsList>
           <TabsTrigger value="1">라벨1</TabsTrigger>
           <TabsTrigger value="2">라벨2</TabsTrigger>


### PR DESCRIPTION
## 문제

[Tabs > Sticky List](https://seed-design.io/react/components/tabs#sticky-list) 예제가 미리보기 박스를 뚫고 아래 문서 영역을 덮고 있었습니다.

## 원인

예제 wrapper가 `height: 600px`인데 `overflow`가 없어 **스크롤 컨테이너가 아니었습니다.** `stickyList`의 기본 레이아웃은 `contentLayout: hug`이라 content가 자기 높이(1000px)만큼 자라고, `overflow: visible`이므로 그대로 문서 위로 흘러나옵니다.

프로덕션 페이지 실측:

```
wrap  clientH 600 / scrollH 1044   → 444px 초과
미리보기 셀 밖으로 넘친 양: 424px  (44 list + 1000 content − 620)
```

`Tabs` 컴포넌트 버그가 아니라, 예제가 "화면"을 흉내 내는 방식의 문제입니다. 실제 앱에서는 화면(body)이 스크롤 컨테이너라 `sticky`가 정상 동작합니다.

## 수정

- wrapper에 `overflowY: auto` — 실제 앱의 화면이 하는 스크롤 컨테이너 역할을 예제에서 흉내
- `TabsRoot`의 `height: 100%` 제거 — hug 레이아웃에서 root를 600px로 묶으면 실제 컨텐츠(1044px)와 어긋나, 따라 쓰기 나쁜 패턴이 됩니다

## 검증

동일한 두 변경을 프로덕션 DOM에 라이브 적용해 측정했습니다.

| 컨테이너 내부 스크롤 | 0 | 300 | 400 | 600 |
|---|---|---|---|---|
| TabsList 상단 오프셋 | 0 | 0 | 0 | 0 |

`TabsList`는 컨테이너 top에 계속 고정되고, 넘치는 444px는 박스 안에서 스크롤됩니다.

## 참고

같은 페이지의 Transition / Swipeable / Carousel Prevent Drag / Scroll to Top도 오버플로우 스캔에 걸렸지만 전부 `overflow: hidden|auto`로 클리핑되는 캐러셀 패널·내부 스크롤 컨텐츠였습니다(측정상 false positive). 실제로 새는 건 Sticky List 하나뿐입니다.

문서 예제 파일만 변경해 패키지 배포와 무관하므로 changeset은 넣지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서 및 예제**
  * 탭 고정 기능 예제의 스크롤 컨테이너를 명확히 개선했습니다.
  * 고정 탭이 부모 스크롤 영역을 기준으로 올바르게 동작하도록 예제 구성을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->