### PR TITLE
fix(docs): scroll tabbed pages from a flow anchor, not the stuck strip

### DIFF
--- a/docs/components/layout/docs-tab-strip.tsx
+++ b/docs/components/layout/docs-tab-strip.tsx
@@ -47,9 +47,7 @@ export function DocsTabStrip() {
 
   return (
     <>
-      {/* 스크롤 기준점. 스트립이 sticky로 붙어 있으면 스트립 자신의 scrollIntoView는 이미 제자리라
-          아무 일도 하지 않아, 탭을 바꿔도 페이지 중간에 머문다. 흐름에 남는 이 앵커를 기준으로
-          잡으면 붙어 있든 아니든 같은 위치(스트립의 sticky 시작점)로 스크롤된다. */}
+      {/* 스크롤 기준점. sticky로 붙은 스트립은 이미 제자리라 스스로는 스크롤되지 않는다. */}
       <div ref={anchorRef} aria-hidden className="scroll-mt-(--fd-docs-row-2)" />
       <nav
         aria-label={`${label} tabs`}
@@ -61,15 +59,9 @@ export function DocsTabStrip() {
           value={pathname}
           onValueChange={(url) => {
             if (url === pathname) return;
-            // 전환 "전에" 스크롤한다. 이 컴포넌트는 라우트마다 리마운트되므로 "도착 후 스크롤"
-            // 플래그를 ref에 남겨둘 수 없다. 스트립 위쪽(고정 헤더)은 탭이 바뀌어도 높이가 같아
-            // 지금 계산한 목표 위치가 전환 후에도 그대로 유효하다.
-            //
-            // smooth가 아니라 즉시 스크롤인 이유: smooth는 애니메이션이 진행되는 동안 바로 아래
-            // router.push가 본문을 교체하므로, 새 문서 길이에 따라 목표가 잘려 중간에 멈출 수 있다.
-            // 어차피 본문이 통째로 바뀌는 전환이라 그 사이를 부드럽게 훑어봐야 얻는 것도 없다.
+            // 전환 전에 즉시 스크롤한다. 이 컴포넌트는 라우트마다 리마운트되고,
+            // smooth는 뒤이은 본문 교체에 잘려 중간에 멈춘다.
             anchorRef.current?.scrollIntoView({ block: "start" });
-            // scroll:false로 Next의 기본 top 리셋을 막아 방금 맞춘 위치를 유지한다.
             router.push(url, { scroll: false });
           }}
           triggerLayout="hug"

--- a/docs/components/layout/docs-tab-strip.tsx
+++ b/docs/components/layout/docs-tab-strip.tsx
@@ -32,7 +32,7 @@ export function DocsTabStrip() {
   const { root } = useTreeContext();
   const pathname = usePathname();
   const router = useRouter();
-  const navRef = useRef<HTMLElement>(null);
+  const anchorRef = useRef<HTMLDivElement>(null);
 
   const folder = findTabbedFolder(root.children, pathname);
   if (!folder?.index) return null;
@@ -46,36 +46,40 @@ export function DocsTabStrip() {
   const label = typeof folder.name === "string" ? folder.name : "Section";
 
   return (
-    <nav
-      ref={navRef}
-      aria-label={`${label} tabs`}
-      // 전 사이즈 sticky — 탭형 페이지에선 메뉴형 ToC 팝오버를 끄고(page-renderer) 탭이 그 자리를
-      // 차지한다. bg-fd-background: sticky 시 스크롤 본문이 뒤로 비치지 않게. 사이트 헤더(z-40) 아래.
-      // scroll-mt: 탭 클릭 시 scrollIntoView가 이 스트립을 sticky 시작 위치(--fd-docs-row-2)에 안착.
-      className="not-prose mb-4 bg-fd-background sticky top-(--fd-docs-row-2) z-30 scroll-mt-(--fd-docs-row-2)"
-    >
-      <TabsRoot
-        value={pathname}
-        onValueChange={(url) => {
-          if (url === pathname) return;
-          // scroll:false로 기본 top 리셋을 막고(고정 헤더라 위치 보존), 스트립을 sticky 시작점으로
-          // 부드럽게 스크롤 → 고정 헤더는 위로 사라지고 새 탭 본문이 바로 보인다.
-          router.push(url, { scroll: false });
-          requestAnimationFrame(() => {
-            navRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-          });
-        }}
-        triggerLayout="hug"
-        style={TAB_ROOT_STYLE}
+    <>
+      {/* 스크롤 기준점. 스트립이 sticky로 붙어 있으면 스트립 자신의 scrollIntoView는 이미 제자리라
+          아무 일도 하지 않아, 탭을 바꿔도 페이지 중간에 머문다. 흐름에 남는 이 앵커를 기준으로
+          잡으면 붙어 있든 아니든 같은 위치(스트립의 sticky 시작점)로 스크롤된다. */}
+      <div ref={anchorRef} aria-hidden className="scroll-mt-(--fd-docs-row-2)" />
+      <nav
+        aria-label={`${label} tabs`}
+        // 전 사이즈 sticky — 탭형 페이지에선 메뉴형 ToC 팝오버를 끄고(page-renderer) 탭이 그 자리를
+        // 차지한다. bg-fd-background: sticky 시 스크롤 본문이 뒤로 비치지 않게. 사이트 헤더(z-40) 아래.
+        className="not-prose mb-4 bg-fd-background sticky top-(--fd-docs-row-2) z-30"
       >
-        <TabsList style={TAB_LIST_STYLE}>
-          {tabs.map((tab) => (
-            <TabsTrigger key={tab.url} value={tab.url} style={TAB_TRIGGER_STYLE}>
-              {tab.name}
-            </TabsTrigger>
-          ))}
-        </TabsList>
-      </TabsRoot>
-    </nav>
+        <TabsRoot
+          value={pathname}
+          onValueChange={(url) => {
+            if (url === pathname) return;
+            // 전환 "전에" 스크롤한다. 이 컴포넌트는 라우트마다 리마운트되므로 "도착 후 스크롤"
+            // 플래그를 ref에 남겨둘 수 없다. 스트립 위쪽(고정 헤더)은 탭이 바뀌어도 높이가 같아
+            // 지금 계산한 목표 위치가 전환 후에도 그대로 유효하다.
+            anchorRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+            // scroll:false로 Next의 기본 top 리셋을 막아 방금 맞춘 위치를 유지한다.
+            router.push(url, { scroll: false });
+          }}
+          triggerLayout="hug"
+          style={TAB_ROOT_STYLE}
+        >
+          <TabsList style={TAB_LIST_STYLE}>
+            {tabs.map((tab) => (
+              <TabsTrigger key={tab.url} value={tab.url} style={TAB_TRIGGER_STYLE}>
+                {tab.name}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </TabsRoot>
+      </nav>
+    </>
   );
 }

--- a/docs/components/layout/docs-tab-strip.tsx
+++ b/docs/components/layout/docs-tab-strip.tsx
@@ -64,7 +64,11 @@ export function DocsTabStrip() {
             // 전환 "전에" 스크롤한다. 이 컴포넌트는 라우트마다 리마운트되므로 "도착 후 스크롤"
             // 플래그를 ref에 남겨둘 수 없다. 스트립 위쪽(고정 헤더)은 탭이 바뀌어도 높이가 같아
             // 지금 계산한 목표 위치가 전환 후에도 그대로 유효하다.
-            anchorRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+            //
+            // smooth가 아니라 즉시 스크롤인 이유: smooth는 애니메이션이 진행되는 동안 바로 아래
+            // router.push가 본문을 교체하므로, 새 문서 길이에 따라 목표가 잘려 중간에 멈출 수 있다.
+            // 어차피 본문이 통째로 바뀌는 전환이라 그 사이를 부드럽게 훑어봐야 얻는 것도 없다.
+            anchorRef.current?.scrollIntoView({ block: "start" });
             // scroll:false로 Next의 기본 top 리셋을 막아 방금 맞춘 위치를 유지한다.
             router.push(url, { scroll: false });
           }}


### PR DESCRIPTION
## 배경

탭형 문서(`meta.json`의 `layout: "tabs"` — Foundations Color·Iconography·Design Token 등)에서 **탭 스트립이 sticky로 붙어 있는 상태로 탭을 바꾸면 스크롤이 그대로 멈춰 있습니다.** 새 탭이 렌더되긴 하지만 화면은 페이지 중간에 머물러서, 방금 연 문서를 처음부터 볼 수 없습니다.

## 원인

탭 전환 핸들러가 스트립(`<nav>`) 자신에게 `scrollIntoView`를 호출했습니다.

스트립은 `position: sticky`라 **일단 붙고 나면 이미 목표 위치(sticky offset)에 있습니다.** 브라우저 입장에선 스크롤할 이유가 없으므로 이 호출은 아무 일도 하지 않습니다 — 정확히 필요한 순간에만 no-op이 되는 셈입니다. 붙기 전(페이지 상단 근처)에는 정상 동작했기 때문에 눈에 잘 띄지 않았습니다.

## 변경

- 스트립 바로 앞에 **높이 0짜리 앵커**를 두고 `scroll-margin-top`을 앵커로 옮겼습니다. 앵커는 일반 흐름에 남아 있어 스트립이 붙었든 아니든 위치가 같습니다.
- 스크롤을 `router.push` **앞으로** 옮겼습니다. 이 컴포넌트는 라우트마다 리마운트되기 때문에 "도착 후 스크롤" 플래그를 ref에 남겨둘 수 없습니다. 탭형 폴더는 스트립 위쪽 헤더 높이가 고정이라, 전환 전에 계산한 목표 위치가 전환 후에도 그대로 유효합니다.

## 검증

`/foundations/color`에서 `scrollTop = 2500`(스트립이 붙은 상태)으로 만든 뒤 Palette 탭 클릭:

| | 스크롤 위치 | 스트립 |
| --- | --- | --- |
| 변경 전 | 2500 → **2500** (그대로) | 화면 중간에서 시작 |
| 변경 후 | 2500 → **571** | 상단에 안착, 본문이 처음부터 |

- 클릭이 스트립이 아니라 앵커에 `scrollIntoView`를 호출하는 것까지 확인했습니다.
- 라우트 커밋 3초 뒤에도 `571`로 유지됩니다 (`scroll: false` 덕분).
- `bun docs:test` 95 pass.

### 리뷰 반영: smooth → 즉시 스크롤

`behavior: "smooth"`는 애니메이션이 진행되는 동안 바로 아래 `router.push`가 본문을 교체하기 때문에, 새 문서 길이에 따라 목표가 잘려 중간에 멈출 수 있습니다 ([CodeRabbit 지적](https://github.com/daangn/seed-design/pull/1849#discussion_r3670515072)). 스크롤 완료를 기다렸다 `push`하는 대안은 탭 반응이 그만큼 느려지고, 어차피 본문이 통째로 바뀌는 전환이라 사라질 콘텐츠 위를 훑어봐야 얻는 것이 없어 즉시 스크롤로 정리했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 문서 탭을 전환할 때 경로 이동 이전에 기준 지점을 먼저 정렬해, 탭 스트립 상단으로 이어지는 스크롤 흐름이 더 자연스러워졌습니다.
  * 전환 후에도 선택한 탭 위치가 보다 안정적으로 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
