### PR TITLE
chore(docs): add credits page and footer link

### DIFF
--- a/docs/app/credits/layout.tsx
+++ b/docs/app/credits/layout.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+import { NoSidebarDocsLayout } from "@/components/layout/no-sidebar-docs-layout";
+import { baseOptions } from "../layout.config";
+import { RootProvider } from "fumadocs-ui/provider/next";
+import DefaultSearchDialog from "@/components/search/search";
+import { TAGS } from "@/app/api/search/constants";
+
+/**
+ * updates와 동일한 사이드바 없는 1컬럼 셸.
+ * credits는 문서 소스가 없는 단독 페이지라 pageTree가 비어 있다 — 사이드바는
+ * NoSidebarDocsLayout이 어차피 렌더하지 않으므로 트리가 쓰이지 않는다.
+ */
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <RootProvider
+      search={{
+        SearchDialog: DefaultSearchDialog,
+        options: {
+          tags: Object.values(TAGS),
+        },
+      }}
+    >
+      <NoSidebarDocsLayout {...baseOptions} tree={{ name: "Credits", children: [] }}>
+        {children}
+      </NoSidebarDocsLayout>
+    </RootProvider>
+  );
+}

--- a/docs/app/credits/page.tsx
+++ b/docs/app/credits/page.tsx
@@ -11,11 +11,6 @@ import type { Metadata } from "next";
 
 export const dynamic = "force-static";
 
