### PR TITLE
refactor(docs): enable Turbopack for production builds

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -22,9 +22,6 @@ const config = {
     ignoreBuildErrors: process.env.NEXT_EXTERNAL_TYPECHECK === "1",
   },
   transpilePackages: ["@seed-design/react", "@seed-design/stackflow"],
-  experimental: {
-    turbopackFileSystemCacheForBuild: process.env.TURBOPACK_FILE_SYSTEM_CACHE === "1",
-  },
   serverExternalPackages: [
     "ts-morph",
     "typescript",

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -1,6 +1,17 @@
+import { readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { createMDX } from "fumadocs-mdx/next";
 
 const withMDX = createMDX();
+const recipeDirectory = fileURLToPath(new URL("../packages/css/recipes", import.meta.url));
+const layeredRecipeAliases = Object.fromEntries(
+  readdirSync(recipeDirectory)
+    .filter((fileName) => fileName.endsWith(".layered.mjs"))
+    .map((fileName) => [
+      `@seed-design/css/recipes/${fileName.replace(".layered.mjs", "")}`,
+      `@seed-design/css/recipes/${fileName.replace(".layered.mjs", ".layered")}`,
+    ]),
+);
 
 /** @type {import('next').NextConfig} */
 const config = {
@@ -11,6 +22,9 @@ const config = {
     ignoreBuildErrors: process.env.NEXT_EXTERNAL_TYPECHECK === "1",
   },
   transpilePackages: ["@seed-design/react", "@seed-design/stackflow"],
+  experimental: {
+    turbopackFileSystemCacheForBuild: process.env.TURBOPACK_FILE_SYSTEM_CACHE === "1",
+  },
   serverExternalPackages: [
     "ts-morph",
     "typescript",
@@ -26,6 +40,11 @@ const config = {
   images: {
     // FIXME: temporal use for static export; will remove after image optimization setup
     unoptimized: true,
+  },
+  turbopack: {
+    // Turbopack은 아직 package exports의 커스텀 condition을 설정할 수 없다.
+    // Webpack의 `seed-layered` condition과 동일한 CSS 진입점을 직접 연결한다.
+    resolveAlias: layeredRecipeAliases,
   },
   webpack: (config) => {
     config.resolve.conditionNames = ["seed-layered", "..."];

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,7 +18,9 @@
     "build-storybook": "storybook build",
     "typecheck": "fumadocs-mdx && next typegen && node node_modules/@typescript/native/bin/tsc --noEmit",
     "images:og:generate": "bun scripts/generate-og-cover-assets.ts",
-    "images:og:validate": "bun scripts/validate-og-cover-assets.ts"
+    "images:og:validate": "bun scripts/validate-og-cover-assets.ts",
+    "build:turbopack": "next build --turbopack",
+    "build:turbopack:cache": "TURBOPACK_FILE_SYSTEM_CACHE=1 next build --turbopack"
   },
   "dependencies": {
     "@dnd-kit/abstract": "^0.4.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "bun run typecheck && NEXT_EXTERNAL_TYPECHECK=1 next build --webpack",
+    "build": "bun run typecheck && NEXT_EXTERNAL_TYPECHECK=1 next build --turbopack",
     "dev": "concurrently \"bun --filter @seed-design/stackflow-spa dev\" \"next dev --webpack\"",
     "start": "concurrently \"bun --filter @seed-design/stackflow-spa dev\" \"next start\"",
     "sanity:dev": "sanity dev",
@@ -18,9 +18,7 @@
     "build-storybook": "storybook build",
     "typecheck": "fumadocs-mdx && next typegen && node node_modules/@typescript/native/bin/tsc --noEmit",
     "images:og:generate": "bun scripts/generate-og-cover-assets.ts",
-    "images:og:validate": "bun scripts/validate-og-cover-assets.ts",
-    "build:turbopack": "next build --turbopack",
-    "build:turbopack:cache": "TURBOPACK_FILE_SYSTEM_CACHE=1 next build --turbopack"
+    "images:og:validate": "bun scripts/validate-og-cover-assets.ts"
   },
   "dependencies": {
     "@dnd-kit/abstract": "^0.4.0",

--- a/ecosystem/rootage/cli/src/index.ts
+++ b/ecosystem/rootage/cli/src/index.ts
@@ -4,7 +4,6 @@ import {
   Authoring,
   buildContext,
   css,
-  runGenerator,
   exchange,
   getComponentSpecDeclarations,
   getSourceFiles,
@@ -16,6 +15,7 @@ import {
   tailwind4,
   validate,
 } from "@seed-design/rootage-core";
+import { runGenerator } from "@seed-design/rootage-core/generator";
 import fs from "fs-extra";
 import path from "node:path";
 import YAML from "yaml";

--- a/ecosystem/rootage/core/package.json
+++ b/ecosystem/rootage/core/package.json
@@ -14,6 +14,11 @@
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js",
       "require": "./lib/index.cjs"
+    },
+    "./generator": {
+      "types": "./lib/generator.d.ts",
+      "import": "./lib/generator.js",
+      "require": "./lib/generator.cjs"
     }
   },
   "main": "./lib/index.cjs",

--- a/ecosystem/rootage/core/src/index.ts
+++ b/ecosystem/rootage/core/src/index.ts
@@ -1,4 +1,3 @@
 export * from "./analyzer";
 export * from "./languages";
 export * from "./parser";
-export * from "./generator";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * CSS 레이어드 레시피가 Turbopack 환경에서도 안정적으로 해석되도록 빌드 구성을 개선했습니다.
  * Rootage CLI의 코드 생성 기능 연결 방식을 정리해 실행 안정성을 높였습니다.
  * Rootage 핵심 패키지의 공개 인터페이스를 정돈해 필요한 기능만 명확하게 노출하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->