### PR TITLE
docs: show which package version each component and hook shipped in

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -49,8 +49,8 @@ Lynx 컴포넌트 문서를 작성할 때는 **웹 버전과의 차이점을 반
 
 ## 콘텐츠 작성 룰 (`content/`)
 
-- 컴포넌트/훅 문서를 신설하면 frontmatter 직후에 "추가된 버전" 불렛을 넣는다.
-  - 형식: `` - `@seed-design/react@2.1.0`, `@seed-design/css@2.3.0`부터 사용할 수 있습니다. ``
+- 컴포넌트/훅 문서를 신설하면 frontmatter 직후에 `<AvailableSince />`를 넣는다.
+  - 형식: `<AvailableSince packages="@seed-design/react@2.1.0, @seed-design/css@2.3.0" />` (콤마로 구분)
   - 패키지 매핑: react components → react + css / react stackflow → stackflow + css / lynx components → lynx-react + lynx-css / lynx hooks → lynx-react
   - 버전은 **그 항목이 처음 사용 가능해진 버전**이다. 새로 만드는 컴포넌트/훅이면 그게 곧 문서와 함께 나갈 다음 릴리스(현재 버전 + changeset bump)이고, 이미 릴리스된 항목의 문서를 뒤늦게 추가하는 경우에는 문서가 나갈 버전이 아니라 그 항목이 실제로 나갔던 버전을 적는다.
 - 문서에 새 MDX 컴포넌트를 도입하면 llms 변환 룰과 fixture를 함께 추가한다 ([app/\_llms/AGENTS.md](app/_llms/AGENTS.md) 참조). 룰이 없으면 llms.txt에 raw JSX가 그대로 새어나간다.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -46,3 +46,13 @@ Lynx 컴포넌트 문서를 작성할 때는 **웹 버전과의 차이점을 반
 - **렌더링 방식 차이**: Lynx에서 지원하지 않는 웹 기능(SVG, 특정 CSS 속성 등)으로 인한 대체 구현
 - **API 차이**: props 차이, 컴파운드 컴포넌트 구조 차이, 이벤트 핸들링(`bindtap` 등)
 - **누락 기능**: 웹에는 있지만 Lynx에서 미지원인 기능
+
+## 콘텐츠 작성 룰 (`content/`)
+
+- 컴포넌트/훅 문서를 신설하면 frontmatter 직후에 "추가된 버전" 불렛을 넣는다.
+  - 형식: `` - `@seed-design/react@2.1.0`, `@seed-design/css@2.3.0`부터 사용할 수 있습니다. ``
+  - 패키지 매핑: react components → react + css / react stackflow → stackflow + css / lynx components → lynx-react + lynx-css / lynx hooks → lynx-react
+  - 버전은 **그 항목이 처음 사용 가능해진 버전**이다. 새로 만드는 컴포넌트/훅이면 그게 곧 문서와 함께 나갈 다음 릴리스(현재 버전 + changeset bump)이고, 이미 릴리스된 항목의 문서를 뒤늦게 추가하는 경우에는 문서가 나갈 버전이 아니라 그 항목이 실제로 나갔던 버전을 적는다.
+- 문서에 새 MDX 컴포넌트를 도입하면 llms 변환 룰과 fixture를 함께 추가한다 ([app/\_llms/AGENTS.md](app/_llms/AGENTS.md) 참조). 룰이 없으면 llms.txt에 raw JSX가 그대로 새어나간다.
+- "SEED"는 "SEED Design System"의 줄임말이다. 풀어 쓰거나 "SEED"로 줄여 쓰고, 중간 표기인 "SEED Design"은 산문에서 쓰지 않는다 (패키지명·저장소명은 예외).
+- `featured: true`(사이드바 강조 dot)는 동시에 3개 안팎으로 유지하고 오래된 것부터 뗀다. 개수가 늘면 강조가 의미를 잃는다.

--- a/docs/app/_llms/__fixtures__/pipeline/combined.input.mdx
+++ b/docs/app/_llms/__fixtures__/pipeline/combined.input.mdx
@@ -1,3 +1,5 @@
+<AvailableSince packages="@seed-design/react@2.0.0, @seed-design/css@2.0.0" />
+
 <ComponentExample name="react/action-button/preview">
   ```tsx
   import { ActionButton } from "seed-design/ui/action-button";

--- a/docs/app/_llms/__fixtures__/pipeline/combined.output.mdx
+++ b/docs/app/_llms/__fixtures__/pipeline/combined.output.mdx
@@ -1,3 +1,5 @@
+사용 가능 버전: @seed-design/react@2.0.0, @seed-design/css@2.0.0
+
 ## Preview
 
 ```tsx

--- a/docs/app/_llms/rules/available-since-rule.test.ts
+++ b/docs/app/_llms/rules/available-since-rule.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeLLMBodyWithRules } from "../normalize-llm-body";
+import { availableSinceRule } from "./available-since-rule";
+
+describe("availableSinceRule", () => {
+  it("converts AvailableSince to a single caption line", () => {
+    const input = `<AvailableSince packages="@seed-design/react@2.0.0, @seed-design/css@2.0.0" />
+
+## Import`;
+
+    const actual = normalizeLLMBodyWithRules(input, [availableSinceRule]);
+
+    expect(actual).toMatchInlineSnapshot(`
+      "사용 가능 버전: @seed-design/react@2.0.0, @seed-design/css@2.0.0
+
+      ## Import"
+    `);
+  });
+
+  it("drops the node when packages is missing", () => {
+    const input = `<AvailableSince />
+
+본문입니다.`;
+
+    const actual = normalizeLLMBodyWithRules(input, [availableSinceRule]);
+
+    expect(actual).toMatchInlineSnapshot(`"본문입니다."`);
+  });
+});

--- a/docs/app/_llms/rules/available-since-rule.ts
+++ b/docs/app/_llms/rules/available-since-rule.ts
@@ -1,0 +1,24 @@
+import type { Rule, RuleNode } from "./types";
+
+/*
+  <AvailableSince packages="@seed-design/react@2.0.0, @seed-design/css@2.0.0" /> 를
+  llms.txt에서는 `사용 가능 버전: @seed-design/react@2.0.0, @seed-design/css@2.0.0`
+  한 줄로 변환합니다.
+*/
+export const availableSinceRule: Rule = {
+  name: "AvailableSince",
+  match: (node): node is RuleNode =>
+    node.type === "mdxJsxFlowElement" && node.name === "AvailableSince",
+  transform: (node, context) => {
+    const packages = context.getStringAttribute(node, "packages")?.trim();
+    // packages가 없으면 화면에도 아무것도 안 나오므로 llms.txt에서도 지운다.
+    if (!packages) return [];
+
+    return [
+      {
+        type: "paragraph",
+        children: [{ type: "text", value: `사용 가능 버전: ${packages}` }],
+      },
+    ];
+  },
+};

--- a/docs/app/_llms/rules/index.ts
+++ b/docs/app/_llms/rules/index.ts
@@ -1,3 +1,4 @@
+import { availableSinceRule } from "./available-since-rule";
 import { badgeRule } from "./badge-rule";
 import { changelogPageRule } from "./changelog-page-rule";
 import { codeBlockTabsRule } from "./codeblock-tabs-rule";
