### PR TITLE
fix(docs): render token tables in llms.txt

### DIFF
--- a/docs/app/_llms/rules/token-reference-rule.ts
+++ b/docs/app/_llms/rules/token-reference-rule.ts
@@ -187,15 +187,16 @@ function resolveRootageDir(): string | null {
 function loadTokenData(): Map<string, Exchange.TokensModel> {
   if (tokenDataCache) return tokenDataCache;
 
-  tokenDataCache = new Map();
   const rootageDir = resolveRootageDir();
 
   if (!rootageDir) {
     console.warn(
       "[TokenReference] rootage __generated__ 디렉토리를 찾지 못해 토큰 표를 건너뜁니다",
     );
-    return tokenDataCache;
+    return new Map();
   }
+
+  tokenDataCache = new Map();
 
   for (const resource of index.resources) {
     const { path } = resource;

--- a/docs/app/_llms/rules/token-reference-rule.ts
+++ b/docs/app/_llms/rules/token-reference-rule.ts
@@ -1,6 +1,5 @@
-import { readFileSync } from "node:fs";
-import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import type {
   MdxJsxAttribute,
   MdxJsxAttributeValueExpression,
@@ -176,14 +175,27 @@ function generateMarkdownTable(
 */
 let tokenDataCache: Map<string, Exchange.TokensModel> | null = null;
 
+function resolveRootageDir(): string | null {
+  const candidates = [
+    join(process.cwd(), "..", "packages", "rootage", "__generated__"),
+    join(process.cwd(), "packages", "rootage", "__generated__"),
+  ];
+
+  return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
 function loadTokenData(): Map<string, Exchange.TokensModel> {
   if (tokenDataCache) return tokenDataCache;
 
   tokenDataCache = new Map();
-  const rootageDir = join(
-    dirname(createRequire(import.meta.url).resolve("@seed-design/rootage-artifacts/package.json")),
-    "__generated__",
-  );
+  const rootageDir = resolveRootageDir();
+
+  if (!rootageDir) {
+    console.warn(
+      "[TokenReference] rootage __generated__ 디렉토리를 찾지 못해 토큰 표를 건너뜁니다",
+    );
+    return tokenDataCache;
+  }
 
   for (const resource of index.resources) {
     const { path } = resource;


### PR DESCRIPTION
## 문제

`<TokenReference />`를 쓰는 llms.txt 페이지 10개가 토큰 표 대신 JSX 태그를 그대로 내보내고 있었습니다. `foundations/design-token/reference.txt`는 frontmatter만 남은 239바이트였고, 이 문서가 "SEED 토큰 전체 목록"의 유일한 출처라 AI 에이전트가 이 URL을 읽어도 아무것도 얻지 못했습니다.

## 원인

룰([`token-reference-rule.ts`](https://github.com/daangn/seed-design/blob/dev/docs/app/_llms/rules/token-reference-rule.ts))은 이미 있었고 유닛 테스트도 통과하고 있었습니다. 깨진 건 데이터 로딩 경로입니다.

```ts
createRequire(import.meta.url).resolve("@seed-design/rootage-artifacts/package.json")
```

turbopack이 번들할 때 이 호출을 모듈 참조로 치환합니다 (빌드 청크에서 `createRequire` 호출이 사라지고 `package.json` 내용이 모듈로 인라인됩니다). `.resolve()`가 실제 파일 경로를 반환하지 못해 이어지는 `readFileSync`가 전부 실패하고, 룰 규약대로 조용히 원본 노드를 반환했습니다.

## 수정

`process.cwd()` 기준으로 `packages/rootage/__generated__`를 찾습니다. `docs/lib/rootage.ts`, `component-grid-rule.ts`, `changelog-page-rule.ts`가 이미 쓰는 방식입니다. 후보를 둘 두는 건 `bun docs:test`가 저장소 루트에서 돌기 때문이고, 못 찾으면 `console.warn`을 남겨 다음번엔 조용히 죽지 않게 했습니다.

정적 JSON import도 검토했지만 `Type 'string' is not assignable to type '"Tokens"'` — `Exchange` 판별자와 맞지 않아 캐스팅이 필요해서 기각했습니다.

## 검증

`docs/out`(Cloudflare Pages에 배포되는 static export) 기준 before → after:

| 페이지 | before | after |
|---|---|---|
| `foundations/design-token/reference` | 239 | **19,910** |
| `foundations/color/palette` | 881 | 6,269 |
| `foundations/gradient` | 350 | 1,848 |
| `foundations/color/color-role` | 9,382 | 15,656 |
| `foundations/typography` | 5,307 | 7,293 |
| `foundations/spacing` | 2,763 | 3,566 |
| `foundations/motion` | 1,484 | 2,120 |
| `foundations/elevation` | 17,152 | 18,658 |
| `foundations/radius` | 629 | 864 |
| `react/components/concepts/interaction-states` | 2,511 | 4,128 |

- 산출물에 남은 미변환 `<TokenReference`: **0개**
- 전체 1,407개 llms 페이지 중 회귀 없음
- `groups` / `regex` / prop 없음 3가지 변형 모두 정상
- `bun docs:test`: 95 pass

`reference.txt`는 378줄 / 약 5.7k 토큰입니다. `foundations` 섹션에는 `llms-full.txt` 합본 라우트가 없어서 이 문서를 직접 요청할 때만 로드되고, 부분만 필요한 에이전트를 위한 축별 페이지(radius 864B, motion 2.1KB 등)는 그대로 있습니다.

## 프리뷰 확인 경로

```
<Branch Preview URL>/llms/foundations/design-token/reference.txt
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 토큰 참조 데이터가 현재 작업 디렉터리에서 올바르게 검색되도록 개선했습니다.
  * 필요한 경로를 찾을 수 없는 경우 경고를 표시하고 안전하게 빈 캐시를 사용합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->