### PR TITLE
docs: update credits contributor list

### DIFF
--- a/docs/components/layout/lib/credits-content.ts
+++ b/docs/components/layout/lib/credits-content.ts
@@ -17,7 +17,6 @@ const MAINTAINERS: Contributor[] = [
   { name: "Lucas", koreanName: "신현성" },
   { name: "Tyler.joo", koreanName: "주찬휘" },
   { name: "Minnie.kim", koreanName: "김민효" },
-  { name: "Zen", koreanName: "김지수" },
   { name: "Tony.kim", koreanName: "김주성" },
   { name: "Antonio", koreanName: "정승원" },
   { name: "Owen.lee", koreanName: "이건우" },
@@ -27,6 +26,9 @@ const MAINTAINERS: Contributor[] = [
 const CONTRIBUTORS: Contributor[] = [
   { name: "Tony", koreanName: "원지혁" },
   { name: "Journy", koreanName: "김지현" },
+  { name: "Ray", koreanName: "오강훈" },
+  { name: "Zen", koreanName: "김지수" },
+  { name: "Gina", koreanName: "조은진" },
   { name: "Iseo", koreanName: "박이서" },
   { name: "Dion", koreanName: "국도연" },
   { name: "Hiko", koreanName: "박시은" },


### PR DESCRIPTION
## Summary

Credits 페이지의 기여자 목록을 업데이트합니다.

- Zen(김지수)을 Maintainers에서 Contributors로 이동
- Contributors에 Ray(오강훈), Gina(조은진) 추가

최종 Contributors 순서: Tony → Journy → Ray → Zen → Gina → Iseo → Dion → Hiko

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
  - 크레딧의 MAINTAINERS 목록에서 Zen 항목을 제거했습니다.
  - CONTRIBUTORS 목록에 Ray, Zen, Gina 항목을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->