### PR TITLE
fix(stackflow): clear stale styles when animate:false pop skips exit-active

### DIFF
--- a/.changeset/quiet-layers-settle.md
+++ b/.changeset/quiet-layers-settle.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/stackflow": patch
+---
+
+`pop({ animate: false })` 로 화면을 닫았을 때 다시 드러난 화면이 왼쪽으로 밀린 채 고정되던 문제를 수정합니다.

--- a/examples/stackflow-spa/src/activities/ActivityAnimateFalseTest.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityAnimateFalseTest.tsx
@@ -1,0 +1,191 @@
+import { VStack } from "@seed-design/react";
+import { IconHouseLine } from "@karrotmarket/react-monochrome-icon";
+import { useFlow, useStack, type StaticActivityComponentType } from "@stackflow/react/future";
+import { useEffect, useState } from "react";
+import { ActionButton } from "seed-design/ui/action-button";
+import {
+  AppBar,
+  AppBarBackButton,
+  AppBarIconButton,
+  AppBarLeft,
+  AppBarMain,
+  AppBarRight,
+} from "seed-design/ui/app-bar";
+import { AppScreen, AppScreenContent } from "seed-design/ui/app-screen";
+
+declare module "@stackflow/config" {
+  interface Register {
+    ActivityAnimateFalseTest: Record<string, never>;
+  }
+}
+
+/**
+ * `animate: false` 와 애니메이션 전환을 섞어 쓸 때의 두 가지 증상을 눈으로 검증하는 테스트 액티비티.
+ *
+ * - **시나리오 A (수정됨)**: 애니메이션 `push` → `pop({ animate: false })`.
+ *   착지 화면이 `-30%` 에 고정되던 버그. 지금은 정상 위치로 돌아와야 한다.
+ * - **시나리오 B (수정 대상 아님)**: `push({ animate: false })` → 애니메이션 `pop()`.
+ *   뒤 화면이 idle 자세(`-30%`)로 안 들어가지만, pop 애니메이션의 첫 키프레임이 `-30%` 라
+ *   즉시 덮어쓴다. 프레임 단위로 재보면 top 이 아직 `x=0`(전체를 가림)인 동안 교정이
+ *   끝나고, top 이 실제로 움직이기 시작하는 프레임부터는 정상 케이스와 궤적이 같다.
+ *   즉 DOM 상태 불일치일 뿐 화면에는 드러나지 않는다.
+ *
+ * 두 경우 모두 `animate: false` 가 코어의 enter-active/exit-active 단계를 건너뛰기 때문에
+ * 생긴다. 차이는 A 는 되돌릴 애니메이션이 아예 없어 영구히 남고, B 는 다음 애니메이션이
+ * 스스로 교정한다는 점이다. 아래 "DOM 실시간" 패널이 실제 인라인 transform 을 그대로
+ * 보여주므로, 눈으로 판정하지 않고 값으로 확인할 수 있다.
+ */
+
+const BEHIND_OFFSET = "translate3d(-30%, 0, 0)";
+
+/** 현재 최상단/바로 뒤 액티비티 layer 의 인라인 transform 을 폴링해서 읽는다. */
+function useLayerTransforms() {
+  const [transforms, setTransforms] = useState({ top: "", behind: "" });
+
+  useEffect(() => {
+    const read = () => {
+      const activities = Array.from(
+        document.querySelectorAll<HTMLElement>("[data-part='activity']"),
+      );
+      const topIndex = activities.findIndex((el) => el.dataset["activityIsTop"] !== undefined);
+      const layerOf = (el: HTMLElement | undefined) =>
+        el?.querySelector<HTMLElement>("[data-part='layer']")?.style.transform ?? "";
+
+      setTransforms({
+        top: layerOf(activities[topIndex]),
+        behind: topIndex > 0 ? layerOf(activities[topIndex - 1]) : "",
+      });
+    };
+
+    read();
+    const timer = setInterval(read, 100);
+    return () => clearInterval(timer);
+  }, []);
+
+  return transforms;
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  const isOffset = value === BEHIND_OFFSET;
+  return (
+    <div style={{ display: "flex", gap: 8, alignItems: "baseline", fontSize: 13 }}>
+      <span style={{ color: "#868b94", minWidth: 96 }}>{label}</span>
+      <code
+        style={{
+          fontFamily: "ui-monospace, monospace",
+          color: isOffset ? "#e8433f" : "#0a840a",
+          fontWeight: 600,
+        }}
+      >
+        {value === "" ? "(없음 — 기본 위치)" : value}
+      </code>
+    </div>
+  );
+}
+
+const ActivityAnimateFalseTest: StaticActivityComponentType<"ActivityAnimateFalseTest"> = () => {
+  const { push, pop } = useFlow();
+  const stack = useStack();
+  const transforms = useLayerTransforms();
+
+  // 배경 액티비티는 stack 변경 시 다시 렌더링되지 않아 라이브 값이 stale 해진다.
+  // mount 시점의 깊이를 고정해 표시한다 (이 화면이 top일 때 항상 현재 깊이와 같다).
+  const [depth] = useState(
+    () =>
+      stack?.activities.filter((activity) => !activity.transitionState.startsWith("exit")).length ??
+      0,
+  );
+
+  return (
+    // 이 버그는 iOS slide 전용이다. 예제 앱의 theme 은 UA 기반이라 데스크톱 브라우저에선
+    // android 로 잡히므로, 어디서 열어도 재현되도록 transitionStyle 을 고정한다.
+    <AppScreen transitionStyle="slideFromRightIOS">
+      <AppBar>
+        <AppBarLeft>
+          <AppBarBackButton />
+        </AppBarLeft>
+        <AppBarMain>animate: false Test</AppBarMain>
+        <AppBarRight>
+          <AppBarIconButton aria-label="Home" onClick={() => push("ActivityHome", {})}>
+            <IconHouseLine />
+          </AppBarIconButton>
+        </AppBarRight>
+      </AppBar>
+      <AppScreenContent>
+        {/* 화면 폭을 꽉 채우는 띠. 레이어가 -30% 밀리면 오른쪽에 컨테이너 배경이 드러난다. */}
+        <div
+          style={{
+            height: 8,
+            background: "repeating-linear-gradient(90deg, #ff6f0f 0 24px, #ffd8b8 24px 48px)",
+          }}
+        />
+        <VStack gap="x6" p="x5">
+          <VStack gap="x1">
+            <div style={{ fontSize: 56, fontWeight: 700, lineHeight: 1 }}>깊이 {depth}</div>
+            <div style={{ fontSize: 15, color: "#868b94" }}>
+              위 줄무늬 띠가 화면 오른쪽 끝까지 닿아 있으면 정상입니다.
+            </div>
+          </VStack>
+
+          <VStack
+            gap="x2"
+            style={{ background: "#f7f8f9", borderRadius: 12, padding: 16 }}
+            aria-live="polite"
+          >
+            <div style={{ fontSize: 13, fontWeight: 700 }}>DOM 실시간 (layer transform)</div>
+            <Row label="최상단" value={transforms.top} />
+            <Row label="바로 뒤" value={transforms.behind} />
+            <div style={{ fontSize: 12, color: "#868b94", lineHeight: 1.5 }}>
+              최상단이 <code>{BEHIND_OFFSET}</code> 이면 버그입니다. 바로 뒤가 그 값인 것은 iOS
+              패럴랙스의 정상 idle 자세입니다.
+            </div>
+          </VStack>
+
+          <VStack gap="x3">
+            <div style={{ fontSize: 15, fontWeight: 700 }}>시나리오 A — 이번에 고친 버그</div>
+            <div style={{ fontSize: 13, color: "#868b94", lineHeight: 1.6 }}>
+              ① 아래 <b>애니메이션 push</b> → ② 다음 화면에서 <b>pop(animate: false)</b>.
+              <br />
+              돌아온 화면이 왼쪽으로 밀려 있지 않고, "최상단"이 <code>(없음)</code> 이면 정상입니다.
+            </div>
+            <ActionButton size="large" onClick={() => push("ActivityAnimateFalseTest", {})}>
+              ① push (애니 O)
+            </ActionButton>
+            <ActionButton
+              size="large"
+              variant="neutralSolid"
+              onClick={() => pop({ animate: false })}
+            >
+              ② pop (animate: false)
+            </ActionButton>
+          </VStack>
+
+          <VStack gap="x3">
+            <div style={{ fontSize: 15, fontWeight: 700 }}>
+              시나리오 B — DOM 불일치 (화면엔 안 드러남)
+            </div>
+            <div style={{ fontSize: 13, color: "#868b94", lineHeight: 1.6 }}>
+              ① 아래 <b>push(animate: false)</b> → 이 시점에 "바로 뒤"가 <code>(없음)</code> 입니다.{" "}
+              <code>{BEHIND_OFFSET}</code> 이어야 정상이에요.
+              <br />② 다음 화면에서 <b>애니메이션 pop</b>. <b>화면은 정상으로 보입니다</b> — pop
+              애니메이션의 첫 키프레임이 <code>{BEHIND_OFFSET}</code> 라서 잘못된 값을 즉시
+              덮어쓰고, 그 교정이 뒤 화면이 아직 top 에 완전히 가려진 동안 끝나거든요.
+              <br />A 와 달리 <b>다음 애니메이션이 스스로 교정</b>하므로 수정 대상이 아닙니다.
+            </div>
+            <ActionButton
+              size="large"
+              onClick={() => push("ActivityAnimateFalseTest", {}, { animate: false })}
+            >
+              ① push (animate: false)
+            </ActionButton>
+            <ActionButton size="large" variant="neutralSolid" onClick={() => pop()}>
+              ② pop (애니 O)
+            </ActionButton>
+          </VStack>
+        </VStack>
+      </AppScreenContent>
+    </AppScreen>
+  );
+};
+
+export default ActivityAnimateFalseTest;

