### PR TITLE
perf(docs): skip cache save on exact hits

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,7 +14,7 @@ inputs:
 outputs:
   build-cache-primary-key:
     description: 'Primary key used for the build output cache'
-    value: ${{ steps.cache-build.outputs.cache-primary-key }}
+    value: ${{ steps.build-cache-key.outputs.value }}
 
 runs:
   using: 'composite'
@@ -36,6 +36,14 @@ runs:
       shell: bash
       run: bun install --frozen-lockfile
 
+    - name: Generate build cache key
+      id: build-cache-key
+      if: ${{ inputs.build-packages == 'true' }}
+      shell: bash
+      env:
+        BUILD_CACHE_KEY: ${{ runner.os }}-build-rootage-${{ inputs.build-rootage }}-${{ hashFiles('packages/**', 'ecosystem/**', 'bun.lock', 'bun.lockb') }}
+      run: echo "value=$BUILD_CACHE_KEY" >> "$GITHUB_OUTPUT"
+
     - name: Cache build outputs
       if: ${{ inputs.build-packages == 'true' }}
       id: cache-build
@@ -48,7 +56,7 @@ runs:
           ecosystem/**/dist
           ecosystem/**/build
           ecosystem/**/lib
-        key: ${{ runner.os }}-build-rootage-${{ inputs.build-rootage }}-${{ hashFiles('packages/**', 'ecosystem/**', 'bun.lock', 'bun.lockb') }}
+        key: ${{ steps.build-cache-key.outputs.value }}
 
     - name: Relink workspace after cache restore
       if: ${{ inputs.build-packages == 'true' && steps.cache-build.outputs.cache-hit == 'true' }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,6 +11,11 @@ inputs:
     required: false
     default: 'false'
 
+outputs:
+  build-cache-primary-key:
+    description: 'Primary key used for the build output cache'
+    value: ${{ steps.cache-build.outputs.cache-primary-key }}
+
 runs:
   using: 'composite'
   steps:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,9 +12,9 @@ inputs:
     default: 'false'
 
 outputs:
-  build-cache-primary-key:
-    description: 'Primary key used for the build output cache'
-    value: ${{ steps.build-cache-key.outputs.value }}
+  build-cache-key-suffix:
+    description: 'OS-independent suffix used for the build output cache key'
+    value: ${{ steps.build-cache-key.outputs.suffix }}
 
 runs:
   using: 'composite'
@@ -41,8 +41,8 @@ runs:
       if: ${{ inputs.build-packages == 'true' }}
       shell: bash
       env:
-        BUILD_CACHE_KEY: ${{ runner.os }}-build-rootage-${{ inputs.build-rootage }}-${{ hashFiles('packages/**', 'ecosystem/**', 'bun.lock', 'bun.lockb') }}
-      run: echo "value=$BUILD_CACHE_KEY" >> "$GITHUB_OUTPUT"
+        BUILD_CACHE_KEY_SUFFIX: rootage-${{ inputs.build-rootage }}-${{ hashFiles('packages/**', 'ecosystem/**', 'bun.lock', 'bun.lockb') }}
+      run: echo "suffix=$BUILD_CACHE_KEY_SUFFIX" >> "$GITHUB_OUTPUT"
 
     - name: Cache build outputs
       if: ${{ inputs.build-packages == 'true' }}
@@ -56,7 +56,7 @@ runs:
           ecosystem/**/dist
           ecosystem/**/build
           ecosystem/**/lib
-        key: ${{ steps.build-cache-key.outputs.value }}
+        key: ${{ runner.os }}-build-${{ steps.build-cache-key.outputs.suffix }}
 
     - name: Relink workspace after cache restore
       if: ${{ inputs.build-packages == 'true' && steps.cache-build.outputs.cache-hit == 'true' }}

--- a/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
@@ -56,6 +56,7 @@ jobs:
             ${{ runner.os }}-figma-images-
 
       - uses: ./.github/actions/setup
+        id: setup
         with:
           build-packages: true
           build-rootage: true
@@ -65,11 +66,11 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: docs/.next/cache
-          # Key the cache by actual docs inputs and workspace artifacts prepared by setup.
-          key: ${{ runner.os }}-nextjs-v2-${{ hashFiles('bun.lock') }}-${{ hashFiles('docs/**/*.js', 'docs/**/*.jsx', 'docs/**/*.mjs', 'docs/**/*.ts', 'docs/**/*.tsx', 'docs/**/*.mdx', 'docs/**/*.css', 'docs/**/*.json', 'packages/**/CHANGELOG.md', 'packages/**/package.json', 'packages/css/**/*.css', 'packages/css/**/*.mjs', 'packages/css/**/*.d.ts', 'packages/rootage/__generated__/**/*.json', 'packages/migration-index/**/*.mjs', 'packages/migration-index/**/*.d.ts') }}-${{ hashFiles('packages/**/lib/**', 'packages/**/dist/**', 'packages/**/build/**', 'ecosystem/**/lib/**', 'ecosystem/**/dist/**', 'ecosystem/**/build/**') }}
-          # Rebuild from the nearest cache with the same dependency graph.
+          # Reuse the build inputs already hashed by setup, then add docs inputs only.
+          key: ${{ runner.os }}-nextjs-${{ steps.setup.outputs.build-cache-primary-key }}-${{ hashFiles('docs/**/*.js', 'docs/**/*.jsx', 'docs/**/*.mjs', 'docs/**/*.ts', 'docs/**/*.tsx', 'docs/**/*.mdx', 'docs/**/*.css', 'docs/**/*.json') }}
+          # Rebuild from the nearest cache when build or docs inputs changed.
           restore-keys: |
-            ${{ runner.os }}-nextjs-v2-${{ hashFiles('bun.lock') }}-
+            ${{ runner.os }}-nextjs-
 
       - name: Build Docs
         working-directory: ./docs

--- a/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
@@ -56,7 +56,8 @@ jobs:
             ${{ runner.os }}-figma-images-
 
       - name: Restore Next.js cache
-        uses: actions/cache@v5
+        id: restore-nextjs-cache
+        uses: actions/cache/restore@v5
         with:
           path: docs/.next/cache
           # Generate a new cache whenever packages or source files change.
@@ -82,6 +83,13 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=6144
         run: |
           bun run build
+
+      - name: Save Next.js cache
+        if: ${{ steps.restore-nextjs-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: docs/.next/cache
+          key: ${{ steps.restore-nextjs-cache.outputs.cache-primary-key }}
 
       - name: Save Figma image cache
         uses: actions/cache/save@v5

--- a/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
@@ -55,21 +55,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-figma-images-
 
+      - uses: ./.github/actions/setup
+        with:
+          build-packages: true
+          build-rootage: true
+
       - name: Restore Next.js cache
         id: restore-nextjs-cache
         uses: actions/cache/restore@v5
         with:
           path: docs/.next/cache
-          # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/bun.lock') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
-          # If source files changed but packages didn't, rebuild from a prior cache.
+          # Key the cache by actual docs inputs and workspace artifacts prepared by setup.
+          key: ${{ runner.os }}-nextjs-v2-${{ hashFiles('bun.lock') }}-${{ hashFiles('docs/**/*.js', 'docs/**/*.jsx', 'docs/**/*.mjs', 'docs/**/*.ts', 'docs/**/*.tsx', 'docs/**/*.mdx', 'docs/**/*.css', 'docs/**/*.json', 'packages/**/CHANGELOG.md', 'packages/**/package.json', 'packages/css/**/*.css', 'packages/css/**/*.mjs', 'packages/css/**/*.d.ts', 'packages/rootage/__generated__/**/*.json', 'packages/migration-index/**/*.mjs', 'packages/migration-index/**/*.d.ts') }}-${{ hashFiles('packages/**/lib/**', 'packages/**/dist/**', 'packages/**/build/**', 'ecosystem/**/lib/**', 'ecosystem/**/dist/**', 'ecosystem/**/build/**') }}
+          # Rebuild from the nearest cache with the same dependency graph.
           restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/bun.lock') }}-
-
-      - uses: ./.github/actions/setup
-        with:
-          build-packages: true
-          build-rootage: true
+            ${{ runner.os }}-nextjs-v2-${{ hashFiles('bun.lock') }}-
 
       - name: Build Docs
         working-directory: ./docs
@@ -179,4 +179,3 @@ jobs:
                 body,
               });
             }
