### PR TITLE
perf(docs): reduce alpha preview build time

### DIFF
--- a/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
@@ -28,6 +28,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
   FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}

--- a/docs/app/llms/react/updates/changelog.txt/route.ts
+++ b/docs/app/llms/react/updates/changelog.txt/route.ts
@@ -1,41 +1,23 @@
 import { baseUrl } from "@/app/metadata";
-import {
-  buildLookupFromSources,
-  groupEntriesByVersion,
-  renderVersionMarkdown,
-} from "@/lib/changelog-llms";
-import type { ChangelogSource } from "@/lib/parse-changelog";
-import { loadChangelogSources, splitVersionSections } from "@/lib/parse-changelog";
+import { getChangelogLlmData, type ChangelogLlmData } from "@/lib/changelog-llms";
 
 export const revalidate = false;
 
 const CHANGELOG_SOURCE_URL = "https://github.com/daangn/seed-design/tree/dev/packages";
 
-async function buildBody(sources: ChangelogSource[]): Promise<string> {
-  const { entries, lookup } = await buildLookupFromSources(sources);
-  const sorted = [...sources].sort((a, b) => a.packageName.localeCompare(b.packageName));
+function buildBody(data: ChangelogLlmData): string {
+  const sorted = [...data.packages.values()].sort((a, b) =>
+    a.packageName.localeCompare(b.packageName),
+  );
 
   return sorted
-    .map(({ packageName, raw }) => {
-      const versions = splitVersionSections(raw);
-      const versionGroups = groupEntriesByVersion(entries, packageName);
-
-      const versionBlocks = versions
-        .map(({ version }) => {
-          const group = versionGroups.get(version);
-          if (!group) return `## ${version}\n\n(no entries)`;
-          return renderVersionMarkdown(packageName, version, group, lookup);
-        })
-        .join("\n\n");
-
-      return `## ${packageName}\n\n${versionBlocks}`;
-    })
+    .map(({ packageName, renderedBlocks }) => `## ${packageName}\n\n${renderedBlocks.join("\n\n")}`)
     .join("\n\n---\n\n");
 }
 
 export async function GET() {
-  const sources = await loadChangelogSources(process.cwd());
-  const body = await buildBody(sources);
+  const data = await getChangelogLlmData();
+  const body = buildBody(data);
 
   const pageUrl = new URL("/react/updates/changelog", baseUrl).toString();
 

--- a/docs/app/llms/react/updates/changelog/[package]/[version]/route.ts
+++ b/docs/app/llms/react/updates/changelog/[package]/[version]/route.ts
@@ -1,8 +1,6 @@
 import {
-  buildLookupFromSources,
+  getChangelogLlmData,
   getSources,
-  groupEntriesByVersion,
-  renderVersionMarkdown,
   toPackageName,
   toSlug,
   toVersionSlug,
@@ -36,29 +34,17 @@ export async function GET(
   const version = decodeURIComponent(params.version.replace(/\.txt$/, ""));
 
   const packageName = toPackageName(slug);
-  const sources = await getSources();
-  const source = sources.find((s) => s.packageName === packageName);
+  const data = await getChangelogLlmData();
+  const packageData = data.packages.get(packageName);
 
-  if (!source) notFound();
+  if (!packageData) notFound();
 
-  const versions = splitVersionSections(source.raw);
-  const idx = versions.findIndex((v) => v.version === version);
+  const idx = packageData.versionIndex.get(version);
 
-  if (idx === -1) notFound();
-
-  const { entries, lookup } = await buildLookupFromSources(sources);
-  const versionGroups = groupEntriesByVersion(entries, packageName);
+  if (idx === undefined) notFound();
 
   // versions는 최신순이므로 0..idx가 해당 버전 포함 이후 전체
-  const sinceVersions = versions.slice(0, idx + 1);
-
-  const body = sinceVersions
-    .map(({ version: v }) => {
-      const group = versionGroups.get(v);
-      if (!group) return `## ${v}\n\n(no entries)`;
-      return renderVersionMarkdown(packageName, v, group, lookup);
-    })
-    .join("\n\n---\n\n");
+  const body = packageData.renderedBlocks.slice(0, idx + 1).join("\n\n---\n\n");
 
   return new Response(
     `# ${packageName} — Changes since ${version}

--- a/docs/app/llms/react/updates/changelog/[package]/llms.txt/route.ts
+++ b/docs/app/llms/react/updates/changelog/[package]/llms.txt/route.ts
@@ -1,14 +1,11 @@
 import { baseUrl } from "@/app/metadata";
 import {
-  buildLookupFromSources,
+  getChangelogLlmData,
   getSources,
-  groupEntriesByVersion,
-  renderVersionMarkdown,
   toPackageName,
   toSlug,
   toVersionSlug,
 } from "@/lib/changelog-llms";
-import { splitVersionSections } from "@/lib/parse-changelog";
 import { notFound } from "next/navigation";
 
 export const revalidate = false;
@@ -21,19 +18,13 @@ export async function generateStaticParams() {
 export async function GET(_request: Request, context: { params: Promise<{ package: string }> }) {
   const { package: slug } = await context.params;
   const packageName = toPackageName(slug);
-  const sources = await getSources();
-  const source = sources.find((s) => s.packageName === packageName);
+  const data = await getChangelogLlmData();
+  const packageData = data.packages.get(packageName);
 
-  if (!source) notFound();
+  if (!packageData) notFound();
 
-  const { entries, lookup } = await buildLookupFromSources(sources);
-  const versionGroups = groupEntriesByVersion(entries, packageName);
-
-  // Use splitVersionSections for ordered version list
-  const versions = splitVersionSections(source.raw);
-
-  const versionList = versions
-    .map(({ version }) => {
+  const versionList = packageData.versions
+    .map((version) => {
       const url = new URL(
         `/llms/react/updates/changelog/${slug}/${toVersionSlug(version)}.txt`,
         baseUrl,
@@ -42,13 +33,7 @@ export async function GET(_request: Request, context: { params: Promise<{ packag
     })
     .join("\n");
 
-  const fullChangelog = versions
-    .map(({ version }) => {
-      const group = versionGroups.get(version);
-      if (!group) return `## ${version}\n\n(no entries)`;
-      return renderVersionMarkdown(packageName, version, group, lookup);
-    })
-    .join("\n\n---\n\n");
+  const fullChangelog = packageData.renderedBlocks.join("\n\n---\n\n");
 
   return new Response(
     `# ${packageName} Changelog

--- a/docs/lib/changelog-llms.test.ts
+++ b/docs/lib/changelog-llms.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+import type { ChangelogSource } from "./parse-changelog";
+import {
+  buildChangelogLlmData,
+  createChangelogLlmDataLoader,
+  renderVersionMarkdown,
+} from "./changelog-llms";
+
+const sources: ChangelogSource[] = [
+  {
+    packageName: "@seed-design/react",
+    raw: `# @seed-design/react
+
+## 2.0.0
+
+### Major Changes
+
+- abc1234: React 2를 출시합니다.
+
+## 1.0.0
+
+### Patch Changes
+
+- Updated dependencies [def5678]
+  - @seed-design/css@1.0.0
+`,
+  },
+  {
+    packageName: "@seed-design/css",
+    raw: `# @seed-design/css
+
+## 1.0.0
+
+### Patch Changes
+
+- def5678: CSS 토큰을 추가합니다.
+`,
+  },
+];
+
+describe("buildChangelogLlmData", () => {
+  it("패키지별 버전 순서와 렌더링 결과를 한 번에 만든다", async () => {
+    const data = await buildChangelogLlmData(sources);
+    const react = data.packages.get("@seed-design/react");
+
+    expect(data.entries).toHaveLength(3);
+    expect(react?.versions).toEqual(["2.0.0", "1.0.0"]);
+    expect(react?.versionIndex.get("2.0.0")).toBe(0);
+    expect(react?.versionIndex.get("1.0.0")).toBe(1);
+    expect(react?.renderedBlocks[0]).toContain("React 2를 출시합니다.");
+    expect(react?.renderedBlocks[1]).toContain("CSS 토큰을 추가합니다.");
+  });
+
+  it("기존 버전 렌더링과 같은 결과를 만든다", async () => {
+    const data = await buildChangelogLlmData(sources);
+    const react = data.packages.get("@seed-design/react");
+    const entries = data.entries.filter(
+      (entry) => entry.package.name === "@seed-design/react" && entry.package.version === "1.0.0",
+    );
+
+    expect(react?.renderedBlocks[1]).toBe(renderVersionMarkdown("1.0.0", entries, data.lookup));
+  });
+});
+
+describe("createChangelogLlmDataLoader", () => {
+  it("동시에 호출해도 같은 초기화 Promise를 공유한다", async () => {
+    let loadCount = 0;
+    const load = createChangelogLlmDataLoader(async () => {
+      loadCount += 1;
+      return sources;
+    });
+
+    const first = load();
+    const second = load();
+    const [firstData, secondData] = await Promise.all([first, second]);
+
+    expect(first).toBe(second);
+    expect(firstData).toBe(secondData);
+    expect(loadCount).toBe(1);
+  });
+});

--- a/docs/lib/changelog-llms.ts
+++ b/docs/lib/changelog-llms.ts
@@ -1,10 +1,28 @@
 import { buildEntryLookup, type EntryLookup } from "@/lib/changelog-data";
 import type { ChangelogEntry, ChangelogSource } from "./parse-changelog";
-import { loadChangelogSources, parseChangelogSources } from "./parse-changelog";
+import {
+  loadChangelogSources,
+  parseChangelogSources,
+  splitVersionSections,
+} from "./parse-changelog";
 
 export type { EntryLookup };
 
 const SCOPE = "@seed-design/";
+
+export interface ChangelogLlmPackageData {
+  packageName: string;
+  versions: string[];
+  versionIndex: ReadonlyMap<string, number>;
+  renderedBlocks: string[];
+}
+
+export interface ChangelogLlmData {
+  sources: ChangelogSource[];
+  entries: ChangelogEntry[];
+  lookup: EntryLookup;
+  packages: ReadonlyMap<string, ChangelogLlmPackageData>;
+}
 
 export function toSlug(packageName: string): string {
   return packageName.replace(SCOPE, "");
@@ -18,13 +36,11 @@ export function toVersionSlug(version: string): string {
   return encodeURIComponent(version);
 }
 
-let sourcesCache: Awaited<ReturnType<typeof loadChangelogSources>> | null = null;
+let sourcesPromise: Promise<ChangelogSource[]> | null = null;
 
 export async function getSources(): Promise<ChangelogSource[]> {
-  if (!sourcesCache) {
-    sourcesCache = await loadChangelogSources(process.cwd());
-  }
-  return sourcesCache;
+  sourcesPromise ??= loadChangelogSources(process.cwd());
+  return sourcesPromise;
 }
 
 export async function buildLookupFromSources(sources: ChangelogSource[]): Promise<{
@@ -35,6 +51,43 @@ export async function buildLookupFromSources(sources: ChangelogSource[]): Promis
   const lookup = buildEntryLookup(entries);
   return { entries, lookup };
 }
+
+export async function buildChangelogLlmData(sources: ChangelogSource[]): Promise<ChangelogLlmData> {
+  const { entries, lookup } = await buildLookupFromSources(sources);
+  const packages = new Map<string, ChangelogLlmPackageData>();
+
+  for (const source of sources) {
+    const versions = splitVersionSections(source.raw).map(({ version }) => version);
+    const versionGroups = groupEntriesByVersion(entries, source.packageName);
+    const renderedBlocks = versions.map((version) => {
+      const group = versionGroups.get(version);
+      if (!group) return `## ${version}\n\n(no entries)`;
+      return renderVersionMarkdown(version, group, lookup);
+    });
+
+    packages.set(source.packageName, {
+      packageName: source.packageName,
+      versions,
+      versionIndex: new Map(versions.map((version, index) => [version, index])),
+      renderedBlocks,
+    });
+  }
+
+  return { sources, entries, lookup, packages };
+}
+
+export function createChangelogLlmDataLoader(
+  loadSources: () => Promise<ChangelogSource[]> = getSources,
+): () => Promise<ChangelogLlmData> {
+  let dataPromise: Promise<ChangelogLlmData> | null = null;
+
+  return () => {
+    dataPromise ??= loadSources().then(buildChangelogLlmData);
+    return dataPromise;
+  };
+}
+
+export const getChangelogLlmData = createChangelogLlmDataLoader();
 
 function entryPlainText(entry: ChangelogEntry): string {
   return entry.contentBlocks
@@ -55,7 +108,6 @@ function formatListItem(text: string, indent = ""): string {
 }
 
 export function renderVersionMarkdown(
-  packageName: string,
   version: string,
   entries: ChangelogEntry[],
   lookup: EntryLookup,

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -7,6 +7,9 @@ const config = {
   output: "export",
   reactStrictMode: true,
   transpilePackages: ["@seed-design/react", "@seed-design/stackflow"],
+  experimental: {
+    cpus: 4,
+  },
   serverExternalPackages: [
     "ts-morph",
     "typescript",

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -7,9 +7,6 @@ const config = {
   output: "export",
   reactStrictMode: true,
   transpilePackages: ["@seed-design/react", "@seed-design/stackflow"],
-  experimental: {
-    cpus: 4,
-  },
   serverExternalPackages: [
     "ts-morph",
     "typescript",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * React 변경 로그 페이지와 패키지별 버전 페이지가 사전 생성된 데이터를 기반으로 더 일관되게 표시됩니다.
  * 변경 로그의 패키지 및 버전 정렬과 전체 내용 표시가 안정화되었습니다.
  * 문서 사이트 빌드 및 페이지 생성 성능이 개선되었습니다.

* **배포**
  * 동일한 브랜치에서 새 배포가 시작되면 이전 진행 중인 배포가 자동으로 취소됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->