### PR TITLE
docs: unify the Korean spelling of 라이선스 in bundler plugin READMEs

### DIFF
--- a/packages/rsbuild-plugin/README.md
+++ b/packages/rsbuild-plugin/README.md
@@ -77,6 +77,6 @@ export default defineConfig({
 2. 선택적으로 color-scheme 메타 태그를 추가하여 브라우저에 컬러 스킴을 알립니다.
 3. Recipe 주석 (`// @recipe(seed): 컴포넌트명`)이 있는 파일에 자동으로 CSS 파일을 임포트합니다.
 
-## 라이센스
+## 라이선스
 
 MIT

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -73,6 +73,6 @@ export default defineConfig({
 2. 선택적으로 color-scheme 메타 태그를 추가하여 브라우저에 컬러 스킴을 알립니다.
 3. Recipe 주석 (`// @recipe(seed): 컴포넌트명`)이 있는 파일에 자동으로 CSS 파일을 임포트합니다.
 
-## 라이센스
+## 라이선스
 
 MIT

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -90,6 +90,6 @@ module.exports = {
 3. Recipe 주석 (`// @recipe(seed): 컴포넌트명`)이 있는 파일에 자동으로 CSS 파일을 임포트합니다.
 4. Webpack과 Rspack 모두 지원합니다.
 
-## 라이센스
+## 라이선스
 
 MIT


### PR DESCRIPTION
번들러 플러그인 3개 README의 섹션 제목이 "라이센스"로 돼 있어 "라이선스"로 맞췄습니다.

- `packages/vite-plugin/README.md`
- `packages/rsbuild-plugin/README.md`
- `packages/webpack-plugin/README.md`

셋 다 서로 복사된 문서라 같은 오타가 남아 있었어요. 레포의 나머지(`NOTICE`, `TECH.md`, `docs/content/**`)는 전부 "라이선스"를 쓰고 있어서 이 3개만 갈라져 있었습니다.

이 변경 후 레포 전체에서 "라이센스" 표기는 0건입니다.

#1869(CONTRIBUTING.md 추가)를 작성하다 발견했는데, 그 PR과 무관한 파일이라 분리했습니다.

changeset은 넣지 않았습니다. 섹션 제목 표기만 바뀌어 소비자 영향이 없습니다.