-              

--- a/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           path: docs/.next/cache
           # Reuse the build inputs already hashed by setup, then add docs inputs only.
-          key: ${{ runner.os }}-nextjs-${{ steps.setup.outputs.build-cache-primary-key }}-${{ hashFiles('docs/**/*.js', 'docs/**/*.jsx', 'docs/**/*.mjs', 'docs/**/*.ts', 'docs/**/*.tsx', 'docs/**/*.mdx', 'docs/**/*.css', 'docs/**/*.json') }}
+          key: ${{ runner.os }}-nextjs-${{ steps.setup.outputs.build-cache-key-suffix }}-${{ hashFiles('docs/**/*.js', 'docs/**/*.jsx', 'docs/**/*.mjs', 'docs/**/*.ts', 'docs/**/*.tsx', 'docs/**/*.mdx', 'docs/**/*.css', 'docs/**/*.json') }}
           # Rebuild from the nearest cache when build or docs inputs changed.
           restore-keys: |
             ${{ runner.os }}-nextjs-

--- a/.github/workflows/deploy-seed-design-docs-prod-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-prod-pages.yml
@@ -54,6 +54,7 @@ jobs:
             ${{ runner.os }}-figma-images-
 
       - uses: ./.github/actions/setup
+        id: setup
         with:
           build-packages: true
           build-rootage: true
