### PR TITLE
docs: add Tim to credits contributor list

### DIFF
--- a/docs/components/layout/lib/credits-content.ts
+++ b/docs/components/layout/lib/credits-content.ts
@@ -25,6 +25,7 @@ const MAINTAINERS: Contributor[] = [
 
 const CONTRIBUTORS: Contributor[] = [
   { name: "Tony", koreanName: "원지혁" },
+  { name: "Tim", koreanName: "김혜성" },
   { name: "Journy", koreanName: "김지현" },
   { name: "Ray", koreanName: "오강훈" },
   { name: "Zen", koreanName: "김지수" },


### PR DESCRIPTION
## 변경 사항

Credits 페이지 CONTRIBUTORS 목록에 Tim(김혜성)을 Tony 다음에 추가했습니다.

## 확인

- `bun docs:test` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 크레딧의 기여자 목록에 신규 기여자 Tim(김혜성)을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->