### PR TITLE
feat(rootage): add an enum property type to component specs

### DIFF
--- a/docs/app/_llms/rules/token-reference-rule.ts
+++ b/docs/app/_llms/rules/token-reference-rule.ts
@@ -128,6 +128,8 @@ function formatTokenValue(entry: Exchange.Value): string {
     }
     case "number":
       return String(entry.value);
+    case "enum":
+      return entry.value;
     case "cubicBezier": {
       if (typeof entry.value === "string") return entry.value;
       return `cubic-bezier(${entry.value.join(", ")})`;

--- a/docs/app/_llms/rules/token-reference-rule.ts
+++ b/docs/app/_llms/rules/token-reference-rule.ts
@@ -5,6 +5,7 @@ import type {
   MdxJsxAttributeValueExpression,
   MdxJsxFlowElement,
 } from "mdast-util-mdx-jsx";
+import { match, P } from "ts-pattern";
 import type { Exchange } from "@seed-design/rootage-core";
 import index from "@seed-design/rootage-artifacts/index.json";
 import type { Rule } from "./types";
@@ -113,32 +114,29 @@ function getRegexFromNode(node: MdxJsxFlowElement): RegExp | null {
   토큰 값을 사람이 읽을 수 있는 문자열로 변환합니다.
 */
 function formatTokenValue(entry: Exchange.Value): string {
-  switch (entry.type) {
-    case "color":
-      return entry.value; // ColorLit | TokenRef - 모두 string
-    case "dimension": {
-      if (typeof entry.value === "string") return entry.value;
-      const { value, unit } = entry.value;
-      if (unit === "rem") return `${value}rem (${Math.round(value * 16)}px)`;
-      return `${value}${unit}`;
-    }
-    case "duration": {
-      if (typeof entry.value === "string") return entry.value;
-      return `${entry.value.value}${entry.value.unit}`;
-    }
-    case "number":
-      return String(entry.value);
-    case "enum":
-      return entry.value;
-    case "cubicBezier": {
-      if (typeof entry.value === "string") return entry.value;
-      return `cubic-bezier(${entry.value.join(", ")})`;
-    }
-    case "shadow":
-    case "gradient":
-      if (typeof entry.value === "string") return entry.value;
-      return JSON.stringify(entry.value);
-  }
+  return (
+    match(entry)
+      .with({ type: "number" }, ({ value }) => String(value))
+      .with(
+        { type: "dimension", value: { unit: "rem" } },
+        ({ value }) => `${value.value}rem (${Math.round(value.value * 16)}px)`,
+      )
+      .with({ type: "dimension", value: { unit: "px" } }, ({ value }) => `${value.value}px`)
+      .with(
+        { type: "duration", value: { unit: P.union("ms", "s") } },
+        ({ value }) => `${value.value}${value.unit}`,
+      )
+      .with(
+        { type: "cubicBezier", value: P.array(P.number) },
+        ({ value }) => `cubic-bezier(${value.join(", ")})`,
+      )
+      .with({ type: P.union("shadow", "gradient"), value: P.array() }, ({ value }) =>
+        JSON.stringify(value),
+      )
+      // 남은 건 전부 문자열 그대로 출력한다 — TokenRef, ColorLit, enum 값.
+      .with({ value: P.string }, ({ value }) => value)
+      .exhaustive()
+  );
 }
 
 /*

--- a/ecosystem/rootage/core/src/analyzer/resolver.test.ts
+++ b/ecosystem/rootage/core/src/analyzer/resolver.test.ts
@@ -266,17 +266,15 @@ describe("resolveReferences", () => {
           },
           data: {
             schema: {
-              slots: [
-                {
-                  name: "root",
-                  properties: [
-                    {
-                      name: "color",
+              slots: {
+                root: {
+                  properties: {
+                    color: {
                       type: "color",
                     },
-                  ],
+                  },
                 },
-              ],
+              },
             },
             definitions: {
               base: {
@@ -419,17 +417,15 @@ describe("getTypeResolvedSourceFile", () => {
           },
           data: {
             schema: {
-              slots: [
-                {
-                  name: "root",
-                  properties: [
-                    {
-                      name: "color",
+              slots: {
+                root: {
+                  properties: {
+                    color: {
                       type: "color",
                     },
-                  ],
+                  },
                 },
-              ],
+              },
             },
             definitions: {
               base: {

--- a/ecosystem/rootage/core/src/analyzer/validate.test.ts
+++ b/ecosystem/rootage/core/src/analyzer/validate.test.ts
@@ -16,7 +16,7 @@ import { validate } from "./validate";
  */
 function componentSpec(
   id: string,
-  rootProperties: Record<string, Exchange.ComponentSpecPropertySchema[string]["type"]>,
+  rootProperties: Exchange.ComponentSpecPropertySchema,
   slots: Record<string, Record<string, Exchange.Value>>,
 ): Exchange.ComponentSpecModel {
   return {
@@ -25,16 +25,7 @@ function componentSpec(
     data: {
       id,
       name: "component",
-      schema: {
-        slots: {
-          root: {
-            properties: Object.fromEntries(
-              Object.entries(rootProperties).map(([name, type]) => [name, { type }]),
-            ),
-          },
-        },
-        variants: {},
-      },
+      schema: { slots: { root: { properties: rootProperties } }, variants: {} },
       definitions: [{ variants: {}, definitions: [{ states: ["enabled"], slots }] }],
     },
   };
@@ -270,7 +261,7 @@ describe("validate", () => {
         ast: Exchange.fromObject(
           componentSpec(
             "3",
-            { color: "color" },
+            { color: { type: "color" } },
             { container: { color: { type: "color", value: "$color.bg.layer-1" } } },
           ),
         ),
@@ -318,7 +309,7 @@ describe("validate", () => {
         ast: Exchange.fromObject(
           componentSpec(
             "3",
-            { color: "color" },
+            { color: { type: "color" } },
             { root: { background: { type: "color", value: "$color.bg.layer-1" } } },
           ),
         ),
@@ -338,7 +329,7 @@ describe("validate", () => {
         ast: Exchange.fromObject(
           componentSpec(
             "1",
-            { color: "color" },
+            { color: { type: "color" } },
             { root: { color: { type: "dimension", value: { value: 8, unit: "px" } } } },
           ),
         ),
@@ -349,6 +340,70 @@ describe("validate", () => {
 
     expect(result.valid).toEqual(false);
     expect(result.message).toContain('Property "color" expects type "color" but got "dimension"');
+  });
+
+  it("should return false if an enum value is not one the schema lists", () => {
+    const files: SourceFile[] = [
+      {
+        fileName: "component",
+        ast: Exchange.fromObject(
+          componentSpec(
+            "1",
+            { scaleScope: { type: "enum", values: ["self", "content"] } },
+            { root: { scaleScope: { type: "enum", value: "contnet" } } },
+          ),
+        ),
+      },
+    ];
+
+    const result = validate(buildContext(files));
+
+    expect(result.valid).toEqual(false);
+    expect(result.message).toContain(
+      'Property "scaleScope" expects one of "self", "content" but got "contnet"',
+    );
+  });
+
+  it("should return false if an enum lists a value that would read as a token reference", () => {
+    const files: SourceFile[] = [
+      {
+        fileName: "component",
+        ast: Exchange.fromObject(
+          componentSpec(
+            "1",
+            { scaleScope: { type: "enum", values: ["self", "$content"] } },
+            { root: { scaleScope: { type: "enum", value: "self" } } },
+          ),
+        ),
+      },
+    ];
+
+    const result = validate(buildContext(files));
+
+    expect(result.valid).toEqual(false);
+    expect(result.message).toContain('Enum value "$content" of property "scaleScope"');
+  });
+
+  it("should return false if an enum lists no values", () => {
+    const files: SourceFile[] = [
+      {
+        fileName: "component",
+        ast: Exchange.fromObject(
+          componentSpec(
+            "1",
+            { scaleScope: { type: "enum", values: [] } },
+            { root: { scaleScope: { type: "enum", value: "self" } } },
+          ),
+        ),
+      },
+    ];
+
+    const result = validate(buildContext(files));
+
+    expect(result.valid).toEqual(false);
+    expect(result.message).toContain(
+      'Property "scaleScope" in slot "root" is an enum with no values',
+    );
   });
 
   it("should return false if schema property is never used in definitions", () => {

--- a/ecosystem/rootage/core/src/analyzer/validate.test.ts
+++ b/ecosystem/rootage/core/src/analyzer/validate.test.ts
@@ -1,9 +1,44 @@
 import dedent from "dedent";
 import { describe, expect, it } from "bun:test";
-import { Authoring } from "../parser";
+import { Authoring, Exchange } from "../parser";
 import { buildContext } from "./context";
 import type { SourceFile } from "./types";
 import { validate } from "./validate";
+
+/**
+ * A ComponentSpec in the exchange format, whose schema declares a single `root`
+ * slot while the definitions may name any slot.
+ *
+ * Exchange values carry their own type tag rather than being typed by the schema,
+ * which makes this the only remaining way to hand `validate` a slot, property, or
+ * value the schema never declared — the authoring parser rejects all three while
+ * parsing (see parser/authoring/component-spec.ts).
+ */
+function componentSpec(
+  id: string,
+  rootProperties: Record<string, Exchange.ComponentSpecPropertySchema[string]["type"]>,
+  slots: Record<string, Record<string, Exchange.Value>>,
+): Exchange.ComponentSpecModel {
+  return {
+    kind: "ComponentSpec",
+    metadata: { id, name: "component" },
+    data: {
+      id,
+      name: "component",
+      schema: {
+        slots: {
+          root: {
+            properties: Object.fromEntries(
+              Object.entries(rootProperties).map(([name, type]) => [name, { type }]),
+            ),
+          },
+        },
+        variants: {},
+      },
+      definitions: [{ variants: {}, definitions: [{ states: ["enabled"], slots }] }],
+    },
+  };
+}
 
 describe("validate", () => {
   it("should return true for valid models", () => {
@@ -232,23 +267,13 @@ describe("validate", () => {
       },
       {
         fileName: "component",
-        ast: Authoring.fromString(dedent`
-        kind: ComponentSpec
-        metadata:
-          id: "3"
-          name: component
-        data:
-          schema:
-            slots:
-              root:
-                properties:
-                  color:
-                    type: color
-          definitions:
-            base:
-              enabled:
-                container:
-                  color: "$color.bg.layer-1"`),
+        ast: Exchange.fromObject(
+          componentSpec(
+            "3",
+            { color: "color" },
+            { container: { color: { type: "color", value: "$color.bg.layer-1" } } },
+          ),
+        ),
       },
     ];
 
@@ -290,23 +315,13 @@ describe("validate", () => {
       },
       {
         fileName: "component",
-        ast: Authoring.fromString(dedent`
-        kind: ComponentSpec
-        metadata:
-          id: "3"
-          name: component
-        data:
-          schema:
-            slots:
-              root:
-                properties:
-                  color:
-                    type: color
-          definitions:
-            base:
-              enabled:
-                root:
-                  background: "$color.bg.layer-1"`),
+        ast: Exchange.fromObject(
+          componentSpec(
+            "3",
+            { color: "color" },
+            { root: { background: { type: "color", value: "$color.bg.layer-1" } } },
+          ),
+        ),
       },
     ];
 
@@ -320,23 +335,13 @@ describe("validate", () => {
     const files: SourceFile[] = [
       {
         fileName: "component",
-        ast: Authoring.fromString(dedent`
-        kind: ComponentSpec
-        metadata:
-          id: "1"
-          name: component
-        data:
-          schema:
-            slots:
-              root:
-                properties:
-                  color:
-                    type: color
-          definitions:
-            base:
-              enabled:
-                root:
-                  color: 8px`),
+        ast: Exchange.fromObject(
+          componentSpec(
+            "1",
+            { color: "color" },
+            { root: { color: { type: "dimension", value: { value: 8, unit: "px" } } } },
+          ),
+        ),
       },
     ];
 

--- a/ecosystem/rootage/core/src/analyzer/validate.ts
+++ b/ecosystem/rootage/core/src/analyzer/validate.ts
@@ -11,6 +11,7 @@ const LITERAL_KIND_TO_TYPE: Record<ValueLit["kind"], PropertySchemaDeclaration["
   ColorHexLit: "color",
   DimensionLit: "dimension",
   NumberLit: "number",
+  EnumLit: "enum",
   DurationLit: "duration",
   CubicBezierLit: "cubicBezier",
   ShadowLit: "shadow",
@@ -101,14 +102,34 @@ export function validate(ctx: RootageCtx): ValidationResult {
   }
 
   for (const componentSpec of componentSpecs) {
-    const slotSchemaMap = new Map<string, Map<string, PropertySchemaDeclaration["type"]>>();
+    const slotSchemaMap = new Map<string, Map<string, PropertySchemaDeclaration>>();
 
     for (const slotSchema of componentSpec.schema.slots) {
-      const propertyTypeMap = new Map<string, PropertySchemaDeclaration["type"]>();
+      const propertySchemaMap = new Map<string, PropertySchemaDeclaration>();
       for (const prop of slotSchema.properties) {
-        propertyTypeMap.set(prop.name, prop.type);
+        if (prop.type === "enum") {
+          if (prop.values.length === 0) {
+            return {
+              valid: false,
+              message: `Property "${prop.name}" in slot "${slotSchema.name}" is an enum with no values in component spec "${componentSpec.name}"`,
+            };
+          }
+
+          // A `$`-prefixed value is indistinguishable from a token reference, and
+          // the reference wins: the parser resolves it before it ever reaches the
+          // enum. Such a value could never be written, so reject the declaration.
+          const tokenLike = prop.values.find((value) => value.startsWith("$"));
+          if (tokenLike) {
+            return {
+              valid: false,
+              message: `Enum value "${tokenLike}" of property "${prop.name}" in slot "${slotSchema.name}" starts with "$" and would be read as a token reference in component spec "${componentSpec.name}"`,
+            };
+          }
+        }
+
+        propertySchemaMap.set(prop.name, prop);
       }
-      slotSchemaMap.set(slotSchema.name, propertyTypeMap);
+      slotSchemaMap.set(slotSchema.name, propertySchemaMap);
     }
 
     const usedProperties = new Map<string, Set<string>>();
@@ -119,19 +140,19 @@ export function validate(ctx: RootageCtx): ValidationResult {
     for (const variant of componentSpec.body) {
       for (const state of variant.body) {
         for (const slot of state.body) {
-          if (!slotSchemaMap.has(slot.slot)) {
+          const propertySchemaMap = slotSchemaMap.get(slot.slot);
+          if (!propertySchemaMap) {
             return {
               valid: false,
               message: `Slot "${slot.slot}" is not defined in schema but used in component spec "${componentSpec.name}"`,
             };
           }
 
-          const propertyTypeMap = slotSchemaMap.get(slot.slot)!;
-
           for (const property of slot.body) {
             usedProperties.get(slot.slot)?.add(property.property);
 
-            if (!propertyTypeMap.has(property.property)) {
+            const propertySchema = propertySchemaMap.get(property.property);
+            if (!propertySchema) {
               return {
                 valid: false,
                 message: `Property "${property.property}" is not defined in slot "${slot.slot}" schema but used in component spec "${componentSpec.name}"`,
@@ -148,7 +169,7 @@ export function validate(ctx: RootageCtx): ValidationResult {
               }
             }
 
-            const expectedType = propertyTypeMap.get(property.property)!;
+            const expectedType = propertySchema.type;
             const actualType = (() => {
               switch (property.value.kind) {
                 case "TokenLit":
@@ -163,6 +184,17 @@ export function validate(ctx: RootageCtx): ValidationResult {
               return {
                 valid: false,
                 message: `Property "${property.property}" expects type "${expectedType}" but got "${actualType}" in component spec "${componentSpec.name}"`,
+              };
+            }
+
+            if (
+              propertySchema.type === "enum" &&
+              property.value.kind === "EnumLit" &&
+              !propertySchema.values.includes(property.value.value)
+            ) {
+              return {
+                valid: false,
+                message: `Property "${property.property}" expects one of ${propertySchema.values.map((value) => `"${value}"`).join(", ")} but got "${property.value.value}" in component spec "${componentSpec.name}"`,
               };
             }
           }

--- a/ecosystem/rootage/core/src/languages/css.test.ts
+++ b/ecosystem/rootage/core/src/languages/css.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { factory, Authoring } from "../parser";
 import { createStringifier, getTokenCss } from "./css";
 
-const { value, tokenReference } = createStringifier({
+const { value, tokenReference, valueOrToken } = createStringifier({
   prefix: "test",
 });
 
@@ -39,6 +39,47 @@ test("stringifier.value should stringify gradient expression", () => {
   const result = value(gradient);
 
   expect(result).toEqual("#000000 0%, #ffffff 100%");
+});
+
+test("stringifier.value should stringify enum expression", () => {
+  const result = value(factory.createEnumLit("content"));
+
+  expect(result).toEqual("content");
+});
+
+test("stringifier.value should stringify an enum parsed from a component spec", () => {
+  const spec: Authoring.ComponentSpecModel = {
+    kind: "ComponentSpec",
+    metadata: { id: "test", name: "test" },
+    data: {
+      schema: {
+        slots: {
+          root: {
+            properties: {
+              scaleScope: { type: "enum", values: ["self", "content"] },
+            },
+          },
+        },
+      },
+      definitions: {
+        base: { pressed: { root: { scaleScope: "content" } } },
+      },
+    },
+  };
+
+  const propertyDecl =
+    Authoring.parseComponentSpecDocument(spec).data.body[0]?.body[0]?.body[0]?.body[0];
+  if (propertyDecl?.kind !== "EnumPropertyDeclaration") {
+    throw new Error("expected the spec to parse into an enum property");
+  }
+
+  expect(value(propertyDecl.value)).toEqual("content");
+});
+
+test("stringifier.valueOrToken should reject an enum", () => {
+  expect(() => valueOrToken(factory.createEnumLit("content"))).toThrow(
+    "Enum values cannot be emitted as CSS",
+  );
 });
 
 test("getTokenCss should generate css code", () => {

--- a/ecosystem/rootage/core/src/languages/css.ts
+++ b/ecosystem/rootage/core/src/languages/css.ts
@@ -66,6 +66,12 @@ function stringifyValueLit(expr: ValueLit, tokenReference?: (token: TokenLit) =>
     return `${expr.value}`;
   }
 
+  // Enums never reach CSS output — `valueOrToken` rejects them. This branch serves
+  // `staticStringifier`, whose only consumer renders literals as documentation text.
+  if (expr.kind === "EnumLit") {
+    return expr.value;
+  }
+
   if (expr.kind === "CubicBezierLit") {
     return stringifyCubicBezierLit(expr);
   }
@@ -113,9 +119,18 @@ export function createStringifier(
   }
 
   function valueOrToken(value: ValueLit | TokenLit): string {
-    return value.kind === "TokenLit"
-      ? tokenReference(value)
-      : stringifyValueLit(value, tokenReference);
+    if (value.kind === "TokenLit") {
+      return tokenReference(value);
+    }
+
+    // Callers drop enum properties before emitting declarations (see languages/
+    // typescript.ts), so one arriving here is a caller bug: it would publish a
+    // design decision as a custom property.
+    if (value.kind === "EnumLit") {
+      throw new Error("Enum values cannot be emitted as CSS");
+    }
+
+    return stringifyValueLit(value, tokenReference);
   }
 
   function declaration({ decl, mode }: { decl: TokenDeclaration; mode: string }) {

--- a/ecosystem/rootage/core/src/languages/exchange/index.ts
+++ b/ecosystem/rootage/core/src/languages/exchange/index.ts
@@ -172,6 +172,11 @@ export function getComponentSpecModel(ast: AST.ComponentSpecDocument): Exchange.
               ? { value: prop.value.value, unit: prop.value.unit }
               : prop.value.identifier,
         };
+      case "EnumPropertyDeclaration":
+        return {
+          type: "enum",
+          value: prop.value.value,
+        };
       case "CubicBezierPropertyDeclaration":
         return {
           type: "cubicBezier",
@@ -227,6 +232,22 @@ export function getComponentSpecModel(ast: AST.ComponentSpecDocument): Exchange.
     return { variants, definitions };
   }
 
+  // Narrowed rather than spread wholesale: `type` and `values` only travel
+  // together while the declaration is still one of the two concrete shapes.
+  function buildPropertySchema(
+    prop: AST.PropertySchemaDeclaration,
+  ): Exchange.ComponentSpecPropertySchema[string] {
+    if (prop.type === "enum") {
+      return compactObject({
+        type: prop.type,
+        values: prop.values,
+        description: prop.description,
+      });
+    }
+
+    return compactObject({ type: prop.type, description: prop.description });
+  }
+
   function buildSchema(schema: AST.SchemaDeclaration): Exchange.ComponentSpecSchema {
     return {
       slots: Object.fromEntries(
@@ -234,13 +255,7 @@ export function getComponentSpecModel(ast: AST.ComponentSpecDocument): Exchange.
           slot.name,
           compactObject({
             properties: Object.fromEntries(
-              slot.properties.map((prop) => [
-                prop.name,
-                compactObject({
-                  type: prop.type,
-                  description: prop.description,
-                }),
-              ]),
+              slot.properties.map((prop) => [prop.name, buildPropertySchema(prop)]),
             ),
             description: slot.description,
           }),

--- a/ecosystem/rootage/core/src/languages/jsonschema.test.ts
+++ b/ecosystem/rootage/core/src/languages/jsonschema.test.ts
@@ -143,13 +143,30 @@ test("getJsonSchema should generate jsonschema for component spec", () => {
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["color", "dimension", "number", "duration", "cubicBezier", "shadow", "gradient"]
+              "enum": ["color", "dimension", "number", "duration", "enum", "cubicBezier", "shadow", "gradient"]
             },
             "description": {
               "type": "string"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
             }
           },
           "required": ["type"],
+          "if": {
+            "properties": { "type": { "const": "enum" } },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["values"]
+          },
+          "else": {
+            "not": { "required": ["values"] }
+          },
           "additionalProperties": false
         },
         "variantsSchema": {
@@ -232,6 +249,9 @@ test("getJsonSchema should generate jsonschema for component spec", () => {
               "$ref": "#/definitions/numberShorthand"
             },
             {
+              "$ref": "#/definitions/enumShorthand"
+            },
+            {
               "$ref": "#/definitions/cubicBezier"
             },
             {
@@ -259,6 +279,10 @@ test("getJsonSchema should generate jsonschema for component spec", () => {
         },
         "numberShorthand": {
           "type": "number"
+        },
+        "enumShorthand": {
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9-]*$"
         },
         "cubicBezier": {
           "type": "object",

--- a/ecosystem/rootage/core/src/languages/jsonschema.test.ts
+++ b/ecosystem/rootage/core/src/languages/jsonschema.test.ts
@@ -282,7 +282,7 @@ test("getJsonSchema should generate jsonschema for component spec", () => {
         },
         "enumShorthand": {
           "type": "string",
-          "pattern": "^[a-zA-Z][a-zA-Z0-9-]*$"
+          "pattern": "^[^#$0-9-].*$"
         },
         "cubicBezier": {
           "type": "object",

--- a/ecosystem/rootage/core/src/languages/jsonschema.ts
+++ b/ecosystem/rootage/core/src/languages/jsonschema.ts
@@ -283,13 +283,14 @@ export function getJsonSchema(tokens: TokenDeclaration[]): string {
       "numberShorthand": {
         "type": "number"
       },${
-        "" /* An enum value is a bare word with no shape of its own. The pattern only
-              rules out the forms that belong to another type — a leading "#", "$", or
-              digit — so a malformed color or dimension can't pass as an enum. */
+        "" /* An enum value is a bare word with no shape of its own, so the pattern can
+              only exclude the leading characters another type claims — "#", "$", a
+              digit, or a negative dimension's "-". Without that, a malformed color or
+              dimension would match this branch of the anyOf instead of being flagged. */
       }
       "enumShorthand": {
         "type": "string",
-        "pattern": "^[a-zA-Z][a-zA-Z0-9-]*$"
+        "pattern": "^[^#$0-9-].*$"
       },
       "cubicBezier": {
         "type": "object",

--- a/ecosystem/rootage/core/src/languages/jsonschema.ts
+++ b/ecosystem/rootage/core/src/languages/jsonschema.ts
@@ -146,13 +146,30 @@ export function getJsonSchema(tokens: TokenDeclaration[]): string {
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["color", "dimension", "number", "duration", "cubicBezier", "shadow", "gradient"]${"" /* NOTE: this should be kept in sync with PropertySchemaDeclaration["type"] */}
+            "enum": ["color", "dimension", "number", "duration", "enum", "cubicBezier", "shadow", "gradient"]${"" /* NOTE: this should be kept in sync with PropertySchemaDeclaration["type"] */}
           },
           "description": {
             "type": "string"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
           }
         },
         "required": ["type"],
+        "if": {
+          "properties": { "type": { "const": "enum" } },
+          "required": ["type"]
+        },
+        "then": {
+          "required": ["values"]
+        },
+        "else": {
+          "not": { "required": ["values"] }
+        },
         "additionalProperties": false
       },
       "variantsSchema": {
@@ -235,6 +252,9 @@ export function getJsonSchema(tokens: TokenDeclaration[]): string {
             "$ref": "#/definitions/numberShorthand"
           },
           {
+            "$ref": "#/definitions/enumShorthand"
+          },
+          {
             "$ref": "#/definitions/cubicBezier"
           },
           {
@@ -262,6 +282,14 @@ export function getJsonSchema(tokens: TokenDeclaration[]): string {
       },
       "numberShorthand": {
         "type": "number"
+      },${
+        "" /* An enum value is a bare word with no shape of its own. The pattern only
+              rules out the forms that belong to another type — a leading "#", "$", or
+              digit — so a malformed color or dimension can't pass as an enum. */
+      }
+      "enumShorthand": {
+        "type": "string",
+        "pattern": "^[a-zA-Z][a-zA-Z0-9-]*$"
       },
       "cubicBezier": {
         "type": "object",

--- a/ecosystem/rootage/core/src/languages/typescript.test.ts
+++ b/ecosystem/rootage/core/src/languages/typescript.test.ts
@@ -287,9 +287,9 @@ metadata:
 data:
   schema:
     slots:
-      - name: root
+      root:
         properties:
-          - name: color
+          color:
             type: color
   definitions:
     base:
@@ -334,9 +334,9 @@ metadata:
 data:
   schema:
     slots:
-      - name: root
+      root:
         properties:
-          - name: color
+          color:
             type: color
   definitions:
     base:

--- a/ecosystem/rootage/core/src/languages/typescript.test.ts
+++ b/ecosystem/rootage/core/src/languages/typescript.test.ts
@@ -529,3 +529,47 @@ test("getTokenDts should generate JSDoc for token descriptions", () => {
     ]
   `);
 });
+
+test("getComponentSpecMjs should omit enum properties and anything left empty by them", () => {
+  const yaml = `
+kind: ComponentSpec
+metadata:
+  id: test
+  name: test
+data:
+  schema:
+    slots:
+      root:
+        properties:
+          color:
+            type: color
+          scaleScope:
+            type: enum
+            values: [self, content]
+  definitions:
+    base:
+      enabled:
+        root:
+          color: "#ffffff"
+      pressed:
+        root:
+          scaleScope: content
+`;
+  const model = Authoring.parseComponentSpecDocument(YAML.parse(yaml));
+
+  const result = getComponentSpecMjs(model.data);
+
+  // `pressed` disappears entirely: its only property is an enum, which leaves the
+  // slot empty, which leaves the state empty.
+  expect(result).toMatchInlineSnapshot(`
+    "export const vars = {
+      "base": {
+        "enabled": {
+          "root": {
+            "color": "#ffffff"
+          }
+        }
+      }
+    }"
+  `);
+});

--- a/ecosystem/rootage/core/src/languages/typescript.ts
+++ b/ecosystem/rootage/core/src/languages/typescript.ts
@@ -66,14 +66,24 @@ export function createStringifier(options: { prefix?: string } = {}) {
           const property: Record<string, string> = {};
 
           for (const propertyDecl of slotDecl.body) {
+            // An enum records a design decision rather than a value CSS can
+            // consume, so it never becomes a custom property.
+            if (propertyDecl.value.kind === "EnumLit") continue;
+
             const propertyKey = propertyDecl.property;
             const expr = propertyDecl.value;
 
             property[propertyKey] = cssStringifier.valueOrToken(expr);
           }
 
+          // A slot holding nothing but enums, or a state left with no slots, would
+          // publish an empty object where consumers expect values.
+          if (Object.keys(property).length === 0) continue;
+
           slot[slotKey] = property;
         }
+
+        if (Object.keys(slot).length === 0) continue;
 
         variant[stateKey] = slot;
       }

--- a/ecosystem/rootage/core/src/parser/ast.ts
+++ b/ecosystem/rootage/core/src/parser/ast.ts
@@ -23,6 +23,15 @@ export interface NumberLit {
   value: number;
 }
 
+/**
+ * One of the values a property's `enum` schema lists. Carries no CSS-expressible
+ * value, so it never reaches the style output.
+ */
+export interface EnumLit {
+  kind: "EnumLit";
+  value: string;
+}
+
 export interface CubicBezierLit {
   kind: "CubicBezierLit";
   value: readonly [number, number, number, number];
@@ -58,6 +67,7 @@ export type ValueLit =
   | DimensionLit
   | DurationLit
   | NumberLit
+  | EnumLit
   | CubicBezierLit
   | ShadowLit
   | GradientLit;
@@ -264,6 +274,16 @@ export interface DurationPropertyDeclaration {
   value: DurationLit | TokenLit;
 }
 
+/**
+ * No `TokenLit` alternative: no token collection has an enum type, so an alias can
+ * never resolve to one. Writing one is caught as a type mismatch by the analyzer.
+ */
+export interface EnumPropertyDeclaration {
+  kind: "EnumPropertyDeclaration";
+  property: string;
+  value: EnumLit;
+}
+
 export interface CubicBezierPropertyDeclaration {
   kind: "CubicBezierPropertyDeclaration";
   property: string;
@@ -293,6 +313,7 @@ export type PropertyDeclaration =
   | DimensionPropertyDeclaration
   | NumberPropertyDeclaration
   | DurationPropertyDeclaration
+  | EnumPropertyDeclaration
   | CubicBezierPropertyDeclaration
   | ShadowPropertyDeclaration
   | GradientPropertyDeclaration
@@ -334,12 +355,22 @@ export interface SlotSchemaDeclaration {
   description?: string;
 }
 
-export interface PropertySchemaDeclaration {
+/**
+ * Named separately from the declaration so it can be passed around — and spread —
+ * without the correlation between `type` and `values` collapsing.
+ */
+export type PropertySchema =
+  | {
+      type: "color" | "dimension" | "number" | "duration" | "cubicBezier" | "shadow" | "gradient";
+      values?: never;
+      description?: string;
+    }
+  | { type: "enum"; values: string[]; description?: string };
+
+export type PropertySchemaDeclaration = {
   kind: "PropertySchemaDeclaration";
   name: string;
-  type: "color" | "dimension" | "number" | "duration" | "cubicBezier" | "shadow" | "gradient";
-  description?: string;
-}
+} & PropertySchema;
 
 export interface VariantSchemaDeclaration {
   kind: "VariantSchemaDeclaration";
@@ -380,6 +411,7 @@ export type Node =
   | DimensionLit
   | DurationLit
   | NumberLit
+  | EnumLit
   | CubicBezierLit
   | ShadowLayerLit
   | ShadowLit
@@ -412,6 +444,7 @@ export type Node =
   | DimensionPropertyDeclaration
   | NumberPropertyDeclaration
   | DurationPropertyDeclaration
+  | EnumPropertyDeclaration
   | CubicBezierPropertyDeclaration
   | ShadowPropertyDeclaration
   | GradientPropertyDeclaration

--- a/ecosystem/rootage/core/src/parser/authoring/component-spec.test.ts
+++ b/ecosystem/rootage/core/src/parser/authoring/component-spec.test.ts
@@ -371,4 +371,79 @@ describe("parseComponentSpecData", () => {
 
     expect(parsed).toEqual(expected);
   });
+
+  it("should reject a property the slot schema does not declare", () => {
+    const yaml = `
+kind: ComponentSpec
+metadata:
+  id: test
+  name: test
+data:
+  schema:
+    slots:
+      root:
+        properties:
+          color:
+            type: color
+  definitions:
+    base:
+      enabled:
+        root:
+          background: "#ffffff"
+`;
+
+    expect(() => parseComponentSpecDeclaration(YAML.parse(yaml))).toThrow(
+      'Property "background" of slot "root" in component spec "test" is not declared in the slot schema.',
+    );
+  });
+
+  it("should reject a value that does not match its declared type", () => {
+    const yaml = `
+kind: ComponentSpec
+metadata:
+  id: test
+  name: test
+data:
+  schema:
+    slots:
+      root:
+        properties:
+          color:
+            type: color
+  definitions:
+    base:
+      enabled:
+        root:
+          color: 8px
+`;
+
+    expect(() => parseComponentSpecDeclaration(YAML.parse(yaml))).toThrow(
+      'is declared as "color" but its value is not a valid color',
+    );
+  });
+
+  it("should accept a token reference under any declared type", () => {
+    const yaml = `
+kind: ComponentSpec
+metadata:
+  id: test
+  name: test
+data:
+  schema:
+    slots:
+      root:
+        properties:
+          color:
+            type: color
+  definitions:
+    base:
+      enabled:
+        root:
+          color: "$dimension.x1"
+`;
+
+    // An alias is well-formed wherever it appears — whether it points at the right
+    // kind of token is settled later, against the resolved token.
+    expect(() => parseComponentSpecDeclaration(YAML.parse(yaml))).not.toThrow();
+  });
 });

--- a/ecosystem/rootage/core/src/parser/authoring/component-spec.test.ts
+++ b/ecosystem/rootage/core/src/parser/authoring/component-spec.test.ts
@@ -33,7 +33,7 @@ describe("parseComponentSpecData", () => {
       factory.createSchemaDeclaration(
         [
           factory.createSlotSchemaDeclaration("root", [
-            factory.createPropertySchemaDeclaration("color", "color"),
+            factory.createPropertySchemaDeclaration("color", { type: "color" }),
           ]),
         ],
         [],
@@ -93,7 +93,7 @@ describe("parseComponentSpecData", () => {
       factory.createSchemaDeclaration(
         [
           factory.createSlotSchemaDeclaration("root", [
-            factory.createPropertySchemaDeclaration("color", "color"),
+            factory.createPropertySchemaDeclaration("color", { type: "color" }),
           ]),
         ],
         [
@@ -171,7 +171,7 @@ describe("parseComponentSpecData", () => {
       factory.createSchemaDeclaration(
         [
           factory.createSlotSchemaDeclaration("root", [
-            factory.createPropertySchemaDeclaration("color", "color"),
+            factory.createPropertySchemaDeclaration("color", { type: "color" }),
           ]),
         ],
         [],
@@ -231,7 +231,7 @@ describe("parseComponentSpecData", () => {
       factory.createSchemaDeclaration(
         [
           factory.createSlotSchemaDeclaration("root", [
-            factory.createPropertySchemaDeclaration("color", "color"),
+            factory.createPropertySchemaDeclaration("color", { type: "color" }),
           ]),
         ],
         [
@@ -329,7 +329,7 @@ describe("parseComponentSpecData", () => {
       factory.createSchemaDeclaration(
         [
           factory.createSlotSchemaDeclaration("root", [
-            factory.createPropertySchemaDeclaration("shadow", "shadow"),
+            factory.createPropertySchemaDeclaration("shadow", { type: "shadow" }),
           ]),
         ],
         [],
@@ -420,6 +420,66 @@ data:
     expect(() => parseComponentSpecDeclaration(YAML.parse(yaml))).toThrow(
       'is declared as "color" but its value is not a valid color',
     );
+  });
+
+  it("should parse a bare word as an enum when the schema declares one", () => {
+    const yaml = `
+kind: ComponentSpec
+metadata:
+  id: test
+  name: test
+data:
+  schema:
+    slots:
+      root:
+        properties:
+          scaleScope:
+            type: enum
+            values: [self, content]
+  definitions:
+    base:
+      pressed:
+        root:
+          scaleScope: content
+`;
+
+    const parsed = parseComponentSpecDeclaration(YAML.parse(yaml));
+
+    const expected = factory.createComponentSpecDeclaration(
+      "test",
+      "test",
+      factory.createSchemaDeclaration(
+        [
+          factory.createSlotSchemaDeclaration("root", [
+            factory.createPropertySchemaDeclaration("scaleScope", {
+              type: "enum",
+              values: ["self", "content"],
+            }),
+          ]),
+        ],
+        [],
+      ),
+      [
+        factory.createVariantDeclaration(
+          [],
+          [
+            factory.createStateDeclaration(
+              [factory.createStateExpression("pressed")],
+              [
+                factory.createSlotDeclaration("root", [
+                  factory.createEnumPropertyDeclaration(
+                    "scaleScope",
+                    factory.createEnumLit("content"),
+                  ),
+                ]),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+
+    expect(parsed).toEqual(expected);
   });
 
   it("should accept a token reference under any declared type", () => {

--- a/ecosystem/rootage/core/src/parser/authoring/component-spec.ts
+++ b/ecosystem/rootage/core/src/parser/authoring/component-spec.ts
@@ -147,7 +147,7 @@ function parseVariantDeclaration(
 
 function parseStateDeclaration(
   key: string,
-  decl: Record<string, Record<string, Document.Value>>,
+  decl: Record<string, Record<string, Document.PropertyValue>>,
   ctx: ParseContext,
 ): StateDeclaration {
   // We'll treat def.states as an array of strings => an array of StateExpression
@@ -186,7 +186,7 @@ function parseStateDeclaration(
  */
 function parsePropertyDeclaration(
   property: string,
-  lhValue: Document.Value,
+  lhValue: Document.PropertyValue,
   { declaredType, context }: { declaredType?: PropertySchemaDeclaration["type"]; context: string },
 ): PropertyDeclaration {
   if (!declaredType) {

--- a/ecosystem/rootage/core/src/parser/authoring/component-spec.ts
+++ b/ecosystem/rootage/core/src/parser/authoring/component-spec.ts
@@ -211,6 +211,9 @@ function parsePropertyDeclaration(
     case "DurationLit":
       return factory.createDurationPropertyDeclaration(property, valueLit);
 
+    case "EnumLit":
+      return factory.createEnumPropertyDeclaration(property, valueLit);
+
     case "CubicBezierLit":
       return factory.createCubicBezierPropertyDeclaration(property, valueLit);
 
@@ -225,8 +228,8 @@ function parsePropertyDeclaration(
 function parsePropertySchemaDeclaration(
   model: Document.ComponentSpecPropertySchema,
 ): PropertySchemaDeclaration[] {
-  return Object.entries(model).map(([name, { type, description }]) =>
-    factory.createPropertySchemaDeclaration(name, type, description),
+  return Object.entries(model).map(([name, schema]) =>
+    factory.createPropertySchemaDeclaration(name, schema),
   );
 }
 

--- a/ecosystem/rootage/core/src/parser/authoring/component-spec.ts
+++ b/ecosystem/rootage/core/src/parser/authoring/component-spec.ts
@@ -15,7 +15,12 @@ import * as factory from "../factory";
 import type * as Document from "./types";
 import { isTokenRef } from "./is-token-ref";
 import { parseMetadataDeclaration } from "./metadata";
-import { parseValue } from "./value";
+import { parseValueAs } from "./value";
+
+interface ParseContext {
+  componentId: string;
+  slotSchemas: Document.ComponentSpecSlotSchema;
+}
 
 export function parseComponentSpecDocument(
   model: Document.ComponentSpecModel,
@@ -30,10 +35,13 @@ export function parseComponentSpecDeclaration(
   model: Document.ComponentSpecModel,
 ): ComponentSpecDeclaration {
   const { id, name } = model.metadata;
+
+  const slotSchemas = model.data.schema?.slots ?? {};
+
   const body: VariantDeclaration[] = [];
 
   for (const [key, value] of Object.entries(model.data.definitions)) {
-    body.push(parseVariantDeclaration(key, value));
+    body.push(parseVariantDeclaration(key, value, { componentId: id, slotSchemas }));
   }
 
   const inferredVariants = inferVariantSchema(model.data.definitions);
@@ -123,6 +131,7 @@ function parseStateExpression(stateExpression: string) {
 function parseVariantDeclaration(
   key: string,
   decl: Document.ComponentSpecVariantDefinitions,
+  ctx: ParseContext,
 ): VariantDeclaration {
   const variantExprs = Object.entries(parseVariantExpression(key)).map(([k, v]) =>
     factory.createVariantExpression(k, v),
@@ -130,7 +139,7 @@ function parseVariantDeclaration(
 
   // Convert definitions => array of StateDeclaration
   const stateDecls: StateDeclaration[] = Object.entries(decl).map(([k, v]) =>
-    parseStateDeclaration(k, v),
+    parseStateDeclaration(k, v, ctx),
   );
 
   return factory.createVariantDeclaration(variantExprs, stateDecls);
@@ -139,6 +148,7 @@ function parseVariantDeclaration(
 function parseStateDeclaration(
   key: string,
   decl: Record<string, Record<string, Document.Value>>,
+  ctx: ParseContext,
 ): StateDeclaration {
   // We'll treat def.states as an array of strings => an array of StateExpression
   const stateExpressions = parseStateExpression(key).map((st) => factory.createStateExpression(st));
@@ -147,10 +157,16 @@ function parseStateDeclaration(
   const slotDecls: SlotDeclaration[] = [];
 
   for (const [slotName, props] of Object.entries(decl)) {
+    const propertySchemas = ctx.slotSchemas[slotName]?.properties;
     const propertyDecls: PropertyDeclaration[] = [];
 
     for (const [propKey, lhValue] of Object.entries(props)) {
-      propertyDecls.push(parsePropertyDeclaration(propKey, lhValue));
+      propertyDecls.push(
+        parsePropertyDeclaration(propKey, lhValue, {
+          declaredType: propertySchemas?.[propKey]?.type,
+          context: `Property "${propKey}" of slot "${slotName}" in component spec "${ctx.componentId}"`,
+        }),
+      );
     }
 
     slotDecls.push(factory.createSlotDeclaration(slotName, propertyDecls));
@@ -162,13 +178,26 @@ function parseStateDeclaration(
 /**
  * Turn a property name + Document.Value => one of property declarations
  * (ColorPropertyDeclaration, DimensionPropertyDeclaration, etc.).
+ *
+ * The token-reference check runs ahead of the type dispatch: an alias looks the
+ * same whatever it points at, so it is well-formed under every declared type, and
+ * whether the two actually agree is checked against the resolved token later (see
+ * analyzer/validate.ts).
  */
-function parsePropertyDeclaration(property: string, lhValue: Document.Value): PropertyDeclaration {
+function parsePropertyDeclaration(
+  property: string,
+  lhValue: Document.Value,
+  { declaredType, context }: { declaredType?: PropertySchemaDeclaration["type"]; context: string },
+): PropertyDeclaration {
+  if (!declaredType) {
+    throw new Error(`${context} is not declared in the slot schema.`);
+  }
+
   if (isTokenRef(lhValue)) {
     return factory.createUnresolvedPropertyDeclaration(property, factory.createTokenLit(lhValue));
   }
 
-  const valueLit = parseValue(lhValue);
+  const valueLit = parseValueAs(declaredType, lhValue, context);
   switch (valueLit.kind) {
     case "ColorHexLit":
       return factory.createColorPropertyDeclaration(property, valueLit);
@@ -234,7 +263,9 @@ function parseVariantSchemaDeclaration(
   });
 }
 
-function parseSchemaDeclaration(model: Document.ComponentSpecSchema): SchemaDeclaration {
+// `Required` because the caller has already merged the inferred variant axes in,
+// so both halves are resolved by the time they reach here.
+function parseSchemaDeclaration(model: Required<Document.ComponentSpecSchema>): SchemaDeclaration {
   return factory.createSchemaDeclaration(
     parseSlotSchemaDeclaration(model.slots),
     parseVariantSchemaDeclaration(model.variants),

--- a/ecosystem/rootage/core/src/parser/authoring/types.ts
+++ b/ecosystem/rootage/core/src/parser/authoring/types.ts
@@ -28,11 +28,22 @@ export type Gradient = {
   value: GradientStop[];
 };
 
+/**
+ * A value from an `enum` property's list, written bare.
+ *
+ * Widening the union to `string` swallows the template-literal members above, so
+ * this type no longer rejects a malformed colour or dimension. There is nothing
+ * shape-based left to check once a type's values are arbitrary words; the parser
+ * dispatches on the declared type and the analyzer checks list membership.
+ */
+export type Enum = string;
+
 export type Value =
   | Color
   | Dimension
   | Number
   | Duration
+  | Enum
   | CubicBezier
   | Shadow
   | Gradient
@@ -108,12 +119,15 @@ export interface ComponentSpecSlotSchema {
   };
 }
 
-export interface ComponentSpecPropertySchema {
-  [name: string]: {
-    type: "color" | "dimension" | "number" | "duration" | "cubicBezier" | "shadow" | "gradient";
-    description?: string;
-  };
-}
+export type ComponentSpecPropertySchema = Record<
+  string,
+  | {
+      type: "color" | "dimension" | "number" | "duration" | "cubicBezier" | "shadow" | "gradient";
+      values?: never;
+      description?: string;
+    }
+  | { type: "enum"; values: string[]; description?: string }
+>;
 
 export interface ComponentSpecVariantSchema {
   [name: string]: {

--- a/ecosystem/rootage/core/src/parser/authoring/types.ts
+++ b/ecosystem/rootage/core/src/parser/authoring/types.ts
@@ -131,7 +131,12 @@ export interface ComponentSpecVariantValueSchema {
 
 export interface ComponentSpecSchema {
   slots: ComponentSpecSlotSchema;
-  variants: ComponentSpecVariantSchema;
+  /**
+   * Optional because the parser infers the variant axes from the keys of
+   * `definitions` and only merges this in on top — most component documents
+   * declare nothing here.
+   */
+  variants?: ComponentSpecVariantSchema;
 }
 
 export type Model = TokenCollectionsModel | TokensModel | ComponentSpecModel;

--- a/ecosystem/rootage/core/src/parser/authoring/types.ts
+++ b/ecosystem/rootage/core/src/parser/authoring/types.ts
@@ -31,10 +31,9 @@ export type Gradient = {
 /**
  * A value from an `enum` property's list, written bare.
  *
- * Widening the union to `string` swallows the template-literal members above, so
- * this type no longer rejects a malformed colour or dimension. There is nothing
- * shape-based left to check once a type's values are arbitrary words; the parser
- * dispatches on the declared type and the analyzer checks list membership.
+ * Kept out of `Value`: being `string`, it would swallow the template-literal
+ * members and stop them rejecting a malformed color or dimension. Only a
+ * component spec property can hold one, so it joins at `PropertyValue` instead.
  */
 export type Enum = string;
 
@@ -43,11 +42,12 @@ export type Value =
   | Dimension
   | Number
   | Duration
-  | Enum
   | CubicBezier
   | Shadow
   | Gradient
   | TokenRef;
+
+export type PropertyValue = Value | Enum;
 
 export interface TokenCollectionsModel {
   kind: "TokenCollections";
@@ -103,7 +103,7 @@ export interface ComponentSpecData {
 export interface ComponentSpecVariantDefinitions {
   [state: string]: {
     [slot: string]: {
-      [property: string]: Value;
+      [property: string]: PropertyValue;
     };
   };
 }

--- a/ecosystem/rootage/core/src/parser/authoring/value.ts
+++ b/ecosystem/rootage/core/src/parser/authoring/value.ts
@@ -175,6 +175,17 @@ function parseGradient(expr: unknown): AST.GradientLit | null {
   return null;
 }
 
+/**
+ * Shape-sniffing entry point: try every parser and take the first one that matches.
+ *
+ * Only `kind: Tokens` needs this. A token declares its type nowhere — the value is
+ * the sole evidence of what it is — so the shape has to be the discriminator, which
+ * is why composite values additionally carry an explicit `type` field to keep the
+ * guess honest (see `parseCubicBezier` / `parseShadow` / `parseGradient`).
+ *
+ * `kind: ComponentSpec` does not need it: its slot schema names the type of every
+ * property, so it goes through `parseValueAs` instead.
+ */
 export function parseValue(input: Document.Value): AST.ValueLit {
   const result =
     parseColor(input) ||
@@ -195,4 +206,47 @@ export function parseValue(input: Document.Value): AST.ValueLit {
   }
 
   throw new Error(`Invalid value expression ${JSON.stringify(input, null, 2)}`);
+}
+
+const PARSE_BY_TYPE = {
+  color: parseColor,
+  dimension: parseDimension,
+  number: parseNumber,
+  duration: parseDuration,
+  cubicBezier: parseCubicBezier,
+  shadow: parseShadow,
+  gradient: parseGradient,
+} as const satisfies Record<
+  AST.PropertySchemaDeclaration["type"],
+  (expr: unknown) => AST.ValueLit | AST.TokenLit | null
+>;
+
+/**
+ * Declared-type entry point: parse a value as the type its slot schema names.
+ *
+ * `context` names where the value came from, for the error message — only the
+ * caller knows the component, slot, and property.
+ */
+export function parseValueAs(
+  type: AST.PropertySchemaDeclaration["type"],
+  input: Document.Value,
+  context: string,
+): AST.ValueLit {
+  const result = PARSE_BY_TYPE[type](input);
+
+  if (!result) {
+    throw new Error(
+      `${context} is declared as "${type}" but its value is not a valid ${type}: ${JSON.stringify(input)}`,
+    );
+  }
+
+  // `parseColor` accepts token references as well as hex. Callers filter those out
+  // with `isTokenRef` before dispatching here, so reaching one is a caller bug.
+  if (result.kind === "TokenLit") {
+    throw new Error(
+      `${context} received a token reference; callers must detect token refs via isTokenRef before invoking parseValueAs.`,
+    );
+  }
+
+  return result;
 }

--- a/ecosystem/rootage/core/src/parser/authoring/value.ts
+++ b/ecosystem/rootage/core/src/parser/authoring/value.ts
@@ -242,7 +242,7 @@ const PARSE_BY_TYPE = {
  */
 export function parseValueAs(
   type: AST.PropertySchemaDeclaration["type"],
-  input: Document.Value,
+  input: Document.PropertyValue,
   context: string,
 ): AST.ValueLit {
   const result = PARSE_BY_TYPE[type](input);

--- a/ecosystem/rootage/core/src/parser/authoring/value.ts
+++ b/ecosystem/rootage/core/src/parser/authoring/value.ts
@@ -75,6 +75,18 @@ function parseDuration(expr: unknown): AST.DurationLit | null {
   return null;
 }
 
+/**
+ * Deliberately absent from `parseValue`: a bare word has no shape to recognize, so
+ * sniffing would accept every unrecognized string and turn a typo into a silent
+ * enum value. Only the declared-type path can reach this.
+ */
+function parseEnum(expr: unknown): AST.EnumLit | null {
+  if (typeof expr === "string" && expr.length > 0) {
+    return factory.createEnumLit(expr);
+  }
+  return null;
+}
+
 function parseCubicBezier(expr: unknown): AST.CubicBezierLit | null {
   if (
     typeof expr === "object" &&
@@ -213,6 +225,7 @@ const PARSE_BY_TYPE = {
   dimension: parseDimension,
   number: parseNumber,
   duration: parseDuration,
+  enum: parseEnum,
   cubicBezier: parseCubicBezier,
   shadow: parseShadow,
   gradient: parseGradient,

--- a/ecosystem/rootage/core/src/parser/exchange/component-spec.test.ts
+++ b/ecosystem/rootage/core/src/parser/exchange/component-spec.test.ts
@@ -49,7 +49,7 @@ describe("parseComponentSpecData", () => {
       factory.createSchemaDeclaration(
         [
           factory.createSlotSchemaDeclaration("root", [
-            factory.createPropertySchemaDeclaration("color", "color"),
+            factory.createPropertySchemaDeclaration("color", { type: "color" }),
           ]),
         ],
         [],
@@ -146,7 +146,7 @@ describe("parseComponentSpecData", () => {
       factory.createSchemaDeclaration(
         [
           factory.createSlotSchemaDeclaration("root", [
-            factory.createPropertySchemaDeclaration("color", "color"),
+            factory.createPropertySchemaDeclaration("color", { type: "color" }),
           ]),
         ],
         [
@@ -240,7 +240,7 @@ describe("parseComponentSpecData", () => {
       factory.createSchemaDeclaration(
         [
           factory.createSlotSchemaDeclaration("root", [
-            factory.createPropertySchemaDeclaration("color", "color"),
+            factory.createPropertySchemaDeclaration("color", { type: "color" }),
           ]),
         ],
         [],
@@ -344,7 +344,7 @@ describe("parseComponentSpecData", () => {
       factory.createSchemaDeclaration(
         [
           factory.createSlotSchemaDeclaration("root", [
-            factory.createPropertySchemaDeclaration("color", "color"),
+            factory.createPropertySchemaDeclaration("color", { type: "color" }),
           ]),
         ],
         [
@@ -485,7 +485,7 @@ describe("parseComponentSpecData", () => {
       factory.createSchemaDeclaration(
         [
           factory.createSlotSchemaDeclaration("root", [
-            factory.createPropertySchemaDeclaration("shadow", "shadow"),
+            factory.createPropertySchemaDeclaration("shadow", { type: "shadow" }),
           ]),
         ],
         [],

--- a/ecosystem/rootage/core/src/parser/exchange/component-spec.ts
+++ b/ecosystem/rootage/core/src/parser/exchange/component-spec.ts
@@ -17,6 +17,7 @@ import { parseMetadataDeclaration } from "./metadata";
 import {
   parseColorValue,
   parseCubicBezierValue,
+  parseEnumValue,
   parseDimensionValue,
   parseDurationValue,
   parseGradientValue,
@@ -104,6 +105,9 @@ function parsePropertyDeclaration(property: string, lhValue: Document.Value): Pr
     case "duration":
       return factory.createDurationPropertyDeclaration(property, parseDurationValue(lhValue));
 
+    case "enum":
+      return factory.createEnumPropertyDeclaration(property, parseEnumValue(lhValue));
+
     case "cubicBezier":
       return factory.createCubicBezierPropertyDeclaration(property, parseCubicBezierValue(lhValue));
 
@@ -118,8 +122,8 @@ function parsePropertyDeclaration(property: string, lhValue: Document.Value): Pr
 function parsePropertySchemaDeclaration(
   model: Document.ComponentSpecPropertySchema,
 ): PropertySchemaDeclaration[] {
-  return Object.entries(model).map(([name, { type, description }]) =>
-    factory.createPropertySchemaDeclaration(name, type, description),
+  return Object.entries(model).map(([name, schema]) =>
+    factory.createPropertySchemaDeclaration(name, schema),
   );
 }
 

--- a/ecosystem/rootage/core/src/parser/exchange/types.ts
+++ b/ecosystem/rootage/core/src/parser/exchange/types.ts
@@ -26,6 +26,14 @@ export type Duration = {
   type: "duration";
   value: DurationLit | TokenRef;
 };
+/**
+ * No `TokenRef` alternative: no token collection has an enum type, so an alias can
+ * never resolve to one.
+ */
+export type Enum = {
+  type: "enum";
+  value: string;
+};
 export type CubicBezier = {
   type: "cubicBezier";
   value: readonly [number, number, number, number] | TokenRef;
@@ -50,7 +58,7 @@ export type Gradient = {
   value: Array<GradientStop> | TokenRef;
 };
 
-export type Value = Color | Dimension | Number | Duration | CubicBezier | Shadow | Gradient;
+export type Value = Color | Dimension | Number | Duration | Enum | CubicBezier | Shadow | Gradient;
 
 export interface ComponentSpecModel {
   kind: "ComponentSpec";
@@ -81,12 +89,15 @@ export interface ComponentSpecData {
   definitions: VariantDeclaration[];
 }
 
-export interface ComponentSpecPropertySchema {
-  [name: string]: {
-    type: "color" | "dimension" | "number" | "duration" | "cubicBezier" | "shadow" | "gradient";
-    description?: string;
-  };
-}
+export type ComponentSpecPropertySchema = Record<
+  string,
+  | {
+      type: "color" | "dimension" | "number" | "duration" | "cubicBezier" | "shadow" | "gradient";
+      values?: never;
+      description?: string;
+    }
+  | { type: "enum"; values: string[]; description?: string }
+>;
 
 export interface ComponentSpecSlotSchema {
   [name: string]: {

--- a/ecosystem/rootage/core/src/parser/exchange/value.ts
+++ b/ecosystem/rootage/core/src/parser/exchange/value.ts
@@ -1,4 +1,5 @@
 import type {
+  EnumLit,
   ColorHexLit,
   CubicBezierLit,
   DimensionLit,
@@ -32,6 +33,7 @@ export function parseValue(
   | DimensionLit
   | DurationLit
   | NumberLit
+  | EnumLit
   | CubicBezierLit
   | ShadowLit
   | GradientLit
@@ -51,6 +53,8 @@ export function parseValue(
       return parseNumberValue(v);
     case "duration":
       return parseDurationValue(v);
+    case "enum":
+      return parseEnumValue(v);
     case "cubicBezier":
       return parseCubicBezierValue(v);
     case "shadow":
@@ -91,6 +95,12 @@ export function parseNumberValue(numVal: Document.Number): NumberLit | TokenLit 
     return factory.createTokenLit(n);
   }
   return factory.createNumberLit(n as number);
+}
+
+/* ------------------ Enum ------------------ */
+
+export function parseEnumValue(enumVal: Document.Enum): EnumLit {
+  return factory.createEnumLit(enumVal.value);
 }
 
 /* ------------------ Duration ------------------ */

--- a/ecosystem/rootage/core/src/parser/factory.ts
+++ b/ecosystem/rootage/core/src/parser/factory.ts
@@ -3,6 +3,7 @@ import type {
   DimensionLit,
   DurationLit,
   NumberLit,
+  EnumLit,
   CubicBezierLit,
   ShadowLayerLit,
   ShadowLit,
@@ -12,6 +13,7 @@ import type {
   ColorPropertyDeclaration,
   DimensionPropertyDeclaration,
   NumberPropertyDeclaration,
+  EnumPropertyDeclaration,
   DurationPropertyDeclaration,
   CubicBezierPropertyDeclaration,
   ShadowPropertyDeclaration,
@@ -48,6 +50,7 @@ import type {
   UnresolvedTokenValueDeclaration,
   UnresolvedPropertyDeclaration,
   SchemaDeclaration,
+  PropertySchema,
   PropertySchemaDeclaration,
   SlotSchemaDeclaration,
   VariantSchemaDeclaration,
@@ -93,6 +96,16 @@ export function createDurationLit(value: number, unit: "ms" | "s"): DurationLit 
 export function createNumberLit(value: number): NumberLit {
   return {
     kind: "NumberLit",
+    value,
+  };
+}
+
+/**
+ * EnumLit factory
+ */
+export function createEnumLit(value: string): EnumLit {
+  return {
+    kind: "EnumLit",
     value,
   };
 }
@@ -232,6 +245,20 @@ export function createNumberPropertyDeclaration(
 ): NumberPropertyDeclaration {
   return {
     kind: "NumberPropertyDeclaration",
+    property,
+    value,
+  };
+}
+
+/**
+ * EnumPropertyDeclaration factory
+ */
+export function createEnumPropertyDeclaration(
+  property: string,
+  value: EnumLit,
+): EnumPropertyDeclaration {
+  return {
+    kind: "EnumPropertyDeclaration",
     property,
     value,
   };
@@ -415,18 +442,16 @@ export function createSlotSchemaDeclaration(
 
 /**
  * PropertySchemaDeclaration factory
+ *
+ * Takes the declaration as one object so the `enum`/`values` correlation survives
+ * the call.
  */
-export function createPropertySchemaDeclaration(
-  name: string,
-  type: "color" | "dimension" | "number" | "duration" | "cubicBezier" | "shadow" | "gradient",
-  description?: string,
-): PropertySchemaDeclaration {
+export function createPropertySchemaDeclaration<T extends PropertySchema>(name: string, schema: T) {
   return {
     kind: "PropertySchemaDeclaration",
     name,
-    type,
-    description,
-  };
+    ...schema,
+  } satisfies { kind: "PropertySchemaDeclaration"; name: string } & PropertySchema;
 }
 
 /**

--- a/ecosystem/rootage/core/src/parser/visit.ts
+++ b/ecosystem/rootage/core/src/parser/visit.ts
@@ -76,6 +76,10 @@ export function visitEachChild<T extends Node>(node: T, fn: (node: Node) => Node
       };
     case "TokenCollectionDeclaration":
       return node;
+    // Only reached when a caller starts from a mode: the collection above returns
+    // itself rather than mapping `modes`, so traversal never descends into one.
+    case "ModeDeclaration":
+      return node;
 
     // ComponentSpec
     case "ComponentSpecDocument":

--- a/ecosystem/rootage/core/src/parser/visit.ts
+++ b/ecosystem/rootage/core/src/parser/visit.ts
@@ -10,6 +10,7 @@ export function visitEachChild<T extends Node>(node: T, fn: (node: Node) => Node
     case "ColorHexLit":
     case "DimensionLit":
     case "NumberLit":
+    case "EnumLit":
     case "DurationLit":
     case "CubicBezierLit":
     case "ShadowLayerLit":
@@ -112,6 +113,7 @@ export function visitEachChild<T extends Node>(node: T, fn: (node: Node) => Node
     case "ColorPropertyDeclaration":
     case "DimensionPropertyDeclaration":
     case "NumberPropertyDeclaration":
+    case "EnumPropertyDeclaration":
     case "DurationPropertyDeclaration":
     case "CubicBezierPropertyDeclaration":
     case "ShadowPropertyDeclaration":

--- a/packages/css/vars/component/menu-sheet-item.d.ts
+++ b/packages/css/vars/component/menu-sheet-item.d.ts
@@ -61,13 +61,9 @@ export declare const vars: {
   /**
    * 라벨을 왼쪽 정렬합니다.
    */
-  "labelAlignLeft": {
-    "enabled": {}
-  },
+  "labelAlignLeft": {},
   /**
    * 라벨을 중앙 정렬합니다.
    */
-  "labelAlignCenter": {
-    "enabled": {}
-  }
+  "labelAlignCenter": {}
 }

--- a/packages/css/vars/component/menu-sheet-item.mjs
+++ b/packages/css/vars/component/menu-sheet-item.mjs
@@ -52,10 +52,6 @@ export const vars = {
       }
     }
   },
-  "labelAlignLeft": {
-    "enabled": {}
-  },
-  "labelAlignCenter": {
-    "enabled": {}
-  }
+  "labelAlignLeft": {},
+  "labelAlignCenter": {}
 }

--- a/packages/lynx-css/vars/component/menu-sheet-item.d.ts
+++ b/packages/lynx-css/vars/component/menu-sheet-item.d.ts
@@ -61,13 +61,9 @@ export declare const vars: {
   /**
    * 라벨을 왼쪽 정렬합니다.
    */
-  "labelAlignLeft": {
-    "enabled": {}
-  },
+  "labelAlignLeft": {},
   /**
    * 라벨을 중앙 정렬합니다.
    */
-  "labelAlignCenter": {
-    "enabled": {}
-  }
+  "labelAlignCenter": {}
 }

--- a/packages/lynx-css/vars/component/menu-sheet-item.mjs
+++ b/packages/lynx-css/vars/component/menu-sheet-item.mjs
@@ -52,10 +52,6 @@ export const vars = {
       }
     }
   },
-  "labelAlignLeft": {
-    "enabled": {}
-  },
-  "labelAlignCenter": {
-    "enabled": {}
-  }
+  "labelAlignLeft": {},
+  "labelAlignCenter": {}
 }

--- a/packages/lynx-qvism-preset/src/vars/component/menu-sheet-item.d.ts
+++ b/packages/lynx-qvism-preset/src/vars/component/menu-sheet-item.d.ts
@@ -61,13 +61,9 @@ export declare const vars: {
   /**
    * 라벨을 왼쪽 정렬합니다.
    */
-  "labelAlignLeft": {
-    "enabled": {}
-  },
+  "labelAlignLeft": {},
   /**
    * 라벨을 중앙 정렬합니다.
    */
-  "labelAlignCenter": {
-    "enabled": {}
-  }
+  "labelAlignCenter": {}
 }

--- a/packages/lynx-qvism-preset/src/vars/component/menu-sheet-item.mjs
+++ b/packages/lynx-qvism-preset/src/vars/component/menu-sheet-item.mjs
@@ -52,10 +52,6 @@ export const vars = {
       }
     }
   },
-  "labelAlignLeft": {
-    "enabled": {}
-  },
-  "labelAlignCenter": {
-    "enabled": {}
-  }
+  "labelAlignLeft": {},
+  "labelAlignCenter": {}
 }

--- a/packages/qvism-preset/src/vars/component/menu-sheet-item.d.ts
+++ b/packages/qvism-preset/src/vars/component/menu-sheet-item.d.ts
@@ -61,13 +61,9 @@ export declare const vars: {
   /**
    * 라벨을 왼쪽 정렬합니다.
    */
-  "labelAlignLeft": {
-    "enabled": {}
-  },
+  "labelAlignLeft": {},
   /**
    * 라벨을 중앙 정렬합니다.
    */
-  "labelAlignCenter": {
-    "enabled": {}
-  }
+  "labelAlignCenter": {}
 }

--- a/packages/qvism-preset/src/vars/component/menu-sheet-item.mjs
+++ b/packages/qvism-preset/src/vars/component/menu-sheet-item.mjs
@@ -52,10 +52,6 @@ export const vars = {
       }
     }
   },
-  "labelAlignLeft": {
-    "enabled": {}
-  },
-  "labelAlignCenter": {
-    "enabled": {}
-  }
+  "labelAlignLeft": {},
+  "labelAlignCenter": {}
 }

--- a/packages/rootage/components/schema.json
+++ b/packages/rootage/components/schema.json
@@ -83,13 +83,30 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["color", "dimension", "number", "duration", "cubicBezier", "shadow", "gradient"]
+          "enum": ["color", "dimension", "number", "duration", "enum", "cubicBezier", "shadow", "gradient"]
         },
         "description": {
           "type": "string"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
         }
       },
       "required": ["type"],
+      "if": {
+        "properties": { "type": { "const": "enum" } },
+        "required": ["type"]
+      },
+      "then": {
+        "required": ["values"]
+      },
+      "else": {
+        "not": { "required": ["values"] }
+      },
       "additionalProperties": false
     },
     "variantsSchema": {
@@ -172,6 +189,9 @@
           "$ref": "#/definitions/numberShorthand"
         },
         {
+          "$ref": "#/definitions/enumShorthand"
+        },
+        {
           "$ref": "#/definitions/cubicBezier"
         },
         {
@@ -199,6 +219,10 @@
     },
     "numberShorthand": {
       "type": "number"
+    },
+    "enumShorthand": {
+      "type": "string",
+      "pattern": "^[a-zA-Z][a-zA-Z0-9-]*$"
     },
     "cubicBezier": {
       "type": "object",

--- a/packages/rootage/components/schema.json
+++ b/packages/rootage/components/schema.json
@@ -222,7 +222,7 @@
     },
     "enumShorthand": {
       "type": "string",
-      "pattern": "^[a-zA-Z][a-zA-Z0-9-]*$"
+      "pattern": "^[^#$0-9-].*$"
     },
     "cubicBezier": {
       "type": "object",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 컴포넌트 속성에서 열거형(enum) 타입과 허용 값 목록을 지원합니다.
  * enum 값의 파싱, 변환 및 스키마 검증을 지원합니다.
  * JSON Schema에서 enum 전용 값 형식과 유효성 규칙을 제공합니다.

* **버그 수정**
  * 선언되지 않은 속성, 허용되지 않은 enum 값, 빈 enum 목록을 올바르게 거부합니다.
  * enum 속성이 결과에 불필요한 CSS 프로퍼티로 포함되지 않도록 개선했습니다.
  * enum만 포함된 슬롯이나 빈 상태가 결과에서 제외됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->