@@ -63,11 +64,11 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: docs/.next/cache
-          # Key the cache by actual docs inputs and workspace artifacts prepared by setup.
-          key: ${{ runner.os }}-nextjs-v2-${{ hashFiles('bun.lock') }}-${{ hashFiles('docs/**/*.js', 'docs/**/*.jsx', 'docs/**/*.mjs', 'docs/**/*.ts', 'docs/**/*.tsx', 'docs/**/*.mdx', 'docs/**/*.css', 'docs/**/*.json', 'packages/**/CHANGELOG.md', 'packages/**/package.json', 'packages/css/**/*.css', 'packages/css/**/*.mjs', 'packages/css/**/*.d.ts', 'packages/rootage/__generated__/**/*.json', 'packages/migration-index/**/*.mjs', 'packages/migration-index/**/*.d.ts') }}-${{ hashFiles('packages/**/lib/**', 'packages/**/dist/**', 'packages/**/build/**', 'ecosystem/**/lib/**', 'ecosystem/**/dist/**', 'ecosystem/**/build/**') }}
-          # Rebuild from the nearest cache with the same dependency graph.
+          # Reuse the build inputs already hashed by setup, then add docs inputs only.
+          key: ${{ runner.os }}-nextjs-${{ steps.setup.outputs.build-cache-primary-key }}-${{ hashFiles('docs/**/*.js', 'docs/**/*.jsx', 'docs/**/*.mjs', 'docs/**/*.ts', 'docs/**/*.tsx', 'docs/**/*.mdx', 'docs/**/*.css', 'docs/**/*.json') }}
+          # Rebuild from the nearest cache when build or docs inputs changed.
           restore-keys: |
-            ${{ runner.os }}-nextjs-v2-${{ hashFiles('bun.lock') }}-
+            ${{ runner.os }}-nextjs-
 
       - name: Build Docs
         working-directory: ./docs

--- a/.github/workflows/deploy-seed-design-docs-prod-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-prod-pages.yml
@@ -53,21 +53,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-figma-images-
 
+      - uses: ./.github/actions/setup
+        with:
+          build-packages: true
+          build-rootage: true
+
       - name: Restore Next.js cache
         id: restore-nextjs-cache
         uses: actions/cache/restore@v5
         with:
           path: docs/.next/cache