--- a/examples/stackflow-spa/src/activities/ActivityHome.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityHome.tsx
@@ -85,6 +85,10 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
       items: [
         { title: "Pop Test (중복 pop 가드)", onClick: () => push("ActivityPopTest", {}) },
         {
+          title: "animate: false Test (밀림 버그)",
+          onClick: () => push("ActivityAnimateFalseTest", {}),
+        },
+        {
           title: `Push to here (current activityIndex: ${activityIndex})`,
           onClick: () => push("ActivityHome", {}),
         },

--- a/examples/stackflow-spa/src/stackflow/Stack.tsx
+++ b/examples/stackflow-spa/src/stackflow/Stack.tsx
@@ -40,6 +40,7 @@ export const { Stack, actions, stepActions } = stackflow({
     ActivityActionButton: lazy(() => import("../activities/ActivityActionButton")),
     ActivityAppBarSlot: lazy(() => import("../activities/ActivityAppBarSlot")),
     ActivityAlertDialog: lazy(() => import("../activities/ActivityAlertDialog")),
+    ActivityAnimateFalseTest: lazy(() => import("../activities/ActivityAnimateFalseTest")),
     ActivityAlertDialogActivity: lazy(() => import("../activities/ActivityAlertDialogActivity")),
     ActivityAlertDialogStep: lazy(() => import("../activities/ActivityAlertDialogStep")),
     ActivityAnimatedTabs: lazy(() => import("../activities/ActivityAnimatedTabs")),

--- a/examples/stackflow-spa/src/stackflow/stackflow.config.ts
+++ b/examples/stackflow-spa/src/stackflow/stackflow.config.ts
@@ -7,6 +7,7 @@ export const config = defineConfig({
     { route: "/", name: "ActivityHome" },
     { route: "/404", name: "ActivityNotFound" },
     { route: "/pop-test", name: "ActivityPopTest" },
+    { route: "/animate-false-test", name: "ActivityAnimateFalseTest" },
     { route: "/accordion", name: "ActivityAccordion" },
     { route: "/action-button", name: "ActivityActionButton" },
     { route: "/app-bar-slot", name: "ActivityAppBarSlot" },

--- a/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.test.tsx
+++ b/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.test.tsx
@@ -1,0 +1,159 @@
+import { aggregate, makeEvent, type DomainEvent, type Stack } from "@stackflow/core";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { appBarAnatomy } from "../AppBar/anatomy";
+import { appScreenAnatomy } from "../AppScreen/anatomy";
+
+// `useGlobalInteraction` (and the `useTopActivity` it calls) only consume
+// `useStack` from @stackflow/react. Mocking just that lets the test feed real
+// Stack snapshots — built by @stackflow/core's own reducer — without pulling in
+// a renderer plugin. Registered before the dynamic import below so the hook
+// picks it up.
+let currentStack: Stack;
+mock.module("@stackflow/react", () => ({ useStack: () => currentStack }));
+
+const { useGlobalInteraction } = await import("./useGlobalInteraction");
+const { findTransitionTargets, setIdlePositions } = await import("./dom");
+
+// happy-dom ships no WAAPI. A `finished` that never settles models an
+// animation that is still in flight, which is all these tests need.
+Element.prototype.animate = (() => ({
+  finished: new Promise<void>(() => {}),
+  cancel() {},
+})) as Element["animate"];
+
+// ─── Real stack snapshots ───────────────────────────────────────────────────
+
+const T0 = 1_000_000;
+const TRANSITION_DURATION = 350;
+
+/** Zero-padded so the reducer's lexicographic sort by id matches insertion order. */
+function evt<T extends DomainEvent["name"]>(
+  seq: number,
+  name: T,
+  params: Omit<Extract<DomainEvent, { name: T }>, "id" | "name" | "eventDate">,
+) {
+  return makeEvent(name, {
+    ...params,
+    id: String(seq).padStart(4, "0"),
+    eventDate: T0 + seq,
+  });
+}
+
+const BASE_EVENTS: DomainEvent[] = [
+  evt(1, "Initialized", { transitionDuration: TRANSITION_DURATION }),
+  evt(2, "ActivityRegistered", { activityName: "Screen" }),
+  evt(3, "Pushed", { activityId: "a1", activityName: "Screen", activityParams: {} }),
+  evt(4, "Pushed", { activityId: "a2", activityName: "Screen", activityParams: {} }),
+];
+
+/** Far enough past every eventDate that both pushes have settled. */
+const SETTLED_AT = T0 + TRANSITION_DURATION * 10;
+
+const POP_SEQ = 5;
+
+function stackAfter(...extraEvents: DomainEvent[]): Stack {
+  return aggregate([...BASE_EVENTS, ...extraEvents], SETTLED_AT);
+}
+
+/** `pop({ animate: false })` — stackflow maps it to `skipExitActiveState`. */
+const POP_WITHOUT_ANIMATION = evt(POP_SEQ, "Popped", { skipExitActiveState: true });
+
+/** A plain animated `pop()`, still mid-flight at `SETTLED_AT`. */
+const POP_WITH_ANIMATION = makeEvent("Popped", {
+  id: String(POP_SEQ).padStart(4, "0"),
+  eventDate: SETTLED_AT,
+});
+
+// ─── Harness ────────────────────────────────────────────────────────────────
+
+function ActivityMarkup({ id, isTop }: { id: string; isTop: boolean }) {
+  return (
+    <section
+      data-part={appScreenAnatomy.activity}
+      data-activity-id={id}
+      data-transition-style="slideFromRightIOS"
+      {...(isTop ? { "data-activity-is-top": "" } : {})}
+    >
+      <div data-part={appScreenAnatomy.layer} data-testid={`${id}-layer`} />
+      <div data-part={appScreenAnatomy.dim} />
+      <div data-part={appBarAnatomy.root}>
+        <div data-part={appBarAnatomy.background} />
+        <div data-part={appBarAnatomy.main} data-testid={`${id}-title`} />
+        <div data-part={appBarAnatomy.icon} data-testid={`${id}-icon`} />
+      </div>
+    </section>
+  );
+}
+
+function Harness() {
+  const { stackRef } = useGlobalInteraction();
+
+  // Mirrors the core's `visibleActivities` filter — exit-done is unmounted.
+  const visible = currentStack.activities.filter((a) => a.transitionState !== "exit-done");
+
+  return (
+    <div ref={stackRef} data-testid="stack">
+      {visible.map((activity) => (
+        <ActivityMarkup key={activity.id} id={activity.id} isTop={activity.isTop} />
+      ))}
+    </div>
+  );
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("useGlobalInteraction — settle safety-net", () => {
+  beforeEach(() => {
+    currentStack = stackAfter();
+  });
+
+  it("leaves the behind layer pinned at its idle offset while a2 is on top", () => {
+    // Premise check: a settled push is idle, with a2 on top.
+    expect(currentStack.globalTransitionState).toBe("idle");
+    expect(currentStack.activities.find((a) => a.isTop)?.id).toBe("a2");
+
+    const { getByTestId, rerender } = render(<Harness />);
+
+    // Exactly what the push's finished handler leaves behind.
+    setIdlePositions(findTransitionTargets(getByTestId("stack")), "slideFromRightIOS");
+    rerender(<Harness />);
+
+    expect(getByTestId("a1-layer").style.transform).toBe("translate3d(-30%, 0, 0)");
+  });
+
+  it("clears the landing activity when pop({ animate: false }) skips exit-active", () => {
+    const { getByTestId, rerender } = render(<Harness />);
+    setIdlePositions(findTransitionTargets(getByTestId("stack")), "slideFromRightIOS");
+
+    currentStack = stackAfter(POP_WITHOUT_ANIMATION);
+
+    // Premise: the transition state machine never moves — a1 just becomes top.
+    expect(currentStack.globalTransitionState).toBe("idle");
+    expect(currentStack.activities.find((a) => a.isTop)?.id).toBe("a1");
+
+    rerender(<Harness />);
+
+    expect(getByTestId("a1-layer").style.transform).toBe("");
+    expect(getByTestId("a1-title").style.transform).toBe("");
+    expect(getByTestId("a1-title").style.opacity).toBe("");
+    expect(getByTestId("a1-icon").style.opacity).toBe("");
+  });
+
+  it("does not touch inline styles while a transition is still in flight", () => {
+    const { getByTestId, rerender } = render(<Harness />);
+    setIdlePositions(findTransitionTargets(getByTestId("stack")), "slideFromRightIOS");
+
+    currentStack = stackAfter(POP_WITH_ANIMATION);
+
+    // Premise: an animated pop parks a2 in exit-active, so the stack is loading.
+    expect(currentStack.globalTransitionState).toBe("loading");
+    expect(currentStack.activities.find((a) => a.id === "a2")?.transitionState).toBe("exit-active");
+
+    rerender(<Harness />);
+
+    // The WAAPI pop animation owns the unwind from here — the safety-net must
+    // stay out of the way until everything settles.
+    expect(getByTestId("a1-layer").style.transform).toBe("translate3d(-30%, 0, 0)");
+  });
+});

--- a/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/useGlobalInteraction.ts
@@ -341,13 +341,22 @@ export function useGlobalInteraction() {
   // top must always be in a clean default state. Wipe all leftover inline
   // styles from the top activity — the behind is left untouched (stays at
   // -30%), this only runs at idle, and it's a no-op if already clean.
+  //
+  // Keyed on the top activity too, not just globalTransitionState: an
+  // `animate: false` navigation makes the core skip the enter-active /
+  // exit-active phase entirely, so globalTransitionState never leaves "idle"
+  // and a state-only dependency would never re-run. That is how a behind
+  // layer became the top while still pinned at -30%.
+  const topActivityId = stack?.activities.find((activity) => activity.isTop)?.id;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: topActivityId is a trigger, not a value read here — clearTopActivityStyles re-queries the DOM
   useLayoutEffect(() => {
     if (stack?.globalTransitionState !== "idle") return;
     const stackEl = stackRef.current;
     if (stackEl) {
       clearTopActivityStyles(stackEl);
     }
-  }, [stack?.globalTransitionState]);
+  }, [stack?.globalTransitionState, topActivityId]);
 
   // Cancel any pending push rAF and running animations on unmount so
   // late-firing finished handlers can't run against a torn-down stack.


### PR DESCRIPTION
## 문제

애니메이션이 있는 `push` 로 화면을 띄운 뒤 `pop({ animate: false })` 로 닫으면, 다시 드러난 화면이 왼쪽으로 화면 폭의 30% 밀린 자리에 **영구히 고정**됩니다.

실기기 DOM 확인 결과, 최상단 액티비티에 "뒤 레이어" 스타일이 그대로 남아 있었습니다.

| 요소 | 남아 있는 인라인 스타일 |
|---|---|
| `[data-part="layer"]` | `transform: translate3d(-30%, 0px, 0px)` |
| `[data-part="appBarMain"]` | `opacity: 0; transform: translate3d(-25%, 0px, 0px)` |
| `[data-part="appBarIcon"]` | `opacity: 0` |

## 원인

`animate: false` 는 **애니메이션만 생략하는 게 아니라 코어 상태머신의 전환 단계를 통째로 건너뜁니다.**

1. `pop({ animate: false })` → `skipExitActiveState` → 코어 리듀서가 `exit-active` 없이 바로 `exit-done`
2. `globalTransitionState` 는 enter-active/exit-active 가 있을 때만 `loading` → **`idle` 에서 한 번도 안 벗어남**
3. `visibleActivities` 가 `exit-done` 을 제외 → 뒤 액티비티가 즉시 `isTop`

그래서 `useGlobalInteraction` 의 두 경로가 **조건문에서 걸러진 게 아니라, dep 값이 안 바뀌어 effect 자체가 재실행되지 않았습니다.**

| 경로 | dep | 값 변화 |
|---|---|---|
| 전환 effect | `topActivity.transitionState` | `enter-done` → `enter-done` (동일) |
| settle 안전망 | `globalTransitionState` | `idle` → `idle` (동일) |

핵심은 **`-30%` 가 덜 지워진 찌꺼기가 아니라는 점**입니다. `setIdlePositions` 가 뒤 레이어에 의도적으로 부여하는 iOS 패럴랙스 정지 자세이고, 이걸 되돌리는 유일한 주체가 pop 애니메이션이었습니다. 즉 진짜 문제는 "역할이 behind → top 으로 바뀌었는데 재분류하는 주체가 없다" 입니다.

## 수정

settle 안전망을 **최상단 액티비티 변경 자체**로도 트리거되게 합니다.

```ts
const topActivityId = stack?.activities.find((activity) => activity.isTop)?.id;
// ...
}, [stack?.globalTransitionState, topActivityId]);
```

`!== "idle"` 가드가 dep array 가 아니라 effect **본문 안**에 있으므로, dep 추가는 호출 횟수만 늘리고 `loading` 인 호출은 전부 첫 줄에서 early return 합니다. 실제 동작이 바뀌는 건 **직전에도 idle, 지금도 idle 인데 top 만 바뀐** 경우뿐이고, 그건 정의상 우리 전환 effect 도 안 돈 경우 = **진행 중인 WAAPI 애니메이션이 없는 시점**입니다.

<details>
<summary>회귀 검토 — 전체 케이스 열거</summary>

| 시나리오 | globalTransitionState | topId | 새로 도는가 |
|---|---|---|---|
| 애니 push (enter-active) | idle→**loading** | 바뀜 | 원래도 돌았음 (early return) |
| 애니 push 정착 | loading→**idle** | 그대로 | 원래도 돌았음 |
| 애니 pop (exit-active) | idle→**loading** | 그대로 | 원래도 돌았음 |
| 애니 pop 정착 | loading→**idle** | 바뀜 | 원래도 돌았음 |
| `pop(2)` / 동시 pop | loading 경유 | — | 원래도 돌았음 |
| 스와이프 `swiping`/`canceling` | **idle 유지** | **그대로** | dep 안 바뀜 |
| 스와이프 `completing` | `pop()` → **loading** | — | 원래도 돌았음 |
| step push/pop | idle 유지 | 그대로 | dep 안 바뀜 |
| **`pop({animate:false})`** | **idle→idle** | **바뀜** | **신규 — 이 PR 의 수정** |
| `push`/`replace({animate:false})` | idle→idle | 바뀜 | 신규 (새 top 은 빈 DOM → no-op) |

가장 걱정되는 스와이프백이 비껴갑니다. 손가락 추적 중에는 stackflow 이벤트가 안 나가 `topId` 가 안 바뀌고, 완료 시점엔 `pop()` 이 애니메이션 있는 pop 이라 `loading` 을 경유합니다.

</details>

## 검증

**유닛 테스트 3개** (`useGlobalInteraction.test.tsx`). `@stackflow/core` 의 순수 함수 `aggregate(events, now)` 로 **실제 Stack 스냅샷**을 만들어 훅에 먹이므로, 테스트 안의 전제 검증(`globalTransitionState === "idle"` 유지, top 이 바뀜)이 코어가 실제로 그렇게 동작한다는 증거가 됩니다.

| 테스트 | 역할 |
|---|---|
| behind 가 idle 에서 `-30%` 에 있음 | 전제 고정 |
| `pop({animate:false})` → 착지 화면 정리됨 | **수정** (수정 전 `translate3d(-30%, 0, 0)` 로 실패 확인) |
| `loading` 중엔 인라인 스타일 안 건드림 | 회귀 가드 |

**브라우저 실측** (`/animate-false-test`)

| 시점 | 뒤 레이어 |
|---|---|
| 애니 push 중 | `translate3d(0px, 0px, 0px)` |
| push 완료 | `translate3d(-30%, 0px, 0px)` ← 정상 idle 자세 |
| **`pop({animate:false})` 직후** | **빈 값** ← 수정 동작 |

**전체 스위트**: 484 → 487 pass, 실패 38 개 동일 (워크스페이스 패키지 미빌드로 인한 기존 실패, stash 후 baseline 실측 확인)

## 고치지 않은 것

`push({ animate: false })` 는 뒤 레이어에 `-30%` 대기 자세를 부여하지 않습니다. DOM 값은 틀려 있지만 **화면에는 드러나지 않아** 수정 대상에서 제외했습니다.

정상 케이스와 프레임 단위로 비교하면:

| 프레임 | 정상 (behind / top) | animate:false push (behind / top) |
|---|---|---|
| pop 직전 | −360 / **0** | **0** / **0** |
| frame 1 | −360 / **0** | **0** / **0** |
| frame 2 | −360 / **0** | **−360** / **0** |
| frame 3 | −354.2 / 19.2 | −354.1 / 19.6 |
| frame 4 이후 | \= | \= |

교정이 일어나는 frame 0~1 구간에서 top 이 계속 `x=0`(전체를 가림)이고, top 이 실제로 움직이기 시작하는 frame 3 부터는 두 궤적이 소수점까지 같습니다. 스와이프백도 `applySwipeStyles` 의 첫 프레임이 `calc(-30% + …)` 라 동일하게 가려진 채 교정됩니다.

**A 와의 차이는 복구 경로의 유무**입니다. A 는 되돌릴 애니메이션이 아예 없어 영구히 남고, 이쪽은 다음 애니메이션의 첫 키프레임이 스스로 교정합니다. 근거는 QA 액티비티와 소스 주석에 남겨뒀습니다.

## 직접 확인하기

QA 액티비티 `/animate-false-test` 를 별도 커밋으로 함께 넣었습니다. 두 시나리오를 재현하고, 인라인 `layer` transform 을 실시간 표시해 눈이 아니라 값으로 판정합니다. 예제 앱 theme 이 UA 기반이라 데스크톱에선 android 로 잡히므로, `transitionStyle` 을 `slideFromRightIOS` 로 고정했습니다.

Stackflow SPA 알파 프리뷰의 `/animate-false-test` 경로에서 바로 눌러보실 수 있습니다.

## 후속

`@seed-design/stackflow` **1.1 라인 백포트**가 필요합니다. 리포터가 1.1.24 를 쓰고 있고 2.0.2 까지 동일 코드라 버전을 올려 회피할 수 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 애니메이션 없이 화면을 닫은 뒤 다시 표시할 때 화면이 왼쪽으로 밀려 고정되는 문제를 수정했습니다.
  - 화면 전환 후 남아 있던 위치 스타일을 올바르게 정리해 정상적인 위치로 표시됩니다.

- **예제**
  - 애니메이션 없는 화면 닫기 동작을 재현하고 확인할 수 있는 테스트 화면을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