-/**
- * 기여자 크레딧 페이지. 사이드바·ToC 없는 중앙 1컬럼(ProsePage)이다.
- * 두 그룹은 같은 타이포 스케일로 렌더한다 — 한쪽을 흐리게 두면 "덜 중요"로
- * 읽히므로, 구분은 그룹 제목으로만 한다.
- */
 export default function CreditsPage() {
   return (
     <ProsePage title={CREDITS_TITLE} description={CREDITS_DESCRIPTION} fullHeight>
@@ -44,33 +39,18 @@ function ContributorGroup({ group }: { group: CreditsGroup }) {
 }
 
 function ContributorItem({ contributor }: { contributor: Contributor }) {
-  const { name, koreanName, link } = contributor;
+  const { name, koreanName } = contributor;
 
-  const body = (
-    <>
+  return (
+    <div>
       <span className="text-fd-foreground text-xl font-medium tracking-tight md:text-2xl">
         {name}
       </span>
       {koreanName ? (
         <span className="text-fd-muted-foreground ml-2 text-xs font-light">{koreanName}</span>
       ) : null}
-    </>
+    </div>
   );
-
-  if (link) {
-    return (
-      <a
-        href={link}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="hover:text-fd-muted-foreground transition-colors"
-      >
-        {body}
-      </a>
-    );
-  }
-
-  return <div>{body}</div>;
 }
 
 export function generateMetadata(): Metadata {

--- a/docs/app/credits/page.tsx
+++ b/docs/app/credits/page.tsx
@@ -1,0 +1,81 @@
+import {
+  CREDITS_DESCRIPTION,
+  CREDITS_GROUPS,
+  CREDITS_TITLE,
+  type Contributor,
+  type CreditsGroup,
+} from "@/components/layout/lib/credits-content";
+import { ProsePage } from "@/components/layout/prose-page";
+import { buildSeoMetadata } from "@/lib/seo";
+import type { Metadata } from "next";
+
+export const dynamic = "force-static";
+
+/**
+ * 기여자 크레딧 페이지. 사이드바·ToC 없는 중앙 1컬럼(ProsePage)이다.
+ * 두 그룹은 같은 타이포 스케일로 렌더한다 — 한쪽을 흐리게 두면 "덜 중요"로
+ * 읽히므로, 구분은 그룹 제목으로만 한다.
+ */
+export default function CreditsPage() {
+  return (
+    <ProsePage title={CREDITS_TITLE} description={CREDITS_DESCRIPTION} fullHeight>
+      <div className="not-prose flex flex-col gap-14 md:gap-20">
+        {CREDITS_GROUPS.map((group) => (
+          <ContributorGroup key={group.title} group={group} />
+        ))}
+      </div>
+    </ProsePage>
+  );
+}
+
+function ContributorGroup({ group }: { group: CreditsGroup }) {
+  return (
+    <section>
+      <h2 className="text-fd-muted-foreground text-base font-extralight">{group.title}</h2>
+      <ul className="mt-6 flex flex-wrap gap-x-10 gap-y-5">
+        {group.contributors.map((contributor) => (
+          <li key={contributor.name}>
+            <ContributorItem contributor={contributor} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function ContributorItem({ contributor }: { contributor: Contributor }) {
+  const { name, koreanName, link } = contributor;
+
+  const body = (
+    <>
+      <span className="text-fd-foreground text-xl font-medium tracking-tight md:text-2xl">
+        {name}
+      </span>
+      {koreanName ? (
+        <span className="text-fd-muted-foreground ml-2 text-xs font-light">{koreanName}</span>
+      ) : null}
+    </>
+  );
+
+  if (link) {
+    return (
+      <a
+        href={link}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="hover:text-fd-muted-foreground transition-colors"
+      >
+        {body}
+      </a>
+    );
+  }
+
+  return <div>{body}</div>;
+}
+
+export function generateMetadata(): Metadata {
+  return buildSeoMetadata({
+    title: CREDITS_TITLE,
+    description: CREDITS_DESCRIPTION,
+  });
+}

--- a/docs/components/layout/lib/credits-content.ts
+++ b/docs/components/layout/lib/credits-content.ts
@@ -1,0 +1,58 @@
+/**
+ * /credits 페이지의 기여자 명단 데이터.
+ * 명단·문구 변경은 이 파일에서만 한다(프레젠테이션은 app/credits/).
+ *
+ * 표기는 사내 호칭을 그대로 쓴다. `koreanName`·`link`는 본인이 원할 때만 채우는
+ * 옵셔널 필드다 — 표기 방식을 기여자 재량에 맡기는 건 Vue 팀 페이지나
+ * All Contributors 스펙과 같은 관습이다. 커밋 기록이 없는 기여자(디자이너 등)가
+ * 명단에 포함되므로 이 목록은 git log에서 생성할 수 없고, 수동으로 관리한다.
+ *
+ * **배열 순서가 곧 표시 순서이며, 기준은 디자인 시스템 팀 합류 순서다.**
+ * 입사일과는 일치하지 않으므로(입사가 빨라도 팀 합류가 늦을 수 있다) 자동 정렬하지 않는다.
+ * 새 사람은 합류 시점에 해당하는 위치에 끼워 넣는다.
+ */
+
+export interface Contributor {
+  /** 표시 이름. 사내 호칭 그대로 쓴다. */
+  name: string;
+  /** 한국어 이름. 본명은 개인정보라 본인 동의를 받은 경우에만 채운다 — 없으면 렌더하지 않는다. */
+  koreanName?: string;
+  /** GitHub·개인 사이트 등. 없으면 이름만 렌더한다. */
+  link?: string;
+}
+
+export interface CreditsGroup {
+  title: string;
+  contributors: Contributor[];
+}
+
+export const CREDITS_TITLE = "Credits";
+export const CREDITS_DESCRIPTION = "SEED는 이 사람들의 손을 거쳐 자랐어요.";
+
+/** 현재 SEED를 유지보수하고 있는 사람들. */
+const MAINTAINERS: Contributor[] = [
+  { name: "June.jung", koreanName: "정현수" },
+  { name: "Max.kim", koreanName: "김동규" },
+  { name: "Lucas", koreanName: "신현성" },
+  { name: "Tyler.joo", koreanName: "주찬휘" },
+  { name: "Minnie.kim", koreanName: "김민효" },
+  { name: "Zen", koreanName: "김지수" },
+  { name: "Tony.kim", koreanName: "김주성" },
+  { name: "Antonio", koreanName: "정승원" },
+  { name: "Owen.lee", koreanName: "이건우" },
+  { name: "Ette", koreanName: "이찬희" },
+];
+
+/** 재직 중이지만 현재 유지보수에 참여하지 않는 사람 + 제작에 도움을 준 사람. */
+const CONTRIBUTORS: Contributor[] = [
+  { name: "Tony", koreanName: "원지혁" },
+  { name: "Journy", koreanName: "김지현" },
+  { name: "Iseo", koreanName: "박이서" },
+  { name: "Dion", koreanName: "국도연" },
+  { name: "Hiko", koreanName: "박시은" },
+];
+
+export const CREDITS_GROUPS: CreditsGroup[] = [
+  { title: "Maintainers", contributors: MAINTAINERS },
+  { title: "Contributors", contributors: CONTRIBUTORS },
+];

--- a/docs/components/layout/lib/credits-content.ts
+++ b/docs/components/layout/lib/credits-content.ts
@@ -1,24 +1,6 @@
-/**
- * /credits 페이지의 기여자 명단 데이터.
- * 명단·문구 변경은 이 파일에서만 한다(프레젠테이션은 app/credits/).
- *
- * 표기는 사내 호칭을 그대로 쓴다. `koreanName`·`link`는 본인이 원할 때만 채우는
- * 옵셔널 필드다 — 표기 방식을 기여자 재량에 맡기는 건 Vue 팀 페이지나
- * All Contributors 스펙과 같은 관습이다. 커밋 기록이 없는 기여자(디자이너 등)가
- * 명단에 포함되므로 이 목록은 git log에서 생성할 수 없고, 수동으로 관리한다.
- *
- * **배열 순서가 곧 표시 순서이며, 기준은 디자인 시스템 팀 합류 순서다.**
- * 입사일과는 일치하지 않으므로(입사가 빨라도 팀 합류가 늦을 수 있다) 자동 정렬하지 않는다.
- * 새 사람은 합류 시점에 해당하는 위치에 끼워 넣는다.
- */
-
 export interface Contributor {
-  /** 표시 이름. 사내 호칭 그대로 쓴다. */
   name: string;
-  /** 한국어 이름. 본명은 개인정보라 본인 동의를 받은 경우에만 채운다 — 없으면 렌더하지 않는다. */
   koreanName?: string;
-  /** GitHub·개인 사이트 등. 없으면 이름만 렌더한다. */
-  link?: string;
 }
 
 export interface CreditsGroup {
@@ -29,7 +11,6 @@ export interface CreditsGroup {
 export const CREDITS_TITLE = "Credits";
 export const CREDITS_DESCRIPTION = "SEED는 이 사람들의 손을 거쳐 자랐어요.";
 
-/** 현재 SEED를 유지보수하고 있는 사람들. */
 const MAINTAINERS: Contributor[] = [
   { name: "June.jung", koreanName: "정현수" },
   { name: "Max.kim", koreanName: "김동규" },
@@ -43,7 +24,6 @@ const MAINTAINERS: Contributor[] = [
   { name: "Ette", koreanName: "이찬희" },
 ];
 
-/** 재직 중이지만 현재 유지보수에 참여하지 않는 사람 + 제작에 도움을 준 사람. */
 const CONTRIBUTORS: Contributor[] = [
   { name: "Tony", koreanName: "원지혁" },
   { name: "Journy", koreanName: "김지현" },

--- a/docs/components/layout/lib/footer-content.ts
+++ b/docs/components/layout/lib/footer-content.ts
@@ -45,6 +45,7 @@ export const FOOTER_MENU: FooterLink[] = [
 export const FOOTER_MORE: FooterLink[] = [
   { label: "Breeze", href: "/breeze" },
   { label: "Migration", href: "/docs/migration/migration-reference" },
+  { label: "Credits", href: "/credits" },
   { label: "GitHub", href: "https://github.com/daangn/seed-design", external: true },
 ];
 

--- a/docs/components/layout/prose-page.tsx
+++ b/docs/components/layout/prose-page.tsx
@@ -11,11 +11,6 @@ interface ProsePageProps {
   children: ReactNode;
   /** 하단 사이트 footer 표시 (기본 true) */
   footer?: boolean;
-  /**
-   * 본문이 짧아도 footer를 첫 화면 밖으로 밀어낸다(기본 false).
-   * min-height는 footer를 뺀 제목+본문 영역에만 건다 — main 전체에 걸면 footer 높이가
-   * 이미 그 값을 채워버려서 아무 효과가 없다.
-   */
   fullHeight?: boolean;
 }
 
@@ -38,7 +33,6 @@ export function ProsePage({
     <div className="[grid-area:main] w-full px-4 py-10 md:px-6 md:py-16 xl:px-8">
       {hero ? <div className="mb-10 w-full md:mb-14">{hero}</div> : null}
       <div className="mx-auto w-full max-w-[1100px]">
-        {/* 사이트 헤더(64px)와 main 상단 패딩(40/64px)을 뺀 높이 — footer가 첫 화면 경계에 걸린다. */}
         <div
           className={clsx(fullHeight && "min-h-[calc(100dvh-104px)] md:min-h-[calc(100dvh-128px)]")}
         >

--- a/docs/components/layout/prose-page.tsx
+++ b/docs/components/layout/prose-page.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import { DocsBody } from "fumadocs-ui/page";
 import type { ReactNode } from "react";
 import { SiteFooter } from "./site-footer";
@@ -10,34 +11,52 @@ interface ProsePageProps {
   children: ReactNode;
   /** 하단 사이트 footer 표시 (기본 true) */
   footer?: boolean;
+  /**
+   * 본문이 짧아도 footer를 첫 화면 밖으로 밀어낸다(기본 false).
+   * min-height는 footer를 뺀 제목+본문 영역에만 건다 — main 전체에 걸면 footer 높이가
+   * 이미 그 값을 채워버려서 아무 효과가 없다.
+   */
+  fullHeight?: boolean;
 }
 
 /**
- * 사이드바 없는 1컬럼 섹션(get-started, updates)용 콘텐츠 셸.
+ * 사이드바 없는 1컬럼 섹션(get-started, updates, credits)용 콘텐츠 셸.
  * - `[grid-area:main]`을 점유하고 좌우 패딩을 헤더(px-4/6/8)와 맞춘다.
  * - `hero` 슬롯: main 컬럼 전체폭까지 넓게(하이라이트 에셋용).
  * - 제목/본문/footer: 가독성을 위해 1100px로 중앙 정렬.
  * 톤은 OverviewLayout과 맞춘다(DocsBody prose 재사용).
  */
-export function ProsePage({ title, description, hero, children, footer = true }: ProsePageProps) {
+export function ProsePage({
+  title,
+  description,
+  hero,
+  children,
+  footer = true,
+  fullHeight = false,
+}: ProsePageProps) {
   return (
     <div className="[grid-area:main] w-full px-4 py-10 md:px-6 md:py-16 xl:px-8">
       {hero ? <div className="mb-10 w-full md:mb-14">{hero}</div> : null}
       <div className="mx-auto w-full max-w-[1100px]">
-        <header className="not-prose mb-10 md:mb-14">
-          {/* get-started/updates 제목 스케일: text-3xl→md:text-[40px] (데스크탑 40px 고정). */}
-          <h1 className="text-fd-foreground text-3xl font-medium tracking-tight text-balance md:text-[40px]">
-            {title}
-          </h1>
-          {description ? (
-            <p className="text-fd-muted-foreground mt-4 text-base font-light text-pretty">
-              {description}
-            </p>
-          ) : null}
-        </header>
-        <DocsBody className="max-w-none prose-p:break-keep prose-p:text-pretty prose-headings:text-balance">
-          {children}
-        </DocsBody>
+        {/* 사이트 헤더(64px)와 main 상단 패딩(40/64px)을 뺀 높이 — footer가 첫 화면 경계에 걸린다. */}
+        <div
+          className={clsx(fullHeight && "min-h-[calc(100dvh-104px)] md:min-h-[calc(100dvh-128px)]")}
+        >
+          <header className="not-prose mb-10 md:mb-14">
+            {/* get-started/updates 제목 스케일: text-3xl→md:text-[40px] (데스크탑 40px 고정). */}
+            <h1 className="text-fd-foreground text-3xl font-medium tracking-tight text-balance md:text-[40px]">
+              {title}
+            </h1>
+            {description ? (
+              <p className="text-fd-muted-foreground mt-4 text-base font-light text-pretty">
+                {description}
+              </p>
+            ) : null}
+          </header>
+          <DocsBody className="max-w-none prose-p:break-keep prose-p:text-pretty prose-headings:text-balance">
+            {children}
+          </DocsBody>
+        </div>
         {footer ? <SiteFooter /> : null}
       </div>
     </div>


### PR DESCRIPTION
문서 사이트에 `/credits` 페이지를 추가하고 footer의 More 열에 링크를 연결했습니다.

## 변경

- `app/credits/` — 사이드바·ToC 없는 중앙 1컬럼 페이지 (`ProsePage` 재사용, `force-static`)
- `components/layout/lib/credits-content.ts` — 명단 데이터. 표시 순서는 배열 순서를 그대로 따르고 런타임 정렬을 두지 않았습니다
- `components/layout/prose-page.tsx` — `fullHeight` prop 추가. 본문이 짧은 페이지에서 footer가 첫 화면 안으로 올라오지 않도록, footer를 뺀 영역에만 `min-height`를 겁니다
- `components/layout/lib/footer-content.ts` — More 열에 링크 한 줄

## 참고

`fullHeight`의 `min-height`는 제목+본문 래퍼에만 겁니다. main 전체에 걸면 footer 높이가 이미 그 값을 채워버려서 아무 효과가 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 기여자·유지보수자 정보를 섹션별로 확인할 수 있는 Credits 페이지를 추가했습니다.
  - 기여자 이름과 한글 이름(있는 경우)을 함께 노출합니다.
  - 문서 검색 대화상자 연동 및 정적 렌더링으로 Credits 콘텐츠를 제공합니다.
- **개선 사항**
  - 푸터 “More” 메뉴에서 Credits로 바로 이동할 수 있게 했습니다.
  - 콘텐츠 페이지에서 전체 높이 레이아웃 옵션을 지원해 화면 구성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->