-          # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/bun.lock') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
-          # If source files changed but packages didn't, rebuild from a prior cache.
+          # Key the cache by actual docs inputs and workspace artifacts prepared by setup.
+          key: ${{ runner.os }}-nextjs-v2-${{ hashFiles('bun.lock') }}-${{ hashFiles('docs/**/*.js', 'docs/**/*.jsx', 'docs/**/*.mjs', 'docs/**/*.ts', 'docs/**/*.tsx', 'docs/**/*.mdx', 'docs/**/*.css', 'docs/**/*.json', 'packages/**/CHANGELOG.md', 'packages/**/package.json', 'packages/css/**/*.css', 'packages/css/**/*.mjs', 'packages/css/**/*.d.ts', 'packages/rootage/__generated__/**/*.json', 'packages/migration-index/**/*.mjs', 'packages/migration-index/**/*.d.ts') }}-${{ hashFiles('packages/**/lib/**', 'packages/**/dist/**', 'packages/**/build/**', 'ecosystem/**/lib/**', 'ecosystem/**/dist/**', 'ecosystem/**/build/**') }}
+          # Rebuild from the nearest cache with the same dependency graph.
           restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/bun.lock') }}-
-
-      - uses: ./.github/actions/setup
-        with:
-          build-packages: true
-          build-rootage: true
+            ${{ runner.os }}-nextjs-v2-${{ hashFiles('bun.lock') }}-
 
       - name: Build Docs
         working-directory: ./docs

--- a/.github/workflows/deploy-seed-design-docs-prod-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-prod-pages.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           path: docs/.next/cache
           # Reuse the build inputs already hashed by setup, then add docs inputs only.
-          key: ${{ runner.os }}-nextjs-${{ steps.setup.outputs.build-cache-primary-key }}-${{ hashFiles('docs/**/*.js', 'docs/**/*.jsx', 'docs/**/*.mjs', 'docs/**/*.ts', 'docs/**/*.tsx', 'docs/**/*.mdx', 'docs/**/*.css', 'docs/**/*.json') }}
+          key: ${{ runner.os }}-nextjs-${{ steps.setup.outputs.build-cache-key-suffix }}-${{ hashFiles('docs/**/*.js', 'docs/**/*.jsx', 'docs/**/*.mjs', 'docs/**/*.ts', 'docs/**/*.tsx', 'docs/**/*.mdx', 'docs/**/*.css', 'docs/**/*.json') }}
           # Rebuild from the nearest cache when build or docs inputs changed.
           restore-keys: |
             ${{ runner.os }}-nextjs-

--- a/.github/workflows/deploy-seed-design-docs-prod-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-prod-pages.yml
@@ -54,7 +54,8 @@ jobs:
             ${{ runner.os }}-figma-images-
 
       - name: Restore Next.js cache
-        uses: actions/cache@v5
+        id: restore-nextjs-cache
+        uses: actions/cache/restore@v5
         with:
           path: docs/.next/cache
           # Generate a new cache whenever packages or source files change.
@@ -80,6 +81,13 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=6144
         run: |
           bun run build
+
+      - name: Save Next.js cache
+        if: ${{ steps.restore-nextjs-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: docs/.next/cache
+          key: ${{ steps.restore-nextjs-cache.outputs.cache-primary-key }}
 
       - name: Save Figma image cache
         uses: actions/cache/save@v5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **개선 사항**
  - 디자인 문서 사이트의 Next.js 빌드 캐시 키가 더 정밀하게 구성되어, 문서 관련 입력 범위에 따라 필요한 결과만 다시 빌드합니다.
  - 문서 배포 워크플로우의 캐시 복원/저장 흐름이 개선되어, 캐시 히트 여부에 따라 불필요한 재생성이 줄어듭니다.
  - 문서(스크립트/스타일/콘텐츠) 변경 사항이 캐시에 더 정확히 반영되어, 최신 콘텐츠가 안정적으로 반영됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->