@@ -11,6 +12,7 @@ import { iconLibraryRule } from "./icon-library-rule";
 import type { AnyRule } from "./types";
 
 export const activeRules: AnyRule[] = [
+  availableSinceRule,
   badgeRule,
   componentExampleRule,
   codeBlockTabsRule,
@@ -24,6 +26,7 @@ export const activeRules: AnyRule[] = [
 ];
 
 export {
+  availableSinceRule,
   badgeRule,
   changelogPageRule,
   codeBlockTabsRule,

--- a/docs/components/available-since.tsx
+++ b/docs/components/available-since.tsx
@@ -1,0 +1,20 @@
+interface AvailableSinceProps {
+  /** 콤마로 구분한 `패키지명@버전` 목록. 예: `"@seed-design/react@2.0.0, @seed-design/css@2.0.0"` */
+  packages: string;
+}
+
+export function AvailableSince({ packages }: AvailableSinceProps) {
+  const entries = packages
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="not-prose my-6 flex flex-col items-end gap-0.5">
+      <span className="text-[11px] font-extralight text-fg-neutral-subtle">사용 가능 버전</span>
+      <span className="text-xs font-light text-fg-neutral">{entries.join(", ")}</span>
+    </div>
+  );
+}

--- a/docs/components/mdx-components.tsx
+++ b/docs/components/mdx-components.tsx
@@ -1,3 +1,4 @@
+import { AvailableSince } from "@/components/available-since";
 import { ColorGrid } from "@/components/color-grid";
 import { Badge } from "@/components/mdx-badge";
 import { BlockCodeTabs } from "@/components/block-code-tabs";
@@ -87,6 +88,7 @@ export const mdxComponents: MDXComponents = {
   ),
 
   // Components
+  AvailableSince,
   Badge,
   Card: DocsCard,
   Cards: DocsCards,

--- a/docs/content/lynx/components/action-button.mdx
+++ b/docs/content/lynx/components/action-button.mdx
@@ -3,6 +3,8 @@ title: Action Button
 description: 명확한 액션을 쉽게 수행할 수 있도록 돕는 기본 인터랙션 컴포넌트입니다.
 ---
 
+- `@seed-design/lynx-react@0.1.0`, `@seed-design/lynx-css@0.1.0`부터 사용할 수 있습니다.
+
 ## Installation
 
 ```package-install

--- a/docs/content/lynx/components/action-button.mdx
+++ b/docs/content/lynx/components/action-button.mdx
@@ -3,7 +3,7 @@ title: Action Button
 description: 명확한 액션을 쉽게 수행할 수 있도록 돕는 기본 인터랙션 컴포넌트입니다.
 ---
 
-- `@seed-design/lynx-react@0.1.0`, `@seed-design/lynx-css@0.1.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />
 
 ## Installation
 

--- a/docs/content/lynx/components/app-bar.mdx
+++ b/docs/content/lynx/components/app-bar.mdx
@@ -3,6 +3,8 @@ title: AppBar
 description: 화면 상단에서 현재 화면의 제목과 탐색 액션을 보여주는 내비게이션 바 컴포넌트입니다.
 ---
 
+- `@seed-design/lynx-react@0.2.0`, `@seed-design/lynx-css@0.2.0`부터 사용할 수 있습니다.
+
 ## Installation
 
 ```package-install

--- a/docs/content/lynx/components/app-bar.mdx
+++ b/docs/content/lynx/components/app-bar.mdx
@@ -3,7 +3,7 @@ title: AppBar
 description: 화면 상단에서 현재 화면의 제목과 탐색 액션을 보여주는 내비게이션 바 컴포넌트입니다.
 ---
 
-- `@seed-design/lynx-react@0.2.0`, `@seed-design/lynx-css@0.2.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/lynx-react@0.2.0, @seed-design/lynx-css@0.2.0" />
 
 ## Installation
 

--- a/docs/content/lynx/components/badge.mdx
+++ b/docs/content/lynx/components/badge.mdx
@@ -3,6 +3,8 @@ title: Badge
 description: 상태나 속성을 짧은 텍스트로 표시하는 정보성 컴포넌트입니다.
 ---
 
+- `@seed-design/lynx-react@0.2.0`, `@seed-design/lynx-css@0.2.0`부터 사용할 수 있습니다.
+
 ## Installation
 
 ```package-install

--- a/docs/content/lynx/components/badge.mdx
+++ b/docs/content/lynx/components/badge.mdx
@@ -3,7 +3,7 @@ title: Badge
 description: 상태나 속성을 짧은 텍스트로 표시하는 정보성 컴포넌트입니다.
 ---
 
-- `@seed-design/lynx-react@0.2.0`, `@seed-design/lynx-css@0.2.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/lynx-react@0.2.0, @seed-design/lynx-css@0.2.0" />
 
 ## Installation
 

--- a/docs/content/lynx/components/bottom-sheet.mdx
+++ b/docs/content/lynx/components/bottom-sheet.mdx
@@ -3,7 +3,7 @@ title: Bottom Sheet
 description: 화면 하단에서 올라오는 시트 컴포넌트로, 드래그·snap·dismiss 상호작용을 제공합니다.
 ---
 
-- `@seed-design/lynx-react@0.1.0`, `@seed-design/lynx-css@0.1.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />
 
 ## Installation
 

--- a/docs/content/lynx/components/bottom-sheet.mdx
+++ b/docs/content/lynx/components/bottom-sheet.mdx
@@ -3,6 +3,8 @@ title: Bottom Sheet
 description: 화면 하단에서 올라오는 시트 컴포넌트로, 드래그·snap·dismiss 상호작용을 제공합니다.
 ---
 
+- `@seed-design/lynx-react@0.1.0`, `@seed-design/lynx-css@0.1.0`부터 사용할 수 있습니다.
+
 ## Installation
 
 ```package-install

--- a/docs/content/lynx/components/checkbox.mdx
+++ b/docs/content/lynx/components/checkbox.mdx
@@ -3,6 +3,8 @@ title: Checkbox
 description: 사용자가 여러 옵션 중 하나 이상을 선택할 수 있게 하는 체크박스 컴포넌트입니다.
 ---
 
+- `@seed-design/lynx-react@0.1.0`, `@seed-design/lynx-css@0.1.0`부터 사용할 수 있습니다.
+
 ## Installation
 
 ```package-install

--- a/docs/content/lynx/components/checkbox.mdx
+++ b/docs/content/lynx/components/checkbox.mdx
@@ -3,7 +3,7 @@ title: Checkbox
 description: 사용자가 여러 옵션 중 하나 이상을 선택할 수 있게 하는 체크박스 컴포넌트입니다.
 ---
 
-- `@seed-design/lynx-react@0.1.0`, `@seed-design/lynx-css@0.1.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />
 
 ## Installation
 

--- a/docs/content/lynx/components/progress-circle.mdx
+++ b/docs/content/lynx/components/progress-circle.mdx
@@ -3,7 +3,7 @@ title: Progress Circle
 description: 작업이 진행 중임을 알리거나 작업 시간을 시각적으로 나타내는 데 사용됩니다.
 ---
 
-- `@seed-design/lynx-react@0.1.0`, `@seed-design/lynx-css@0.1.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />
 
 ## Installation
 

--- a/docs/content/lynx/components/progress-circle.mdx
+++ b/docs/content/lynx/components/progress-circle.mdx
@@ -3,6 +3,8 @@ title: Progress Circle
 description: 작업이 진행 중임을 알리거나 작업 시간을 시각적으로 나타내는 데 사용됩니다.
 ---
 
+- `@seed-design/lynx-react@0.1.0`, `@seed-design/lynx-css@0.1.0`부터 사용할 수 있습니다.
+
 ## Installation
 
 ```package-install

--- a/docs/content/lynx/components/radio-group.mdx
+++ b/docs/content/lynx/components/radio-group.mdx
@@ -3,6 +3,8 @@ title: RadioGroup
 description: 사용자가 여러 옵션 중 하나만 선택할 수 있게 하는 라디오 그룹 컴포넌트입니다.
 ---
 
+- `@seed-design/lynx-react@0.1.0`, `@seed-design/lynx-css@0.1.0`부터 사용할 수 있습니다.
+
 ## Installation
 
 ```package-install

--- a/docs/content/lynx/components/radio-group.mdx
+++ b/docs/content/lynx/components/radio-group.mdx
@@ -3,7 +3,7 @@ title: RadioGroup
 description: 사용자가 여러 옵션 중 하나만 선택할 수 있게 하는 라디오 그룹 컴포넌트입니다.
 ---
 
-- `@seed-design/lynx-react@0.1.0`, `@seed-design/lynx-css@0.1.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />
 
 ## Installation
 

--- a/docs/content/lynx/components/switch.mdx
+++ b/docs/content/lynx/components/switch.mdx
@@ -3,6 +3,8 @@ title: Switch
 description: 특정 옵션이나 설정을 켜거나 끌 수 있도록 돕는 토글 컴포넌트입니다.
 ---
 
+- `@seed-design/lynx-react@0.1.0`, `@seed-design/lynx-css@0.1.0`부터 사용할 수 있습니다.
+
 ## Installation
 
 ```package-install

--- a/docs/content/lynx/components/switch.mdx
+++ b/docs/content/lynx/components/switch.mdx
@@ -3,7 +3,7 @@ title: Switch
 description: 특정 옵션이나 설정을 켜거나 끌 수 있도록 돕는 토글 컴포넌트입니다.
 ---
 
-- `@seed-design/lynx-react@0.1.0`, `@seed-design/lynx-css@0.1.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />
 
 ## Installation
 

--- a/docs/content/lynx/components/tag-group.mdx
+++ b/docs/content/lynx/components/tag-group.mdx
@@ -3,7 +3,7 @@ title: Tag Group
 description: 텍스트 태그를 수평으로 나열해 여러 속성·상태·메타데이터를 한눈에 보여주는 정보 요약 컴포넌트입니다.
 ---
 
-- `@seed-design/lynx-react@0.1.0`, `@seed-design/lynx-css@0.1.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />
 
 ## Installation
 

--- a/docs/content/lynx/components/tag-group.mdx
+++ b/docs/content/lynx/components/tag-group.mdx
@@ -3,6 +3,8 @@ title: Tag Group
 description: 텍스트 태그를 수평으로 나열해 여러 속성·상태·메타데이터를 한눈에 보여주는 정보 요약 컴포넌트입니다.
 ---
 
+- `@seed-design/lynx-react@0.1.0`, `@seed-design/lynx-css@0.1.0`부터 사용할 수 있습니다.
+
 ## Installation
 
 ```package-install

--- a/docs/content/lynx/hooks/use-controllable-state.mdx
+++ b/docs/content/lynx/hooks/use-controllable-state.mdx
@@ -3,6 +3,8 @@ title: useControllableState
 description: Controlled/uncontrolled 상태 패턴을 지원하는 훅입니다.
 ---
 
+- `@seed-design/lynx-react@0.1.0`부터 사용할 수 있습니다.
+
 ## Import
 
 ```ts

--- a/docs/content/lynx/hooks/use-controllable-state.mdx
+++ b/docs/content/lynx/hooks/use-controllable-state.mdx
@@ -3,7 +3,7 @@ title: useControllableState
 description: Controlled/uncontrolled 상태 패턴을 지원하는 훅입니다.
 ---
 
-- `@seed-design/lynx-react@0.1.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/lynx-react@0.1.0" />
 
 ## Import
 

--- a/docs/content/lynx/hooks/use-icon-color.mdx
+++ b/docs/content/lynx/hooks/use-icon-color.mdx
@@ -3,7 +3,7 @@ title: useIconColor
 description: Lynx image 아이콘의 CSS color를 native tint-color로 동기화하는 훅입니다.
 ---
 
-- `@seed-design/lynx-react@0.1.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/lynx-react@0.1.0" />
 
 ## Import
 

--- a/docs/content/lynx/hooks/use-icon-color.mdx
+++ b/docs/content/lynx/hooks/use-icon-color.mdx
@@ -3,6 +3,8 @@ title: useIconColor
 description: Lynx image 아이콘의 CSS color를 native tint-color로 동기화하는 훅입니다.
 ---
 
+- `@seed-design/lynx-react@0.1.0`부터 사용할 수 있습니다.
+
 ## Import
 
 ```ts

--- a/docs/content/lynx/hooks/use-press-tap.mdx
+++ b/docs/content/lynx/hooks/use-press-tap.mdx
@@ -3,7 +3,7 @@ title: usePressTap
 description: Lynx 요소의 press/tap 인터랙션 상태를 관리하는 훅입니다.
 ---
 
-- `@seed-design/lynx-react@0.1.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/lynx-react@0.1.0" />
 
 ## Import
 

--- a/docs/content/lynx/hooks/use-press-tap.mdx
+++ b/docs/content/lynx/hooks/use-press-tap.mdx
@@ -3,6 +3,8 @@ title: usePressTap
 description: Lynx 요소의 press/tap 인터랙션 상태를 관리하는 훅입니다.
 ---
 
+- `@seed-design/lynx-react@0.1.0`부터 사용할 수 있습니다.
+
 ## Import
 
 ```ts

--- a/docs/content/lynx/hooks/use-safe-area.mdx
+++ b/docs/content/lynx/hooks/use-safe-area.mdx
@@ -3,6 +3,8 @@ title: useSafeArea
 description: Lynx 앱에서 top/bottom safe area inset 값을 가져오는 훅입니다.
 ---
 
+- `@seed-design/lynx-react@0.1.0`부터 사용할 수 있습니다.
+
 ## Import
 
 ```ts

--- a/docs/content/lynx/hooks/use-safe-area.mdx
+++ b/docs/content/lynx/hooks/use-safe-area.mdx
@@ -3,7 +3,7 @@ title: useSafeArea
 description: Lynx 앱에서 top/bottom safe area inset 값을 가져오는 훅입니다.
 ---
 
-- `@seed-design/lynx-react@0.1.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/lynx-react@0.1.0" />
 
 ## Import
 

--- a/docs/content/lynx/hooks/use-seed-class-name.mdx
+++ b/docs/content/lynx/hooks/use-seed-class-name.mdx
@@ -3,6 +3,8 @@ title: useSeedClassName
 description: root `<page>`에 적용할 테마 className을 반환하고 테마 변경을 구독하는 훅입니다.
 ---
 
+- `@seed-design/lynx-react@0.3.0`부터 사용할 수 있습니다.
+
 ## Import
 
 ```ts

--- a/docs/content/lynx/hooks/use-seed-class-name.mdx
+++ b/docs/content/lynx/hooks/use-seed-class-name.mdx
@@ -3,7 +3,7 @@ title: useSeedClassName
 description: root `<page>`에 적용할 테마 className을 반환하고 테마 변경을 구독하는 훅입니다.
 ---
 
-- `@seed-design/lynx-react@0.3.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/lynx-react@0.3.0" />
 
 ## Import
 

--- a/docs/content/react/components/accordion.mdx
+++ b/docs/content/react/components/accordion.mdx
@@ -3,7 +3,7 @@ title: Accordion
 description: 여러 개의 관련된 콘텐츠 섹션을 수직으로 나열하고, 각 섹션을 펼치거나 접어 정보를 탐색할 수 있는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@2.0.0`, `@seed-design/css@2.0.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@2.0.0, @seed-design/css@2.0.0" />
 
 <ComponentExample name="react/accordion/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/accordion.mdx
+++ b/docs/content/react/components/accordion.mdx
@@ -3,6 +3,8 @@ title: Accordion
 description: 여러 개의 관련된 콘텐츠 섹션을 수직으로 나열하고, 각 섹션을 펼치거나 접어 정보를 탐색할 수 있는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@2.0.0`, `@seed-design/css@2.0.0`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/accordion/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/action-button.mdx
+++ b/docs/content/react/components/action-button.mdx
@@ -3,7 +3,7 @@ title: Action Button
 description: 명확한 액션을 쉽게 수행할 수 있도록 돕는 기본 인터랙션 컴포넌트입니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/action-button/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/action-button.mdx
+++ b/docs/content/react/components/action-button.mdx
@@ -3,6 +3,8 @@ title: Action Button
 description: 명확한 액션을 쉽게 수행할 수 있도록 돕는 기본 인터랙션 컴포넌트입니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/action-button/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/alert-dialog.mdx
+++ b/docs/content/react/components/alert-dialog.mdx
@@ -3,7 +3,7 @@ title: Alert Dialog
 description: 사용자의 확인이 반드시 필요한 경우 강력한 표현 및 경고 수단으로 활용하는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/alert-dialog/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/alert-dialog.mdx
+++ b/docs/content/react/components/alert-dialog.mdx
@@ -3,6 +3,8 @@ title: Alert Dialog
 description: 사용자의 확인이 반드시 필요한 경우 강력한 표현 및 경고 수단으로 활용하는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/alert-dialog/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/article.mdx
+++ b/docs/content/react/components/article.mdx
@@ -3,7 +3,7 @@ title: Article
 description: Article은 일관된 selection 및 줄바꿈 정책을 사용할 수 있게 돕는 유틸리티 컴포넌트입니다.
 ---
 
-- `@seed-design/react@1.0.6`, `@seed-design/css@1.0.6`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@1.0.6, @seed-design/css@1.0.6" />
 
 <ComponentExample name="react/article/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/article.mdx
+++ b/docs/content/react/components/article.mdx
@@ -3,6 +3,8 @@ title: Article
 description: Article은 일관된 selection 및 줄바꿈 정책을 사용할 수 있게 돕는 유틸리티 컴포넌트입니다.
 ---
 
+- `@seed-design/react@1.0.6`, `@seed-design/css@1.0.6`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/article/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/aspect-ratio.mdx
+++ b/docs/content/react/components/aspect-ratio.mdx
@@ -3,6 +3,8 @@ title: Aspect Ratio
 description: 가로(width)가 정해지면 비율에 따라 세로(height)가 자동으로 결정되는 레이아웃 컨테이너입니다.
 ---
 
+- `@seed-design/react@1.2.1`, `@seed-design/css@1.2.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/aspect-ratio/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/aspect-ratio.mdx
+++ b/docs/content/react/components/aspect-ratio.mdx
@@ -3,7 +3,7 @@ title: Aspect Ratio
 description: 가로(width)가 정해지면 비율에 따라 세로(height)가 자동으로 결정되는 레이아웃 컨테이너입니다.
 ---
 
-- `@seed-design/react@1.2.1`, `@seed-design/css@1.2.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@1.2.0, @seed-design/css@1.2.0" />
 
 <ComponentExample name="react/aspect-ratio/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/attachment-display-field.mdx
+++ b/docs/content/react/components/attachment-display-field.mdx
@@ -3,7 +3,7 @@ title: Attachment Display Field
 description: 외부 소스에서 제공된 미디어를 URL 기반으로 표시하고 관리하는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@2.0.0`, `@seed-design/css@2.0.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@2.0.0, @seed-design/css@2.0.0" />
 
 <ComponentExample name="react/attachment-display-field/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/attachment-display-field.mdx
+++ b/docs/content/react/components/attachment-display-field.mdx
@@ -3,6 +3,8 @@ title: Attachment Display Field
 description: 외부 소스에서 제공된 미디어를 URL 기반으로 표시하고 관리하는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@2.0.0`, `@seed-design/css@2.0.0`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/attachment-display-field/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/attachment-field.mdx
+++ b/docs/content/react/components/attachment-field.mdx
@@ -3,7 +3,7 @@ title: Attachment Field
 description: 파일을 선택하거나 드래그 앤 드롭으로 업로드할 수 있는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@2.0.0`, `@seed-design/css@2.0.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@2.0.0, @seed-design/css@2.0.0" />
 
 <ComponentExample name="react/attachment-field/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/attachment-field.mdx
+++ b/docs/content/react/components/attachment-field.mdx
@@ -3,6 +3,8 @@ title: Attachment Field
 description: 파일을 선택하거나 드래그 앤 드롭으로 업로드할 수 있는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@2.0.0`, `@seed-design/css@2.0.0`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/attachment-field/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/avatar.mdx
+++ b/docs/content/react/components/avatar.mdx
@@ -3,7 +3,7 @@ title: Avatar
 description: 사용자의 프로필 이미지를 표시하는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/avatar/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/avatar.mdx
+++ b/docs/content/react/components/avatar.mdx
@@ -3,6 +3,8 @@ title: Avatar
 description: 사용자의 프로필 이미지를 표시하는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/avatar/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/badge.mdx
+++ b/docs/content/react/components/badge.mdx
@@ -3,6 +3,8 @@ title: Badge
 description: 객체의 속성이나 상태를 시각적으로 표현하는 작은 텍스트 라벨입니다. 사용자의 주의를 끌고 콘텐츠의 빠른 인지와 탐색을 돕기 위해 사용됩니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/badge/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/badge.mdx
+++ b/docs/content/react/components/badge.mdx
@@ -3,7 +3,7 @@ title: Badge
 description: 객체의 속성이나 상태를 시각적으로 표현하는 작은 텍스트 라벨입니다. 사용자의 주의를 끌고 콘텐츠의 빠른 인지와 탐색을 돕기 위해 사용됩니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/badge/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/bottom-sheet.mdx
+++ b/docs/content/react/components/bottom-sheet.mdx
@@ -3,6 +3,8 @@ title: Bottom Sheet
 description: 화면 하단에서 올라오는 모달 컴포넌트입니다. 추가 정보나 액션 목록을 제공하면서도 현재 컨텍스트를 유지할 때 사용됩니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/bottom-sheet/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/bottom-sheet.mdx
+++ b/docs/content/react/components/bottom-sheet.mdx
@@ -3,7 +3,7 @@ title: Bottom Sheet
 description: 화면 하단에서 올라오는 모달 컴포넌트입니다. 추가 정보나 액션 목록을 제공하면서도 현재 컨텍스트를 유지할 때 사용됩니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/bottom-sheet/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/callout.mdx
+++ b/docs/content/react/components/callout.mdx
@@ -3,6 +3,8 @@ title: Callout
 description: 사용자에게 중요한 정보나 팁을 시각적으로 강조하여 전달하는 메시지 컴포넌트입니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/callout/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/callout.mdx
+++ b/docs/content/react/components/callout.mdx
@@ -3,7 +3,7 @@ title: Callout
 description: 사용자에게 중요한 정보나 팁을 시각적으로 강조하여 전달하는 메시지 컴포넌트입니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/callout/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/checkbox.mdx
+++ b/docs/content/react/components/checkbox.mdx
@@ -3,6 +3,8 @@ title: Checkbox
 description: 사용자가 하나 이상의 옵션을 선택할 수 있게 해주는 컴포넌트입니다. 목록에서 여러 항목을 선택하거나 약관 동의와 같은 선택적 작업에 사용됩니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/checkbox/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/checkbox.mdx
+++ b/docs/content/react/components/checkbox.mdx
@@ -3,7 +3,7 @@ title: Checkbox
 description: 사용자가 하나 이상의 옵션을 선택할 수 있게 해주는 컴포넌트입니다. 목록에서 여러 항목을 선택하거나 약관 동의와 같은 선택적 작업에 사용됩니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/checkbox/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/chip-tabs.mdx
+++ b/docs/content/react/components/chip-tabs.mdx
@@ -3,6 +3,8 @@ title: Chip Tabs
 description: Chip 형태로 표현된 탭 컴포넌트입니다. 카테고리나 필터를 선택하여 콘텐츠를 전환할 때 사용됩니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/chip-tabs/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/chip-tabs.mdx
+++ b/docs/content/react/components/chip-tabs.mdx
@@ -3,7 +3,7 @@ title: Chip Tabs
 description: Chip 형태로 표현된 탭 컴포넌트입니다. 카테고리나 필터를 선택하여 콘텐츠를 전환할 때 사용됩니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/chip-tabs/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/chip.mdx
+++ b/docs/content/react/components/chip.mdx
@@ -3,7 +3,7 @@ title: Chip
 description: 사용자가 선택하거나 입력하는 값을 표시하는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@0.1.4`, `@seed-design/css@0.1.4`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.1.4, @seed-design/css@0.1.4" />
 
 <ComponentExample name="react/chip/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/chip.mdx
+++ b/docs/content/react/components/chip.mdx
@@ -3,6 +3,8 @@ title: Chip
 description: 사용자가 선택하거나 입력하는 값을 표시하는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@0.1.4`, `@seed-design/css@0.1.4`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/chip/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/content-placeholder.mdx
+++ b/docs/content/react/components/content-placeholder.mdx
@@ -3,7 +3,7 @@ title: Content Placeholder
 description: 이미지나 콘텐츠가 로드되지 않았을 때, 해당 영역의 성격을 전달하는 대체 시각 요소입니다.
 ---
 
-- `@seed-design/react@1.2.8`, `@seed-design/css@1.2.6`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@1.2.8, @seed-design/css@1.2.6" />
 
 <ComponentExample name="react/content-placeholder/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/content-placeholder.mdx
+++ b/docs/content/react/components/content-placeholder.mdx
@@ -3,6 +3,8 @@ title: Content Placeholder
 description: 이미지나 콘텐츠가 로드되지 않았을 때, 해당 영역의 성격을 전달하는 대체 시각 요소입니다.
 ---
 
+- `@seed-design/react@1.2.8`, `@seed-design/css@1.2.6`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/content-placeholder/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/contextual-floating-button.mdx
+++ b/docs/content/react/components/contextual-floating-button.mdx
@@ -3,7 +3,7 @@ title: Contextual Floating Button
 description: 화면 위에 떠 있으며 특정 상황에서만 나타나는 보조적인 동작을 위한 버튼입니다.
 ---
 
-- `@seed-design/react@0.0.30`, `@seed-design/css@0.0.30`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.30, @seed-design/css@0.0.30" />
 
 <ComponentExample name="react/contextual-floating-button/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/contextual-floating-button.mdx
+++ b/docs/content/react/components/contextual-floating-button.mdx
@@ -3,6 +3,8 @@ title: Contextual Floating Button
 description: 화면 위에 떠 있으며 특정 상황에서만 나타나는 보조적인 동작을 위한 버튼입니다.
 ---
 
+- `@seed-design/react@0.0.30`, `@seed-design/css@0.0.30`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/contextual-floating-button/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/dialog.mdx
+++ b/docs/content/react/components/dialog.mdx
@@ -3,6 +3,8 @@ title: Dialog
 description: 화면 중앙에 떠서 사용자의 주의를 모으는 다이얼로그입니다. 제목, 본문, 푸터와 닫기 버튼을 갖추어 폼이나 스크롤되는 콘텐츠 등 풍부한 내용을 담을 때 사용합니다.
 ---
 
+- `@seed-design/react@2.1.0`, `@seed-design/css@2.3.0`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/dialog/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/dialog.mdx
+++ b/docs/content/react/components/dialog.mdx
@@ -3,7 +3,7 @@ title: Dialog
 description: 화면 중앙에 떠서 사용자의 주의를 모으는 다이얼로그입니다. 제목, 본문, 푸터와 닫기 버튼을 갖추어 폼이나 스크롤되는 콘텐츠 등 풍부한 내용을 담을 때 사용합니다.
 ---
 
-- `@seed-design/react@2.1.0`, `@seed-design/css@2.3.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@2.1.0, @seed-design/css@2.3.0" />
 
 <ComponentExample name="react/dialog/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/divider.mdx
+++ b/docs/content/react/components/divider.mdx
@@ -3,6 +3,8 @@ title: Divider
 description: 시각적 구분자로써 역할을 하며, 콘텐츠 간의 구획을 명확히 나누는 데 사용하는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@0.0.15`, `@seed-design/css@0.0.15`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/divider/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/divider.mdx
+++ b/docs/content/react/components/divider.mdx
@@ -3,7 +3,7 @@ title: Divider
 description: 시각적 구분자로써 역할을 하며, 콘텐츠 간의 구획을 명확히 나누는 데 사용하는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@0.0.15`, `@seed-design/css@0.0.15`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.14, @seed-design/css@0.0.14" />
 
 <ComponentExample name="react/divider/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/field-button.mdx
+++ b/docs/content/react/components/field-button.mdx
@@ -3,7 +3,7 @@ title: Field Button
 description: 입력 필드 형태의 버튼으로, 선택창이나 피커를 열 때 사용합니다. 선택이 완료되면 버튼 라벨에 선택된 값이 표시됩니다.
 ---
 
-- `@seed-design/react@1.1.1`, `@seed-design/css@1.1.4`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@1.1.0, @seed-design/css@1.1.0" />
 
 <ComponentExample name="react/field-button/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/field-button.mdx
+++ b/docs/content/react/components/field-button.mdx
@@ -3,6 +3,8 @@ title: Field Button
 description: 입력 필드 형태의 버튼으로, 선택창이나 피커를 열 때 사용합니다. 선택이 완료되면 버튼 라벨에 선택된 값이 표시됩니다.
 ---
 
+- `@seed-design/react@1.1.1`, `@seed-design/css@1.1.4`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/field-button/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/floating-action-button.mdx
+++ b/docs/content/react/components/floating-action-button.mdx
@@ -3,6 +3,8 @@ title: Floating Action Button
 description: 화면 상에 떠 있으며 주요 액션을 실행하는 버튼입니다.
 ---
 
+- `@seed-design/react@0.0.30`, `@seed-design/css@0.0.30`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/floating-action-button/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/floating-action-button.mdx
+++ b/docs/content/react/components/floating-action-button.mdx
@@ -3,7 +3,7 @@ title: Floating Action Button
 description: 화면 상에 떠 있으며 주요 액션을 실행하는 버튼입니다.
 ---
 
-- `@seed-design/react@0.0.30`, `@seed-design/css@0.0.30`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.30, @seed-design/css@0.0.30" />
 
 <ComponentExample name="react/floating-action-button/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/help-bubble-tooltip.mdx
+++ b/docs/content/react/components/help-bubble-tooltip.mdx
@@ -3,7 +3,7 @@ title: Help Bubble Tooltip
 description: 포인터를 올리거나 포커스했을 때 보조 정보를 보여주는 툴팁 형태의 Help Bubble입니다.
 ---
 
-- `@seed-design/react@2.0.0`, `@seed-design/css@2.0.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@2.0.0, @seed-design/css@2.0.0" />
 
 <ComponentExample name="react/help-bubble-tooltip/preview" isolate>
   ```json doc-gen:file

--- a/docs/content/react/components/help-bubble-tooltip.mdx
+++ b/docs/content/react/components/help-bubble-tooltip.mdx
@@ -3,6 +3,8 @@ title: Help Bubble Tooltip
 description: 포인터를 올리거나 포커스했을 때 보조 정보를 보여주는 툴팁 형태의 Help Bubble입니다.
 ---
 
+- `@seed-design/react@2.0.0`, `@seed-design/css@2.0.0`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/help-bubble-tooltip/preview" isolate>
   ```json doc-gen:file
   {

--- a/docs/content/react/components/help-bubble.mdx
+++ b/docs/content/react/components/help-bubble.mdx
@@ -3,7 +3,7 @@ title: Help Bubble
 description: 사용자에게 컴포넌트의 상태나 특정 기능에 대한 추가 정보를 제공하는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/help-bubble/preview" isolate>
   ```json doc-gen:file

--- a/docs/content/react/components/help-bubble.mdx
+++ b/docs/content/react/components/help-bubble.mdx
@@ -3,6 +3,8 @@ title: Help Bubble
 description: 사용자에게 컴포넌트의 상태나 특정 기능에 대한 추가 정보를 제공하는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/help-bubble/preview" isolate>
   ```json doc-gen:file
   {

--- a/docs/content/react/components/identity-placeholder.mdx
+++ b/docs/content/react/components/identity-placeholder.mdx
@@ -3,7 +3,7 @@ title: Identity Placeholder
 description: 인물을 표현하는 이미지가 로드되지 않았을 때 보여지는 대체 시각 요소입니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/identity-placeholder/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/identity-placeholder.mdx
+++ b/docs/content/react/components/identity-placeholder.mdx
@@ -3,6 +3,8 @@ title: Identity Placeholder
 description: 인물을 표현하는 이미지가 로드되지 않았을 때 보여지는 대체 시각 요소입니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/identity-placeholder/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/image-frame.mdx
+++ b/docs/content/react/components/image-frame.mdx
@@ -3,7 +3,7 @@ title: Image Frame
 description: 사용자가 업로드한 이미지를 표시하기 위한 컴포넌트입니다.
 ---
 
-- `@seed-design/react@1.2.1`, `@seed-design/css@1.2.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@1.2.0, @seed-design/css@1.2.0" />
 
 <ComponentExample name="react/image-frame/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/image-frame.mdx
+++ b/docs/content/react/components/image-frame.mdx
@@ -3,6 +3,8 @@ title: Image Frame
 description: 사용자가 업로드한 이미지를 표시하기 위한 컴포넌트입니다.
 ---
 
+- `@seed-design/react@1.2.1`, `@seed-design/css@1.2.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/image-frame/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/list.mdx
+++ b/docs/content/react/components/list.mdx
@@ -3,6 +3,8 @@ title: List
 description: 가로 행으로 구성된 콘텐츠를 표현하는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@0.2.3`, `@seed-design/css@0.2.3`부터 사용할 수 있습니다.
+
 
 <ComponentExample name="react/list/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/list.mdx
+++ b/docs/content/react/components/list.mdx
@@ -3,7 +3,7 @@ title: List
 description: 가로 행으로 구성된 콘텐츠를 표현하는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@0.2.3`, `@seed-design/css@0.2.3`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.2.3, @seed-design/css@0.2.3" />
 
 
 <ComponentExample name="react/list/preview">

--- a/docs/content/react/components/manner-temp-badge.mdx
+++ b/docs/content/react/components/manner-temp-badge.mdx
@@ -3,6 +3,8 @@ title: Manner Temp Badge
 description: 매너 온도를 배지 형태로 표현하는 컴포넌트입니다. 콤팩트한 공간에서 사용자의 매너 온도 레벨을 간단히 표시할 때 사용됩니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/manner-temp-badge/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/manner-temp-badge.mdx
+++ b/docs/content/react/components/manner-temp-badge.mdx
@@ -3,7 +3,7 @@ title: Manner Temp Badge
 description: 매너 온도를 배지 형태로 표현하는 컴포넌트입니다. 콤팩트한 공간에서 사용자의 매너 온도 레벨을 간단히 표시할 때 사용됩니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/manner-temp-badge/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/manner-temp.mdx
+++ b/docs/content/react/components/manner-temp.mdx
@@ -3,7 +3,7 @@ title: Manner Temp
 description: 사용자의 매너온도를 시각적으로 표현하는 컴포넌트입니다. 신뢰도/매너 정도를 직관적으로 보여주는 데에 사용합니다.
 ---
 
-- `@seed-design/react@0.0.13`, `@seed-design/css@0.0.13`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.9, @seed-design/css@0.0.9" />
 
 <ComponentExample name="react/manner-temp/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/manner-temp.mdx
+++ b/docs/content/react/components/manner-temp.mdx
@@ -3,6 +3,8 @@ title: Manner Temp
 description: 사용자의 매너온도를 시각적으로 표현하는 컴포넌트입니다. 신뢰도/매너 정도를 직관적으로 보여주는 데에 사용합니다.
 ---
 
+- `@seed-design/react@0.0.13`, `@seed-design/css@0.0.13`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/manner-temp/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/menu.mdx
+++ b/docs/content/react/components/menu.mdx
@@ -3,7 +3,7 @@ title: Menu
 description: 사용자가 취할 수 있는 선택지나 액션 리스트를 제공하는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@2.0.0`, `@seed-design/css@2.0.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@2.0.0, @seed-design/css@2.0.0" />
 
 <ComponentExample name="react/menu/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/menu.mdx
+++ b/docs/content/react/components/menu.mdx
@@ -3,6 +3,8 @@ title: Menu
 description: 사용자가 취할 수 있는 선택지나 액션 리스트를 제공하는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@2.0.0`, `@seed-design/css@2.0.0`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/menu/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/page-banner.mdx
+++ b/docs/content/react/components/page-banner.mdx
@@ -3,7 +3,7 @@ title: Page Banner
 description: 페이지 상단에 위치하며 사용자에게 전체적인 상태나 중요한 메시지를 전달하는 상위 레벨 메시지 컴포넌트입니다.
 ---
 
-- `@seed-design/react@0.1.14`, `@seed-design/css@0.1.14`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.1.14, @seed-design/css@0.1.14" />
 
 <ComponentExample name="react/page-banner/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/page-banner.mdx
+++ b/docs/content/react/components/page-banner.mdx
@@ -3,6 +3,8 @@ title: Page Banner
 description: 페이지 상단에 위치하며 사용자에게 전체적인 상태나 중요한 메시지를 전달하는 상위 레벨 메시지 컴포넌트입니다.
 ---
 
+- `@seed-design/react@0.1.14`, `@seed-design/css@0.1.14`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/page-banner/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/progress-circle.mdx
+++ b/docs/content/react/components/progress-circle.mdx
@@ -3,7 +3,7 @@ title: Progress Circle
 description: 작업이 진행 중임을 알리거나 작업 시간을 시각적으로 나타내는 데 사용됩니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/progress-circle/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/progress-circle.mdx
+++ b/docs/content/react/components/progress-circle.mdx
@@ -3,6 +3,8 @@ title: Progress Circle
 description: 작업이 진행 중임을 알리거나 작업 시간을 시각적으로 나타내는 데 사용됩니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/progress-circle/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/pull-to-refresh.mdx
+++ b/docs/content/react/components/pull-to-refresh.mdx
@@ -3,7 +3,7 @@ title: Pull To Refresh
 description: 사용자가 화면을 아래로 당겨 콘텐츠를 새로고침할 수 있게 해주는 컴포넌트입니다. 모바일 환경에서 최신 콘텐츠를 불러올 때 사용됩니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <StackflowExample path="/pull-to-refresh-preview">
   ```json doc-gen:file

--- a/docs/content/react/components/pull-to-refresh.mdx
+++ b/docs/content/react/components/pull-to-refresh.mdx
@@ -3,6 +3,8 @@ title: Pull To Refresh
 description: 사용자가 화면을 아래로 당겨 콘텐츠를 새로고침할 수 있게 해주는 컴포넌트입니다. 모바일 환경에서 최신 콘텐츠를 불러올 때 사용됩니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <StackflowExample path="/pull-to-refresh-preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/quantity-picker.mdx
+++ b/docs/content/react/components/quantity-picker.mdx
@@ -3,6 +3,8 @@ title: Quantity Picker
 description: 정수 단위의 수량을 늘리거나 줄일 때 사용하는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@2.1.0`, `@seed-design/css@2.3.0`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/quantity-picker/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/quantity-picker.mdx
+++ b/docs/content/react/components/quantity-picker.mdx
@@ -3,7 +3,7 @@ title: Quantity Picker
 description: 정수 단위의 수량을 늘리거나 줄일 때 사용하는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@2.1.0`, `@seed-design/css@2.3.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@2.1.0, @seed-design/css@2.3.0" />
 
 <ComponentExample name="react/quantity-picker/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/radio-group.mdx
+++ b/docs/content/react/components/radio-group.mdx
@@ -3,7 +3,7 @@ title: Radio Group
 description: 여러 옵션 중 하나를 선택할 수 있도록 할 때 사용하는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@0.2.3`, `@seed-design/css@0.2.3`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.2.3, @seed-design/css@0.2.3" />
 
 <ComponentExample name="react/radio-group/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/radio-group.mdx
+++ b/docs/content/react/components/radio-group.mdx
@@ -3,6 +3,8 @@ title: Radio Group
 description: 여러 옵션 중 하나를 선택할 수 있도록 할 때 사용하는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@0.2.3`, `@seed-design/css@0.2.3`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/radio-group/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/reaction-button.mdx
+++ b/docs/content/react/components/reaction-button.mdx
@@ -3,7 +3,7 @@ title: Reaction Button
 description: 사용자가 콘텐츠에 대한 반응을 표현할 수 있게 해주는 컴포넌트입니다. 좋아요, 관심있어요 등의 감정적 피드백을 간편하게 제공할 때 사용됩니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/reaction-button/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/reaction-button.mdx
+++ b/docs/content/react/components/reaction-button.mdx
@@ -3,6 +3,8 @@ title: Reaction Button
 description: 사용자가 콘텐츠에 대한 반응을 표현할 수 있게 해주는 컴포넌트입니다. 좋아요, 관심있어요 등의 감정적 피드백을 간편하게 제공할 때 사용됩니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/reaction-button/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/result-section.mdx
+++ b/docs/content/react/components/result-section.mdx
@@ -3,6 +3,8 @@ title: Result Section
 description: 데이터 로딩 결과, 사용자의 액션 완료 여부 등 사용자에 액션에 대한 결과를 제공하는 템플릿입니다. 주로 전체 화면이나 특정 영역을 차지하여 다음 액션을 유도하거나 현재 상황을 안내하는 역할을 합니다.
 ---
 
+- `@seed-design/react@1.1.10`, `@seed-design/css@1.1.10`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/result-section/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/result-section.mdx
+++ b/docs/content/react/components/result-section.mdx
@@ -3,7 +3,7 @@ title: Result Section
 description: 데이터 로딩 결과, 사용자의 액션 완료 여부 등 사용자에 액션에 대한 결과를 제공하는 템플릿입니다. 주로 전체 화면이나 특정 영역을 차지하여 다음 액션을 유도하거나 현재 상황을 안내하는 역할을 합니다.
 ---
 
-- `@seed-design/react@1.1.10`, `@seed-design/css@1.1.10`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@1.1.10, @seed-design/css@1.1.10" />
 
 <ComponentExample name="react/result-section/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/scroll-fog.mdx
+++ b/docs/content/react/components/scroll-fog.mdx
@@ -3,7 +3,7 @@ title: Scroll Fog
 description: 스크롤 가능한 영역에서 사용자에게 추가 콘텐츠가 있음을 시각적으로 알려주는 힌트 역할을 합니다.
 ---
 
-- `@seed-design/react@1.1.4`, `@seed-design/css@1.1.4`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@1.1.3, @seed-design/css@1.1.3" />
 
 <ComponentExample name="react/scroll-fog/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/scroll-fog.mdx
+++ b/docs/content/react/components/scroll-fog.mdx
@@ -3,6 +3,8 @@ title: Scroll Fog
 description: 스크롤 가능한 영역에서 사용자에게 추가 콘텐츠가 있음을 시각적으로 알려주는 힌트 역할을 합니다.
 ---
 
+- `@seed-design/react@1.1.4`, `@seed-design/css@1.1.4`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/scroll-fog/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/segmented-control.mdx
+++ b/docs/content/react/components/segmented-control.mdx
@@ -3,7 +3,7 @@ title: Segmented Control
 description: 여러 옵션 중 하나를 선택하여 관련 콘텐츠를 즉시 필터링하거나 전환할 때 사용하는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/segmented-control/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/segmented-control.mdx
+++ b/docs/content/react/components/segmented-control.mdx
@@ -3,6 +3,8 @@ title: Segmented Control
 description: 여러 옵션 중 하나를 선택하여 관련 콘텐츠를 즉시 필터링하거나 전환할 때 사용하는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/segmented-control/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/select-box.mdx
+++ b/docs/content/react/components/select-box.mdx
@@ -3,7 +3,7 @@ title: Select Box
 description: 명확한 테두리를 가진 컨테이너를 활용하여, 정의된 목록 중 하나 이상의 옵션을 선택하는 UI 요소입니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/select-box/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/select-box.mdx
+++ b/docs/content/react/components/select-box.mdx
@@ -3,6 +3,8 @@ title: Select Box
 description: 명확한 테두리를 가진 컨테이너를 활용하여, 정의된 목록 중 하나 이상의 옵션을 선택하는 UI 요소입니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/select-box/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/select.mdx
+++ b/docs/content/react/components/select.mdx
@@ -3,7 +3,7 @@ title: Select
 description: 트리거를 눌러 열리는 목록에서 값을 선택하는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@2.1.0`, `@seed-design/css@2.3.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@2.1.0, @seed-design/css@2.3.0" />
 
 <ComponentExample name="react/select/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/select.mdx
+++ b/docs/content/react/components/select.mdx
@@ -3,6 +3,8 @@ title: Select
 description: 트리거를 눌러 열리는 목록에서 값을 선택하는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@2.1.0`, `@seed-design/css@2.3.0`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/select/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/side-panel.mdx
+++ b/docs/content/react/components/side-panel.mdx
@@ -3,7 +3,7 @@ title: Side Panel
 description: 화면 좌측 또는 우측 가장자리에서 슬라이드하여 나타나는 패널 컴포넌트입니다. 데스크탑 환경에서 추가 콘텐츠나 네비게이션을 제공할 때 사용됩니다.
 ---
 
-- `@seed-design/react@2.0.0`, `@seed-design/css@2.0.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@2.0.0, @seed-design/css@2.0.0" />
 
 <ComponentExample name="react/side-panel/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/side-panel.mdx
+++ b/docs/content/react/components/side-panel.mdx
@@ -3,6 +3,8 @@ title: Side Panel
 description: 화면 좌측 또는 우측 가장자리에서 슬라이드하여 나타나는 패널 컴포넌트입니다. 데스크탑 환경에서 추가 콘텐츠나 네비게이션을 제공할 때 사용됩니다.
 ---
 
+- `@seed-design/react@2.0.0`, `@seed-design/css@2.0.0`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/side-panel/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/skeleton.mdx
+++ b/docs/content/react/components/skeleton.mdx
@@ -3,7 +3,7 @@ title: Skeleton
 description: 콘텐츠가 로딩되는 동안 이후 나타날 요소의 윤곽을 미리 보여주어 로딩 시간을 짧게 느끼게 하는 UI 요소입니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/skeleton/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/skeleton.mdx
+++ b/docs/content/react/components/skeleton.mdx
@@ -3,6 +3,8 @@ title: Skeleton
 description: 콘텐츠가 로딩되는 동안 이후 나타날 요소의 윤곽을 미리 보여주어 로딩 시간을 짧게 느끼게 하는 UI 요소입니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/skeleton/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/slider.mdx
+++ b/docs/content/react/components/slider.mdx
@@ -3,6 +3,8 @@ title: Slider
 description: 지정된 범위 내에서 하나 또는 두 개의 값을 선택해 입력할 수 있는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@1.1.1`, `@seed-design/css@1.1.4`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/slider/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/slider.mdx
+++ b/docs/content/react/components/slider.mdx
@@ -3,7 +3,7 @@ title: Slider
 description: 지정된 범위 내에서 하나 또는 두 개의 값을 선택해 입력할 수 있는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@1.1.1`, `@seed-design/css@1.1.4`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@1.1.0, @seed-design/css@1.1.0" />
 
 <ComponentExample name="react/slider/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/snackbar.mdx
+++ b/docs/content/react/components/snackbar.mdx
@@ -3,7 +3,7 @@ title: Snackbar
 description: 화면 하단에 일시적으로 나타나 상태나 결과를 안내하는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/snackbar/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/snackbar.mdx
+++ b/docs/content/react/components/snackbar.mdx
@@ -3,6 +3,8 @@ title: Snackbar
 description: 화면 하단에 일시적으로 나타나 상태나 결과를 안내하는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/snackbar/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/swipeable-menu-sheet.mdx
+++ b/docs/content/react/components/swipeable-menu-sheet.mdx
@@ -3,7 +3,7 @@ title: Swipeable Menu Sheet
 description: 사용자의 작업과 관련된 선택지를 제공하는 시트 형태의 컴포넌트입니다.
 ---
 
-- `@seed-design/react@2.0.0`, `@seed-design/css@2.0.0`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@2.0.0, @seed-design/css@2.0.0" />
 
 <ComponentExample name="react/swipeable-menu-sheet/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/swipeable-menu-sheet.mdx
+++ b/docs/content/react/components/swipeable-menu-sheet.mdx
@@ -3,6 +3,8 @@ title: Swipeable Menu Sheet
 description: 사용자의 작업과 관련된 선택지를 제공하는 시트 형태의 컴포넌트입니다.
 ---
 
+- `@seed-design/react@2.0.0`, `@seed-design/css@2.0.0`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/swipeable-menu-sheet/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/switch.mdx
+++ b/docs/content/react/components/switch.mdx
@@ -3,6 +3,8 @@ title: Switch
 description: 특정 설정 및 상태를 즉시 켜거나 끌 수 있도록 하는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/switch/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/switch.mdx
+++ b/docs/content/react/components/switch.mdx
@@ -3,7 +3,7 @@ title: Switch
 description: 특정 설정 및 상태를 즉시 켜거나 끌 수 있도록 하는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/switch/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/tabs.mdx
+++ b/docs/content/react/components/tabs.mdx
@@ -3,7 +3,7 @@ title: Tabs
 description: 한 화면 내에서 콘텐츠를 탭 단위로 구분하여 전환할 수 있는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/tabs/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/tabs.mdx
+++ b/docs/content/react/components/tabs.mdx
@@ -3,6 +3,8 @@ title: Tabs
 description: 한 화면 내에서 콘텐츠를 탭 단위로 구분하여 전환할 수 있는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/tabs/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/tag-group.mdx
+++ b/docs/content/react/components/tag-group.mdx
@@ -3,6 +3,8 @@ title: Tag Group
 description: 아이콘과 텍스트 태그를 수평으로 나열해 여러 속성·상태·메타데이터를 한눈에 보여주는 정보 요약 컴포넌트입니다.
 ---
 
+- `@seed-design/react@1.0.6`, `@seed-design/css@1.0.6`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/tag-group/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/tag-group.mdx
+++ b/docs/content/react/components/tag-group.mdx
@@ -3,7 +3,7 @@ title: Tag Group
 description: 아이콘과 텍스트 태그를 수평으로 나열해 여러 속성·상태·메타데이터를 한눈에 보여주는 정보 요약 컴포넌트입니다.
 ---
 
-- `@seed-design/react@1.0.6`, `@seed-design/css@1.0.6`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@1.0.6, @seed-design/css@1.0.6" />
 
 <ComponentExample name="react/tag-group/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/text-field-input.mdx
+++ b/docs/content/react/components/text-field-input.mdx
@@ -3,6 +3,8 @@ title: Text Field Input
 description: 한 줄 텍스트를 입력받는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@1.1.1`, `@seed-design/css@1.1.4`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/text-field-input/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/text-field-input.mdx
+++ b/docs/content/react/components/text-field-input.mdx
@@ -3,7 +3,7 @@ title: Text Field Input
 description: 한 줄 텍스트를 입력받는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@1.1.1`, `@seed-design/css@1.1.4`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@1.1.0, @seed-design/css@1.1.0" />
 
 <ComponentExample name="react/text-field-input/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/text-field-textarea.mdx
+++ b/docs/content/react/components/text-field-textarea.mdx
@@ -3,6 +3,8 @@ title: Text Field Textarea
 description: 여러 줄의 긴 텍스트를 입력받고 자동으로 높이를 조절하는 컴포넌트입니다.
 ---
 
+- `@seed-design/react@1.1.1`, `@seed-design/css@1.1.4`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/text-field-textarea/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/text-field-textarea.mdx
+++ b/docs/content/react/components/text-field-textarea.mdx
@@ -3,7 +3,7 @@ title: Text Field Textarea
 description: 여러 줄의 긴 텍스트를 입력받고 자동으로 높이를 조절하는 컴포넌트입니다.
 ---
 
-- `@seed-design/react@1.1.1`, `@seed-design/css@1.1.4`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@1.1.0, @seed-design/css@1.1.0" />
 
 <ComponentExample name="react/text-field-textarea/preview">
   ```json doc-gen:file

--- a/docs/content/react/components/toggle-button.mdx
+++ b/docs/content/react/components/toggle-button.mdx
@@ -3,6 +3,8 @@ title: Toggle Button
 description: 사용자가 특정 상태를 켜거나 끌 수 있게 해주는 버튼 형태의 컴포넌트입니다. 필터링이나 뷰 전환과 같은 즉각적인 상태 변경에 사용됩니다.
 ---
 
+- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <ComponentExample name="react/toggle-button/preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/components/toggle-button.mdx
+++ b/docs/content/react/components/toggle-button.mdx
@@ -3,7 +3,7 @@ title: Toggle Button
 description: 사용자가 특정 상태를 켜거나 끌 수 있게 해주는 버튼 형태의 컴포넌트입니다. 필터링이나 뷰 전환과 같은 즉각적인 상태 변경에 사용됩니다.
 ---
 
-- `@seed-design/react@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/react@0.0.1, @seed-design/css@0.0.1" />
 
 <ComponentExample name="react/toggle-button/preview">
   ```json doc-gen:file

--- a/docs/content/react/stackflow/alert-dialog.mdx
+++ b/docs/content/react/stackflow/alert-dialog.mdx
@@ -3,6 +3,8 @@ title: Alert Dialog
 description: Alert Dialog를 Stackflow와 함께 사용하는 방법을 안내합니다.
 ---
 
+- `@seed-design/stackflow@1.1.9`, `@seed-design/css@1.1.7`부터 사용할 수 있습니다.
+
 <Card title="Alert Dialog" href="/react/components/alert-dialog">
 
 Alert Dialog 컴포넌트에 대해 자세히 알아봅니다.

--- a/docs/content/react/stackflow/alert-dialog.mdx
+++ b/docs/content/react/stackflow/alert-dialog.mdx
@@ -3,7 +3,7 @@ title: Alert Dialog
 description: Alert Dialog를 Stackflow와 함께 사용하는 방법을 안내합니다.
 ---
 
-- `@seed-design/stackflow@1.1.9`, `@seed-design/css@1.1.7`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/stackflow@1.1.5, @seed-design/css@1.1.5" />
 
 <Card title="Alert Dialog" href="/react/components/alert-dialog">
 

--- a/docs/content/react/stackflow/app-screen.mdx
+++ b/docs/content/react/stackflow/app-screen.mdx
@@ -3,7 +3,7 @@ title: App Screen
 description: Stackflow 네비게이션에서 개별 화면을 구성하는 컴포넌트입니다. 모바일 앱과 같은 화면 전환 경험을 제공할 때 사용됩니다.
 ---
 
-- `@seed-design/stackflow@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/stackflow@0.0.1, @seed-design/css@0.0.1" />
 
 <StackflowExample path="/app-screen-preview">
   ```json doc-gen:file

--- a/docs/content/react/stackflow/app-screen.mdx
+++ b/docs/content/react/stackflow/app-screen.mdx
@@ -3,6 +3,8 @@ title: App Screen
 description: Stackflow 네비게이션에서 개별 화면을 구성하는 컴포넌트입니다. 모바일 앱과 같은 화면 전환 경험을 제공할 때 사용됩니다.
 ---
 
+- `@seed-design/stackflow@0.0.1`, `@seed-design/css@0.0.1`부터 사용할 수 있습니다.
+
 <StackflowExample path="/app-screen-preview">
   ```json doc-gen:file
   {

--- a/docs/content/react/stackflow/bottom-sheet.mdx
+++ b/docs/content/react/stackflow/bottom-sheet.mdx
@@ -3,7 +3,7 @@ title: Bottom Sheet
 description: Bottom Sheet를 Stackflow와 함께 사용하는 방법을 안내합니다.
 ---
 
-- `@seed-design/stackflow@1.1.9`, `@seed-design/css@1.1.7`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/stackflow@1.1.5, @seed-design/css@1.1.5" />
 
 <Card title="Bottom Sheet" href="/react/components/bottom-sheet">
 

--- a/docs/content/react/stackflow/bottom-sheet.mdx
+++ b/docs/content/react/stackflow/bottom-sheet.mdx
@@ -3,6 +3,8 @@ title: Bottom Sheet
 description: Bottom Sheet를 Stackflow와 함께 사용하는 방법을 안내합니다.
 ---
 
+- `@seed-design/stackflow@1.1.9`, `@seed-design/css@1.1.7`부터 사용할 수 있습니다.
+
 <Card title="Bottom Sheet" href="/react/components/bottom-sheet">
 
 Bottom Sheet 컴포넌트에 대해 자세히 알아봅니다.

--- a/docs/content/react/stackflow/menu-sheet.mdx
+++ b/docs/content/react/stackflow/menu-sheet.mdx
@@ -3,6 +3,8 @@ title: Menu Sheet
 description: Menu Sheet를 Stackflow와 함께 사용하는 방법을 안내합니다.
 ---
 
+- `@seed-design/stackflow@1.1.9`, `@seed-design/css@1.1.7`부터 사용할 수 있습니다.
+
 <Card title="Menu Sheet" href="/react/components/menu-sheet">
 
 Menu Sheet 컴포넌트에 대해 자세히 알아봅니다.

--- a/docs/content/react/stackflow/menu-sheet.mdx
+++ b/docs/content/react/stackflow/menu-sheet.mdx
@@ -3,7 +3,7 @@ title: Menu Sheet
 description: Menu Sheet를 Stackflow와 함께 사용하는 방법을 안내합니다.
 ---
 
-- `@seed-design/stackflow@1.1.9`, `@seed-design/css@1.1.7`부터 사용할 수 있습니다.
+<AvailableSince packages="@seed-design/stackflow@1.1.5, @seed-design/css@1.1.5" />
 
 <Card title="Menu Sheet" href="/react/components/menu-sheet">
 


### PR DESCRIPTION
## 무엇을

문서 컴포넌트/훅 페이지에 "어느 패키지 몇 버전부터 쓸 수 있는지"를 표시합니다. [Adobe Spectrum](https://spectrum.adobe.com/page/button-group/)이 페이지마다 버전을 가볍게 적어두는 것과 같은 목적입니다.

```mdx
---
title: Select
description: 트리거를 눌러 열리는 목록에서 값을 선택하는 컴포넌트입니다.
---

<AvailableSince packages="@seed-design/react@2.1.0, @seed-design/css@2.3.0" />
```

frontmatter 바로 다음, 첫 예제 앞에 놓았습니다. `사용 가능 버전` 캡션 아래에 `패키지@버전` 칩을 세로로 쌓습니다. llms.txt에는 전용 변환 룰(`app/_llms/rules/available-since-rule.ts`)이 `사용 가능 버전: @seed-design/react@2.1.0, @seed-design/css@2.3.0` 한 줄로 내보냅니다.

| 그룹 | 파일 수 | 표기 패키지 |
|---|---|---|
| `react/components` | 50 | react + css |
| `react/stackflow` | 4 | stackflow + css |
| `lynx/components` | 9 | lynx-react + lynx-css |
| `lynx/hooks` | 5 | lynx-react |

deprecated 문서 13개, concepts/foundation, `stackflow/getting-started`(컴포넌트가 아닌 플러그인 설정 가이드)는 제외했습니다.

## 버전을 어떻게 구했나

1차 도출은 git으로 했습니다. 문서의 최초 추가 커밋 → `git tag --contains` → 그 커밋을 포함하는 **가장 이른 stable 태그**(pre-release 배제). 이 워크트리가 shallow clone이라 2026-06-30 이전 문서는 HEAD 기준 `--follow`가 graft 커밋으로 수렴해서, 완전한 히스토리를 가진 `@seed-design/react@2.0.0` 태그를 두 번째 앵커로 썼습니다. 리네임 체인이 오염된 3건은 개별 보정했습니다.

- `tag-group`: registry `--follow`가 2026-01 리네임 커밋을 최초로 잡음 → CHANGELOG로 1.0.6 확정
- `contextual-floating-button`: 리네임 체인이 `BoxButton.tsx`(2024-08)까지 거슬러 오염 → 0.0.30
- `select-box`: overhaul(#1144)로 문서가 재생성돼 `--follow` 단절 → 구 트리 최초 커밋(2024-12-03, #485)

**다만 이 방법이 재는 건 "문서가 릴리스에 포함된 시점"이지 "코드를 쓸 수 있게 된 시점"이 아닙니다.** 코드 PR과 문서 PR이 분리되면 한 패치씩 밀립니다. 그래서 npm에 실제 배포된 tarball을 전부 받아 대조했습니다 — 각 버전의 `lib/components/` 구성과 심볼을 뽑고, 표기 버전에 있고 직전 stable에는 없는지를 이진 탐색으로 확인하는 방식입니다.

68건 중 12건이 어긋나 **npm 실물 기준으로 보정**했습니다. 짝이 되는 css 버전은 그 릴리스와 같은 시각에 배포된 버전으로 맞췄습니다(monorepo 동시 배포).

| 문서 | 표기 → 보정 |
|---|---|
| aspect-ratio, image-frame | 1.2.1 → 1.2.0 |
| field-button, slider, text-field-input, text-field-textarea | 1.1.1 → 1.1.0 |
| scroll-fog | 1.1.4 → 1.1.3 |
| divider | 0.0.15 → 0.0.14 |
| manner-temp | 0.0.13 → 0.0.9 |
| stackflow alert-dialog, bottom-sheet, menu-sheet | 1.1.9 → 1.1.5 |

자동 대조가 오판한 2건은 손으로 확인해 표기를 유지했습니다.

- `dialog`: `Dialog` 디렉토리는 0.0.1부터 있지만 그건 AlertDialog의 실체입니다. 범용 Dialog의 지표인 `ResponsiveDialog`는 2.1.0에만 존재 → 2.1.0 유지
- `result-section`: `Text`/`VStack` 조합 snippet이라 패키지 export 기준이 성립하지 않음 → 문서 기준 1.1.10 유지

lynx 14건은 보정 없이 전부 일치했습니다.

<details>
<summary>68개 전수 도출 표 (1차 git 도출 — 레지스트리 보정 전 기록)</summary>

| 파일 | 도출 커밋 | 버전 | 소스 교차검증 | 확실도 |
|---|---|---|---|---|
| docs/content/react/components/action-button.mdx | e40b765d3 2024-09-30 feat: Example Architecture (#439) | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/components/list.mdx | 12faf5a50 2025-09-05 feat: introduce List, Checkmark and RadioGroup components (#752) | @seed-design/react@0.2.3, @seed-design/css@0.2.3 | 0.2.3 | HIGH |
| docs/content/react/components/manner-temp-badge.mdx | de83c228a 2025-01-22 feat: add manner temp badge | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/components/tag-group.mdx | 6aafce022 2025-10-23 feat: add Tag Group (#975) | @seed-design/react@1.0.6, @seed-design/css@1.0.6 | 1.2.1 | CHECK |
| docs/content/react/components/help-bubble-tooltip.mdx | 029d052c7 2026-06-09 feat(react): add HelpBubbleTooltip (#1635) | @seed-design/react@2.0.0, @seed-design/css@2.0.0 | 2.0.0 | HIGH |
| docs/content/react/components/attachment-display-field.mdx | 195f80efb 2026-06-02 feat: add component AttachmentDisplay (#1587) | @seed-design/react@2.0.0, @seed-design/css@2.0.0 | 2.0.0 | HIGH |
| docs/content/react/components/page-banner.mdx | f806356f0 2025-08-22 feat: add `page-banner`; deprecate `inline-banner` (#876) | @seed-design/react@0.1.14, @seed-design/css@0.1.14 | 0.1.14 | HIGH |
| docs/content/react/components/identity-placeholder.mdx | f4ebec5cf 2024-12-20 feat: avatar | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/components/content-placeholder.mdx | 67a778017 2026-03-19 feat: add content-placeholder component (#1338) | @seed-design/react@1.2.8, @seed-design/css@1.2.6 | 1.2.8 | HIGH |
| docs/content/react/components/chip.mdx | 0ffcd481d 2025-07-22 feat: implement Chip (#804) | @seed-design/react@0.1.4, @seed-design/css@0.1.4 | 0.1.4 | HIGH |
| docs/content/react/components/divider.mdx | d49e69751 2025-04-21 fix: update Divider component to correct rendering issues and modify props interface | @seed-design/react@0.0.15, @seed-design/css@0.0.15 | - | HIGH |
| docs/content/react/components/accordion.mdx | 31bf164e3 2026-05-08 feat(react): `Accordion` (#1405, #1576) | @seed-design/react@2.0.0, @seed-design/css@2.0.0 | 2.0.0 | HIGH |
| docs/content/react/components/alert-dialog.mdx | 2492a414e 2025-01-17 feat: re-write dialog without stackflow | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/components/aspect-ratio.mdx | 8ea512194 2026-01-23 feat: headless/react-image, react/aspect-ratio, react/image-frame (#1136) | @seed-design/react@1.2.1, @seed-design/css@1.2.1 | - | HIGH |
| docs/content/react/components/scroll-fog.mdx | bc3cd6fd1 2025-11-11 feat: scrollable, scroll-fog (#1012) | @seed-design/react@1.1.4, @seed-design/css@1.1.4 | - | HIGH |
| docs/content/react/components/swipeable-menu-sheet.mdx | f982d618a 2026-06-19 feat(swipable-menu-sheet): add component, snippet, docs, and story (#1577) | @seed-design/react@2.0.0, @seed-design/css@2.0.0 | 2.0.0 | HIGH |
| docs/content/react/components/tabs.mdx | 162ed28cf 2024-08-30 Tabs, ChipTabs (#428) | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/components/side-panel.mdx | 98b52a705 2026-06-16 feat(react): add `SidePanel` component (#1463) | @seed-design/react@2.0.0, @seed-design/css@2.0.0 | 2.0.0 | HIGH |
| docs/content/react/components/slider.mdx | a55f58486 2025-11-03 feat: add slider (#987) | @seed-design/react@1.1.1, @seed-design/css@1.1.4 | 1.1.1 | HIGH |
| docs/content/react/components/bottom-sheet.mdx | 19b939383 2024-12-25 feat: bottom sheet | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/components/attachment-field.mdx | 555525aa4 2026-05-04 feat: add component Attachment Input & Field (#1354, #1499, #1510, #1584) | @seed-design/react@2.0.0, @seed-design/css@2.0.0 | 2.0.0 | HIGH |
| docs/content/react/components/contextual-floating-button.mdx | 6b893acc1 2025-06-02 feat(react): introduce Contextual Floating Button component | @seed-design/react@0.0.30, @seed-design/css@0.0.30 | 0.0.1 | CHECK |
| docs/content/react/components/progress-circle.mdx | 8464f65f7 2024-12-09 feat: ProgressCircle (#491) | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/components/floating-action-button.mdx | 306b8e311 2025-06-02 fix: keep FAB component as-is and mark as deprecated | @seed-design/react@0.0.30, @seed-design/css@0.0.30 | 0.0.30 | HIGH |
| docs/content/react/components/result-section.mdx | 6472737fe 2025-11-27 feat: add snippet result-section; deprecate error-state (#1052) | @seed-design/react@1.1.10, @seed-design/css@1.1.10 | 1.1.10 | HIGH |
| docs/content/react/components/toggle-button.mdx | 0681ec49e 2024-12-20 feat: toggle button | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/components/badge.mdx | 2f8d72aac 2024-10-16 feat: badge | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | - | HIGH |
| docs/content/react/components/chip-tabs.mdx | 162ed28cf 2024-08-30 Tabs, ChipTabs (#428) | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/components/field-button.mdx | 8963b6fbc 2025-11-04 feat: make header & footer parts from TextField into Field elements (#871) | @seed-design/react@1.1.1, @seed-design/css@1.1.4 | 1.1.1 | HIGH |
| docs/content/react/components/article.mdx | f2ddf294b 2025-10-22 feat: add Article; support textDecorationLine=underline, whiteSpace, userSelect for Text (#971) | @seed-design/react@1.0.6, @seed-design/css@1.0.6 | - | HIGH |
| docs/content/react/components/image-frame.mdx | 8ea512194 2026-01-23 feat: headless/react-image, react/aspect-ratio, react/image-frame (#1136) | @seed-design/react@1.2.1, @seed-design/css@1.2.1 | - | HIGH |
| docs/content/react/components/skeleton.mdx | adab01519 2024-12-13 feat: skeleton | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | - | HIGH |
| docs/content/react/components/text-field-input.mdx | 8963b6fbc 2025-11-04 feat: make header & footer parts from TextField into Field elements (#871) | @seed-design/react@1.1.1, @seed-design/css@1.1.4 | - | HIGH |
| docs/content/react/components/select-box.mdx | 0ba13b8a6 2024-12-03 feat: Select Box 컴포넌트를 추가해요 (#485) | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/components/checkbox.mdx | 162ed28cf 2024-08-30 Tabs, ChipTabs (#428) | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/components/snackbar.mdx | ed426311c 2025-01-09 feat: snackbar snippet and docs | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/components/callout.mdx | d5b310425 2024-11-27 feat: Callout 컴포넌트를 추가해요 (#468) | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/components/select.mdx | 4dad2e99d 2026-07-28 feat(select): add Select component (#1749) | @seed-design/react@2.1.0, @seed-design/css@2.3.0 | 2.1.0 | HIGH |
| docs/content/react/components/reaction-button.mdx | 5d9d4aa5c 2024-12-24 feat: reaction button | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/components/manner-temp.mdx | 63f86516a 2025-03-19 feat: add MannerTemp component (#609) | @seed-design/react@0.0.13, @seed-design/css@0.0.13 | 0.0.13 | HIGH |
| docs/content/react/components/radio-group.mdx | 12faf5a50 2025-09-05 feat: introduce List, Checkmark and RadioGroup components (#752) | @seed-design/react@0.2.3, @seed-design/css@0.2.3 | 0.2.3 | HIGH |
| docs/content/react/components/switch.mdx | 0f890741d 2024-10-08 docs: switch, expand button | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/components/text-field-textarea.mdx | 8963b6fbc 2025-11-04 feat: make header & footer parts from TextField into Field elements (#871) | @seed-design/react@1.1.1, @seed-design/css@1.1.4 | - | HIGH |
| docs/content/react/components/quantity-picker.mdx | 19f07f5b7 2026-07-28 feat(quantity-picker): restore quantity picker component | @seed-design/react@2.1.0, @seed-design/css@2.3.0 | 2.1.0 | HIGH |
| docs/content/react/components/segmented-control.mdx | 5f3d2d3ff 2024-11-28 feat: Segmented Control 컴포넌트를 추가해요 (#475) | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/components/help-bubble.mdx | 36e66bfae 2024-12-10 feat: help bubble (draft) | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/components/menu.mdx | 69e3b9726 2026-05-04 feat(menu): add Menu; refactor Dialog & Drawer to use new useDismissibleLayer hook (#1410, #1455, #1642, #1656) | @seed-design/react@2.0.0, @seed-design/css@2.0.0 | 2.0.0 | HIGH |
| docs/content/react/components/dialog.mdx | 6ba729276 2026-07-28 feat(content-dialog): add component Dialog (#1747) | @seed-design/react@2.1.0, @seed-design/css@2.3.0 | 2.1.0 | HIGH |
| docs/content/react/components/avatar.mdx | f4ebec5cf 2024-12-20 feat: avatar | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/components/pull-to-refresh.mdx | 416c6a4f2 2025-02-12 feat: add pull to refresh to registry | @seed-design/react@0.0.1, @seed-design/css@0.0.1 | 0.0.1 | HIGH |
| docs/content/react/stackflow/menu-sheet.mdx | 7529e315c 2025-11-14 docs: embed QA app to docs (#1005) | @seed-design/stackflow@1.1.9, @seed-design/css@1.1.7 | - | HIGH |
| docs/content/react/stackflow/alert-dialog.mdx | 7529e315c 2025-11-14 docs: embed QA app to docs (#1005) | @seed-design/stackflow@1.1.9, @seed-design/css@1.1.7 | - | HIGH |
| docs/content/react/stackflow/bottom-sheet.mdx | 7529e315c 2025-11-14 docs: embed QA app to docs (#1005) | @seed-design/stackflow@1.1.9, @seed-design/css@1.1.7 | - | HIGH |
| docs/content/react/stackflow/app-screen.mdx | 259292c14 2024-12-25 feat: stackflow integration (#497) | @seed-design/stackflow@0.0.1, @seed-design/css@0.0.1 | - | HIGH |
| docs/content/lynx/components/action-button.mdx | 699af2ce6 2026-06-04 feat: Lynx (#1310) | @seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0 | 0.1.0 | HIGH |
| docs/content/lynx/components/tag-group.mdx | 699af2ce6 2026-06-04 feat: Lynx (#1310) | @seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0 | 0.1.0 | HIGH |
| docs/content/lynx/components/bottom-sheet.mdx | 699af2ce6 2026-06-04 feat: Lynx (#1310) | @seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0 | 0.1.0 | HIGH |
| docs/content/lynx/components/progress-circle.mdx | 699af2ce6 2026-06-04 feat: Lynx (#1310) | @seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0 | 0.1.0 | HIGH |
| docs/content/lynx/components/badge.mdx | 26d3517d4 2026-06-08 feat(lynx): add badge component (#1637) | @seed-design/lynx-react@0.2.0, @seed-design/lynx-css@0.2.0 | 0.2.0 | HIGH |
| docs/content/lynx/components/checkbox.mdx | 699af2ce6 2026-06-04 feat: Lynx (#1310) | @seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0 | 0.1.0 | HIGH |
| docs/content/lynx/components/app-bar.mdx | c8d4c26ba 2026-06-09 feat(lynx): add app bar component (#1641) | @seed-design/lynx-react@0.2.0, @seed-design/lynx-css@0.2.0 | 0.2.0 | HIGH |
| docs/content/lynx/components/radio-group.mdx | 699af2ce6 2026-06-04 feat: Lynx (#1310) | @seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0 | 0.1.0 | HIGH |
| docs/content/lynx/components/switch.mdx | 699af2ce6 2026-06-04 feat: Lynx (#1310) | @seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0 | 0.1.0 | HIGH |
| docs/content/lynx/hooks/use-safe-area.mdx | 699af2ce6 2026-06-04 feat: Lynx (#1310) | @seed-design/lynx-react@0.1.0 | 0.1.0 | HIGH |
| docs/content/lynx/hooks/use-icon-color.mdx | 699af2ce6 2026-06-04 feat: Lynx (#1310) | @seed-design/lynx-react@0.1.0 | 0.1.0 | HIGH |
| docs/content/lynx/hooks/use-press-tap.mdx | 699af2ce6 2026-06-04 feat: Lynx (#1310) | @seed-design/lynx-react@0.1.0 | 0.1.0 | HIGH |
| docs/content/lynx/hooks/use-seed-class-name.mdx | 2ad8e8cc9 2026-07-02 feat(lynx-react): add reactive useSeedClassName hook for theme changes (#1741) | @seed-design/lynx-react@0.3.0 | 0.3.0 | HIGH |
| docs/content/lynx/hooks/use-controllable-state.mdx | 699af2ce6 2026-06-04 feat: Lynx (#1310) | @seed-design/lynx-react@0.1.0 | 0.1.0 | HIGH |

삽입: 68개

</details>

## 룰은 어디에 남기나

이런 편집 룰(버전 표기 의무, 새 MDX 컴포넌트 도입 시 llms 변환 룰 추가, "SEED" 표기, featured 운영 기준)이 기록될 곳이 없었습니다. 스킬을 새로 만드는 대신 [docs/AGENTS.md](https://github.com/daangn/seed-design/blob/claude/docs-versioning-guidelines-b628bb/docs/AGENTS.md)에 "콘텐츠 작성 룰" 섹션을 열었습니다. `content/` MDX를 편집하는 순간 경로 기반으로 자동 로드되니 "항상 참조"가 구조로 보장되고, `content/` 하위에는 AGENTS.md를 둘 수 없어서(fumadocs 스캔) 여기가 최하위 착지점입니다.

에이전트가 그대로 따라 쓸 내용(버전 표기 형식·패키지 매핑·버전 기준, llms 변환 룰, "SEED" 표기, featured 개수)만 10줄로 담았습니다.

커밋은 넷으로 나눠 뒀습니다 — 백필 / AGENTS.md 섹션 / `AvailableSince` 컴포넌트+llms 룰 / 68개 문서 교체.

## 검증

- 백필 커버리지: `react/components` 50/50, `react/stackflow` 4/4(getting-started 제외), `lynx/components` 9/9, `lynx/hooks` 5/5 — 남은 불렛 0개
- 버전 정확도: 레지스트리 tarball 전수 대조 — 68건 중 12건 보정 후 재검증 통과 (lynx 14건은 보정 없음)
- `bun docs:test` → **97 pass / 0 fail** (룰 단위 inline snapshot 2개 + 파이프라인 fixture 케이스 추가)
- 렌더 확인 (alpha): [react/components/accordion](https://claude-docs-versioning-guide.seed-design.pages.dev/react/components/accordion) — description 아래 우측에 캡션/버전 2줄, 라이트·다크·모바일 확인
- llms.txt 확인: [llms/react/components/accordion.txt](https://claude-docs-versioning-guide.seed-design.pages.dev/llms/react/components/accordion.txt) → `사용 가능 버전: @seed-design/react@2.0.0, @seed-design/css@2.0.0`

`bun run --cwd docs typecheck`는 이 워크트리에서 원래 실행 불가입니다(`@typescript/native`가 루트·docs 어디에도 설치돼 있지 않음). 이 PR과 무관한 baseline입니다.

changeset은 없습니다 (docs 앱은 배포 패키지가 아님).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **문서**
  - React·Lynx 컴포넌트와 훅, Stackflow 가이드에 사용 가능한 패키지 및 최소 버전 정보를 추가했습니다.
  - 문서 작성 규칙을 정리해 버전 표기, 패키지 매핑, MDX 작성 기준을 안내합니다.
  - 컴포넌트 페이지와 문서 변환 결과에서 지원 버전을 일관되게 확인할 수 있습니다.

- **테스트**
  - 지원 버전 정보의 정상 변환과 필수 정보 누락 시 제외 동작을 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


