### PR TITLE
feat(rootage): generate typed declarations for the JSON artifacts

### DIFF
--- a/ecosystem/rootage/cli/src/index.ts
+++ b/ecosystem/rootage/cli/src/index.ts
@@ -254,6 +254,43 @@ async function writeJson() {
   });
 }
 
+// The `.mjs` re-exports its sibling `.json`, so the pair has to land in the same
+// directory the `json` command wrote to.
+function writeExchangeTs(withoutExt: string, value: unknown) {
+  const dtsName = `${withoutExt}.d.ts`;
+
+  writeFileSync({
+    filename: dtsName,
+    code: typescript.getExchangeDts(value),
+    writePath: path.join(process.cwd(), dir, dtsName),
+  });
+
+  const mjsName = `${withoutExt}.mjs`;
+
+  writeFileSync({
+    filename: mjsName,
+    code: typescript.getExchangeMjs(`${path.basename(withoutExt)}.json`),
+    writePath: path.join(process.cwd(), dir, mjsName),
+  });
+}
+
+async function writeJsonTs() {
+  const { ctx, models } = await prepare();
+
+  for (const { fileName, ast } of getSourceFiles(ctx)) {
+    const relativePath = path.relative(artifactsDir, fileName);
+    const withoutExt = relativePath.replace(path.extname(relativePath), "");
+
+    writeExchangeTs(withoutExt, exchange.getModel(ast));
+  }
+
+  const artifactsPkg = JSON.parse(
+    fs.readFileSync(path.join(artifactsDir, "package.json"), "utf-8"),
+  );
+
+  writeExchangeTs("index", exchange.getIndex(models, { version: artifactsPkg.version }));
+}
+
 async function writeFile(filePath: string, content: string) {
   try {
     await fs.mkdirp(path.dirname(filePath));
@@ -407,6 +444,22 @@ yargs(process.argv.slice(2))
     async () => {
       console.log("Start");
       await writeJson();
+      console.log("Done");
+    },
+  )
+  .command(
+    "json-ts <dir>",
+    "Generate typed declarations beside the JSON",
+    (yargs) => {
+      return yargs.positional("dir", {
+        describe: "Output directory",
+        type: "string",
+        default: "./",
+      });
+    },
+    async () => {
+      console.log("Start");
+      await writeJsonTs();
       console.log("Done");
     },
   )

--- a/ecosystem/rootage/cli/src/index.ts
+++ b/ecosystem/rootage/cli/src/index.ts
@@ -223,40 +223,17 @@ async function writeJsonSchema() {
   });
 }
 
-async function writeJson() {
-  const { ctx, models } = await prepare();
-
-  for (const { fileName, ast } of getSourceFiles(ctx)) {
-    const content = exchange.getModel(ast);
-    const code = JSON.stringify(content, null, 2);
-    const relativePath = path.relative(artifactsDir, fileName);
-    const withoutExt = relativePath.replace(path.extname(relativePath), "");
-    const writePath = path.join(process.cwd(), dir, `${withoutExt}.json`);
-
-    writeFileSync({
-      filename: `${withoutExt}.json`,
-      code,
-      writePath: writePath,
-    });
-  }
-
-  // Generate and write index.json
-  const artifactsPkg = JSON.parse(
-    fs.readFileSync(path.join(artifactsDir, "package.json"), "utf-8"),
-  );
-  const indexContent = exchange.getIndex(models, { version: artifactsPkg.version });
-  const indexPath = path.join(process.cwd(), dir, "index.json");
+// The `.mjs` re-exports its sibling `.json` and the `.d.ts` describes it, so all three
+// are written together: split across commands, one could be generated without the others.
+function writeExchange(withoutExt: string, value: unknown) {
+  const jsonName = `${withoutExt}.json`;
 
   writeFileSync({
-    filename: "index.json",
-    code: JSON.stringify(indexContent, null, 2),
-    writePath: indexPath,
+    filename: jsonName,
+    code: JSON.stringify(value, null, 2),
+    writePath: path.join(process.cwd(), dir, jsonName),
   });
-}
 
-// The `.mjs` re-exports its sibling `.json`, so the pair has to land in the same
-// directory the `json` command wrote to.
-function writeExchangeTs(withoutExt: string, value: unknown) {
   const dtsName = `${withoutExt}.d.ts`;
 
   writeFileSync({
@@ -281,14 +258,14 @@ async function writeJsonTs() {
     const relativePath = path.relative(artifactsDir, fileName);
     const withoutExt = relativePath.replace(path.extname(relativePath), "");
 
-    writeExchangeTs(withoutExt, exchange.getModel(ast));
+    writeExchange(withoutExt, exchange.getModel(ast));
   }
 
   const artifactsPkg = JSON.parse(
     fs.readFileSync(path.join(artifactsDir, "package.json"), "utf-8"),
   );
 
-  writeExchangeTs("index", exchange.getIndex(models, { version: artifactsPkg.version }));
+  writeExchange("index", exchange.getIndex(models, { version: artifactsPkg.version }));
 }
 
 async function writeFile(filePath: string, content: string) {
@@ -432,24 +409,8 @@ yargs(process.argv.slice(2))
     },
   )
   .command(
-    "json <dir>",
-    "Generate JSON",
-    (yargs) => {
-      return yargs.positional("dir", {
-        describe: "Output directory",
-        type: "string",
-        default: "./",
-      });
-    },
-    async () => {
-      console.log("Start");
-      await writeJson();
-      console.log("Done");
-    },
-  )
-  .command(
     "json-ts <dir>",
-    "Generate typed declarations beside the JSON",
+    "Generate JSON artifacts with their typed declarations",
     (yargs) => {
       return yargs.positional("dir", {
         describe: "Output directory",

--- a/ecosystem/rootage/core/src/languages/typescript.test.ts
+++ b/ecosystem/rootage/core/src/languages/typescript.test.ts
@@ -648,6 +648,12 @@ describe("getExchangeDts", () => {
     );
   });
 
+  it("should write non-finite numbers as null, as JSON.stringify does", () => {
+    expect(getExchangeDts({ value: Number.POSITIVE_INFINITY })).toBe(
+      'declare const artifact: {\n  "value": null;\n};\nexport default artifact;\n',
+    );
+  });
+
   it("should render empty containers", () => {
     expect(getExchangeDts({ variants: {}, states: [] })).toBe(
       'declare const artifact: {\n  "variants": {};\n  "states": readonly [];\n};\nexport default artifact;\n',

--- a/ecosystem/rootage/core/src/languages/typescript.test.ts
+++ b/ecosystem/rootage/core/src/languages/typescript.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, test } from "bun:test";
 import YAML from "yaml";
 import { Authoring } from "../parser";
-import { createStringifier } from "./typescript";
+import { createStringifier, getExchangeDts, getExchangeMjs } from "./typescript";
 
 const { getComponentSpecDts, getComponentSpecMjs, getTokenDts, getTokenMjs } = createStringifier({
   prefix: "test",
@@ -572,4 +572,93 @@ data:
       }
     }"
   `);
+});
+
+describe("getExchangeDts", () => {
+  it("should keep token references, enum values and unlike array entries narrow", () => {
+    const result = getExchangeDts({
+      schema: {
+        slots: {
+          label: {
+            properties: { textAlign: { type: "enum", values: ["leading", "center"] } },
+          },
+        },
+      },
+      definitions: [
+        { variants: {}, slots: { root: { color: { type: "color", value: "$color.bg.neutral" } } } },
+        {
+          variants: { labelAlign: "center" },
+          slots: { label: { textAlign: { type: "enum", value: "center" } } },
+        },
+      ],
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      "declare const artifact: {
+        "schema": {
+          "slots": {
+            "label": {
+              "properties": {
+                "textAlign": {
+                  "type": "enum";
+                  "values": readonly [
+                    "leading",
+                    "center",
+                  ];
+                };
+              };
+            };
+          };
+        };
+        "definitions": readonly [
+          {
+            "variants": {};
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "variants": {
+              "labelAlign": "center";
+            };
+            "slots": {
+              "label": {
+                "textAlign": {
+                  "type": "enum";
+                  "value": "center";
+                };
+              };
+            };
+          },
+        ];
+      };
+      export default artifact;
+      "
+    `);
+  });
+
+  it("should drop undefined-valued keys, as JSON.stringify does", () => {
+    expect(getExchangeDts({ type: "color", description: undefined })).toBe(
+      'declare const artifact: {\n  "type": "color";\n};\nexport default artifact;\n',
+    );
+  });
+
+  it("should render empty containers", () => {
+    expect(getExchangeDts({ variants: {}, states: [] })).toBe(
+      'declare const artifact: {\n  "variants": {};\n  "states": readonly [];\n};\nexport default artifact;\n',
+    );
+  });
+});
+
+describe("getExchangeMjs", () => {
+  it("should re-export the sibling JSON", () => {
+    expect(getExchangeMjs("menu-sheet-item.json")).toBe(
+      'import artifact from "./menu-sheet-item.json" with { type: "json" };\nexport default artifact;\n',
+    );
+  });
 });

--- a/ecosystem/rootage/core/src/languages/typescript.ts
+++ b/ecosystem/rootage/core/src/languages/typescript.ts
@@ -319,11 +319,7 @@ function stringifyLiteralType(value: unknown, depth: number): string {
     return `readonly [\n${items.join(",\n")},\n${pad}]`;
   }
 
-  // Undefined-valued keys are dropped to match `JSON.stringify`: the declaration has
-  // to describe the file that ships beside it, not the model it was built from.
-  const entries = Object.entries(value as Record<string, unknown>).filter(
-    ([_, item]) => item !== undefined,
-  );
+  const entries = Object.entries(value as Record<string, unknown>);
   if (entries.length === 0) return "{}";
 
   const props = entries.map(
@@ -341,9 +337,15 @@ function stringifyLiteralType(value: unknown, depth: number): string {
  * into a union that cannot be indexed. A declaration keeps both, and costs less to
  * check — its types resolve lazily from syntax, where a JSON module's are
  * synthesized in full the moment it is loaded.
+ *
+ * The value is put through `JSON.stringify` rather than read as given: the declaration
+ * has to describe the file that ships beside it, and only JSON itself knows what it
+ * does to an `undefined` property or a non-finite number.
  */
 export function getExchangeDts(value: unknown): string {
-  return `declare const artifact: ${stringifyLiteralType(value, 0)};\nexport default artifact;\n`;
+  const json: unknown = JSON.parse(JSON.stringify(value));
+
+  return `declare const artifact: ${stringifyLiteralType(json, 0)};\nexport default artifact;\n`;
 }
 
 /**

--- a/ecosystem/rootage/core/src/languages/typescript.ts
+++ b/ecosystem/rootage/core/src/languages/typescript.ts
@@ -300,3 +300,56 @@ export function createStringifier(options: { prefix?: string } = {}) {
     getTokenDts,
   };
 }
+
+const INDENT = "  ";
+
+function stringifyLiteralType(value: unknown, depth: number): string {
+  if (value === null) return "null";
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+
+  const pad = INDENT.repeat(depth);
+  const padInner = INDENT.repeat(depth + 1);
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "readonly []";
+
+    const items = value.map((item) => `${padInner}${stringifyLiteralType(item, depth + 1)}`);
+
+    return `readonly [\n${items.join(",\n")},\n${pad}]`;
+  }
+
+  // Undefined-valued keys are dropped to match `JSON.stringify`: the declaration has
+  // to describe the file that ships beside it, not the model it was built from.
+  const entries = Object.entries(value as Record<string, unknown>).filter(
+    ([_, item]) => item !== undefined,
+  );
+  if (entries.length === 0) return "{}";
+
+  const props = entries.map(
+    ([key, item]) => `${padInner}${JSON.stringify(key)}: ${stringifyLiteralType(item, depth + 1)}`,
+  );
+
+  return `{\n${props.join(";\n")};\n${pad}}`;
+}
+
+/**
+ * Declares an exchange artifact with every literal kept narrow.
+ *
+ * A `.json` import cannot: TypeScript widens each literal, so a token reference and
+ * an enum value both arrive as `string`, and an array of unlike entries collapses
+ * into a union that cannot be indexed. A declaration keeps both, and costs less to
+ * check — its types resolve lazily from syntax, where a JSON module's are
+ * synthesized in full the moment it is loaded.
+ */
+export function getExchangeDts(value: unknown): string {
+  return `declare const artifact: ${stringifyLiteralType(value, 0)};\nexport default artifact;\n`;
+}
+
+/**
+ * Re-exports the sibling JSON instead of inlining it, so the data lives in one file
+ * and the declaration beside this module is what supplies the narrow types.
+ */
+export function getExchangeMjs(jsonFileName: string): string {
+  return `import artifact from "./${jsonFileName}" with { type: "json" };\nexport default artifact;\n`;
+}

--- a/packages/rootage/__generated__/collections.d.ts
+++ b/packages/rootage/__generated__/collections.d.ts
@@ -1,0 +1,65 @@
+declare const artifact: {
+  "kind": "TokenCollections";
+  "metadata": {
+    "id": "collections";
+    "name": "collections";
+  };
+  "data": readonly [
+    {
+      "name": "global";
+      "modes": readonly [
+        {
+          "id": "default";
+        },
+      ];
+    },
+    {
+      "name": "color";
+      "modes": readonly [
+        {
+          "id": "theme-light";
+        },
+        {
+          "id": "theme-dark";
+        },
+      ];
+    },
+    {
+      "name": "motion";
+      "modes": readonly [
+        {
+          "id": "preferred";
+        },
+        {
+          "id": "reduced";
+        },
+      ];
+    },
+    {
+      "name": "viewport-width";
+      "modes": readonly [
+        {
+          "id": "base";
+          "description": "세로 모드 폰";
+        },
+        {
+          "id": "sm";
+          "description": "가로 모드 폰 또는 좁은 태블릿";
+        },
+        {
+          "id": "md";
+          "description": "태블릿";
+        },
+        {
+          "id": "lg";
+          "description": "데스크톱";
+        },
+        {
+          "id": "xl";
+          "description": "넓은 데스크톱";
+        },
+      ];
+    },
+  ];
+};
+export default artifact;

--- a/packages/rootage/__generated__/collections.mjs
+++ b/packages/rootage/__generated__/collections.mjs
@@ -1,0 +1,2 @@
+import artifact from "./collections.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/color.d.ts
+++ b/packages/rootage/__generated__/color.d.ts
@@ -1,0 +1,2440 @@
+declare const artifact: {
+  "kind": "Tokens";
+  "metadata": {
+    "id": "color";
+    "name": "Color";
+    "lastUpdated": "26-06-15";
+  };
+  "data": {
+    "collection": "color";
+    "tokens": {
+      "$color.palette.gray-00": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffffff";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#000000";
+          };
+        };
+      };
+      "$color.palette.gray-100": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#f7f8f9";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#16171b";
+          };
+        };
+      };
+      "$color.palette.gray-200": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#f3f4f5";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#1d2025";
+          };
+        };
+      };
+      "$color.palette.gray-300": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#eeeff1";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#2b2e35";
+          };
+        };
+      };
+      "$color.palette.gray-400": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#dcdee3";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#393d46";
+          };
+        };
+      };
+      "$color.palette.gray-500": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#d1d3d8";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#5b606a";
+          };
+        };
+      };
+      "$color.palette.gray-600": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#b0b3ba";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#868b94";
+          };
+        };
+      };
+      "$color.palette.gray-700": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#868b94";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#b0b3ba";
+          };
+        };
+      };
+      "$color.palette.gray-800": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#555d6d";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#dcdee3";
+          };
+        };
+      };
+      "$color.palette.gray-900": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#2a3038";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#e9eaec";
+          };
+        };
+      };
+      "$color.palette.gray-1000": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#1a1c20";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#f3f4f5";
+          };
+        };
+      };
+      "$color.palette.carrot-100": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#fff2ec";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#31241f";
+          };
+        };
+      };
+      "$color.palette.carrot-200": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffe8db";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#4b291c";
+          };
+        };
+      };
+      "$color.palette.carrot-300": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffd5c0";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#6b311c";
+          };
+        };
+      };
+      "$color.palette.carrot-400": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffb999";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#923600";
+          };
+        };
+      };
+      "$color.palette.carrot-500": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ff9364";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#bd4201";
+          };
+        };
+      };
+      "$color.palette.carrot-600": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ff6600";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#e65200";
+          };
+        };
+      };
+      "$color.palette.carrot-700": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#e14d00";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#ff6600";
+          };
+        };
+      };
+      "$color.palette.carrot-800": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#b93901";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#ff9e65";
+          };
+        };
+      };
+      "$color.palette.carrot-900": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#862b00";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#eecebc";
+          };
+        };
+      };
+      "$color.palette.carrot-1000": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#471601";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#f4eeea";
+          };
+        };
+      };
+      "$color.palette.blue-100": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#eff6ff";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#202742";
+          };
+        };
+      };
+      "$color.palette.blue-200": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#e2edfc";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#1e3352";
+          };
+        };
+      };
+      "$color.palette.blue-300": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#cbdffa";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#1a4275";
+          };
+        };
+      };
+      "$color.palette.blue-400": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#aacefd";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#0f559e";
+          };
+        };
+      };
+      "$color.palette.blue-500": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#85b8fd";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#1964d8";
+          };
+        };
+      };
+      "$color.palette.blue-600": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#5e98fe";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#1e82eb";
+          };
+        };
+      };
+      "$color.palette.blue-700": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#217cf9";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#41a2f9";
+          };
+        };
+      };
+      "$color.palette.blue-800": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#135fcd";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#83bcf9";
+          };
+        };
+      };
+      "$color.palette.blue-900": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#0b4596";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#b9d7fb";
+          };
+        };
+      };
+      "$color.palette.blue-1000": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#032451";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#e5f0fe";
+          };
+        };
+      };
+      "$color.palette.red-100": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#fdf0f0";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#322323";
+          };
+        };
+      };
+      "$color.palette.red-200": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#fde7e7";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#4f2624";
+          };
+        };
+      };
+      "$color.palette.red-300": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#fed4d2";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#742826";
+          };
+        };
+      };
+      "$color.palette.red-400": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#feb7b3";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#a12621";
+          };
+        };
+      };
+      "$color.palette.red-500": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#fe928d";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#ca2319";
+          };
+        };
+      };
+      "$color.palette.red-600": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#fc6a66";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#f73526";
+          };
+        };
+      };
+      "$color.palette.red-700": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#fa342c";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#ff6e60";
+          };
+        };
+      };
+      "$color.palette.red-800": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ca1d13";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#ffa299";
+          };
+        };
+      };
+      "$color.palette.red-900": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#921708";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#f8c5c3";
+          };
+        };
+      };
+      "$color.palette.red-1000": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#4a1209";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#fdf2f2";
+          };
+        };
+      };
+      "$color.palette.green-100": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#edfaf6";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#202926";
+          };
+        };
+      };
+      "$color.palette.green-200": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#d9f6e9";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#20362e";
+          };
+        };
+      };
+      "$color.palette.green-300": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#b9e9d2";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#20493b";
+          };
+        };
+      };
+      "$color.palette.green-400": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#7ddcb3";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#19604c";
+          };
+        };
+      };
+      "$color.palette.green-500": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#42c593";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#117956";
+          };
+        };
+      };
+      "$color.palette.green-600": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#10ab7d";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#1b946d";
+          };
+        };
+      };
+      "$color.palette.green-700": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#079171";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#22b27f";
+          };
+        };
+      };
+      "$color.palette.green-800": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#00745f";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#35ce9a";
+          };
+        };
+      };
+      "$color.palette.green-900": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#075445";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#93e5c0";
+          };
+        };
+      };
+      "$color.palette.green-1000": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#0a2b24";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#d4f6ef";
+          };
+        };
+      };
+      "$color.palette.yellow-100": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#fff7de";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#302819";
+          };
+        };
+      };
+      "$color.palette.yellow-200": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#fdefb9";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#413218";
+          };
+        };
+      };
+      "$color.palette.yellow-300": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#fbdc65";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#543e15";
+          };
+        };
+      };
+      "$color.palette.yellow-400": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#e9c647";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#714e15";
+          };
+        };
+      };
+      "$color.palette.yellow-500": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#d4ab28";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#91601b";
+          };
+        };
+      };
+      "$color.palette.yellow-600": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#c49725";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#b6720d";
+          };
+        };
+      };
+      "$color.palette.yellow-700": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#9b7821";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#ca901c";
+          };
+        };
+      };
+      "$color.palette.yellow-800": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#755b22";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#dab156";
+          };
+        };
+      };
+      "$color.palette.yellow-900": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#4f3e1f";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#e5d49b";
+          };
+        };
+      };
+      "$color.palette.yellow-1000": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#2c2512";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#f7f0cd";
+          };
+        };
+      };
+      "$color.palette.purple-100": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#f5f3fe";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#28213b";
+          };
+        };
+      };
+      "$color.palette.purple-200": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#efeafe";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#3b2873";
+          };
+        };
+      };
+      "$color.palette.purple-300": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#e1d8ff";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#443081";
+          };
+        };
+      };
+      "$color.palette.purple-400": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#d0c0ff";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#5a3bb1";
+          };
+        };
+      };
+      "$color.palette.purple-500": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#b8a1ff";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#764fd9";
+          };
+        };
+      };
+      "$color.palette.purple-600": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#9f84fb";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#8e6bee";
+          };
+        };
+      };
+      "$color.palette.purple-700": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#8969ea";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#a78df0";
+          };
+        };
+      };
+      "$color.palette.purple-800": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#6d50cb";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#beadf2";
+          };
+        };
+      };
+      "$color.palette.purple-900": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#50379b";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#d9cefa";
+          };
+        };
+      };
+      "$color.palette.purple-1000": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#29175d";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#f0edfc";
+          };
+        };
+      };
+      "$color.palette.static-black": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#000000";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#000000";
+          };
+        };
+      };
+      "$color.palette.static-black-alpha-100": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#00000007";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#00000007";
+          };
+        };
+      };
+      "$color.palette.static-black-alpha-200": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#0000000c";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#0000000c";
+          };
+        };
+      };
+      "$color.palette.static-black-alpha-300": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#00000010";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#00000010";
+          };
+        };
+      };
+      "$color.palette.static-black-alpha-400": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#00000021";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#00000021";
+          };
+        };
+      };
+      "$color.palette.static-black-alpha-500": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#0000002c";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#0000002c";
+          };
+        };
+      };
+      "$color.palette.static-black-alpha-600": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#0000004c";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#0000004c";
+          };
+        };
+      };
+      "$color.palette.static-black-alpha-700": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#00000074";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#00000074";
+          };
+        };
+      };
+      "$color.palette.static-black-alpha-800": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#000000a2";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#000000a2";
+          };
+        };
+      };
+      "$color.palette.static-black-alpha-900": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#000000d0";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#000000d0";
+          };
+        };
+      };
+      "$color.palette.static-black-alpha-1000": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#000000e3";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#000000e3";
+          };
+        };
+      };
+      "$color.palette.static-white": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffffff";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#ffffff";
+          };
+        };
+      };
+      "$color.palette.static-white-alpha-50": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffffff0d";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#ffffff0d";
+          };
+        };
+      };
+      "$color.palette.static-white-alpha-100": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffffff17";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#ffffff17";
+          };
+        };
+      };
+      "$color.palette.static-white-alpha-200": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffffff20";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#ffffff20";
+          };
+        };
+      };
+      "$color.palette.static-white-alpha-300": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffffff2e";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#ffffff2e";
+          };
+        };
+      };
+      "$color.palette.static-white-alpha-400": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffffff3d";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#ffffff3d";
+          };
+        };
+      };
+      "$color.palette.static-white-alpha-500": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffffff60";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#ffffff60";
+          };
+        };
+      };
+      "$color.palette.static-white-alpha-600": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffffff8b";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#ffffff8b";
+          };
+        };
+      };
+      "$color.palette.static-white-alpha-700": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffffffb3";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#ffffffb3";
+          };
+        };
+      };
+      "$color.palette.static-white-alpha-800": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffffffde";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#ffffffde";
+          };
+        };
+      };
+      "$color.palette.static-white-alpha-900": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffffffea";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#ffffffea";
+          };
+        };
+      };
+      "$color.palette.static-white-alpha-1000": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#fffffff4";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#fffffff4";
+          };
+        };
+      };
+      "$color.fg.brand": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.carrot-600";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.carrot-700";
+          };
+        };
+        "description": "브랜드와 관련된 요소들이 즉각적으로 인식될 수 있도록 돕습니다.";
+      };
+      "$color.fg.brand-contrast": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.carrot-700";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.carrot-700";
+          };
+        };
+        "description": "브랜드와 관련된 요소들이 즉각적으로 인식될 수 있도록 돕습니다. (contrast)";
+      };
+      "$color.fg.critical": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.red-700";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.red-700";
+          };
+        };
+        "description": "오류, 경고 또는 중요한 문제를 나타내는 데 사용됩니다.";
+      };
+      "$color.fg.critical-contrast": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.red-900";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.red-900";
+          };
+        };
+        "description": "오류, 경고 또는 중요한 문제를 나타내는 데 사용됩니다. (contrast)";
+      };
+      "$color.fg.disabled": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-500";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-500";
+          };
+        };
+      };
+      "$color.fg.informative": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.blue-700";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.blue-700";
+          };
+        };
+        "description": "사용자에게 유용한 정보를 제공하거나 상태를 설명할 때 사용됩니다.";
+      };
+      "$color.fg.informative-contrast": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.blue-900";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.blue-900";
+          };
+        };
+        "description": "사용자에게 유용한 정보를 제공하거나 상태를 설명할 때 사용됩니다. (contrast)";
+      };
+      "$color.fg.neutral": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-1000";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-1000";
+          };
+        };
+        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다.";
+      };
+      "$color.fg.neutral-inverted": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-00";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-100";
+          };
+        };
+        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (inverted)";
+      };
+      "$color.fg.neutral-muted": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-800";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-800";
+          };
+        };
+        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (muted)";
+      };
+      "$color.fg.neutral-subtle": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-700";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-700";
+          };
+        };
+        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (subtle)";
+      };
+      "$color.fg.placeholder": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-600";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-600";
+          };
+        };
+      };
+      "$color.fg.positive": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.green-700";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.green-700";
+          };
+        };
+        "description": "성공적인 작업, 확인, 또는 긍정적인 상태를 나타내는 데 사용됩니다.";
+      };
+      "$color.fg.positive-contrast": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.green-900";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.green-900";
+          };
+        };
+        "description": "성공적인 작업, 확인, 또는 긍정적인 상태를 나타내는 데 사용됩니다. (contrast)";
+      };
+      "$color.fg.warning": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.yellow-700";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.yellow-700";
+          };
+        };
+        "description": "사용자의 주의가 필요한 경고 메시지나 안내 사항을 전달하는 데 사용됩니다.";
+      };
+      "$color.fg.warning-contrast": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.yellow-900";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.yellow-900";
+          };
+        };
+        "description": "사용자의 주의가 필요한 경고 메시지나 안내 사항을 전달하는 데 사용됩니다. (contrast)";
+      };
+      "$color.bg.brand-solid": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.carrot-600";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.carrot-700";
+          };
+        };
+        "description": "브랜드와 관련된 요소들이 즉각적으로 인식될 수 있도록 돕습니다. 화면에서 가장 중요한 액션을 강조하는데 사용할 수 있습니다. (solid)";
+      };
+      "$color.bg.brand-solid-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.carrot-700";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.carrot-800";
+          };
+        };
+        "description": "브랜드와 관련된 요소들이 즉각적으로 인식될 수 있도록 돕습니다. 화면에서 가장 중요한 액션을 강조하는데 사용할 수 있습니다. (solid-pressed)";
+      };
+      "$color.bg.brand-weak": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.carrot-100";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.carrot-100";
+          };
+        };
+        "description": "브랜드와 관련된 요소들이 즉각적으로 인식될 수 있도록 돕습니다. 화면에서 가장 중요한 액션을 강조하는데 사용할 수 있습니다. (weak)";
+      };
+      "$color.bg.brand-weak-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.carrot-200";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.carrot-200";
+          };
+        };
+        "description": "브랜드와 관련된 요소들이 즉각적으로 인식될 수 있도록 돕습니다. 화면에서 가장 중요한 액션을 강조하는데 사용할 수 있습니다. (weak-pressed)";
+      };
+      "$color.bg.critical-solid": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.red-700";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.red-600";
+          };
+        };
+        "description": "오류, 경고 또는 중요한 문제를 나타내는 데 사용됩니다. (solid)";
+      };
+      "$color.bg.critical-solid-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.red-800";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.red-700";
+          };
+        };
+        "description": "오류, 경고 또는 중요한 문제를 나타내는 데 사용됩니다. (solid-pressed)";
+      };
+      "$color.bg.critical-weak": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.red-100";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.red-100";
+          };
+        };
+        "description": "오류, 경고 또는 중요한 문제를 나타내는 데 사용됩니다. (weak)";
+      };
+      "$color.bg.critical-weak-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.red-200";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.red-200";
+          };
+        };
+        "description": "오류, 경고 또는 중요한 문제를 나타내는 데 사용됩니다. (weak-pressed)";
+      };
+      "$color.bg.disabled": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-200";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-300";
+          };
+        };
+      };
+      "$color.bg.informative-solid": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.blue-700";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.blue-600";
+          };
+        };
+        "description": "사용자에게 유용한 정보를 제공하거나 상태를 설명할 때 사용됩니다. (solid)";
+      };
+      "$color.bg.informative-solid-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.blue-800";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.blue-700";
+          };
+        };
+        "description": "사용자에게 유용한 정보를 제공하거나 상태를 설명할 때 사용됩니다. (solid-pressed)";
+      };
+      "$color.bg.informative-weak": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.blue-100";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.blue-100";
+          };
+        };
+        "description": "사용자에게 유용한 정보를 제공하거나 상태를 설명할 때 사용됩니다. (weak)";
+      };
+      "$color.bg.informative-weak-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.blue-200";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.blue-200";
+          };
+        };
+        "description": "사용자에게 유용한 정보를 제공하거나 상태를 설명할 때 사용됩니다. (weak-pressed)";
+      };
+      "$color.bg.layer-basement": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-200";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-00";
+          };
+        };
+        "description": "가장 낮은 0단계의 '대지'입니다. 화면 가장 깊은 곳에 위치하는 전체 배경색입니다.";
+      };
+      "$color.bg.layer-default": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-00";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-100";
+          };
+        };
+        "description": "basement 바로 위에 놓이는 기본 표면입니다. 대부분의 스크린 콘텐츠(List, TextField 등)가 이 레이어 위에서 표현됩니다.";
+      };
+      "$color.bg.layer-default-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-100";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-300";
+          };
+        };
+        "description": "basement 바로 위에 놓이는 기본 표면입니다. 대부분의 스크린 콘텐츠(List, TextField 등)가 이 레이어 위에서 표현됩니다. (pressed)";
+      };
+      "$color.bg.layer-fill": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-100";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-200";
+          };
+        };
+        "description": "@deprecated @seed-design/css@3.0.0에서 새 이름 토큰으로 대체·제거될 예정입니다.";
+      };
+      "$color.bg.layer-floating": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-00";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-200";
+          };
+        };
+        "description": "화면의 모든 콘텐츠 위를 덮으며(floating) 나타나는 임시 레이어입니다. 사용자의 상호작용을 필요로 하는 모달(Modal)성 요소들이 여기에 속합니다.";
+      };
+      "$color.bg.layer-floating-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-100";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-300";
+          };
+        };
+        "description": "화면의 모든 콘텐츠 위를 덮으며(floating) 나타나는 임시 레이어입니다. 사용자의 상호작용을 필요로 하는 모달(Modal)성 요소들이 여기에 속합니다. (pressed)";
+      };
+      "$color.bg.magic-weak": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#f9f2ee";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#201f1f";
+          };
+        };
+      };
+      "$color.bg.neutral-inverted": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-900";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-1000";
+          };
+        };
+        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (inverted)";
+      };
+      "$color.bg.neutral-inverted-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-800";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-800";
+          };
+        };
+        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (inverted-pressed)";
+      };
+      "$color.bg.neutral-solid": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-1000";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-300";
+          };
+        };
+        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (solid)";
+      };
+      "$color.bg.neutral-weak": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-200";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-300";
+          };
+        };
+        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (weak)";
+      };
+      "$color.bg.neutral-weak-alpha": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.static-black-alpha-200";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.static-white-alpha-200";
+          };
+        };
+        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (weak-alpha) `$color.layer.basement` 위에서 컴포넌트의 가시성을 보장하기 위해 사용됩니다.";
+      };
+      "$color.bg.neutral-weak-alpha-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.static-black-alpha-300";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.static-white-alpha-300";
+          };
+        };
+        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (weak-alpha-pressed) `$color.layer.basement` 위에서 컴포넌트의 가시성을 보장하기 위해 사용됩니다.";
+      };
+      "$color.bg.neutral-weak-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-300";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-400";
+          };
+        };
+        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (weak-pressed)";
+      };
+      "$color.bg.overlay": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.static-black-alpha-700";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.static-black-alpha-700";
+          };
+        };
+      };
+      "$color.bg.overlay-muted": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.static-black-alpha-500";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.static-black-alpha-500";
+          };
+        };
+      };
+      "$color.bg.positive-solid": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.green-700";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.green-500";
+          };
+        };
+        "description": "성공적인 작업, 확인, 또는 긍정적인 상태를 나타내는 데 사용됩니다. (solid)";
+      };
+      "$color.bg.positive-solid-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.green-800";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.green-600";
+          };
+        };
+        "description": "성공적인 작업, 확인, 또는 긍정적인 상태를 나타내는 데 사용됩니다. (solid-pressed)";
+      };
+      "$color.bg.positive-weak": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.green-100";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.green-100";
+          };
+        };
+        "description": "성공적인 작업, 확인, 또는 긍정적인 상태를 나타내는 데 사용됩니다. (weak)";
+      };
+      "$color.bg.positive-weak-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.green-200";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.green-200";
+          };
+        };
+        "description": "성공적인 작업, 확인, 또는 긍정적인 상태를 나타내는 데 사용됩니다. (weak-pressed)";
+      };
+      "$color.bg.transparent": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#00000000";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#ffffff00";
+          };
+        };
+      };
+      "$color.bg.transparent-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.static-black-alpha-100";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.static-white-alpha-50";
+          };
+        };
+      };
+      "$color.bg.transparent-selected": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.static-black-alpha-200";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.static-white-alpha-100";
+          };
+        };
+      };
+      "$color.bg.transparent-selected-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.static-black-alpha-300";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.static-white-alpha-200";
+          };
+        };
+      };
+      "$color.bg.warning-solid": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.yellow-300";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.yellow-800";
+          };
+        };
+        "description": "사용자의 주의가 필요한 경고 메시지나 안내 사항을 전달하는 데 사용됩니다. (solid)";
+      };
+      "$color.bg.warning-solid-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.yellow-400";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.yellow-900";
+          };
+        };
+        "description": "사용자의 주의가 필요한 경고 메시지나 안내 사항을 전달하는 데 사용됩니다. (solid-pressed)";
+      };
+      "$color.bg.warning-weak": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.yellow-100";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.yellow-100";
+          };
+        };
+        "description": "사용자의 주의가 필요한 경고 메시지나 안내 사항을 전달하는 데 사용됩니다. (weak)";
+      };
+      "$color.bg.warning-weak-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.yellow-200";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.yellow-200";
+          };
+        };
+        "description": "사용자의 주의가 필요한 경고 메시지나 안내 사항을 전달하는 데 사용됩니다. (weak-pressed)";
+      };
+      "$color.stroke.brand-solid": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.carrot-700";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.carrot-700";
+          };
+        };
+        "description": "브랜드와 관련된 요소들이 즉각적으로 인식될 수 있도록 돕습니다. 화면에서 가장 중요한 액션을 강조하는데 사용할 수 있습니다. (solid)";
+      };
+      "$color.stroke.brand-weak": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.carrot-300";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.carrot-300";
+          };
+        };
+        "description": "브랜드와 관련된 요소들이 즉각적으로 인식될 수 있도록 돕습니다. 화면에서 가장 중요한 액션을 강조하는데 사용할 수 있습니다. (weak)";
+      };
+      "$color.stroke.critical-solid": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.red-700";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.red-700";
+          };
+        };
+        "description": "오류, 경고 또는 중요한 문제를 나타내는 데 사용됩니다. (solid)";
+      };
+      "$color.stroke.critical-weak": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.red-300";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.red-300";
+          };
+        };
+        "description": "오류, 경고 또는 중요한 문제를 나타내는 데 사용됩니다. (weak)";
+      };
+      "$color.stroke.focus-ring": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.blue-600";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.blue-600";
+          };
+        };
+      };
+      "$color.stroke.informative-solid": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.blue-700";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.blue-700";
+          };
+        };
+        "description": "사용자에게 유용한 정보를 제공하거나 상태를 설명할 때 사용됩니다. (solid)";
+      };
+      "$color.stroke.informative-weak": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.blue-300";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.blue-300";
+          };
+        };
+        "description": "사용자에게 유용한 정보를 제공하거나 상태를 설명할 때 사용됩니다. (weak)";
+      };
+      "$color.stroke.neutral-contrast": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-1000";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-1000";
+          };
+        };
+        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (contrast)";
+      };
+      "$color.stroke.neutral-muted": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.static-black-alpha-300";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.static-white-alpha-100";
+          };
+        };
+        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (muted)";
+      };
+      "$color.stroke.neutral-solid": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-800";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-800";
+          };
+        };
+        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (solid)";
+      };
+      "$color.stroke.neutral-subtle": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.static-black-alpha-200";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.static-white-alpha-50";
+          };
+        };
+        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (subtle)";
+      };
+      "$color.stroke.neutral-weak": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.gray-400";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.gray-400";
+          };
+        };
+        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (weak)";
+      };
+      "$color.stroke.positive-solid": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.green-700";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.green-700";
+          };
+        };
+        "description": "성공적인 작업, 확인, 또는 긍정적인 상태를 나타내는 데 사용됩니다. (solid)";
+      };
+      "$color.stroke.positive-weak": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.green-300";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.green-300";
+          };
+        };
+        "description": "성공적인 작업, 확인, 또는 긍정적인 상태를 나타내는 데 사용됩니다. (weak)";
+      };
+      "$color.stroke.warning-solid": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.yellow-700";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.yellow-700";
+          };
+        };
+        "description": "사용자의 주의가 필요한 경고 메시지나 안내 사항을 전달하는 데 사용됩니다. (solid)";
+      };
+      "$color.stroke.warning-weak": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "$color.palette.yellow-300";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "$color.palette.yellow-300";
+          };
+        };
+        "description": "사용자의 주의가 필요한 경고 메시지나 안내 사항을 전달하는 데 사용됩니다. (weak)";
+      };
+      "$color.manner-temp.l1.bg": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#f1f2f3";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#292929";
+          };
+        };
+      };
+      "$color.manner-temp.l1.text": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#757b85";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#b8b8b9";
+          };
+        };
+      };
+      "$color.manner-temp.l10.bg": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffebee";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#34040a";
+          };
+        };
+      };
+      "$color.manner-temp.l10.text": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#cb0123";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#fb6f82";
+          };
+        };
+      };
+      "$color.manner-temp.l2.bg": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#f8f4ec";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#332605";
+          };
+        };
+      };
+      "$color.manner-temp.l2.text": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ab863f";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#f5db97";
+          };
+        };
+      };
+      "$color.manner-temp.l3.bg": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#fff5e5";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#372b01";
+          };
+        };
+      };
+      "$color.manner-temp.l3.text": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#e08a00";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#fdda65";
+          };
+        };
+      };
+      "$color.manner-temp.l4.bg": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#fff3e5";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#372301";
+          };
+        };
+      };
+      "$color.manner-temp.l4.text": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#f57e00";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#fbbe55";
+          };
+        };
+      };
+      "$color.manner-temp.l5.bg": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#fff1e5";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#371f01";
+          };
+        };
+      };
+      "$color.manner-temp.l5.text": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ff7300";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#faac4b";
+          };
+        };
+      };
+      "$color.manner-temp.l6.bg": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#fff0e5";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#351b03";
+          };
+        };
+      };
+      "$color.manner-temp.l6.text": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ff6600";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#fc9855";
+          };
+        };
+      };
+      "$color.manner-temp.l7.bg": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffefe5";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#371701";
+          };
+        };
+      };
+      "$color.manner-temp.l7.text": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ff5100";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#f97a25";
+          };
+        };
+      };
+      "$color.manner-temp.l8.bg": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffeee5";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#380f00";
+          };
+        };
+      };
+      "$color.manner-temp.l8.text": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ff3300";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#fe6a34";
+          };
+        };
+      };
+      "$color.manner-temp.l9.bg": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#fdeded";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#380500";
+          };
+        };
+      };
+      "$color.manner-temp.l9.text": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#e82c45";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#fe6a5d";
+          };
+        };
+      };
+      "$color.banner.blue": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#e1f7ff";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#0d2a3a";
+          };
+        };
+      };
+      "$color.banner.cool-gray": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ebf1f5";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#242c33";
+          };
+        };
+      };
+      "$color.banner.green": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#f0fbe5";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#1e361c";
+          };
+        };
+      };
+      "$color.banner.orange": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#fff2e1";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#42230a";
+          };
+        };
+      };
+      "$color.banner.pink": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffebf1";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#3b172c";
+          };
+        };
+      };
+      "$color.banner.purple": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#f5ecff";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#2e1e45";
+          };
+        };
+      };
+      "$color.banner.red": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#ffecee";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#3a0f15";
+          };
+        };
+      };
+      "$color.banner.teal": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#e6faf6";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#143633";
+          };
+        };
+      };
+      "$color.banner.warm-gray": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#f2f0ee";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#2f2b27";
+          };
+        };
+      };
+      "$color.banner.yellow": {
+        "values": {
+          "theme-light": {
+            "type": "color";
+            "value": "#fffae1";
+          };
+          "theme-dark": {
+            "type": "color";
+            "value": "#3e2b00";
+          };
+        };
+      };
+    };
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/color.mjs
+++ b/packages/rootage/__generated__/color.mjs
@@ -1,0 +1,2 @@
+import artifact from "./color.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/accordion-item.d.ts
+++ b/packages/rootage/__generated__/components/accordion-item.d.ts
@@ -1,0 +1,502 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "accordion-item";
+    "name": "Accordion Item";
+  };
+  "data": {
+    "id": "accordion-item";
+    "name": "Accordion Item";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "strokeColor": {
+              "type": "color";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "dividerColor": {
+              "type": "color";
+            };
+            "dividerPaddingX": {
+              "type": "dimension";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "trigger": {
+          "properties": {
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "marginX": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+          };
+        };
+        "prefix": {
+          "properties": {
+            "paddingRight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "title": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "description": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "suffixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "paddingLeft": {
+              "type": "dimension";
+            };
+            "rotateDuration": {
+              "type": "duration";
+            };
+            "rotateTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "body": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "content": {
+          "properties": {
+            "expandHeightDuration": {
+              "type": "duration";
+            };
+            "expandHeightTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "collapseHeightDuration": {
+              "type": "duration";
+            };
+            "collapseHeightTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "medium": {};
+            "large": {};
+          };
+          "defaultValue": "medium";
+        };
+        "variant": {
+          "values": {
+            "inline": {
+              "description": "Accordion Item들이 하나의 연속된 목록처럼 표현됩니다. 밀접하게 관련된 항목들을 컴팩트하게 나열할 때 사용합니다.";
+            };
+            "separated": {
+              "description": "각 Accordion Item이 개별 카드 형태로 분리되어 표현됩니다. 항목 간 시각적 독립성이 필요하거나, 각 섹션의 중요도가 동등할 때 사용합니다.";
+            };
+          };
+          "defaultValue": "inline";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "trigger": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+              };
+              "body": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+                "rotateDuration": {
+                  "type": "duration";
+                  "value": "$duration.d6";
+                };
+                "rotateTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "content": {
+                "expandHeightDuration": {
+                  "type": "duration";
+                  "value": "$duration.d6";
+                };
+                "expandHeightTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "collapseHeightDuration": {
+                  "type": "duration";
+                  "value": "$duration.d6";
+                };
+                "collapseHeightTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "trigger": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+                "marginX": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "trigger": {
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "prefix": {
+                "paddingRight": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+              };
+              "title": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "description": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+                "paddingLeft": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "trigger": {
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+              };
+              "prefix": {
+                "paddingRight": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+              };
+              "title": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t7";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t7";
+                };
+              };
+              "description": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "paddingLeft": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "inline";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "dividerColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-subtle";
+                };
+                "dividerPaddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "separated";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/accordion-item.mjs
+++ b/packages/rootage/__generated__/components/accordion-item.mjs
@@ -1,0 +1,2 @@
+import artifact from "./accordion-item.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/accordion.d.ts
+++ b/packages/rootage/__generated__/components/accordion.d.ts
@@ -1,0 +1,87 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "accordion";
+    "name": "Accordion";
+  };
+  "data": {
+    "id": "accordion";
+    "name": "Accordion";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "variant": {
+          "values": {
+            "separated": {
+              "description": "각 Accordion Item이 개별 카드 형태로 분리되어 표현됩니다. 항목 간 시각적 독립성이 필요하거나, 각 섹션의 중요도가 동등할 때 사용합니다.";
+            };
+            "inline": {
+              "description": "Accordion Item들이 하나의 연속된 목록처럼 표현됩니다. 밀접하게 관련된 항목들을 컴팩트하게 나열할 때 사용합니다.";
+            };
+          };
+          "defaultValue": "separated";
+        };
+        "size": {
+          "values": {
+            "medium": {};
+            "large": {};
+          };
+          "defaultValue": "medium";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {
+          "variant": "separated";
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "separated";
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/accordion.mjs
+++ b/packages/rootage/__generated__/components/accordion.mjs
@@ -1,0 +1,2 @@
+import artifact from "./accordion.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/action-button.d.ts
+++ b/packages/rootage/__generated__/components/action-button.d.ts
@@ -1,0 +1,1638 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "action-button";
+    "name": "Action Button";
+  };
+  "data": {
+    "id": "action-button";
+    "name": "Action Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "scale": {
+              "type": "number";
+            };
+            "scaleDuration": {
+              "type": "duration";
+            };
+            "scaleTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "color": {
+              "type": "color";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "minWidth": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+          "description": "layout=iconOnly에서 사용되는 아이콘 슬롯입니다.";
+        };
+        "prefixIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+          "description": "주로 액션의 의미를 보조합니다. suffixIcon과 함께 사용할 수 없습니다.";
+        };
+        "suffixIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+          "description": "Chevron처럼 동작을 보조하는 역할입니다. prefixIcon과 함께 사용할 수 없습니다.";
+        };
+        "progressCircle": {
+          "properties": {
+            "trackColor": {
+              "type": "color";
+            };
+            "rangeColor": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "thickness": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "variant": {
+          "values": {
+            "brandSolid": {
+              "description": "브랜드의 핵심 가치를 전달하며, 사용자 간 연결이 일어나는 서비스의 주요 기능에 사용합니다. 한 화면에 하나만 사용하는 것을 권장합니다.";
+            };
+            "neutralSolid": {
+              "description": "대부분의 화면에서 CTA로 사용합니다. 한 화면에 하나만 사용하는 것을 권장합니다.";
+            };
+            "neutralWeak": {
+              "description": "CTA를 제외한 대부분의 액션에 사용됩니다.";
+            };
+            "criticalSolid": {
+              "description": "삭제나 초기화처럼 되돌릴 수 없는 중요한 작업에 사용합니다.";
+            };
+            "neutralOutline": {
+              "description": "variant=brandSolid, neutralSolid, criticalSolid와 함께 사용할 수 없으며, variant=brandOutline과 조합하여 사용하는 것을 권장합니다.";
+            };
+            "brandOutline": {
+              "description": "variant=brandSolid, neutralSolid, criticalSolid와 함께 사용할 수 없으며, variant=neutralOutline과 조합하여 사용하는 것을 권장합니다.";
+            };
+            "ghost": {
+              "description": "배경 없이 텍스트와 아이콘만 표시됩니다. 모두 동일한 색상을 사용하는 조건에서 icon, prefix icon, suffix icon, label에 정의된 color를 변경할 수 있으며, label의 fontWeight를 `$font-weight.regular` 또는 `$font-weight.medium`으로 변경하여 주목도를 조절할 수 있습니다.";
+            };
+          };
+          "defaultValue": "brandSolid";
+        };
+        "size": {
+          "values": {
+            "xsmall": {
+              "description": "작은 공간에서 효율적으로 사용할 수 있는 Pill 형태로 제공됩니다.";
+            };
+            "small": {
+              "description": "화면 중앙에서 범용적으로 사용됩니다.";
+            };
+            "medium": {
+              "description": "화면 중앙에서 범용적으로 사용됩니다.";
+            };
+            "large": {
+              "description": "주로 CTA 역할로 사용됩니다.";
+            };
+          };
+          "defaultValue": "xsmall";
+        };
+        "layout": {
+          "values": {
+            "withText": {
+              "description": "텍스트와 함께 아이콘을 표시할 수 있습니다.";
+            };
+            "iconOnly": {
+              "description": "아이콘만으로 의미를 전달하기 때문에 접근성이 떨어집니다. 꼭 필요한 경우에만 접근성 레이블과 함께 사용하는 것을 권장합니다.";
+            };
+          };
+          "defaultValue": "withText";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "scaleDuration": {
+                  "type": "duration";
+                  "value": "$duration.pressed-scale";
+                };
+                "scaleTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.pressed-scale";
+                };
+              };
+              "label": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "brandSolid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-solid";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "progressCircle": {
+                "trackColor": {
+                  "type": "color";
+                  "value": "$color.palette.static-white-alpha-300";
+                };
+                "rangeColor": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-solid-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "loading",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-solid-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "neutralSolid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+              "progressCircle": {
+                "trackColor": {
+                  "type": "color";
+                  "value": "$color.palette.static-white-alpha-300";
+                };
+                "rangeColor": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "loading",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "neutralWeak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "progressCircle": {
+                "trackColor": {
+                  "type": "color";
+                  "value": "$color.palette.gray-500";
+                };
+                "rangeColor": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "loading",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "criticalSolid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.critical-solid";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "progressCircle": {
+                "trackColor": {
+                  "type": "color";
+                  "value": "$color.palette.static-white-alpha-300";
+                };
+                "rangeColor": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.critical-solid-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "loading",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.critical-solid-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "neutralOutline";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "progressCircle": {
+                "trackColor": {
+                  "type": "color";
+                  "value": "$color.palette.gray-500";
+                };
+                "rangeColor": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "loading",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "brandOutline";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.brand";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.brand";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.brand";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.brand";
+                };
+              };
+              "progressCircle": {
+                "trackColor": {
+                  "type": "color";
+                  "value": "$color.palette.carrot-200";
+                };
+                "rangeColor": {
+                  "type": "color";
+                  "value": "$color.bg.brand-solid";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "loading",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "ghost";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "#ffffff00";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "progressCircle": {
+                "trackColor": {
+                  "type": "color";
+                  "value": "$color.palette.gray-500";
+                };
+                "rangeColor": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "#ffffff00";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "loading",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "xsmall";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x8";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+              };
+              "progressCircle": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 14;
+                    "unit": "px";
+                  };
+                };
+                "thickness": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "scale": {
+                  "type": "number";
+                  "value": "$scale.s95";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "xsmall";
+          "layout": "withText";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "xsmall";
+          "layout": "iconOnly";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minWidth": {
+                  "type": "dimension";
+                  "value": "$dimension.x8";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x9";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r2";
+                };
+              };
+              "progressCircle": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 14;
+                    "unit": "px";
+                  };
+                };
+                "thickness": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "scale": {
+                  "type": "number";
+                  "value": "$scale.s97";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+          "layout": "withText";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+          "layout": "iconOnly";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minWidth": {
+                  "type": "dimension";
+                  "value": "$dimension.x9";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x10";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r2";
+                };
+              };
+              "progressCircle": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 16;
+                    "unit": "px";
+                  };
+                };
+                "thickness": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "scale": {
+                  "type": "number";
+                  "value": "$scale.s97";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+          "layout": "withText";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+          "layout": "iconOnly";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minWidth": {
+                  "type": "dimension";
+                  "value": "$dimension.x10";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 18;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x13";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+              };
+              "progressCircle": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 18;
+                    "unit": "px";
+                  };
+                };
+                "thickness": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "scale": {
+                  "type": "number";
+                  "value": "$scale.s98";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+          "layout": "withText";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t6";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t6";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+          "layout": "iconOnly";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minWidth": {
+                  "type": "dimension";
+                  "value": "$dimension.x13";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/action-button.mjs
+++ b/packages/rootage/__generated__/components/action-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./action-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/action-chip.d.ts
+++ b/packages/rootage/__generated__/components/action-chip.d.ts
@@ -1,0 +1,455 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "action-chip";
+    "name": "Action Chip";
+    "deprecated": "Use Chip.Button with variant=\"solid\" instead.";
+    "lastUpdated": "25-07-16";
+  };
+  "data": {
+    "id": "action-chip";
+    "name": "Action Chip";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "minWidth": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "suffixIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "count": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "small": {};
+            "medium": {};
+          };
+          "defaultValue": "small";
+        };
+        "layout": {
+          "values": {
+            "withText": {};
+            "iconOnly": {};
+          };
+          "defaultValue": "withText";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "count": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "count": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x8";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "count": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x9";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "count": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+          "layout": "withText";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+          "layout": "iconOnly";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minWidth": {
+                  "type": "dimension";
+                  "value": "$dimension.x8";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+          "layout": "withText";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+          "layout": "iconOnly";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minWidth": {
+                  "type": "dimension";
+                  "value": "$dimension.x9";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/action-chip.mjs
+++ b/packages/rootage/__generated__/components/action-chip.mjs
@@ -1,0 +1,2 @@
+import artifact from "./action-chip.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/action-sheet-close-button.d.ts
+++ b/packages/rootage/__generated__/components/action-sheet-close-button.d.ts
@@ -1,0 +1,116 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "action-sheet-close-button";
+    "name": "Action Sheet Close Button";
+    "deprecated": "No longer used.";
+  };
+  "data": {
+    "id": "action-sheet-close-button";
+    "name": "Action Sheet Close Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating";
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 50;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/action-sheet-close-button.mjs
+++ b/packages/rootage/__generated__/components/action-sheet-close-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./action-sheet-close-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/action-sheet-item.d.ts
+++ b/packages/rootage/__generated__/components/action-sheet-item.d.ts
@@ -1,0 +1,160 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "action-sheet-item";
+    "name": "Action Sheet Item";
+    "deprecated": "Use menu-sheet-item instead.";
+  };
+  "data": {
+    "id": "action-sheet-item";
+    "name": "Action Sheet Item";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {
+        "tone": {
+          "values": {
+            "neutral": {};
+            "critical": {};
+          };
+          "defaultValue": "neutral";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating";
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 50;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "neutral";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "critical";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/action-sheet-item.mjs
+++ b/packages/rootage/__generated__/components/action-sheet-item.mjs
@@ -1,0 +1,2 @@
+import artifact from "./action-sheet-item.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/action-sheet.d.ts
+++ b/packages/rootage/__generated__/components/action-sheet.d.ts
@@ -1,0 +1,270 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "action-sheet";
+    "name": "Action Sheet";
+    "deprecated": "Use menu-sheet instead.";
+  };
+  "data": {
+    "id": "action-sheet";
+    "name": "Action Sheet";
+    "schema": {
+      "slots": {
+        "backdrop": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "enterOpacity": {
+              "type": "number";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitOpacity": {
+              "type": "number";
+            };
+          };
+        };
+        "content": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "maxWidth": {
+              "type": "dimension";
+            };
+            "topCornerRadius": {
+              "type": "dimension";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "header": {
+          "properties": {
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "title": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "description": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "divider": {
+          "properties": {
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+            "marginX": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "backdrop": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.overlay";
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d2";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter";
+                };
+                "enterOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d2";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.exit";
+                };
+                "exitOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+              };
+              "content": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating";
+                };
+                "maxWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 480;
+                    "unit": "px";
+                  };
+                };
+                "topCornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r5";
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d6";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter-expressive";
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d4";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.exit";
+                };
+              };
+              "header": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+              };
+              "title": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+              };
+              "description": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+              };
+              "divider": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+                "marginX": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/action-sheet.mjs
+++ b/packages/rootage/__generated__/components/action-sheet.mjs
@@ -1,0 +1,2 @@
+import artifact from "./action-sheet.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/alert-dialog.d.ts
+++ b/packages/rootage/__generated__/components/alert-dialog.d.ts
@@ -1,0 +1,308 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "alert-dialog";
+    "name": "Alert Dialog";
+  };
+  "data": {
+    "id": "alert-dialog";
+    "name": "Alert Dialog";
+    "schema": {
+      "slots": {
+        "backdrop": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "enterOpacity": {
+              "type": "number";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitOpacity": {
+              "type": "number";
+            };
+          };
+        };
+        "content": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "marginX": {
+              "type": "dimension";
+            };
+            "marginY": {
+              "type": "dimension";
+            };
+            "maxWidth": {
+              "type": "dimension";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "enterOpacity": {
+              "type": "number";
+            };
+            "enterScale": {
+              "type": "number";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitOpacity": {
+              "type": "number";
+            };
+          };
+        };
+        "header": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingTop": {
+              "type": "dimension";
+            };
+          };
+        };
+        "footer": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingTop": {
+              "type": "dimension";
+            };
+            "paddingBottom": {
+              "type": "dimension";
+            };
+          };
+        };
+        "title": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "description": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "backdrop": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.overlay";
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d2";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter";
+                };
+                "enterOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d2";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.exit";
+                };
+                "exitOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+              };
+              "content": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r5";
+                };
+                "marginX": {
+                  "type": "dimension";
+                  "value": "$dimension.x8";
+                };
+                "marginY": {
+                  "type": "dimension";
+                  "value": "$dimension.x16";
+                };
+                "maxWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 272;
+                    "unit": "px";
+                  };
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d4";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter-expressive";
+                };
+                "enterOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "enterScale": {
+                  "type": "number";
+                  "value": 1.3;
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d2";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.exit";
+                };
+                "exitOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+              };
+              "header": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+                "paddingTop": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+              };
+              "footer": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+                "paddingTop": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "paddingBottom": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t7";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t7";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/alert-dialog.mjs
+++ b/packages/rootage/__generated__/components/alert-dialog.mjs
@@ -1,0 +1,2 @@
+import artifact from "./alert-dialog.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/attachment-input-dropzone.d.ts
+++ b/packages/rootage/__generated__/components/attachment-input-dropzone.d.ts
@@ -1,0 +1,146 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "attachment-input-dropzone";
+    "name": "Attachment Input Dropzone";
+  };
+  "data": {
+    "id": "attachment-input-dropzone";
+    "name": "Attachment Input Dropzone";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "height": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+          };
+          "description": "파일을 root 위로 dragging over 하는 동안 border style이 dashed에서 solid로 변경됩니다.";
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 120;
+                    "unit": "px";
+                  };
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.palette.gray-500";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "draggingOver",
+            ];
+            "slots": {
+              "root": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-solid";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/attachment-input-dropzone.mjs
+++ b/packages/rootage/__generated__/components/attachment-input-dropzone.mjs
@@ -1,0 +1,2 @@
+import artifact from "./attachment-input-dropzone.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/attachment-input-item-action-button.d.ts
+++ b/packages/rootage/__generated__/components/attachment-input-item-action-button.d.ts
@@ -1,0 +1,150 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "attachment-input-item-action-button";
+    "name": "Attachment Input Item Action Button";
+  };
+  "data": {
+    "id": "attachment-input-item-action-button";
+    "name": "Attachment Input Item Action Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {
+        "type": {
+          "values": {
+            "file": {};
+            "image": {};
+          };
+          "defaultValue": "file";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t2";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t2";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "type": "file";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "type": "image";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/attachment-input-item-action-button.mjs
+++ b/packages/rootage/__generated__/components/attachment-input-item-action-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./attachment-input-item-action-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/attachment-input-item-remove-button.d.ts
+++ b/packages/rootage/__generated__/components/attachment-input-item-remove-button.d.ts
@@ -1,0 +1,128 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "attachment-input-item-remove-button";
+    "name": "Attachment Input Item Remove Button";
+  };
+  "data": {
+    "id": "attachment-input-item-remove-button";
+    "name": "Attachment Input Item Remove Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+            "offset": {
+              "type": "dimension";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-default";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-weak";
+                };
+                "offset": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-default-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/attachment-input-item-remove-button.mjs
+++ b/packages/rootage/__generated__/components/attachment-input-item-remove-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./attachment-input-item-remove-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/attachment-input-item.d.ts
+++ b/packages/rootage/__generated__/components/attachment-input-item.d.ts
@@ -1,0 +1,449 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "attachment-input-item";
+    "name": "Attachment Input Item";
+  };
+  "data": {
+    "id": "attachment-input-item";
+    "name": "Attachment Input Item";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "width": {
+              "type": "dimension";
+            };
+            "height": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+            "opacity": {
+              "type": "number";
+            };
+          };
+        };
+        "thumbnail": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+          };
+        };
+        "thumbnailIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "name": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "size": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "backdrop": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "removeButtonMask": {
+          "properties": {
+            "offset": {
+              "type": "dimension";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+          "description": "dragging 상태에서는 표시되지 않습니다.";
+        };
+        "badge": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "height": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+          };
+        };
+        "badgeLabel": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {
+        "type": {
+          "values": {
+            "file": {};
+            "image": {};
+          };
+          "defaultValue": "file";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 80;
+                    "unit": "px";
+                  };
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+              "thumbnail": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak";
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x12";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r2";
+                };
+              };
+              "thumbnailIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+              };
+              "name": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t2";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t2";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+              "size": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t1";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t1";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+              "removeButtonMask": {
+                "offset": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "type": "file";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 160;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-weak";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "readonly",
+            ];
+            "slots": {
+              "thumbnailIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "name": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "size": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "dragging",
+            ];
+            "slots": {
+              "thumbnailIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "name": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "size": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "type": "image";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 80;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-subtle";
+                };
+              };
+              "backdrop": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.overlay";
+                };
+              };
+              "badge": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.overlay";
+                };
+                "height": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+              };
+              "badgeLabel": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t2";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t2";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "readonly",
+            ];
+            "slots": {
+              "root": {
+                "opacity": {
+                  "type": "number";
+                  "value": 0.5;
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "dragging",
+            ];
+            "slots": {
+              "root": {
+                "opacity": {
+                  "type": "number";
+                  "value": 0.5;
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/attachment-input-item.mjs
+++ b/packages/rootage/__generated__/components/attachment-input-item.mjs
@@ -1,0 +1,2 @@
+import artifact from "./attachment-input-item.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/attachment-input-trigger.d.ts
+++ b/packages/rootage/__generated__/components/attachment-input-trigger.d.ts
@@ -1,0 +1,211 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "attachment-input-trigger";
+    "name": "Attachment Input Trigger";
+  };
+  "data": {
+    "id": "attachment-input-trigger";
+    "name": "Attachment Input Trigger";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "itemCount": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "maxItemCount": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 80;
+                    "unit": "px";
+                  };
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-weak";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+              "itemCount": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t2";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t2";
+                };
+              };
+              "maxItemCount": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t2";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t2";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "itemCount": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "maxItemCount": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/attachment-input-trigger.mjs
+++ b/packages/rootage/__generated__/components/attachment-input-trigger.mjs
@@ -1,0 +1,2 @@
+import artifact from "./attachment-input-trigger.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/attachment-input.d.ts
+++ b/packages/rootage/__generated__/components/attachment-input.d.ts
@@ -1,0 +1,59 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "attachment-input";
+    "name": "Attachment Input";
+  };
+  "data": {
+    "id": "attachment-input";
+    "name": "Attachment Input";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+          "description": "Attachment Input Dropzone과 Items를 감싸는 컨테이너입니다.";
+        };
+        "items": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+          "description": "Attachment Input Trigger 및 Attachment Input Items를 감싸는 컨테이너입니다.";
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+              "items": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/attachment-input.mjs
+++ b/packages/rootage/__generated__/components/attachment-input.mjs
@@ -1,0 +1,2 @@
+import artifact from "./attachment-input.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/avatar-stack.d.ts
+++ b/packages/rootage/__generated__/components/avatar-stack.d.ts
@@ -1,0 +1,397 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "avatar-stack";
+    "name": "Avatar Stack";
+  };
+  "data": {
+    "id": "avatar-stack";
+    "name": "Avatar Stack";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "item": {
+          "properties": {
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "20": {};
+            "24": {};
+            "36": {};
+            "42": {};
+            "48": {};
+            "56": {};
+            "64": {};
+            "80": {};
+            "96": {};
+            "108": {};
+          };
+          "defaultValue": "20";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "item": {
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.bg.layer-default";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "20";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": {
+                    "value": -5;
+                    "unit": "px";
+                  };
+                };
+              };
+              "item": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "24";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": {
+                    "value": -6;
+                    "unit": "px";
+                  };
+                };
+              };
+              "item": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "36";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": {
+                    "value": -8;
+                    "unit": "px";
+                  };
+                };
+              };
+              "item": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "42";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": {
+                    "value": -10;
+                    "unit": "px";
+                  };
+                };
+              };
+              "item": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "48";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": {
+                    "value": -12;
+                    "unit": "px";
+                  };
+                };
+              };
+              "item": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "56";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": {
+                    "value": -13;
+                    "unit": "px";
+                  };
+                };
+              };
+              "item": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 3;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "64";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": {
+                    "value": -16;
+                    "unit": "px";
+                  };
+                };
+              };
+              "item": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 3;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "80";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": {
+                    "value": -20;
+                    "unit": "px";
+                  };
+                };
+              };
+              "item": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 4;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "96";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": {
+                    "value": -24;
+                    "unit": "px";
+                  };
+                };
+              };
+              "item": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 5;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "108";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": {
+                    "value": -27;
+                    "unit": "px";
+                  };
+                };
+              };
+              "item": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 5;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/avatar-stack.mjs
+++ b/packages/rootage/__generated__/components/avatar-stack.mjs
@@ -1,0 +1,2 @@
+import artifact from "./avatar-stack.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/avatar.d.ts
+++ b/packages/rootage/__generated__/components/avatar.d.ts
@@ -1,0 +1,699 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "avatar";
+    "name": "Avatar";
+  };
+  "data": {
+    "id": "avatar";
+    "name": "Avatar";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+          };
+        };
+        "badgeMask": {
+          "properties": {
+            "offset": {
+              "type": "dimension";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+          "description": "size=20에서는 지원되지 않습니다.";
+        };
+        "badge": {
+          "properties": {
+            "offset": {
+              "type": "dimension";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+          "description": "size=20에서는 지원되지 않습니다.";
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "20": {
+              "description": "대표 사용처: 댓글을 남긴 사용자";
+            };
+            "24": {
+              "description": "대표 사용처: 답글 프로필";
+            };
+            "36": {
+              "description": "대표 사용처: 댓글 프로필";
+            };
+            "42": {
+              "description": "대표 사용처: 게시글 상세 내 프로필";
+            };
+            "48": {
+              "description": "대표 사용처: 작은 리스트";
+            };
+            "56": {
+              "description": "대표 사용처: 큰 리스트";
+            };
+            "64": {
+              "description": "대표 사용처: 프로필 상세, 캐러셀";
+            };
+            "80": {};
+            "96": {};
+            "108": {
+              "description": "대표 사용처: 프로필 수정";
+            };
+          };
+          "defaultValue": "20";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-subtle";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "20";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 20;
+                    "unit": "px";
+                  };
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "24";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 24;
+                    "unit": "px";
+                  };
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+              "badgeMask": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 14;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 12;
+                    "unit": "px";
+                  };
+                };
+              };
+              "badge": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 15;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 10;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "36";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 36;
+                    "unit": "px";
+                  };
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+              "badgeMask": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 20;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 18;
+                    "unit": "px";
+                  };
+                };
+              };
+              "badge": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 14;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "42";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 42;
+                    "unit": "px";
+                  };
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+              "badgeMask": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 24;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 20;
+                    "unit": "px";
+                  };
+                };
+              };
+              "badge": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 26;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 16;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "48";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 48;
+                    "unit": "px";
+                  };
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+              "badgeMask": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 28;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+              };
+              "badge": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 30;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 18;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "56";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 56;
+                    "unit": "px";
+                  };
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+              "badgeMask": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 34;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 24;
+                    "unit": "px";
+                  };
+                };
+              };
+              "badge": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 36;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 20;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "64";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 64;
+                    "unit": "px";
+                  };
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+              "badgeMask": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 40;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 26;
+                    "unit": "px";
+                  };
+                };
+              };
+              "badge": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 42;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "80";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 80;
+                    "unit": "px";
+                  };
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+              "badgeMask": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 52;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 32;
+                    "unit": "px";
+                  };
+                };
+              };
+              "badge": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 54;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 28;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "96";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 96;
+                    "unit": "px";
+                  };
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+              "badgeMask": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 62;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 38;
+                    "unit": "px";
+                  };
+                };
+              };
+              "badge": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 65;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 32;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "108";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 108;
+                    "unit": "px";
+                  };
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+              "badgeMask": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 70;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 44;
+                    "unit": "px";
+                  };
+                };
+              };
+              "badge": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 74;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 36;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/avatar.mjs
+++ b/packages/rootage/__generated__/components/avatar.mjs
@@ -1,0 +1,2 @@
+import artifact from "./avatar.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/badge.d.ts
+++ b/packages/rootage/__generated__/components/badge.d.ts
@@ -1,0 +1,760 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "badge";
+    "name": "Badge";
+  };
+  "data": {
+    "id": "badge";
+    "name": "Badge";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "maxWidth": {
+              "type": "dimension";
+              "description": "10글자 이상의 텍스트를 말줄임 처리하기 위해 설정된 최대 너비입니다.";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "large": {};
+            "medium": {};
+          };
+          "defaultValue": "large";
+        };
+        "variant": {
+          "values": {
+            "weak": {
+              "description": "반복적인 구조를 가진 환경에서 사용합니다. 배경색이 있는 경우에는 권장하지 않습니다.";
+            };
+            "solid": {
+              "description": "배경이 복잡하거나 이미지 위에 Badge가 겹치는 경우 사용합니다.";
+            };
+            "outline": {
+              "description": "중간 정도의 주목도가 필요한 본문 또는 상세 화면에서 사용합니다.";
+            };
+          };
+          "defaultValue": "weak";
+        };
+        "tone": {
+          "values": {
+            "neutral": {
+              "description": "상태가 특별히 없거나, 상태값이 명확하지 않은 초기 상태";
+            };
+            "brand": {};
+            "informative": {
+              "description": "베타 기능 안내, 사용자 권한 제한, 정보 기반 메시지";
+            };
+            "positive": {
+              "description": "완료, 적용됨, 승인됨, 발행됨, 저장 성공, 검토 통과";
+            };
+            "warning": {
+              "description": "만료 임박, 제출 누락, 필수 정보 부족 등 잠재적 문제 상태";
+            };
+            "critical": {
+              "description": "검수 거절, 제재 상태, 편집 불가, 유효성 검증 실패";
+            };
+          };
+          "defaultValue": "neutral";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "maxWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 6.75;
+                    "unit": "rem";
+                  };
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r1_5";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t2";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t2";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "maxWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 7.5;
+                    "unit": "rem";
+                  };
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r1";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t1";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t1";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "weak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "solid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "outline";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+              "label": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "neutral";
+          "variant": "weak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "neutral";
+          "variant": "solid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-800";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "neutral";
+          "variant": "outline";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "brand";
+          "variant": "weak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-weak";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.brand-contrast";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "brand";
+          "variant": "solid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-solid";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "brand";
+          "variant": "outline";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.brand-weak";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.brand";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "informative";
+          "variant": "weak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.informative-weak";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.informative-contrast";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "informative";
+          "variant": "solid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.informative-solid";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "informative";
+          "variant": "outline";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.informative-weak";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.informative";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "positive";
+          "variant": "weak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.positive-weak";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.positive-contrast";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "positive";
+          "variant": "solid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.positive-solid";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "positive";
+          "variant": "outline";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.positive-weak";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.positive";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "warning";
+          "variant": "weak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.warning-weak";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.warning-contrast";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "warning";
+          "variant": "solid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.warning-solid";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-black-alpha-900";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "warning";
+          "variant": "outline";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.warning-weak";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.warning";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "critical";
+          "variant": "weak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.critical-weak";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical-contrast";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "critical";
+          "variant": "solid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.critical-solid";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "critical";
+          "variant": "outline";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.critical-weak";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/badge.mjs
+++ b/packages/rootage/__generated__/components/badge.mjs
@@ -1,0 +1,2 @@
+import artifact from "./badge.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/bottom-sheet-close-button.d.ts
+++ b/packages/rootage/__generated__/components/bottom-sheet-close-button.d.ts
@@ -1,0 +1,107 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "bottom-sheet-close-button";
+    "name": "Bottom Sheet Close Button";
+  };
+  "data": {
+    "id": "bottom-sheet-close-button";
+    "name": "Bottom Sheet Close Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "targetSize": {
+              "type": "dimension";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "targetSize": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 44;
+                    "unit": "px";
+                  };
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 28;
+                    "unit": "px";
+                  };
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 14;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/bottom-sheet-close-button.mjs
+++ b/packages/rootage/__generated__/components/bottom-sheet-close-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./bottom-sheet-close-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/bottom-sheet-handle.d.ts
+++ b/packages/rootage/__generated__/components/bottom-sheet-handle.d.ts
@@ -1,0 +1,137 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "bottom-sheet-handle";
+    "name": "Bottom Sheet Handle";
+  };
+  "data": {
+    "id": "bottom-sheet-handle";
+    "name": "Bottom Sheet Handle";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "fromTop": {
+              "type": "dimension";
+            };
+            "width": {
+              "type": "dimension";
+            };
+            "height": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "borderRadius": {
+              "type": "dimension";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "touchArea": {
+          "properties": {
+            "width": {
+              "type": "dimension";
+            };
+            "height": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fromTop": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 6;
+                    "unit": "px";
+                  };
+                };
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 36;
+                    "unit": "px";
+                  };
+                };
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 4;
+                    "unit": "px";
+                  };
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-400";
+                };
+                "borderRadius": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 9999;
+                    "unit": "px";
+                  };
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "touchArea": {
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 44;
+                    "unit": "px";
+                  };
+                };
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 44;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-500";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/bottom-sheet-handle.mjs
+++ b/packages/rootage/__generated__/components/bottom-sheet-handle.mjs
@@ -1,0 +1,2 @@
+import artifact from "./bottom-sheet-handle.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/bottom-sheet.d.ts
+++ b/packages/rootage/__generated__/components/bottom-sheet.d.ts
@@ -1,0 +1,436 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "bottom-sheet";
+    "name": "Bottom Sheet";
+  };
+  "data": {
+    "id": "bottom-sheet";
+    "name": "Bottom Sheet";
+    "schema": {
+      "slots": {
+        "backdrop": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "enterOpacity": {
+              "type": "number";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitOpacity": {
+              "type": "number";
+            };
+          };
+        };
+        "content": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "maxWidth": {
+              "type": "dimension";
+            };
+            "topCornerRadius": {
+              "type": "dimension";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "header": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingTop": {
+              "type": "dimension";
+            };
+            "paddingBottom": {
+              "type": "dimension";
+            };
+          };
+        };
+        "body": {
+          "properties": {
+            "paddingX": {
+              "type": "dimension";
+            };
+          };
+        };
+        "footer": {
+          "properties": {
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingTop": {
+              "type": "dimension";
+            };
+            "paddingBottom": {
+              "type": "dimension";
+            };
+          };
+        };
+        "title": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "paddingLeft": {
+              "type": "dimension";
+            };
+            "paddingRight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "description": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+          };
+        };
+        "closeButton": {
+          "properties": {
+            "fromTop": {
+              "type": "dimension";
+            };
+            "fromRight": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "headerAlignment": {
+          "values": {
+            "left": {};
+            "center": {};
+          };
+          "defaultValue": "left";
+        };
+        "closeButton": {
+          "values": {
+            "true": {};
+            "false": {};
+          };
+          "defaultValue": "true";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "backdrop": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.overlay";
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d6";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter";
+                };
+                "enterOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d4";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.exit";
+                };
+                "exitOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+              };
+              "content": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating";
+                };
+                "maxWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 640;
+                    "unit": "px";
+                  };
+                };
+                "topCornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r6";
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d6";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter-expressive";
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d4";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.exit";
+                };
+              };
+              "header": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "paddingTop": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "paddingBottom": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "body": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+              };
+              "footer": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+                "paddingTop": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+                "paddingBottom": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t8";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t8";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+              };
+              "closeButton": {
+                "fromTop": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "fromRight": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "headerAlignment": "left";
+          "closeButton": "true";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "title": {
+                "paddingRight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 56;
+                    "unit": "px";
+                  };
+                };
+                "paddingLeft": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "headerAlignment": "left";
+          "closeButton": "false";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "title": {
+                "paddingLeft": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+                "paddingRight": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "headerAlignment": "center";
+          "closeButton": "true";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "title": {
+                "paddingLeft": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 56;
+                    "unit": "px";
+                  };
+                };
+                "paddingRight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 56;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "headerAlignment": "center";
+          "closeButton": "false";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "title": {
+                "paddingLeft": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+                "paddingRight": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/bottom-sheet.mjs
+++ b/packages/rootage/__generated__/components/bottom-sheet.mjs
@@ -1,0 +1,2 @@
+import artifact from "./bottom-sheet.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/callout.d.ts
+++ b/packages/rootage/__generated__/components/callout.d.ts
@@ -1,0 +1,614 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "callout";
+    "name": "Callout";
+  };
+  "data": {
+    "id": "callout";
+    "name": "Callout";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "gradient": {
+              "type": "gradient";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+          "description": "아이콘은 Fill 타입 사용을 권장합니다.";
+        };
+        "title": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "description": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "link": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+          "description": "root가 클릭 영역인 Actionable Callout에서는 표시를 권장하지 않습니다.";
+        };
+        "suffixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "targetSize": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {
+        "tone": {
+          "values": {
+            "neutral": {
+              "description": "일반적인 정보를 전달합니다.";
+            };
+            "informative": {
+              "description": "유용한 정보를 제공합니다.";
+            };
+            "positive": {
+              "description": "긍정적인 상태를 나타냅니다.";
+            };
+            "warning": {
+              "description": "주의가 필요한 상태를 나타냅니다.";
+            };
+            "critical": {
+              "description": "중요한 문제를 나타냅니다.";
+            };
+            "magic": {
+              "description": "AI 기능을 나타냅니다.";
+            };
+          };
+          "defaultValue": "neutral";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r2_5";
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 50;
+                    "unit": "px";
+                  };
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "title": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+              "description": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+              "link": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "targetSize": {
+                  "type": "dimension";
+                  "value": "$dimension.x10";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "neutral";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "link": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "informative";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.informative-weak";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.informative-contrast";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.informative-contrast";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.informative-contrast";
+                };
+              };
+              "link": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.informative-contrast";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.informative-contrast";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.informative-weak-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "positive";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.positive-weak";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.positive-contrast";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.positive-contrast";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.positive-contrast";
+                };
+              };
+              "link": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.positive-contrast";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.positive-contrast";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.positive-weak-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "warning";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.warning-weak";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.warning-contrast";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.warning-contrast";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.warning-contrast";
+                };
+              };
+              "link": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.warning-contrast";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.warning-contrast";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.warning-weak-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "critical";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.critical-weak";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical-contrast";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical-contrast";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical-contrast";
+                };
+              };
+              "link": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical-contrast";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical-contrast";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.critical-weak-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "magic";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gradient": {
+                  "type": "gradient";
+                  "value": "$gradient.glow-magic";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "link": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "gradient": {
+                  "type": "gradient";
+                  "value": "$gradient.glow-magic-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/callout.mjs
+++ b/packages/rootage/__generated__/components/callout.mjs
@@ -1,0 +1,2 @@
+import artifact from "./callout.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/checkbox-group.d.ts
+++ b/packages/rootage/__generated__/components/checkbox-group.d.ts
@@ -1,0 +1,44 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "checkbox-group";
+    "name": "Checkbox Group";
+  };
+  "data": {
+    "id": "checkbox-group";
+    "name": "Checkbox Group";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "gapY": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gapY": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/checkbox-group.mjs
+++ b/packages/rootage/__generated__/components/checkbox-group.mjs
@@ -1,0 +1,2 @@
+import artifact from "./checkbox-group.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/checkbox.d.ts
+++ b/packages/rootage/__generated__/components/checkbox.d.ts
@@ -1,0 +1,197 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "checkbox";
+    "name": "Checkbox";
+  };
+  "data": {
+    "id": "checkbox";
+    "name": "Checkbox";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "weight": {
+          "values": {
+            "regular": {};
+            "bold": {};
+          };
+          "defaultValue": "regular";
+        };
+        "size": {
+          "values": {
+            "medium": {};
+            "large": {};
+          };
+          "defaultValue": "medium";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "weight": "regular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "weight": "bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x8";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x9";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/checkbox.mjs
+++ b/packages/rootage/__generated__/components/checkbox.mjs
@@ -1,0 +1,2 @@
+import artifact from "./checkbox.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/checkmark.d.ts
+++ b/packages/rootage/__generated__/components/checkmark.d.ts
@@ -1,0 +1,574 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "checkmark";
+    "name": "Checkmark";
+  };
+  "data": {
+    "id": "checkmark";
+    "name": "Checkmark";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+      };
+      "variants": {
+        "variant": {
+          "values": {
+            "square": {
+              "description": "필수 선택 항목이고 사용자가 해당 내용을 인지해야 하는 경우 사용합니다.";
+            };
+            "ghost": {
+              "description": "필수 선택 항목이 아니고, 3개 이하 항목으로 구성되는 경우 사용하는 것을 권장합니다.";
+            };
+          };
+          "defaultValue": "square";
+        };
+        "tone": {
+          "values": {
+            "brand": {};
+            "neutral": {};
+          };
+          "defaultValue": "brand";
+        };
+        "size": {
+          "values": {
+            "medium": {};
+            "large": {};
+          };
+          "defaultValue": "medium";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "square";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-weak";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "enabled",
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 0;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "#00000000";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+              "selected",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "square";
+          "tone": "brand";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-solid";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-solid-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "square";
+          "tone": "neutral";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "ghost";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.placeholder";
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+              "selected",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "ghost";
+          "tone": "brand";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+              "selected",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.brand";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.carrot-200";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "ghost";
+          "tone": "neutral";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+              "selected",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-200";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r1";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r1";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "square";
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 12;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "square";
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 14;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "ghost";
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 14;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "ghost";
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 18;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/checkmark.mjs
+++ b/packages/rootage/__generated__/components/checkmark.mjs
@@ -1,0 +1,2 @@
+import artifact from "./checkmark.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/chip-tablist.d.ts
+++ b/packages/rootage/__generated__/components/chip-tablist.d.ts
@@ -1,0 +1,108 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "chip-tablist";
+    "name": "Chip Tablist";
+  };
+  "data": {
+    "id": "chip-tablist";
+    "name": "Chip Tablist";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "paddingX": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "variant": {
+          "values": {
+            "neutralSolid": {};
+            "neutralOutline": {};
+          };
+          "defaultValue": "neutralSolid";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 8;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "neutralSolid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 8;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "neutralOutline";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 8;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/chip-tablist.mjs
+++ b/packages/rootage/__generated__/components/chip-tablist.mjs
@@ -1,0 +1,2 @@
+import artifact from "./chip-tablist.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/chip.d.ts
+++ b/packages/rootage/__generated__/components/chip.d.ts
@@ -1,0 +1,930 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "chip";
+    "name": "Chip";
+    "lastUpdated": "25-07-17";
+  };
+  "data": {
+    "id": "chip";
+    "name": "Chip";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "height": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "minWidth": {
+              "type": "dimension";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "opacity": {
+              "type": "number";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "paddingLeft": {
+              "type": "dimension";
+            };
+          };
+          "description": "Icon, Avatar, Image를 넣을 수 있습니다. 들어오는 요소에 따라 좌측 여백이 달라집니다.";
+        };
+        "prefixAvatar": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "suffixIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "paddingRight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "variant": {
+          "values": {
+            "solid": {
+              "description": "기본 스타일입니다.";
+            };
+            "outlineStrong": {
+              "description": "명확한 구분이 필요한 경우 사용합니다.";
+            };
+            "outlineWeak": {
+              "description": "Selection 사용 시 주목도가 낮은 스타일로 권장됩니다.";
+            };
+          };
+          "defaultValue": "solid";
+        };
+        "size": {
+          "values": {
+            "small": {};
+            "medium": {};
+            "large": {};
+          };
+          "defaultValue": "small";
+        };
+        "layout": {
+          "values": {
+            "withText": {};
+            "iconOnly": {};
+          };
+          "defaultValue": "withText";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+              };
+              "prefixIcon": {
+                "paddingLeft": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+              };
+              "prefixAvatar": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+              };
+              "suffixIcon": {
+                "paddingRight": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+              };
+              "label": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "solid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-alpha";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-alpha-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "opacity": {
+                  "type": "number";
+                  "value": 0.5;
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+              " pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+              " disabled",
+            ];
+            "slots": {
+              "root": {
+                "opacity": {
+                  "type": "number";
+                  "value": 0.5;
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "outlineStrong";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "opacity": {
+                  "type": "number";
+                  "value": 0.5;
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+              " pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+              " disabled",
+            ];
+            "slots": {
+              "root": {
+                "opacity": {
+                  "type": "number";
+                  "value": 0.5;
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "outlineWeak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "opacity": {
+                  "type": "number";
+                  "value": 0.5;
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-contrast";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+              " pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+              " disabled",
+            ];
+            "slots": {
+              "root": {
+                "opacity": {
+                  "type": "number";
+                  "value": 0.5;
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 32;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "prefixAvatar": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 36;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "prefixAvatar": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 40;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "paddingLeft": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "prefixAvatar": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x7";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+          "layout": "withText";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 44;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+          "layout": "withText";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minWidth": {
+                  "type": "dimension";
+                  "value": "$dimension.x12";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+          "layout": "withText";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minWidth": {
+                  "type": "dimension";
+                  "value": "$dimension.x13";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+          "layout": "iconOnly";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minWidth": {
+                  "type": "dimension";
+                  "value": "$dimension.x8";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+          "layout": "iconOnly";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minWidth": {
+                  "type": "dimension";
+                  "value": "$dimension.x9";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+          "layout": "iconOnly";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minWidth": {
+                  "type": "dimension";
+                  "value": "$dimension.x10";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/chip.mjs
+++ b/packages/rootage/__generated__/components/chip.mjs
@@ -1,0 +1,2 @@
+import artifact from "./chip.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/content-placeholder.d.ts
+++ b/packages/rootage/__generated__/components/content-placeholder.d.ts
@@ -1,0 +1,172 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "content-placeholder";
+    "name": "Content Placeholder";
+  };
+  "data": {
+    "id": "content-placeholder";
+    "name": "Content Placeholder";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "asset": {
+          "properties": {
+            "minWidth": {
+              "type": "dimension";
+            };
+            "maxWidth": {
+              "type": "dimension";
+            };
+            "heightFraction": {
+              "type": "number";
+              "description": "root slot 대한 asset slot의 높이 비율입니다.";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {
+        "type": {
+          "values": {
+            "default": {};
+            "buySell": {};
+            "car": {};
+            "commerce": {};
+            "coupon": {};
+            "food": {};
+            "group": {};
+            "image": {};
+            "jobs": {};
+            "business": {};
+            "post": {};
+            "realty": {};
+          };
+          "defaultValue": "default";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-200";
+                };
+              };
+              "asset": {
+                "minWidth": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "maxWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 160;
+                    "unit": "px";
+                  };
+                };
+                "heightFraction": {
+                  "type": "number";
+                  "value": 0.5;
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-400";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "type": "default";
+        };
+        "definitions": readonly [];
+      },
+      {
+        "variants": {
+          "type": "buySell";
+        };
+        "definitions": readonly [];
+      },
+      {
+        "variants": {
+          "type": "car";
+        };
+        "definitions": readonly [];
+      },
+      {
+        "variants": {
+          "type": "commerce";
+        };
+        "definitions": readonly [];
+      },
+      {
+        "variants": {
+          "type": "coupon";
+        };
+        "definitions": readonly [];
+      },
+      {
+        "variants": {
+          "type": "food";
+        };
+        "definitions": readonly [];
+      },
+      {
+        "variants": {
+          "type": "group";
+        };
+        "definitions": readonly [];
+      },
+      {
+        "variants": {
+          "type": "image";
+        };
+        "definitions": readonly [];
+      },
+      {
+        "variants": {
+          "type": "jobs";
+        };
+        "definitions": readonly [];
+      },
+      {
+        "variants": {
+          "type": "business";
+        };
+        "definitions": readonly [];
+      },
+      {
+        "variants": {
+          "type": "post";
+        };
+        "definitions": readonly [];
+      },
+      {
+        "variants": {
+          "type": "realty";
+        };
+        "definitions": readonly [];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/content-placeholder.mjs
+++ b/packages/rootage/__generated__/components/content-placeholder.mjs
@@ -1,0 +1,2 @@
+import artifact from "./content-placeholder.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/contextual-floating-button.d.ts
+++ b/packages/rootage/__generated__/components/contextual-floating-button.d.ts
@@ -1,0 +1,474 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "contextual-floating-button";
+    "name": "Contextual Floating Button";
+  };
+  "data": {
+    "id": "contextual-floating-button";
+    "name": "Contextual Floating Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "shadow": {
+              "type": "shadow";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "color": {
+              "type": "color";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "progressCircle": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "thickness": {
+              "type": "dimension";
+            };
+            "trackColor": {
+              "type": "color";
+            };
+            "rangeColor": {
+              "type": "color";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "variant": {
+          "values": {
+            "solid": {
+              "description": "배경과 대비되는 강조된 보조 액션으로 중요도 높은 행동 유도 시 적합합니다.";
+            };
+            "layer": {
+              "description": "시각적 부담 없이 부드럽게 액션을 유도합니다.";
+            };
+          };
+          "defaultValue": "solid";
+        };
+        "layout": {
+          "values": {
+            "withText": {
+              "description": "label과 prefixIcon을 함께 표시합니다.";
+            };
+            "iconOnly": {
+              "description": "icon만 표시합니다. 아이콘만으로 의미를 전달하기 때문에 접근성 레이블과 함께 사용해야 합니다.";
+            };
+          };
+          "defaultValue": "withText";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "shadow": {
+                  "type": "shadow";
+                  "value": "$shadow.s3";
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "progressCircle": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 16;
+                    "unit": "px";
+                  };
+                };
+                "thickness": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "solid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted";
+                };
+              };
+              "progressCircle": {
+                "trackColor": {
+                  "type": "color";
+                  "value": "$color.palette.gray-700";
+                };
+                "rangeColor": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "loading",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "layer";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating";
+                };
+              };
+              "progressCircle": {
+                "trackColor": {
+                  "type": "color";
+                  "value": "$color.palette.gray-500";
+                };
+                "rangeColor": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "loading",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "layout": "withText";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 36;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 16;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "layout": "iconOnly";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 44;
+                    "unit": "px";
+                  };
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/contextual-floating-button.mjs
+++ b/packages/rootage/__generated__/components/contextual-floating-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./contextual-floating-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/control-chip.d.ts
+++ b/packages/rootage/__generated__/components/control-chip.d.ts
@@ -1,0 +1,525 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "control-chip";
+    "name": "Control Chip";
+    "deprecated": "Use Chip.Toggle or Chip.Button instead.";
+    "lastUpdated": "25-07-16";
+  };
+  "data": {
+    "id": "control-chip";
+    "name": "Control Chip";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "strokeColor": {
+              "type": "color";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "minWidth": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "suffixIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "count": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "small": {};
+            "medium": {};
+          };
+          "defaultValue": "small";
+        };
+        "layout": {
+          "values": {
+            "withText": {};
+            "iconOnly": {};
+          };
+          "defaultValue": "withText";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "count": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-default-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 0;
+                    "unit": "px";
+                  };
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-solid-muted";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "count": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white-alpha-800";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+              " pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-solid-muted-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "count": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x8";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "count": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x9";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "count": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+          "layout": "withText";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+          "layout": "iconOnly";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minWidth": {
+                  "type": "dimension";
+                  "value": "$dimension.x8";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+          "layout": "withText";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+          "layout": "iconOnly";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minWidth": {
+                  "type": "dimension";
+                  "value": "$dimension.x9";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/control-chip.mjs
+++ b/packages/rootage/__generated__/components/control-chip.mjs
@@ -1,0 +1,2 @@
+import artifact from "./control-chip.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/dialog-close-button.d.ts
+++ b/packages/rootage/__generated__/components/dialog-close-button.d.ts
@@ -1,0 +1,125 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "dialog-close-button";
+    "name": "Dialog Close Button";
+  };
+  "data": {
+    "id": "dialog-close-button";
+    "name": "Dialog Close Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 52;
+                    "unit": "px";
+                  };
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/dialog-close-button.mjs
+++ b/packages/rootage/__generated__/components/dialog-close-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./dialog-close-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/dialog.d.ts
+++ b/packages/rootage/__generated__/components/dialog.d.ts
@@ -1,0 +1,455 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "dialog";
+    "name": "Dialog";
+  };
+  "data": {
+    "id": "dialog";
+    "name": "Dialog";
+    "schema": {
+      "slots": {
+        "backdrop": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "enterOpacity": {
+              "type": "number";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitOpacity": {
+              "type": "number";
+            };
+          };
+        };
+        "content": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "maxWidth": {
+              "type": "dimension";
+            };
+            "widthFraction": {
+              "type": "number";
+              "description": "viewport width 또는 parent width에 대한 비율입니다. viewport `md` 미만에서 적용합니다.";
+            };
+            "maxHeightFraction": {
+              "type": "number";
+              "description": "viewport height 또는 parent height에 대한 최대 비율입니다.";
+            };
+            "marginX": {
+              "type": "dimension";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "enterOpacity": {
+              "type": "number";
+            };
+            "enterScale": {
+              "type": "number";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitOpacity": {
+              "type": "number";
+            };
+          };
+        };
+        "header": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingTop": {
+              "type": "dimension";
+            };
+            "paddingBottom": {
+              "type": "dimension";
+            };
+            "closeButtonGap": {
+              "type": "dimension";
+              "description": "closeButton이 표시되는 경우 paddingRight에 추가되는 여백입니다.";
+            };
+          };
+        };
+        "body": {
+          "properties": {
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingBottom": {
+              "type": "dimension";
+              "description": "body의 하단 padding이며, 동시에 하단 scroll fog 그라데이션의 높이로도 사용됩니다. 본문이 오버플로되어 스크롤 가능한 경우에만 적용됩니다.";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+              "description": "본문이 스크롤된(scrolled) 상태에서 body 상단에 나타나는 divider의 두께입니다.";
+            };
+            "strokeColor": {
+              "type": "color";
+              "description": "본문이 스크롤된(scrolled) 상태에서 body 상단에 나타나는 divider의 색상입니다.";
+            };
+            "strokeDuration": {
+              "type": "duration";
+            };
+            "strokeTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "footer": {
+          "properties": {
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingTop": {
+              "type": "dimension";
+            };
+            "paddingBottom": {
+              "type": "dimension";
+            };
+          };
+        };
+        "title": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "description": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "closeButton": {
+          "properties": {
+            "fromTop": {
+              "type": "dimension";
+            };
+            "fromRight": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "medium": {};
+            "large": {};
+          };
+          "defaultValue": "medium";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "backdrop": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.overlay";
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d2";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter";
+                };
+                "enterOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d2";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.exit";
+                };
+                "exitOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+              };
+              "content": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r5";
+                };
+                "widthFraction": {
+                  "type": "number";
+                  "value": 0.9;
+                };
+                "maxHeightFraction": {
+                  "type": "number";
+                  "value": 0.8;
+                };
+                "marginX": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d4";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter-expressive";
+                };
+                "enterOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "enterScale": {
+                  "type": "number";
+                  "value": 1.3;
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d2";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.exit";
+                };
+                "exitOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+              };
+              "header": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "paddingTop": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "paddingBottom": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "closeButtonGap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+              };
+              "body": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "paddingBottom": {
+                  "type": "dimension";
+                  "value": "$dimension.x12";
+                };
+                "strokeDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "strokeTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "footer": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "paddingTop": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "paddingBottom": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t8";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t8";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+              "closeButton": {
+                "fromTop": {
+                  "type": "dimension";
+                  "value": "$dimension.x7";
+                };
+                "fromRight": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "scrolled",
+            ];
+            "slots": {
+              "body": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "content": {
+                "maxWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 480;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "content": {
+                "maxWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 800;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/dialog.mjs
+++ b/packages/rootage/__generated__/components/dialog.mjs
@@ -1,0 +1,2 @@
+import artifact from "./dialog.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/divider.d.ts
+++ b/packages/rootage/__generated__/components/divider.d.ts
@@ -1,0 +1,47 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "divider";
+    "name": "Divider";
+  };
+  "data": {
+    "id": "divider";
+    "name": "Divider";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "thickness": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "thickness": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/divider.mjs
+++ b/packages/rootage/__generated__/components/divider.mjs
@@ -1,0 +1,2 @@
+import artifact from "./divider.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/extended-action-sheet-close-button.d.ts
+++ b/packages/rootage/__generated__/components/extended-action-sheet-close-button.d.ts
@@ -1,0 +1,123 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "extended-action-sheet-close-button";
+    "name": "Extended Action Sheet Close Button";
+    "deprecated": "No longer used.";
+  };
+  "data": {
+    "id": "extended-action-sheet-close-button";
+    "name": "Extended Action Sheet Close Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak";
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 52;
+                    "unit": "px";
+                  };
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/extended-action-sheet-close-button.mjs
+++ b/packages/rootage/__generated__/components/extended-action-sheet-close-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./extended-action-sheet-close-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/extended-action-sheet-item.d.ts
+++ b/packages/rootage/__generated__/components/extended-action-sheet-item.d.ts
@@ -1,0 +1,198 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "extended-action-sheet-item";
+    "name": "Extended Action Sheet Item";
+    "deprecated": "Use menu-sheet-item instead.";
+  };
+  "data": {
+    "id": "extended-action-sheet-item";
+    "name": "Extended Action Sheet Item";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {
+        "tone": {
+          "values": {
+            "neutral": {};
+            "critical": {};
+          };
+          "defaultValue": "neutral";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak";
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 52;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "neutral";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "critical";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/extended-action-sheet-item.mjs
+++ b/packages/rootage/__generated__/components/extended-action-sheet-item.mjs
@@ -1,0 +1,2 @@
+import artifact from "./extended-action-sheet-item.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/extended-action-sheet.d.ts
+++ b/packages/rootage/__generated__/components/extended-action-sheet.d.ts
@@ -1,0 +1,309 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "extended-action-sheet";
+    "name": "Extended Action Sheet";
+    "deprecated": "Use menu-sheet instead.";
+  };
+  "data": {
+    "id": "extended-action-sheet";
+    "name": "Extended Action Sheet";
+    "schema": {
+      "slots": {
+        "backdrop": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "enterOpacity": {
+              "type": "number";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitOpacity": {
+              "type": "number";
+            };
+          };
+        };
+        "content": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "maxWidth": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "topCornerRadius": {
+              "type": "dimension";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "header": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingBottom": {
+              "type": "dimension";
+            };
+          };
+        };
+        "title": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "description": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "list": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "group": {
+          "properties": {
+            "cornerRadius": {
+              "type": "dimension";
+            };
+          };
+        };
+        "divider": {
+          "properties": {
+            "strokeBottomWidth": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+          };
+        };
+        "footer": {
+          "properties": {
+            "paddingTop": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "backdrop": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.overlay";
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d2";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter";
+                };
+                "enterOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d2";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.exit";
+                };
+                "exitOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+              };
+              "content": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating";
+                };
+                "maxWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 480;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "topCornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r5";
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d6";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter-expressive";
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d4";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.exit";
+                };
+              };
+              "header": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "paddingBottom": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "title": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t6";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t6";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "description": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+              };
+              "list": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+              "group": {
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r4";
+                };
+              };
+              "divider": {
+                "strokeBottomWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+              };
+              "footer": {
+                "paddingTop": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/extended-action-sheet.mjs
+++ b/packages/rootage/__generated__/components/extended-action-sheet.mjs
@@ -1,0 +1,2 @@
+import artifact from "./extended-action-sheet.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/extended-fab.d.ts
+++ b/packages/rootage/__generated__/components/extended-fab.d.ts
@@ -1,0 +1,338 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "extended-fab";
+    "name": "Extended Fab";
+    "deprecated": "Use contextual-floating-button instead.";
+  };
+  "data": {
+    "id": "extended-fab";
+    "name": "Extended Fab";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "shadow": {
+              "type": "shadow";
+            };
+            "color": {
+              "type": "color";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "variant": {
+          "values": {
+            "neutralSolid": {
+              "description": "기본 FAB 스타일입니다.";
+            };
+            "layerFloating": {
+              "description": "플로팅 레이어 위에 사용하는 스타일입니다.";
+            };
+          };
+          "defaultValue": "neutralSolid";
+        };
+        "size": {
+          "values": {
+            "small": {};
+            "medium": {};
+          };
+          "defaultValue": "small";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "shadow": {
+                  "type": "shadow";
+                  "value": readonly [
+                    {
+                      "color": "#00000026";
+                      "offsetX": {
+                        "value": 0;
+                        "unit": "px";
+                      };
+                      "offsetY": {
+                        "value": 2;
+                        "unit": "px";
+                      };
+                      "blur": {
+                        "value": 6;
+                        "unit": "px";
+                      };
+                      "spread": {
+                        "value": 0;
+                        "unit": "px";
+                      };
+                    },
+                  ];
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "neutralSolid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "layerFloating";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 40;
+                    "unit": "px";
+                  };
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 16;
+                    "unit": "px";
+                  };
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 48;
+                    "unit": "px";
+                  };
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 16;
+                    "unit": "px";
+                  };
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/extended-fab.mjs
+++ b/packages/rootage/__generated__/components/extended-fab.mjs
@@ -1,0 +1,2 @@
+import artifact from "./extended-fab.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/fab.d.ts
+++ b/packages/rootage/__generated__/components/fab.d.ts
@@ -1,0 +1,125 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "fab";
+    "name": "Fab";
+    "deprecated": "Use contextual-floating-button instead.";
+  };
+  "data": {
+    "id": "fab";
+    "name": "Fab";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "shadow": {
+              "type": "shadow";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 44;
+                    "unit": "px";
+                  };
+                };
+                "shadow": {
+                  "type": "shadow";
+                  "value": readonly [
+                    {
+                      "color": "#00000026";
+                      "offsetX": {
+                        "value": 0;
+                        "unit": "px";
+                      };
+                      "offsetY": {
+                        "value": 2;
+                        "unit": "px";
+                      };
+                      "blur": {
+                        "value": 6;
+                        "unit": "px";
+                      };
+                      "spread": {
+                        "value": 0;
+                        "unit": "px";
+                      };
+                    },
+                  ];
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/fab.mjs
+++ b/packages/rootage/__generated__/components/fab.mjs
@@ -1,0 +1,2 @@
+import artifact from "./fab.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/field-label.d.ts
+++ b/packages/rootage/__generated__/components/field-label.d.ts
@@ -1,0 +1,109 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "field-label";
+    "name": "Field Label";
+  };
+  "data": {
+    "id": "field-label";
+    "name": "Field Label";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {
+        "weight": {
+          "values": {
+            "medium": {};
+            "bold": {};
+          };
+          "defaultValue": "medium";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "weight": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "weight": "bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/field-label.mjs
+++ b/packages/rootage/__generated__/components/field-label.mjs
@@ -1,0 +1,2 @@
+import artifact from "./field-label.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/field.d.ts
+++ b/packages/rootage/__generated__/components/field.d.ts
@@ -1,0 +1,382 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "field";
+    "name": "Field";
+  };
+  "data": {
+    "id": "field";
+    "name": "Field";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "header": {
+          "properties": {
+            "paddingX": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "indicatorIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "paddingTop": {
+              "type": "dimension";
+            };
+            "paddingLeft": {
+              "type": "dimension";
+            };
+          };
+          "description": "필수 입력 필드임을 나타내는 아이콘입니다. indicatorText 및 Field Label과의 조화를 위해 폰트 스케일링에 반응합니다.";
+        };
+        "indicatorText": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+              "description": "Field Label과의 조화를 위해 Field Label의 lineHeight와 동일한 값을 갖습니다.";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "paddingLeft": {
+              "type": "dimension";
+            };
+          };
+        };
+        "footer": {
+          "properties": {
+            "paddingX": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "description": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "descriptionIcon": {
+          "properties": {
+            "paddingRight": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "errorMessage": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "errorIcon": {
+          "properties": {
+            "paddingRight": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "characterCount": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "maxCharacterCount": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+              "header": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+              "indicatorIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical";
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 0.375;
+                    "unit": "rem";
+                  };
+                };
+                "paddingTop": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 0.25;
+                    "unit": "rem";
+                  };
+                };
+                "paddingLeft": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 0.125;
+                    "unit": "rem";
+                  };
+                };
+              };
+              "indicatorText": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "paddingLeft": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 0.25;
+                    "unit": "rem";
+                  };
+                };
+              };
+              "footer": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "descriptionIcon": {
+                "paddingRight": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "errorMessage": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "errorIcon": {
+                "paddingRight": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical";
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "characterCount": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "maxCharacterCount": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "invalid",
+            ];
+            "slots": {
+              "characterCount": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical";
+                };
+              };
+              "maxCharacterCount": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/field.mjs
+++ b/packages/rootage/__generated__/components/field.mjs
@@ -1,0 +1,2 @@
+import artifact from "./field.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/floating-action-button.d.ts
+++ b/packages/rootage/__generated__/components/floating-action-button.d.ts
@@ -1,0 +1,260 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "floating-action-button";
+    "name": "Floating Action Button";
+  };
+  "data": {
+    "id": "floating-action-button";
+    "name": "Floating Action Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "shadow": {
+              "type": "shadow";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "layoutDuration": {
+              "type": "duration";
+            };
+            "layoutTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "sizeDuration": {
+              "type": "duration";
+            };
+            "sizeTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {
+        "extended": {
+          "values": {
+            "true": {
+              "description": "라벨이 포함된 확장 형태로, 버튼의 역할을 명확히 전달합니다.";
+            };
+            "false": {
+              "description": "아이콘만 표시되는 기본 형태입니다.";
+            };
+          };
+          "defaultValue": "true";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-solid";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "shadow": {
+                  "type": "shadow";
+                  "value": "$shadow.s3";
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "layoutDuration": {
+                  "type": "duration";
+                  "value": "$duration.d4";
+                };
+                "layoutTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+                "sizeDuration": {
+                  "type": "duration";
+                  "value": "$duration.d4";
+                };
+                "sizeTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-solid-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "extended": "true";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4_5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 48;
+                    "unit": "px";
+                  };
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "extended": "false";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 56;
+                    "unit": "px";
+                  };
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/floating-action-button.mjs
+++ b/packages/rootage/__generated__/components/floating-action-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./floating-action-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/help-bubble.d.ts
+++ b/packages/rootage/__generated__/components/help-bubble.d.ts
@@ -1,0 +1,311 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "help-bubble";
+    "name": "Help Bubble";
+  };
+  "data": {
+    "id": "help-bubble";
+    "name": "Help Bubble";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "enterScale": {
+              "type": "number";
+            };
+            "enterOpacity": {
+              "type": "number";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitScale": {
+              "type": "number";
+            };
+            "exitOpacity": {
+              "type": "number";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "arrow": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "width": {
+              "type": "dimension";
+            };
+            "height": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "gutter": {
+              "type": "dimension";
+              "description": "arrow와 타겟 요소 사이의 거리를 정의합니다.";
+            };
+            "padding": {
+              "type": "dimension";
+              "description": "arrow와 root의 경계 사이의 최소 간격을 정의합니다.";
+            };
+          };
+        };
+        "body": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "title": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "description": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "closeButton": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "targetSize": {
+              "type": "dimension";
+            };
+            "marginTop": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "enterScale": {
+                  "type": "number";
+                  "value": 0.9;
+                };
+                "enterOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d4";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter";
+                };
+                "exitScale": {
+                  "type": "number";
+                  "value": 1;
+                };
+                "exitOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d4";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "arrow": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted";
+                };
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 12;
+                    "unit": "px";
+                  };
+                };
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 8;
+                    "unit": "px";
+                  };
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+                "gutter": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 4;
+                    "unit": "px";
+                  };
+                };
+                "padding": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 14;
+                    "unit": "px";
+                  };
+                };
+              };
+              "body": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+              };
+              "closeButton": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+                "targetSize": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 38;
+                    "unit": "px";
+                  };
+                };
+                "marginTop": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/help-bubble.mjs
+++ b/packages/rootage/__generated__/components/help-bubble.mjs
@@ -1,0 +1,2 @@
+import artifact from "./help-bubble.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/identity-placeholder.d.ts
+++ b/packages/rootage/__generated__/components/identity-placeholder.d.ts
@@ -1,0 +1,57 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "identity-placeholder";
+    "name": "Identity Placeholder";
+  };
+  "data": {
+    "id": "identity-placeholder";
+    "name": "Identity Placeholder";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "image": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-500";
+                };
+              };
+              "image": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white-alpha-800";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/identity-placeholder.mjs
+++ b/packages/rootage/__generated__/components/identity-placeholder.mjs
@@ -1,0 +1,2 @@
+import artifact from "./identity-placeholder.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/image-frame-floater.d.ts
+++ b/packages/rootage/__generated__/components/image-frame-floater.d.ts
@@ -1,0 +1,48 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "image-frame-floater";
+    "name": "Image Frame Floater";
+  };
+  "data": {
+    "id": "image-frame-floater";
+    "name": "Image Frame Floater";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "offset": {
+              "type": "dimension";
+              "description": "image-frame root slot의 padding property로 대체되었습니다.";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "offset": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 6;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/image-frame-floater.mjs
+++ b/packages/rootage/__generated__/components/image-frame-floater.mjs
@@ -1,0 +1,2 @@
+import artifact from "./image-frame-floater.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/image-frame-indicator.d.ts
+++ b/packages/rootage/__generated__/components/image-frame-indicator.d.ts
@@ -1,0 +1,100 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "image-frame-indicator";
+    "name": "Image Frame Indicator";
+  };
+  "data": {
+    "id": "image-frame-indicator";
+    "name": "Image Frame Indicator";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+              "description": "인디케이터 배경색입니다.";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-black-alpha-800";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t1";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t1";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/image-frame-indicator.mjs
+++ b/packages/rootage/__generated__/components/image-frame-indicator.mjs
@@ -1,0 +1,2 @@
+import artifact from "./image-frame-indicator.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/image-frame-reaction-button.d.ts
+++ b/packages/rootage/__generated__/components/image-frame-reaction-button.d.ts
@@ -1,0 +1,160 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "image-frame-reaction-button";
+    "name": "Image Frame Reaction Button";
+  };
+  "data": {
+    "id": "image-frame-reaction-button";
+    "name": "Image Frame Reaction Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+              "description": "보이는 버튼 크기입니다.";
+            };
+            "targetSize": {
+              "type": "dimension";
+              "description": "터치 영역 크기입니다.";
+            };
+          };
+          "description": "하트 아이콘 토글 버튼입니다. 이미지 위에서 좋아요 기능에 사용됩니다.";
+        };
+        "fillIcon": {
+          "properties": {
+            "gradient": {
+              "type": "gradient";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "shadow": {
+              "type": "shadow";
+            };
+          };
+          "description": "lineIcon 아래에 내려가는 하트 아이콘입니다.";
+        };
+        "lineIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+          "description": "fillIcon 위로 올라가는 하트 아이콘입니다.";
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "targetSize": {
+                  "type": "dimension";
+                  "value": "$dimension.x10";
+                };
+              };
+              "fillIcon": {
+                "gradient": {
+                  "type": "gradient";
+                  "value": readonly [
+                    {
+                      "color": "$color.palette.static-black-alpha-600";
+                      "position": 0;
+                    },
+                    {
+                      "color": "$color.palette.static-black-alpha-600";
+                      "position": 1;
+                    },
+                  ];
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "shadow": {
+                  "type": "shadow";
+                  "value": readonly [
+                    {
+                      "color": "#00000026";
+                      "offsetX": {
+                        "value": 0;
+                        "unit": "px";
+                      };
+                      "offsetY": {
+                        "value": 2;
+                        "unit": "px";
+                      };
+                      "blur": {
+                        "value": 4;
+                        "unit": "px";
+                      };
+                      "spread": {
+                        "value": 0;
+                        "unit": "px";
+                      };
+                    },
+                  ];
+                };
+              };
+              "lineIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+            ];
+            "slots": {
+              "fillIcon": {
+                "gradient": {
+                  "type": "gradient";
+                  "value": readonly [
+                    {
+                      "color": "#FF9A56";
+                      "position": 0;
+                    },
+                    {
+                      "color": "#FF6600";
+                      "position": 1;
+                    },
+                  ];
+                };
+              };
+              "lineIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/image-frame-reaction-button.mjs
+++ b/packages/rootage/__generated__/components/image-frame-reaction-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./image-frame-reaction-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/image-frame.d.ts
+++ b/packages/rootage/__generated__/components/image-frame.d.ts
@@ -1,0 +1,98 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "image-frame";
+    "name": "Image Frame";
+  };
+  "data": {
+    "id": "image-frame";
+    "name": "Image Frame";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "strokeColor": {
+              "type": "color";
+              "description": "stroke 옵션 사용 시 적용되는 테두리 색상입니다.";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+              "description": "stroke 옵션 사용 시 적용되는 테두리 두께입니다.";
+            };
+            "padding": {
+              "type": "dimension";
+              "description": "내부에 오버레이 요소가 존재하는 경우 이미지 모서리와 오버레이 요소 사이의 간격입니다. 이 값은 기본값이며 변경할 수 있습니다.";
+            };
+          };
+        };
+      };
+      "variants": {
+        "stroke": {
+          "values": {
+            "true": {
+              "description": "이미지 테두리에 스트로크를 표시합니다.";
+            };
+            "false": {
+              "description": "테두리를 표시하지 않습니다.";
+            };
+          };
+          "defaultValue": "true";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "padding": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "stroke": "true";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-subtle";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "stroke": "false";
+        };
+        "definitions": readonly [];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/image-frame.mjs
+++ b/packages/rootage/__generated__/components/image-frame.mjs
@@ -1,0 +1,2 @@
+import artifact from "./image-frame.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/inline-banner.d.ts
+++ b/packages/rootage/__generated__/components/inline-banner.d.ts
@@ -1,0 +1,582 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "inline-banner";
+    "name": "Inline Banner";
+    "deprecated": "Use Page Banner instead.";
+  };
+  "data": {
+    "id": "inline-banner";
+    "name": "Inline Banner";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "marginRight": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "title": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "description": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "link": {
+          "properties": {
+            "targetHeight": {
+              "type": "dimension";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "marginLeft": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "suffixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "targetSize": {
+              "type": "dimension";
+            };
+            "marginLeft": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {
+        "variant": {
+          "values": {
+            "neutralWeak": {};
+            "positiveWeak": {};
+            "informativeWeak": {};
+            "warningWeak": {};
+            "warningSolid": {};
+            "criticalWeak": {};
+            "criticalSolid": {};
+          };
+          "defaultValue": "neutralWeak";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x10";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "marginRight": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+              "title": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+              "description": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+              "link": {
+                "targetHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x10";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t2";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t2";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "marginLeft": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "targetSize": {
+                  "type": "dimension";
+                  "value": "$dimension.x10";
+                };
+                "marginLeft": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "neutralWeak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "link": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "positiveWeak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.positive-weak";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.positive-contrast";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.positive-contrast";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.positive-contrast";
+                };
+              };
+              "link": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.positive-contrast";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.positive-contrast";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "informativeWeak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.informative-weak";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.informative-contrast";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.informative-contrast";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.informative-contrast";
+                };
+              };
+              "link": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.informative-contrast";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.informative-contrast";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "warningWeak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.warning-weak";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.warning-contrast";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.warning-contrast";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.warning-contrast";
+                };
+              };
+              "link": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.warning-contrast";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.warning-contrast";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "warningSolid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.warning-solid";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "link": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "criticalWeak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.critical-weak";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical-contrast";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical-contrast";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical-contrast";
+                };
+              };
+              "link": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical-contrast";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical-contrast";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "criticalSolid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.critical-solid";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "link": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/inline-banner.mjs
+++ b/packages/rootage/__generated__/components/inline-banner.mjs
@@ -1,0 +1,2 @@
+import artifact from "./inline-banner.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/input-button.d.ts
+++ b/packages/rootage/__generated__/components/input-button.d.ts
@@ -1,0 +1,559 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "input-button";
+    "name": "Input Button";
+  };
+  "data": {
+    "id": "input-button";
+    "name": "Input Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "height": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+            "color": {
+              "type": "color";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "strokeDuration": {
+              "type": "duration";
+              "description": "enabled 상태의 stroke 위에 invalid 상태의 stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다.";
+            };
+            "strokeTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "value": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "placeholder": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "prefixText": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "suffixText": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "suffixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "clearButton": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "large": {
+              "description": "뷰포트 너비와 관계없이 사용할 수 있습니다.";
+            };
+            "medium": {
+              "description": "Breakpoint `lg` 이상(데스크톱)에서만 사용하고, 모바일에서는 사용하지 않습니다. 정밀한 선택이 가능한 마우스 입력 환경에서 사이즈를 더 작게 만들고자 할 때 사용합니다.";
+            };
+          };
+          "defaultValue": "large";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-weak";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "strokeDuration": {
+                  "type": "duration";
+                  "value": {
+                    "value": 0.1;
+                    "unit": "s";
+                  };
+                };
+                "strokeTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "value": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "placeholder": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.placeholder";
+                };
+              };
+              "prefixText": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+              };
+              "suffixText": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+              };
+              "clearButton": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "invalid",
+            ];
+            "slots": {
+              "root": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.critical-solid";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+              };
+              "value": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "placeholder": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixText": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixText": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "readonly",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+              };
+              "value": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "placeholder": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.placeholder";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": "$dimension.x13";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "value": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "placeholder": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "prefixText": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+              };
+              "suffixText": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+              };
+              "clearButton": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": "$dimension.x10";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r2";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "value": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "placeholder": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "prefixText": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "suffixText": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "clearButton": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4_5";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/input-button.mjs
+++ b/packages/rootage/__generated__/components/input-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./input-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/link-content.d.ts
+++ b/packages/rootage/__generated__/components/link-content.d.ts
@@ -1,0 +1,211 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "link-content";
+    "name": "Link Content";
+    "deprecated": "Use Action Button with variant=\"ghost\" instead.";
+  };
+  "data": {
+    "id": "link-content";
+    "name": "Link Content";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "suffixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "weight": {
+          "values": {
+            "regular": {};
+            "bold": {};
+          };
+          "defaultValue": "regular";
+        };
+        "size": {
+          "values": {
+            "t4": {};
+            "t5": {};
+            "t6": {};
+          };
+          "defaultValue": "t4";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {
+          "weight": "regular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "weight": "bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "t4";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "t5";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "t6";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t6";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t6";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/link-content.mjs
+++ b/packages/rootage/__generated__/components/link-content.mjs
@@ -1,0 +1,2 @@
+import artifact from "./link-content.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/list-header.d.ts
+++ b/packages/rootage/__generated__/components/list-header.d.ts
@@ -1,0 +1,134 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "list-header";
+    "name": "List Header";
+  };
+  "data": {
+    "id": "list-header";
+    "name": "List Header";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {
+        "variant": {
+          "values": {
+            "mediumWeak": {};
+            "boldSolid": {};
+          };
+          "defaultValue": "mediumWeak";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "mediumWeak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "boldSolid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/list-header.mjs
+++ b/packages/rootage/__generated__/components/list-header.mjs
@@ -1,0 +1,2 @@
+import artifact from "./list-header.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/list-item.d.ts
+++ b/packages/rootage/__generated__/components/list-item.d.ts
@@ -1,0 +1,402 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "list-item";
+    "name": "List Item";
+  };
+  "data": {
+    "id": "list-item";
+    "name": "List Item";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "paddingY": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "color": {
+              "type": "color";
+            };
+            "marginX": {
+              "type": "dimension";
+              "description": "pressed 시 배경 레이어는 좌우 폭이 marginX만큼 줄어들고, 배경 레이어 위 요소들이 위치하는 레이아웃 레이어는 scale로 인해 전체적으로 줄어드는 형태로 두 레이어가 별개로 작동합니다. 이 값은 OS 동작 줄이기 설정의 영향을 받지 않습니다.";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "marginDuration": {
+              "type": "duration";
+            };
+            "marginTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "borderRadiusDuration": {
+              "type": "duration";
+            };
+            "borderRadiusTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "contentScale": {
+              "type": "number";
+              "description": "pressed 시 배경 레이어는 좌우 폭이 marginX만큼 줄어들고, 배경 레이어 위 요소들이 위치하는 레이아웃 레이어는 scale로 인해 전체적으로 줄어드는 형태로 두 레이어가 별개로 작동합니다.";
+            };
+            "contentScaleDuration": {
+              "type": "duration";
+            };
+            "contentScaleTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "body": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingRight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "title": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "detail": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "prefix": {
+          "properties": {
+            "paddingRight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "suffix": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "suffixText": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "suffixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "marginDuration": {
+                  "type": "duration";
+                  "value": "$duration.d3";
+                };
+                "marginTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "borderRadiusDuration": {
+                  "type": "duration";
+                  "value": "$duration.d3";
+                };
+                "borderRadiusTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "contentScaleDuration": {
+                  "type": "duration";
+                  "value": "$duration.pressed-scale";
+                };
+                "contentScaleTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.pressed-scale";
+                };
+              };
+              "body": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+                "paddingRight": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+              "detail": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+              "prefix": {
+                "paddingRight": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffix": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+              };
+              "suffixText": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 18;
+                    "unit": "px";
+                  };
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+                "marginX": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "contentScale": {
+                  "type": "number";
+                  "value": "$scale.s97";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "highlighted",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-weak";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "highlighted",
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-weak-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "detail": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/list-item.mjs
+++ b/packages/rootage/__generated__/components/list-item.mjs
@@ -1,0 +1,2 @@
+import artifact from "./list-item.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/manner-temp-badge.d.ts
+++ b/packages/rootage/__generated__/components/manner-temp-badge.d.ts
@@ -1,0 +1,374 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "manner-temp-badge";
+    "name": "Manner Temp Badge";
+  };
+  "data": {
+    "id": "manner-temp-badge";
+    "name": "Manner Temp Badge";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "minHeight": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {
+        "level": {
+          "values": {
+            "l1": {};
+            "l2": {};
+            "l3": {};
+            "l4": {};
+            "l5": {};
+            "l6": {};
+            "l7": {};
+            "l8": {};
+            "l9": {};
+            "l10": {};
+          };
+          "defaultValue": "l1";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t1";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t1";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l1";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l1.bg";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l1.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l2";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l2.bg";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l2.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l3";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l3.bg";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l3.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l4";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l4.bg";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l4.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l5";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l5.bg";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l5.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l6";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l6.bg";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l6.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l7";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l7.bg";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l7.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l8";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l8.bg";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l8.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l9";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l9.bg";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l9.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l10";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l10.bg";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l10.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/manner-temp-badge.mjs
+++ b/packages/rootage/__generated__/components/manner-temp-badge.mjs
@@ -1,0 +1,2 @@
+import artifact from "./manner-temp-badge.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/manner-temp.d.ts
+++ b/packages/rootage/__generated__/components/manner-temp.d.ts
@@ -1,0 +1,310 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "manner-temp";
+    "name": "Manner Temp";
+  };
+  "data": {
+    "id": "manner-temp";
+    "name": "Manner Temp";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "emote": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "bleed": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "level": {
+          "values": {
+            "l1": {};
+            "l2": {};
+            "l3": {};
+            "l4": {};
+            "l5": {};
+            "l6": {};
+            "l7": {};
+            "l8": {};
+            "l9": {};
+            "l10": {};
+          };
+          "defaultValue": "l1";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+              "emote": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x8";
+                };
+                "bleed": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l1";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l1.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l2";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l2.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l3";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l3.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l4";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l4.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l5";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l5.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l6";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l6.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l7";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l7.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l8";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l8.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l9";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l9.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "level": "l10";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.manner-temp.l10.text";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/manner-temp.mjs
+++ b/packages/rootage/__generated__/components/manner-temp.mjs
@@ -1,0 +1,2 @@
+import artifact from "./manner-temp.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/menu-item.d.ts
+++ b/packages/rootage/__generated__/components/menu-item.d.ts
@@ -1,0 +1,449 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "menu-item";
+    "name": "Menu Item";
+  };
+  "data": {
+    "id": "menu-item";
+    "name": "Menu Item";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "marginX": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "marginDuration": {
+              "type": "duration";
+            };
+            "marginTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "borderRadiusDuration": {
+              "type": "duration";
+            };
+            "borderRadiusTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "suffixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "body": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "description": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "medium": {
+              "description": "뷰포트 너비와 관계없이 사용할 수 있습니다.";
+            };
+            "small": {
+              "description": "Breakpoint `lg` 이상(데스크톱)에서만 사용하고, 모바일에서는 사용하지 않습니다. 정밀한 선택이 가능한 마우스 입력 환경에서 사이즈를 더 작게 만들고자 할 때 사용합니다.";
+            };
+          };
+          "defaultValue": "medium";
+        };
+        "tone": {
+          "values": {
+            "neutral": {
+              "description": "일반적인 작업을 수행하는 기본 아이템입니다.";
+            };
+            "critical": {
+              "description": "데이터 삭제와 같이 되돌릴 수 없는 작업을 수행하는 아이템입니다.";
+            };
+          };
+          "defaultValue": "neutral";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "marginDuration": {
+                  "type": "duration";
+                  "value": "$duration.d3";
+                };
+                "marginTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "borderRadiusDuration": {
+                  "type": "duration";
+                  "value": "$duration.d3";
+                };
+                "borderRadiusTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "body": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+              };
+              "label": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+              "description": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+                "marginX": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 18;
+                    "unit": "px";
+                  };
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "description": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 18;
+                    "unit": "px";
+                  };
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 16;
+                    "unit": "px";
+                  };
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "description": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t2";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t2";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "neutral";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "critical";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/menu-item.mjs
+++ b/packages/rootage/__generated__/components/menu-item.mjs
@@ -1,0 +1,2 @@
+import artifact from "./menu-item.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/menu-sheet-close-button.d.ts
+++ b/packages/rootage/__generated__/components/menu-sheet-close-button.d.ts
@@ -1,0 +1,122 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "menu-sheet-close-button";
+    "name": "Menu Sheet Close Button";
+  };
+  "data": {
+    "id": "menu-sheet-close-button";
+    "name": "Menu Sheet Close Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak";
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 52;
+                    "unit": "px";
+                  };
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/menu-sheet-close-button.mjs
+++ b/packages/rootage/__generated__/components/menu-sheet-close-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./menu-sheet-close-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/menu-sheet-item.d.ts
+++ b/packages/rootage/__generated__/components/menu-sheet-item.d.ts
@@ -1,0 +1,285 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "menu-sheet-item";
+    "name": "Menu Sheet Item";
+  };
+  "data": {
+    "id": "menu-sheet-item";
+    "name": "Menu Sheet Item";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "content": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "description": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {
+        "tone": {
+          "values": {
+            "neutral": {
+              "description": "일반적인 작업을 수행하는 기본 아이템입니다.";
+            };
+            "critical": {
+              "description": "데이터 삭제와 같이 되돌릴 수 없는 작업을 수행하는 아이템입니다.";
+            };
+          };
+          "defaultValue": "neutral";
+        };
+        "labelAlign": {
+          "values": {
+            "left": {
+              "description": "라벨을 왼쪽 정렬합니다.";
+            };
+            "center": {
+              "description": "라벨을 중앙 정렬합니다.";
+            };
+          };
+          "defaultValue": "left";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak";
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 52;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+              };
+              "content": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+              "description": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "neutral";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "critical";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "labelAlign": "left";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {};
+          },
+        ];
+      },
+      {
+        "variants": {
+          "labelAlign": "center";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {};
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/menu-sheet-item.mjs
+++ b/packages/rootage/__generated__/components/menu-sheet-item.mjs
@@ -1,0 +1,2 @@
+import artifact from "./menu-sheet-item.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/menu-sheet.d.ts
+++ b/packages/rootage/__generated__/components/menu-sheet.d.ts
@@ -1,0 +1,315 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "menu-sheet";
+    "name": "Menu Sheet";
+  };
+  "data": {
+    "id": "menu-sheet";
+    "name": "Menu Sheet";
+    "schema": {
+      "slots": {
+        "backdrop": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "enterOpacity": {
+              "type": "number";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitOpacity": {
+              "type": "number";
+            };
+          };
+        };
+        "content": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "maxWidth": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingTop": {
+              "type": "dimension";
+            };
+            "paddingBottom": {
+              "type": "dimension";
+            };
+            "topCornerRadius": {
+              "type": "dimension";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "header": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingBottom": {
+              "type": "dimension";
+            };
+          };
+        };
+        "title": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "description": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "list": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "group": {
+          "properties": {
+            "cornerRadius": {
+              "type": "dimension";
+            };
+          };
+        };
+        "divider": {
+          "properties": {
+            "strokeBottomWidth": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+          };
+        };
+        "footer": {
+          "properties": {
+            "paddingTop": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "backdrop": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.overlay";
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d2";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter";
+                };
+                "enterOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d2";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.exit";
+                };
+                "exitOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+              };
+              "content": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating";
+                };
+                "maxWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 480;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+                "paddingTop": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "paddingBottom": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "topCornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r5";
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d6";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter-expressive";
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d4";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.exit";
+                };
+              };
+              "header": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "paddingBottom": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "title": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t6";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t6";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "description": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+              };
+              "list": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+              "group": {
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r4";
+                };
+              };
+              "divider": {
+                "strokeBottomWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+              };
+              "footer": {
+                "paddingTop": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/menu-sheet.mjs
+++ b/packages/rootage/__generated__/components/menu-sheet.mjs
@@ -1,0 +1,2 @@
+import artifact from "./menu-sheet.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/menu.d.ts
+++ b/packages/rootage/__generated__/components/menu.d.ts
@@ -1,0 +1,320 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "menu";
+    "name": "Menu";
+  };
+  "data": {
+    "id": "menu";
+    "name": "Menu";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "shadow": {
+              "type": "shadow";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "enterScale": {
+              "type": "number";
+            };
+            "enterOpacity": {
+              "type": "number";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitScale": {
+              "type": "number";
+            };
+            "exitOpacity": {
+              "type": "number";
+            };
+            "gutter": {
+              "type": "dimension";
+              "description": "트리거와 메뉴 사이의 간격을 정의합니다.";
+            };
+            "overflowPadding": {
+              "type": "dimension";
+              "description": "메뉴와 뷰포트 경계 사이의 최소 간격을 정의합니다.";
+            };
+            "maxHeight": {
+              "type": "dimension";
+            };
+            "width": {
+              "type": "dimension";
+            };
+          };
+        };
+        "group": {
+          "properties": {};
+        };
+        "groupLabel": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "divider": {
+          "properties": {
+            "marginX": {
+              "type": "dimension";
+            };
+            "height": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "medium": {
+              "description": "뷰포트 너비와 관계없이 사용할 수 있습니다.";
+            };
+            "small": {
+              "description": "Breakpoint `lg` 이상(데스크톱)에서만 사용하고, 모바일에서는 사용하지 않습니다. 정밀한 선택이 가능한 마우스 입력 환경에서 사이즈를 더 작게 만들고자 할 때 사용합니다.";
+            };
+          };
+          "defaultValue": "medium";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r5";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating";
+                };
+                "shadow": {
+                  "type": "shadow";
+                  "value": "$shadow.s3";
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d3";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter";
+                };
+                "enterScale": {
+                  "type": "number";
+                  "value": 0.95;
+                };
+                "enterOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d2";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.exit";
+                };
+                "exitScale": {
+                  "type": "number";
+                  "value": 0.95;
+                };
+                "exitOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "gutter": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "overflowPadding": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "maxHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 480;
+                    "unit": "px";
+                  };
+                };
+              };
+              "groupLabel": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+              "divider": {
+                "marginX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 240;
+                    "unit": "px";
+                  };
+                };
+              };
+              "groupLabel": {
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 200;
+                    "unit": "px";
+                  };
+                };
+              };
+              "groupLabel": {
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/menu.mjs
+++ b/packages/rootage/__generated__/components/menu.mjs
@@ -1,0 +1,2 @@
+import artifact from "./menu.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/notification-badge.d.ts
+++ b/packages/rootage/__generated__/components/notification-badge.d.ts
@@ -1,0 +1,233 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "notification-badge";
+    "name": "Notification Badge";
+  };
+  "data": {
+    "id": "notification-badge";
+    "name": "Notification Badge";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "minWidth": {
+              "type": "dimension";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "iconAttachedInsetEnd": {
+              "type": "dimension";
+            };
+            "iconAttachedInsetTop": {
+              "type": "dimension";
+            };
+            "textAttachedGap": {
+              "type": "dimension";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "large": {
+              "description": "라벨을 포함해 구체적인 알림 수나 상태 정보를 제공합니다. 세부 정보가 중요하고 충분한 공간이 있을 때 사용합니다. 내부 라벨을 반드시 포함해야 합니다.";
+            };
+            "small": {
+              "description": "간결한 도트 형태로, 텍스트 없이 상태 변화만 표시합니다. 알림의 존재 여부만 중요하거나 공간이 제한된 경우에 적합합니다. 내부 라벨은 지원하지 않습니다.";
+            };
+          };
+          "defaultValue": "large";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-solid";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 18;
+                    "unit": "px";
+                  };
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 18;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 0;
+                    "unit": "px";
+                  };
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "iconAttachedInsetEnd": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 8;
+                    "unit": "px";
+                  };
+                };
+                "iconAttachedInsetTop": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 14;
+                    "unit": "px";
+                  };
+                };
+                "textAttachedGap": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t1-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t1-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 6;
+                    "unit": "px";
+                  };
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "iconAttachedInsetEnd": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 7;
+                    "unit": "px";
+                  };
+                };
+                "iconAttachedInsetTop": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 7;
+                    "unit": "px";
+                  };
+                };
+                "textAttachedGap": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/notification-badge.mjs
+++ b/packages/rootage/__generated__/components/notification-badge.mjs
@@ -1,0 +1,2 @@
+import artifact from "./notification-badge.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/page-banner.d.ts
+++ b/packages/rootage/__generated__/components/page-banner.d.ts
@@ -1,0 +1,957 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "page-banner";
+    "name": "Page Banner";
+  };
+  "data": {
+    "id": "page-banner";
+    "name": "Page Banner";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "gradient": {
+              "type": "gradient";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "marginRight": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+          "description": "아이콘은 Fill 타입 사용을 권장합니다.";
+        };
+        "content": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "title": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "description": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "button": {
+          "properties": {
+            "targetHeight": {
+              "type": "dimension";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "suffixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "targetSize": {
+              "type": "dimension";
+            };
+            "marginLeft": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {
+        "tone": {
+          "values": {
+            "neutral": {};
+            "positive": {};
+            "informative": {};
+            "warning": {};
+            "critical": {};
+            "magic": {
+              "description": "AI 기능을 나타냅니다. variant=solid와 조합하여 사용하지 않습니다.";
+            };
+          };
+          "defaultValue": "neutral";
+        };
+        "variant": {
+          "values": {
+            "weak": {
+              "description": "배경색이 연한 스타일입니다.";
+            };
+            "solid": {
+              "description": "배경색이 진한 스타일입니다.";
+            };
+          };
+          "defaultValue": "weak";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x10";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "marginRight": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+              "content": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+              };
+              "title": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+              "description": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+              "button": {
+                "targetHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x10";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "targetSize": {
+                  "type": "dimension";
+                  "value": "$dimension.x10";
+                };
+                "marginLeft": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "neutral";
+          "variant": "weak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "button": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "neutral";
+          "variant": "solid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+              "button": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "positive";
+          "variant": "weak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.positive-weak";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.positive-contrast";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.positive-contrast";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.positive-contrast";
+                };
+              };
+              "button": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.positive-contrast";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.positive-contrast";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.positive-weak-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "positive";
+          "variant": "solid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.positive-solid";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "button": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.positive-solid-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "informative";
+          "variant": "weak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.informative-weak";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.informative-contrast";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.informative-contrast";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.informative-contrast";
+                };
+              };
+              "button": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.informative-contrast";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.informative-contrast";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.informative-weak-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "informative";
+          "variant": "solid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.informative-solid";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "button": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.informative-solid-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "warning";
+          "variant": "weak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.warning-weak";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.warning-contrast";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.warning-contrast";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.warning-contrast";
+                };
+              };
+              "button": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.warning-contrast";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.warning-contrast";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.warning-weak-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "warning";
+          "variant": "solid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.warning-solid";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-black-alpha-900";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-black-alpha-900";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-black-alpha-900";
+                };
+              };
+              "button": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-black-alpha-900";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-black-alpha-900";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.warning-solid-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "critical";
+          "variant": "weak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.critical-weak";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical-contrast";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical-contrast";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical-contrast";
+                };
+              };
+              "button": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical-contrast";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical-contrast";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.critical-weak-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "critical";
+          "variant": "solid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.critical-solid";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "button": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.critical-solid-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "magic";
+          "variant": "weak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gradient": {
+                  "type": "gradient";
+                  "value": "$gradient.glow-magic";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "button": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "gradient": {
+                  "type": "gradient";
+                  "value": "$gradient.glow-magic-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/page-banner.mjs
+++ b/packages/rootage/__generated__/components/page-banner.mjs
@@ -1,0 +1,2 @@
+import artifact from "./page-banner.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/progress-circle.d.ts
+++ b/packages/rootage/__generated__/components/progress-circle.d.ts
@@ -1,0 +1,319 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "progress-circle";
+    "name": "Progress Circle";
+  };
+  "data": {
+    "id": "progress-circle";
+    "name": "Progress Circle";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "thickness": {
+              "type": "dimension";
+            };
+          };
+        };
+        "track": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "range": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "lengthDuration": {
+              "type": "duration";
+            };
+            "lengthTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "rotateDuration": {
+              "type": "duration";
+            };
+            "headTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "tailTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "rotateTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "24": {
+              "description": "특정 요소 안에서 사용하는 경우 사용합니다.";
+            };
+            "40": {
+              "description": "주로 전체 페이지 로딩에 사용합니다.";
+            };
+          };
+          "defaultValue": "40";
+        };
+        "indeterminate": {
+          "values": {
+            "false": {
+              "description": "대기 시간이 얼마나 남은지 아는 상황일 때 사용합니다. 진행 상황에 맞춰서 원을 채웁니다.";
+            };
+            "true": {
+              "description": "대기 시간이 얼마나 남은지 모르는 상황일 때 사용합니다. 계속해서 회전하는 동작을 합니다.";
+            };
+          };
+          "defaultValue": "false";
+        };
+        "tone": {
+          "values": {
+            "neutral": {
+              "description": "가장 보편적으로 사용되며 스타일보다는 로딩 상태의 인식이 더 중요한 경우 사용합니다.";
+            };
+            "brand": {
+              "description": "사용자 경험의 초기 단계에서 브랜드 컬러를 통해 주요 전환점을 강조할 때 사용합니다.";
+            };
+            "staticWhite": {
+              "description": "화면 전체를 어둡게 덮는 오버레이(Overlay) 위에 로딩 상태를 표시할 때 사용합니다.";
+            };
+          };
+          "defaultValue": "neutral";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {
+          "size": "40";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x10";
+                };
+                "thickness": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 5;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "24";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "thickness": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 3;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "indeterminate": "false";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "range": {
+                "lengthDuration": {
+                  "type": "duration";
+                  "value": {
+                    "value": 300;
+                    "unit": "ms";
+                  };
+                };
+                "lengthTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": readonly [
+                    0,
+                    0,
+                    0.15,
+                    1,
+                  ];
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "indeterminate": "true";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "range": {
+                "lengthDuration": {
+                  "type": "duration";
+                  "value": {
+                    "value": 1.2;
+                    "unit": "s";
+                  };
+                };
+                "rotateDuration": {
+                  "type": "duration";
+                  "value": {
+                    "value": 1.2;
+                    "unit": "s";
+                  };
+                };
+                "headTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": readonly [
+                    0.35,
+                    0,
+                    0.65,
+                    1,
+                  ];
+                };
+                "tailTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": readonly [
+                    0.35,
+                    0,
+                    0.65,
+                    0.6,
+                  ];
+                };
+                "rotateTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": readonly [
+                    0.35,
+                    0.25,
+                    0.65,
+                    0.75,
+                  ];
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "neutral";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "track": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-200";
+                };
+              };
+              "range": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-500";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "brand";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "track": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.carrot-200";
+                };
+              };
+              "range": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-solid";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "staticWhite";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "track": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white-alpha-300";
+                };
+              };
+              "range": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/progress-circle.mjs
+++ b/packages/rootage/__generated__/components/progress-circle.mjs
@@ -1,0 +1,2 @@
+import artifact from "./progress-circle.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/quantity-picker-button.d.ts
+++ b/packages/rootage/__generated__/components/quantity-picker-button.d.ts
@@ -1,0 +1,301 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "quantity-picker-button";
+    "name": "Quantity Picker Button";
+  };
+  "data": {
+    "id": "quantity-picker-button";
+    "name": "Quantity Picker Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "progressCircle": {
+          "properties": {
+            "trackColor": {
+              "type": "color";
+            };
+            "rangeColor": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "thickness": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "small": {};
+            "medium": {};
+            "large": {};
+          };
+          "defaultValue": "small";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "progressCircle": {
+                "trackColor": {
+                  "type": "color";
+                  "value": "$color.palette.gray-500";
+                };
+                "rangeColor": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "loading",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x9";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r2";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 16;
+                    "unit": "px";
+                  };
+                };
+              };
+              "progressCircle": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 16;
+                    "unit": "px";
+                  };
+                };
+                "thickness": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x10";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r2";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 18;
+                    "unit": "px";
+                  };
+                };
+              };
+              "progressCircle": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 18;
+                    "unit": "px";
+                  };
+                };
+                "thickness": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x13";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+              };
+              "progressCircle": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+                "thickness": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/quantity-picker-button.mjs
+++ b/packages/rootage/__generated__/components/quantity-picker-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./quantity-picker-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/quantity-picker.d.ts
+++ b/packages/rootage/__generated__/components/quantity-picker.d.ts
@@ -1,0 +1,310 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "quantity-picker";
+    "name": "Quantity Picker";
+  };
+  "data": {
+    "id": "quantity-picker";
+    "name": "Quantity Picker";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "height": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+          };
+        };
+        "valueDisplay": {
+          "properties": {
+            "paddingX": {
+              "type": "dimension";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "divider": {
+          "properties": {
+            "width": {
+              "type": "dimension";
+            };
+            "height": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "small": {};
+            "medium": {};
+            "large": {};
+          };
+          "defaultValue": "small";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-default";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-weak";
+                };
+              };
+              "valueDisplay": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "divider": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-subtle";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "invalid",
+            ];
+            "slots": {
+              "root": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.critical-solid";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "valueDisplay": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": "$dimension.x9";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r2";
+                };
+              };
+              "valueDisplay": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "divider": {
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "height": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": "$dimension.x10";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r2";
+                };
+              };
+              "valueDisplay": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "divider": {
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "height": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": "$dimension.x13";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+              };
+              "valueDisplay": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t6";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t6";
+                };
+              };
+              "divider": {
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "height": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/quantity-picker.mjs
+++ b/packages/rootage/__generated__/components/quantity-picker.mjs
@@ -1,0 +1,2 @@
+import artifact from "./quantity-picker.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/radio-group.d.ts
+++ b/packages/rootage/__generated__/components/radio-group.d.ts
@@ -1,0 +1,44 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "radio-group";
+    "name": "Radio Group";
+  };
+  "data": {
+    "id": "radio-group";
+    "name": "Radio Group";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "gapY": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gapY": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/radio-group.mjs
+++ b/packages/rootage/__generated__/components/radio-group.mjs
@@ -1,0 +1,2 @@
+import artifact from "./radio-group.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/radio.d.ts
+++ b/packages/rootage/__generated__/components/radio.d.ts
@@ -1,0 +1,197 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "radio";
+    "name": "Radio";
+  };
+  "data": {
+    "id": "radio";
+    "name": "Radio";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "weight": {
+          "values": {
+            "regular": {};
+            "bold": {};
+          };
+          "defaultValue": "regular";
+        };
+        "size": {
+          "values": {
+            "medium": {};
+            "large": {};
+          };
+          "defaultValue": "medium";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "weight": "regular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "weight": "bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x8";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x9";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/radio.mjs
+++ b/packages/rootage/__generated__/components/radio.mjs
@@ -1,0 +1,2 @@
+import artifact from "./radio.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/radiomark.d.ts
+++ b/packages/rootage/__generated__/components/radiomark.d.ts
@@ -1,0 +1,400 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "radiomark";
+    "name": "Radiomark";
+  };
+  "data": {
+    "id": "radiomark";
+    "name": "Radiomark";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "tone": {
+          "values": {
+            "brand": {};
+            "neutral": {};
+          };
+          "defaultValue": "brand";
+        };
+        "size": {
+          "values": {
+            "medium": {};
+            "large": {};
+          };
+          "defaultValue": "medium";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-weak";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+              };
+              "icon": {
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "enabled",
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "enabled",
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 0;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "#00000000";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "brand";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-solid";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "enabled",
+              "selected",
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-solid-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-300";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.palette.gray-300";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-300";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "neutral";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "enabled",
+              "selected",
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-300";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.palette.gray-300";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-300";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/radiomark.mjs
+++ b/packages/rootage/__generated__/components/radiomark.mjs
@@ -1,0 +1,2 @@
+import artifact from "./radiomark.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/reaction-button.d.ts
+++ b/packages/rootage/__generated__/components/reaction-button.d.ts
@@ -1,0 +1,505 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "reaction-button";
+    "name": "Reaction Button";
+  };
+  "data": {
+    "id": "reaction-button";
+    "name": "Reaction Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "count": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "progressCircle": {
+          "properties": {
+            "trackColor": {
+              "type": "color";
+            };
+            "rangeColor": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "thickness": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "xsmall": {};
+            "small": {};
+          };
+          "defaultValue": "xsmall";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+              "count": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "progressCircle": {
+                "trackColor": {
+                  "type": "color";
+                  "value": "$color.palette.gray-500";
+                };
+                "rangeColor": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.brand-weak";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.brand";
+                };
+              };
+              "count": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.brand";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.brand";
+                };
+              };
+              "progressCircle": {
+                "trackColor": {
+                  "type": "color";
+                  "value": "$color.palette.carrot-200";
+                };
+                "rangeColor": {
+                  "type": "color";
+                  "value": "$color.fg.brand";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 0;
+                    "unit": "px";
+                  };
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "count": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "loading",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+              "loading",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "xsmall";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x8";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 18;
+                    "unit": "px";
+                  };
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+              };
+              "count": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+              };
+              "progressCircle": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 14;
+                    "unit": "px";
+                  };
+                };
+                "thickness": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x9";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 18;
+                    "unit": "px";
+                  };
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+              };
+              "count": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+              };
+              "progressCircle": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 14;
+                    "unit": "px";
+                  };
+                };
+                "thickness": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/reaction-button.mjs
+++ b/packages/rootage/__generated__/components/reaction-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./reaction-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/scroll-fog.d.ts
+++ b/packages/rootage/__generated__/components/scroll-fog.d.ts
@@ -1,0 +1,61 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "scroll-fog";
+    "name": "Scroll Fog";
+  };
+  "data": {
+    "id": "scroll-fog";
+    "name": "Scroll Fog";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "fromColor": {
+              "type": "color";
+            };
+            "toColor": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fromColor": {
+                  "type": "color";
+                  "value": "#00000000";
+                };
+                "toColor": {
+                  "type": "color";
+                  "value": "#000000ff";
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 20;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/scroll-fog.mjs
+++ b/packages/rootage/__generated__/components/scroll-fog.mjs
@@ -1,0 +1,2 @@
+import artifact from "./scroll-fog.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/segmented-control-indicator.d.ts
+++ b/packages/rootage/__generated__/components/segmented-control-indicator.d.ts
@@ -1,0 +1,108 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "segmented-control-indicator";
+    "name": "Segmented Control Indicator";
+  };
+  "data": {
+    "id": "segmented-control-indicator";
+    "name": "Segmented Control Indicator";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+            "transformDuration": {
+              "type": "duration";
+            };
+            "transformTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-00";
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "transformDuration": {
+                  "type": "duration";
+                  "value": "$duration.d4";
+                };
+                "transformTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-100";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/segmented-control-indicator.mjs
+++ b/packages/rootage/__generated__/components/segmented-control-indicator.mjs
@@ -1,0 +1,2 @@
+import artifact from "./segmented-control-indicator.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/segmented-control-item.d.ts
+++ b/packages/rootage/__generated__/components/segmented-control-item.d.ts
@@ -1,0 +1,206 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "segmented-control-item";
+    "name": "Segmented Control Item";
+  };
+  "data": {
+    "id": "segmented-control-item";
+    "name": "Segmented Control Item";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "minWidth": {
+              "type": "dimension";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 86;
+                    "unit": "px";
+                  };
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 34;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/segmented-control-item.mjs
+++ b/packages/rootage/__generated__/components/segmented-control-item.mjs
@@ -1,0 +1,2 @@
+import artifact from "./segmented-control-item.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/segmented-control.d.ts
+++ b/packages/rootage/__generated__/components/segmented-control.d.ts
@@ -1,0 +1,58 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "segmented-control";
+    "name": "Segmented Control";
+  };
+  "data": {
+    "id": "segmented-control";
+    "name": "Segmented Control";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "padding": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "padding": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-alpha";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/segmented-control.mjs
+++ b/packages/rootage/__generated__/components/segmented-control.mjs
@@ -1,0 +1,2 @@
+import artifact from "./segmented-control.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/select-box-checkmark.d.ts
+++ b/packages/rootage/__generated__/components/select-box-checkmark.d.ts
@@ -1,0 +1,150 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "select-box-checkmark";
+    "name": "Select Box Checkmark";
+  };
+  "data": {
+    "id": "select-box-checkmark";
+    "name": "Select Box Checkmark";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 15;
+                    "unit": "px";
+                  };
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.placeholder";
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "enabled",
+              "selected",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "enabled",
+              "selected",
+              "pressed",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+              "selected",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/select-box-checkmark.mjs
+++ b/packages/rootage/__generated__/components/select-box-checkmark.mjs
@@ -1,0 +1,2 @@
+import artifact from "./select-box-checkmark.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/select-box-group.d.ts
+++ b/packages/rootage/__generated__/components/select-box-group.d.ts
@@ -1,0 +1,51 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "select-box-group";
+    "name": "Select Box Group";
+  };
+  "data": {
+    "id": "select-box-group";
+    "name": "Select Box Group";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "gapX": {
+              "type": "dimension";
+            };
+            "gapY": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gapX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+                "gapY": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-y.component-default";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/select-box-group.mjs
+++ b/packages/rootage/__generated__/components/select-box-group.mjs
@@ -1,0 +1,2 @@
+import artifact from "./select-box-group.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/select-box.d.ts
+++ b/packages/rootage/__generated__/components/select-box.d.ts
@@ -1,0 +1,469 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "select-box";
+    "name": "Select Box";
+  };
+  "data": {
+    "id": "select-box";
+    "name": "Select Box";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+            "color": {
+              "type": "color";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "strokeDuration": {
+              "type": "duration";
+              "description": "enabled 상태의 stroke 위에 selected 상태의 stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다.";
+            };
+            "strokeTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "trigger": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingLeft": {
+              "type": "dimension";
+            };
+            "paddingRight": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+          };
+        };
+        "content": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "body": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingRight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "description": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "footer": {
+          "properties": {
+            "expandHeightDuration": {
+              "type": "duration";
+              "description": "열릴 때는 천천히 펼쳐지고 빠르게 fade in됩니다.";
+            };
+            "expandHeightTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "expandOpacityDuration": {
+              "type": "duration";
+              "description": "열릴 때는 천천히 펼쳐지고 빠르게 fade in됩니다.";
+            };
+            "expandOpacityTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "collapseHeightDuration": {
+              "type": "duration";
+              "description": "닫힐 때는 빠르게 접히고 천천히 fade out됩니다.";
+            };
+            "collapseHeightTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "collapseOpacityDuration": {
+              "type": "duration";
+              "description": "닫힐 때는 빠르게 접히고 천천히 fade out됩니다.";
+            };
+            "collapseOpacityTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+      };
+      "variants": {
+        "layout": {
+          "values": {
+            "horizontal": {};
+            "vertical": {};
+          };
+          "defaultValue": "horizontal";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "strokeDuration": {
+                  "type": "duration";
+                  "value": {
+                    "value": 0.1;
+                    "unit": "s";
+                  };
+                };
+                "strokeTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "trigger": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+              };
+              "body": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+                "paddingRight": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+              };
+              "label": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+              "footer": {
+                "expandHeightDuration": {
+                  "type": "duration";
+                  "value": {
+                    "value": 400;
+                    "unit": "ms";
+                  };
+                };
+                "expandHeightTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "expandOpacityDuration": {
+                  "type": "duration";
+                  "value": "$duration.d6";
+                };
+                "expandOpacityTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "collapseHeightDuration": {
+                  "type": "duration";
+                  "value": "$duration.d6";
+                };
+                "collapseHeightTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "collapseOpacityDuration": {
+                  "type": "duration";
+                  "value": {
+                    "value": 400;
+                    "unit": "ms";
+                  };
+                };
+                "collapseOpacityTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "enabled",
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-contrast";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "enabled",
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "layout": "horizontal";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "trigger": {
+                "paddingLeft": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+                "paddingRight": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "content": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "layout": "vertical";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "trigger": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+              };
+              "content": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/select-box.mjs
+++ b/packages/rootage/__generated__/components/select-box.mjs
@@ -1,0 +1,2 @@
+import artifact from "./select-box.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/select-item.d.ts
+++ b/packages/rootage/__generated__/components/select-item.d.ts
@@ -1,0 +1,363 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "select-item";
+    "name": "Select Item";
+  };
+  "data": {
+    "id": "select-item";
+    "name": "Select Item";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "marginX": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "marginDuration": {
+              "type": "duration";
+            };
+            "marginTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "body": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "description": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "indicator": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "large": {
+              "description": "뷰포트 너비와 관계없이 사용할 수 있습니다.";
+            };
+            "medium": {
+              "description": "Breakpoint `lg` 이상(데스크톱)에서만 사용하고, 모바일에서는 사용하지 않습니다. 정밀한 선택이 가능한 마우스 입력 환경에서 사이즈를 더 작게 만들고자 할 때 사용합니다.";
+            };
+          };
+          "defaultValue": "large";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "marginDuration": {
+                  "type": "duration";
+                  "value": "$duration.d3";
+                };
+                "marginTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "body": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+              };
+              "label": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "description": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+              "indicator": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+                "marginX": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "indicator": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "description": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+              };
+              "indicator": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4_5";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "description": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t2";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t2";
+                };
+              };
+              "indicator": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/select-item.mjs
+++ b/packages/rootage/__generated__/components/select-item.mjs
@@ -1,0 +1,2 @@
+import artifact from "./select-item.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/select-trigger.d.ts
+++ b/packages/rootage/__generated__/components/select-trigger.d.ts
@@ -1,0 +1,452 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "select-trigger";
+    "name": "Select Trigger";
+  };
+  "data": {
+    "id": "select-trigger";
+    "name": "Select Trigger";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "height": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+            "color": {
+              "type": "color";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "strokeDuration": {
+              "type": "duration";
+              "description": "enabled 상태의 stroke 위에 invalid 상태의 stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다.";
+            };
+            "strokeTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "value": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "placeholder": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "suffixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "openRotateDuration": {
+              "type": "duration";
+            };
+            "openRotateTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "closeRotateDuration": {
+              "type": "duration";
+            };
+            "closeRotateTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "large": {
+              "description": "뷰포트 너비와 관계없이 사용할 수 있습니다.";
+            };
+            "medium": {
+              "description": "Breakpoint `lg` 이상(데스크톱)에서만 사용하고, 모바일에서는 사용하지 않습니다. 정밀한 선택이 가능한 마우스 입력 환경에서 사이즈를 더 작게 만들고자 할 때 사용합니다.";
+            };
+          };
+          "defaultValue": "large";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-weak";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "strokeDuration": {
+                  "type": "duration";
+                  "value": {
+                    "value": 0.1;
+                    "unit": "s";
+                  };
+                };
+                "strokeTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "value": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "placeholder": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.placeholder";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+                "openRotateDuration": {
+                  "type": "duration";
+                  "value": "$duration.d3";
+                };
+                "openRotateTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "closeRotateDuration": {
+                  "type": "duration";
+                  "value": "$duration.d2";
+                };
+                "closeRotateTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "invalid",
+            ];
+            "slots": {
+              "root": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.critical-solid";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+              };
+              "value": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "placeholder": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "readonly",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+              };
+              "value": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "placeholder": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.placeholder";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": "$dimension.x13";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "value": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "placeholder": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": "$dimension.x10";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r2";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "value": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "placeholder": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/select-trigger.mjs
+++ b/packages/rootage/__generated__/components/select-trigger.mjs
@@ -1,0 +1,2 @@
+import artifact from "./select-trigger.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/select.d.ts
+++ b/packages/rootage/__generated__/components/select.d.ts
@@ -1,0 +1,299 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "select";
+    "name": "Select";
+  };
+  "data": {
+    "id": "select";
+    "name": "Select";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "shadow": {
+              "type": "shadow";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "enterScale": {
+              "type": "number";
+            };
+            "enterOpacity": {
+              "type": "number";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitScale": {
+              "type": "number";
+            };
+            "exitOpacity": {
+              "type": "number";
+            };
+            "gutter": {
+              "type": "dimension";
+              "description": "트리거와 목록 사이의 간격을 정의합니다.";
+            };
+            "overflowPadding": {
+              "type": "dimension";
+              "description": "목록과 뷰포트 경계 사이의 최소 간격을 정의합니다.";
+            };
+            "maxHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "group": {
+          "properties": {};
+        };
+        "groupLabel": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "divider": {
+          "properties": {
+            "marginX": {
+              "type": "dimension";
+            };
+            "height": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "large": {
+              "description": "뷰포트 너비와 관계없이 사용할 수 있습니다.";
+            };
+            "medium": {
+              "description": "Breakpoint `lg` 이상(데스크톱)에서만 사용하고, 모바일에서는 사용하지 않습니다. 정밀한 선택이 가능한 마우스 입력 환경에서 사이즈를 더 작게 만들고자 할 때 사용합니다.";
+            };
+          };
+          "defaultValue": "large";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r5";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating";
+                };
+                "shadow": {
+                  "type": "shadow";
+                  "value": "$shadow.s3";
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d3";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter";
+                };
+                "enterScale": {
+                  "type": "number";
+                  "value": 0.95;
+                };
+                "enterOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d2";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.exit";
+                };
+                "exitScale": {
+                  "type": "number";
+                  "value": 0.95;
+                };
+                "exitOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "gutter": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "overflowPadding": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "maxHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 480;
+                    "unit": "px";
+                  };
+                };
+              };
+              "groupLabel": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+              "divider": {
+                "marginX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "groupLabel": {
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "groupLabel": {
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/select.mjs
+++ b/packages/rootage/__generated__/components/select.mjs
@@ -1,0 +1,2 @@
+import artifact from "./select.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/side-panel-close-button.d.ts
+++ b/packages/rootage/__generated__/components/side-panel-close-button.d.ts
@@ -1,0 +1,125 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "side-panel-close-button";
+    "name": "Side Panel Close Button";
+  };
+  "data": {
+    "id": "side-panel-close-button";
+    "name": "Side Panel Close Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 52;
+                    "unit": "px";
+                  };
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 22;
+                    "unit": "px";
+                  };
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.transparent-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/side-panel-close-button.mjs
+++ b/packages/rootage/__generated__/components/side-panel-close-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./side-panel-close-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/side-panel.d.ts
+++ b/packages/rootage/__generated__/components/side-panel.d.ts
@@ -1,0 +1,453 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "side-panel";
+    "name": "Side Panel";
+  };
+  "data": {
+    "id": "side-panel";
+    "name": "Side Panel";
+    "schema": {
+      "slots": {
+        "backdrop": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "enterOpacity": {
+              "type": "number";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitOpacity": {
+              "type": "number";
+            };
+          };
+        };
+        "content": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "width": {
+              "type": "dimension";
+            };
+            "widthFraction": {
+              "type": "number";
+              "description": "viewport 또는 parent width에 대한 mobile content width 비율입니다.";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+          "description": "하단 safe-area inset을 content의 하단 패딩으로 적용합니다.";
+        };
+        "header": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingTop": {
+              "type": "dimension";
+              "description": "이 값은 상단 safe-area inset과 합산하여 적용합니다.";
+            };
+            "paddingBottom": {
+              "type": "dimension";
+            };
+            "closeButtonGap": {
+              "type": "dimension";
+              "description": "closeButton이 표시되는 경우 paddingRight에 추가되는 여백입니다.";
+            };
+          };
+        };
+        "body": {
+          "properties": {
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingBottom": {
+              "type": "dimension";
+              "description": "body의 하단 padding이며, 동시에 하단 scroll fog 그라데이션의 높이로도 사용됩니다.";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+              "description": "본문이 스크롤된(scrolled) 상태에서 body 상단에 나타나는 divider의 색상입니다.";
+            };
+            "strokeDuration": {
+              "type": "duration";
+            };
+            "strokeTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "footer": {
+          "properties": {
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingTop": {
+              "type": "dimension";
+            };
+            "paddingBottom": {
+              "type": "dimension";
+            };
+          };
+        };
+        "title": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "description": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "closeButton": {
+          "properties": {
+            "fromTop": {
+              "type": "dimension";
+            };
+            "fromRight": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "small": {};
+            "medium": {};
+            "large": {};
+          };
+          "defaultValue": "small";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "backdrop": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.overlay";
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d6";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter";
+                };
+                "enterOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d6";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.exit";
+                };
+                "exitOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+              };
+              "content": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-floating";
+                };
+                "widthFraction": {
+                  "type": "number";
+                  "value": 0.8;
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d6";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter-expressive";
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d6";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.exit-expressive";
+                };
+              };
+              "header": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 70;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "paddingTop": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "paddingBottom": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "closeButtonGap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+              };
+              "body": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "paddingBottom": {
+                  "type": "dimension";
+                  "value": "$dimension.x12";
+                };
+                "strokeDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "strokeTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "footer": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "paddingTop": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "paddingBottom": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t8";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t8";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+              "description": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+              "closeButton": {
+                "fromTop": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 28;
+                    "unit": "px";
+                  };
+                };
+                "fromRight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 24;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "scrolled",
+            ];
+            "slots": {
+              "body": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "content": {
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 480;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "content": {
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 720;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "content": {
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 960;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/side-panel.mjs
+++ b/packages/rootage/__generated__/components/side-panel.mjs
@@ -1,0 +1,2 @@
+import artifact from "./side-panel.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/skeleton.d.ts
+++ b/packages/rootage/__generated__/components/skeleton.d.ts
@@ -1,0 +1,237 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "skeleton";
+    "name": "Skeleton";
+  };
+  "data": {
+    "id": "skeleton";
+    "name": "Skeleton";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+          };
+        };
+        "shimmer": {
+          "properties": {
+            "duration": {
+              "type": "duration";
+            };
+            "timingFunction": {
+              "type": "cubicBezier";
+            };
+            "gradient": {
+              "type": "gradient";
+            };
+          };
+        };
+      };
+      "variants": {
+        "radius": {
+          "values": {
+            "0": {
+              "description": "기본값입니다.";
+            };
+            "8": {
+              "description": "텍스트 콘텐츠에 사용합니다.";
+            };
+            "16": {
+              "description": "카드 및 썸네일에 사용합니다.";
+            };
+            "full": {
+              "description": "Avatar(원형) 콘텐츠에 사용합니다.";
+            };
+          };
+          "defaultValue": "0";
+        };
+        "tone": {
+          "values": {
+            "neutral": {
+              "description": "데이터를 불러오는 일반적인 로딩 경험에 사용합니다.";
+            };
+            "magic": {
+              "description": "AI 기능이 활성화되었을 때 사용합니다.";
+            };
+          };
+          "defaultValue": "neutral";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "shimmer": {
+                "duration": {
+                  "type": "duration";
+                  "value": {
+                    "value": 1.5;
+                    "unit": "s";
+                  };
+                };
+                "timingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "radius": "0";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 0;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "radius": "8";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 8;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "radius": "16";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 16;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "radius": "full";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "neutral";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-200";
+                };
+              };
+              "shimmer": {
+                "gradient": {
+                  "type": "gradient";
+                  "value": "$gradient.shimmer-neutral";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "magic";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.magic-weak";
+                };
+              };
+              "shimmer": {
+                "gradient": {
+                  "type": "gradient";
+                  "value": "$gradient.shimmer-magic";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/skeleton.mjs
+++ b/packages/rootage/__generated__/components/skeleton.mjs
@@ -1,0 +1,2 @@
+import artifact from "./skeleton.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/slider-thumb.d.ts
+++ b/packages/rootage/__generated__/components/slider-thumb.d.ts
@@ -1,0 +1,115 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "slider-thumb";
+    "name": "Slider Thumb";
+  };
+  "data": {
+    "id": "slider-thumb";
+    "name": "Slider Thumb";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "scaleDuration": {
+              "type": "duration";
+            };
+            "scaleTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "translateDuration": {
+              "type": "duration";
+            };
+            "translateTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "scale": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted";
+                };
+                "scaleDuration": {
+                  "type": "duration";
+                  "value": "$duration.d3";
+                };
+                "scaleTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "translateDuration": {
+                  "type": "duration";
+                  "value": "$duration.d3";
+                };
+                "translateTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "scale": {
+                  "type": "number";
+                  "value": 1.2;
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/slider-thumb.mjs
+++ b/packages/rootage/__generated__/components/slider-thumb.mjs
@@ -1,0 +1,2 @@
+import artifact from "./slider-thumb.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/slider-tick.d.ts
+++ b/packages/rootage/__generated__/components/slider-tick.d.ts
@@ -1,0 +1,98 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "slider-tick";
+    "name": "Slider Tick";
+  };
+  "data": {
+    "id": "slider-tick";
+    "name": "Slider Tick";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "width": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {
+        "weight": {
+          "values": {
+            "thin": {};
+            "thick": {};
+          };
+          "defaultValue": "thin";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "weight": "thin";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "weight": "thick";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "width": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/slider-tick.mjs
+++ b/packages/rootage/__generated__/components/slider-tick.mjs
@@ -1,0 +1,2 @@
+import artifact from "./slider-tick.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/slider.d.ts
+++ b/packages/rootage/__generated__/components/slider.d.ts
@@ -1,0 +1,402 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "slider";
+    "name": "Slider";
+  };
+  "data": {
+    "id": "slider";
+    "name": "Slider";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "control": {
+          "properties": {
+            "height": {
+              "type": "dimension";
+            };
+          };
+        };
+        "track": {
+          "properties": {
+            "height": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "range": {
+          "properties": {
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "widthDuration": {
+              "type": "duration";
+            };
+            "widthTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "thumb": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "valueIndicatorRoot": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+              "description": "value indicator 내부 좌우 여백입니다. arrow와 valueIndicatorRoot 경계 사이의 최소 간격에도 동일한 값이 적용됩니다.";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "offsetY": {
+              "type": "dimension";
+            };
+            "enterScale": {
+              "type": "number";
+            };
+            "enterOpacity": {
+              "type": "number";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitScale": {
+              "type": "number";
+            };
+            "exitOpacity": {
+              "type": "number";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "translateDuration": {
+              "type": "duration";
+            };
+            "translateTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+          "description": "arrow width + (valueIndicatorRoot paddingX * 2)만큼의 최소 너비를 가집니다.";
+        };
+        "valueIndicatorArrow": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "width": {
+              "type": "dimension";
+            };
+            "height": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "gutter": {
+              "type": "dimension";
+              "description": "arrow와 thumb 사이의 거리를 정의합니다.";
+            };
+          };
+        };
+        "valueIndicatorLabel": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "marker": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+              };
+              "control": {
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 26;
+                    "unit": "px";
+                  };
+                };
+              };
+              "track": {
+                "height": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-400";
+                };
+              };
+              "range": {
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "widthDuration": {
+                  "type": "duration";
+                  "value": "$duration.d3";
+                };
+                "widthTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "thumb": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted";
+                };
+              };
+              "valueIndicatorRoot": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r1_5";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "offsetY": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+                "enterScale": {
+                  "type": "number";
+                  "value": 0.9;
+                };
+                "enterOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d4";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter";
+                };
+                "exitScale": {
+                  "type": "number";
+                  "value": 1;
+                };
+                "exitOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d4";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "translateDuration": {
+                  "type": "duration";
+                  "value": "$duration.d3";
+                };
+                "translateTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "valueIndicatorArrow": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted";
+                };
+                "width": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "height": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r0_5";
+                };
+                "gutter": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+              };
+              "valueIndicatorLabel": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+              "marker": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "track": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+              };
+              "range": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "thumb": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "marker": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/slider.mjs
+++ b/packages/rootage/__generated__/components/slider.mjs
@@ -1,0 +1,2 @@
+import artifact from "./slider.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/snackbar.d.ts
+++ b/packages/rootage/__generated__/components/snackbar.d.ts
@@ -1,0 +1,361 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "snackbar";
+    "name": "Snackbar";
+  };
+  "data": {
+    "id": "snackbar";
+    "name": "Snackbar";
+    "schema": {
+      "slots": {
+        "region": {
+          "properties": {
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "offsetDuration": {
+              "type": "duration";
+            };
+            "offsetTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "maxWidth": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "enterOpacity": {
+              "type": "number";
+            };
+            "enterScale": {
+              "type": "number";
+            };
+            "enterDuration": {
+              "type": "duration";
+            };
+            "enterTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "exitScale": {
+              "type": "number";
+            };
+            "exitOpacity": {
+              "type": "number";
+            };
+            "exitDuration": {
+              "type": "duration";
+            };
+            "exitTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "content": {
+          "properties": {
+            "paddingX": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "message": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "paddingRight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "actionButton": {
+          "properties": {
+            "targetPaddingX": {
+              "type": "dimension";
+            };
+            "targetMinHeight": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {
+        "variant": {
+          "values": {
+            "default": {};
+            "positive": {};
+            "critical": {};
+          };
+          "defaultValue": "default";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "region": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "offsetDuration": {
+                  "type": "duration";
+                  "value": "$duration.d4";
+                };
+                "offsetTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r2";
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 44;
+                    "unit": "px";
+                  };
+                };
+                "maxWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 560;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "enterOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "enterScale": {
+                  "type": "number";
+                  "value": 0.8;
+                };
+                "enterDuration": {
+                  "type": "duration";
+                  "value": "$duration.d3";
+                };
+                "enterTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.enter";
+                };
+                "exitOpacity": {
+                  "type": "number";
+                  "value": 0;
+                };
+                "exitScale": {
+                  "type": "number";
+                  "value": 0.8;
+                };
+                "exitDuration": {
+                  "type": "duration";
+                  "value": "$duration.d2";
+                };
+                "exitTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.exit";
+                };
+              };
+              "content": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+              "message": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 24;
+                    "unit": "px";
+                  };
+                };
+                "paddingRight": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+              };
+              "actionButton": {
+                "targetPaddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "targetMinHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 44;
+                    "unit": "px";
+                  };
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.brand";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "default";
+        };
+        "definitions": readonly [];
+      },
+      {
+        "variants": {
+          "variant": "positive";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.positive";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "critical";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.critical";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/snackbar.mjs
+++ b/packages/rootage/__generated__/components/snackbar.mjs
@@ -1,0 +1,2 @@
+import artifact from "./snackbar.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/switch.d.ts
+++ b/packages/rootage/__generated__/components/switch.d.ts
@@ -1,0 +1,208 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "switch";
+    "name": "Switch";
+  };
+  "data": {
+    "id": "switch";
+    "name": "Switch";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "height": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "opacity": {
+              "type": "number";
+            };
+            "opacityDuration": {
+              "type": "duration";
+            };
+            "opacityTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "16": {};
+            "24": {};
+            "32": {};
+          };
+          "defaultValue": "32";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "label": {
+                "opacity": {
+                  "type": "number";
+                  "value": 0.58;
+                };
+                "opacityDuration": {
+                  "type": "duration";
+                  "value": "$duration.d1";
+                };
+                "opacityTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "32";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": "$dimension.x8";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "24";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "16";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/switch.mjs
+++ b/packages/rootage/__generated__/components/switch.mjs
@@ -1,0 +1,2 @@
+import artifact from "./switch.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/switchmark.d.ts
+++ b/packages/rootage/__generated__/components/switchmark.d.ts
@@ -1,0 +1,503 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "switchmark";
+    "name": "Switchmark";
+    "lastUpdated": "25-12-16";
+  };
+  "data": {
+    "id": "switchmark";
+    "name": "Switchmark";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "colorDelay": {
+              "type": "duration";
+            };
+            "opacity": {
+              "type": "number";
+            };
+            "opacityDuration": {
+              "type": "duration";
+            };
+            "opacityTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "height": {
+              "type": "dimension";
+            };
+            "width": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+          };
+        };
+        "thumb": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "colorDelay": {
+              "type": "duration";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "height": {
+              "type": "dimension";
+            };
+            "width": {
+              "type": "dimension";
+            };
+            "scale": {
+              "type": "number";
+            };
+            "scaleDuration": {
+              "type": "duration";
+            };
+            "scaleTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "translateDuration": {
+              "type": "duration";
+            };
+            "translateTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+      };
+      "variants": {
+        "tone": {
+          "values": {
+            "brand": {};
+            "neutral": {};
+          };
+          "defaultValue": "brand";
+        };
+        "size": {
+          "values": {
+            "16": {};
+            "24": {};
+            "32": {};
+          };
+          "defaultValue": "32";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-600";
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.d1";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "colorDelay": {
+                  "type": "duration";
+                  "value": {
+                    "value": 20;
+                    "unit": "ms";
+                  };
+                };
+              };
+              "thumb": {
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "scale": {
+                  "type": "number";
+                  "value": 0.8;
+                };
+                "scaleDuration": {
+                  "type": "duration";
+                  "value": "$duration.d3";
+                };
+                "scaleTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "translateDuration": {
+                  "type": "duration";
+                  "value": "$duration.d3";
+                };
+                "translateTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.d1";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+                "colorDelay": {
+                  "type": "duration";
+                  "value": {
+                    "value": 20;
+                    "unit": "ms";
+                  };
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "opacity": {
+                  "type": "number";
+                  "value": 0.38;
+                };
+                "opacityDuration": {
+                  "type": "duration";
+                  "value": "$duration.d1";
+                };
+                "opacityTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+            ];
+            "slots": {
+              "thumb": {
+                "scale": {
+                  "type": "number";
+                  "value": 1;
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "brand";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "thumb": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "enabled",
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-solid";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "neutral";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "thumb": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-inverted";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "enabled",
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-inverted";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "thumb": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-black-alpha-700";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-600";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "32";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 32;
+                    "unit": "px";
+                  };
+                };
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 52;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 3;
+                    "unit": "px";
+                  };
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 3;
+                    "unit": "px";
+                  };
+                };
+              };
+              "thumb": {
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 26;
+                    "unit": "px";
+                  };
+                };
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 26;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "24";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 24;
+                    "unit": "px";
+                  };
+                };
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 38;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+              "thumb": {
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 20;
+                    "unit": "px";
+                  };
+                };
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 20;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "16";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 16;
+                    "unit": "px";
+                  };
+                };
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 26;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+              "thumb": {
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 12;
+                    "unit": "px";
+                  };
+                };
+                "width": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 12;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/switchmark.mjs
+++ b/packages/rootage/__generated__/components/switchmark.mjs
@@ -1,0 +1,2 @@
+import artifact from "./switchmark.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/tab.d.ts
+++ b/packages/rootage/__generated__/components/tab.d.ts
@@ -1,0 +1,190 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "tab";
+    "name": "Tab";
+  };
+  "data": {
+    "id": "tab";
+    "name": "Tab";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "minHeight": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "medium": {};
+            "small": {};
+          };
+          "defaultValue": "medium";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 44;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 40;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/tab.mjs
+++ b/packages/rootage/__generated__/components/tab.mjs
@@ -1,0 +1,2 @@
+import artifact from "./tab.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/tablist.d.ts
+++ b/packages/rootage/__generated__/components/tablist.d.ts
@@ -1,0 +1,226 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "tablist";
+    "name": "Tablist";
+  };
+  "data": {
+    "id": "tablist";
+    "name": "Tablist";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "strokeBottomWidth": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "height": {
+              "type": "dimension";
+            };
+          };
+        };
+        "indicator": {
+          "properties": {
+            "height": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "transformDuration": {
+              "type": "duration";
+            };
+            "transformTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "insetX": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "layout": {
+          "values": {
+            "hug": {};
+            "fill": {};
+          };
+          "defaultValue": "hug";
+        };
+        "size": {
+          "values": {
+            "small": {};
+            "medium": {};
+          };
+          "defaultValue": "small";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-default";
+                };
+                "strokeBottomWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-muted";
+                };
+              };
+              "indicator": {
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "transformDuration": {
+                  "type": "duration";
+                  "value": "$duration.d4";
+                };
+                "transformTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "layout": "hug";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+              };
+              "indicator": {
+                "insetX": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 0;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "layout": "fill";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "paddingX": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 0;
+                    "unit": "px";
+                  };
+                };
+              };
+              "indicator": {
+                "insetX": {
+                  "type": "dimension";
+                  "value": "$dimension.spacing-x.global-gutter";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 40;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 44;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/tablist.mjs
+++ b/packages/rootage/__generated__/components/tablist.mjs
@@ -1,0 +1,2 @@
+import artifact from "./tablist.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/tag-group-item.d.ts
+++ b/packages/rootage/__generated__/components/tag-group-item.d.ts
@@ -1,0 +1,403 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "tag-group-item";
+    "name": "Tag Group Item";
+  };
+  "data": {
+    "id": "tag-group-item";
+    "name": "Tag Group Item";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+        "suffixIcon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "t2": {};
+            "t3": {};
+            "t4": {};
+          };
+          "defaultValue": "t2";
+        };
+        "weight": {
+          "values": {
+            "regular": {};
+            "bold": {};
+          };
+          "defaultValue": "regular";
+        };
+        "tone": {
+          "values": {
+            "neutralSubtle": {};
+            "neutral": {};
+            "brand": {};
+          };
+          "defaultValue": "neutralSubtle";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x0_5";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "t2";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t2";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t2";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "t3";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 13;
+                    "unit": "px";
+                  };
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 13;
+                    "unit": "px";
+                  };
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 13;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "t4";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "weight": "regular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "weight": "bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "neutralSubtle";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "neutral";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "brand";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.brand";
+                };
+              };
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.brand";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.brand";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.brand";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/tag-group-item.mjs
+++ b/packages/rootage/__generated__/components/tag-group-item.mjs
@@ -1,0 +1,2 @@
+import artifact from "./tag-group-item.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/tag-group.d.ts
+++ b/packages/rootage/__generated__/components/tag-group.d.ts
@@ -1,0 +1,138 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "tag-group";
+    "name": "Tag Group";
+  };
+  "data": {
+    "id": "tag-group";
+    "name": "Tag Group";
+    "schema": {
+      "slots": {
+        "separator": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {
+        "size": {
+          "values": {
+            "t2": {};
+            "t3": {};
+            "t4": {};
+          };
+          "defaultValue": "t2";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "separator": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.gray-600";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "t2";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "separator": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t2";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t2";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "t3";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "separator": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "t4";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "separator": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/tag-group.mjs
+++ b/packages/rootage/__generated__/components/tag-group.mjs
@@ -1,0 +1,2 @@
+import artifact from "./tag-group.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/text-button.d.ts
+++ b/packages/rootage/__generated__/components/text-button.d.ts
@@ -1,0 +1,115 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "text-button";
+    "name": "Text Button";
+  };
+  "data": {
+    "id": "text-button";
+    "name": "Text Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {};
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x9";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r2";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-default-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/text-button.mjs
+++ b/packages/rootage/__generated__/components/text-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./text-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/text-input.d.ts
+++ b/packages/rootage/__generated__/components/text-input.d.ts
@@ -1,0 +1,887 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "text-input";
+    "name": "Text Input";
+  };
+  "data": {
+    "id": "text-input";
+    "name": "Text Input";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "gap": {
+              "type": "dimension";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+            "strokeWidth": {
+              "type": "dimension";
+            };
+            "strokeBottomWidth": {
+              "type": "dimension";
+            };
+            "strokeColor": {
+              "type": "color";
+            };
+            "color": {
+              "type": "color";
+            };
+            "strokeDuration": {
+              "type": "duration";
+              "description": "enabled 상태의 stroke 위에 focused/invalid 상태의 stroke가 fade in/out 되는 데에 걸리는 시간입니다. stroke 두께나 색상 자체를 transition하지 않습니다.";
+            };
+            "strokeTimingFunction": {
+              "type": "cubicBezier";
+            };
+          };
+        };
+        "value": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "placeholder": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "prefixText": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "suffixText": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "suffixIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "variant": {
+          "values": {
+            "outline": {
+              "description": "기본 스타일입니다.";
+            };
+            "underline": {
+              "description": "화면에 하나의 Input만 있는 경우 사용을 권장합니다.";
+            };
+          };
+          "defaultValue": "outline";
+        };
+        "size": {
+          "values": {
+            "large": {
+              "description": "뷰포트 너비와 관계없이 사용할 수 있습니다.";
+            };
+            "medium": {
+              "description": "Breakpoint `lg` 이상(데스크톱)에서만 사용하고, 모바일에서는 사용하지 않습니다. 정밀한 선택이 가능한 마우스 입력 환경에서 사이즈를 더 작게 만들고자 할 때 사용합니다.";
+            };
+          };
+          "defaultValue": "large";
+        };
+        "type": {
+          "values": {
+            "singleline": {};
+            "multiline": {};
+          };
+          "defaultValue": "singleline";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-weak";
+                };
+                "strokeDuration": {
+                  "type": "duration";
+                  "value": {
+                    "value": 0.1;
+                    "unit": "s";
+                  };
+                };
+                "strokeTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "value": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+              "placeholder": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.placeholder";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+              "prefixText": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+              };
+              "suffixText": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-subtle";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "focused",
+            ];
+            "slots": {
+              "root": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.neutral-contrast";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "invalid",
+            ];
+            "slots": {
+              "root": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.critical-solid";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "invalid",
+              "focused",
+            ];
+            "slots": {
+              "root": {
+                "strokeColor": {
+                  "type": "color";
+                  "value": "$color.stroke.critical-solid";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "value": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "placeholder": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixText": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixText": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "outline";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "focused",
+            ];
+            "slots": {
+              "root": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "invalid",
+            ];
+            "slots": {
+              "root": {
+                "strokeWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "readonly",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "outline";
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x13";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r3";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "value": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "placeholder": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "prefixText": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+              };
+              "suffixText": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "outline";
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x10";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.r2";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "value": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "placeholder": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "prefixText": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "suffixText": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "underline";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "strokeBottomWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 1;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "focused",
+            ];
+            "slots": {
+              "root": {
+                "strokeBottomWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "invalid",
+            ];
+            "slots": {
+              "root": {
+                "strokeBottomWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "readonly",
+            ];
+            "slots": {
+              "value": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+              };
+              "placeholder": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "underline";
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x10";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+              "value": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t6";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t6";
+                };
+              };
+              "placeholder": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t6";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t6";
+                };
+              };
+              "prefixText": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t6";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t6";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+              };
+              "suffixText": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t6";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t6";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x6";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "underline";
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 34;
+                    "unit": "px";
+                  };
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+              };
+              "value": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "placeholder": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "prefixText": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+              };
+              "suffixText": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "type": "singleline";
+        };
+        "definitions": readonly [];
+      },
+      {
+        "variants": {
+          "type": "multiline";
+          "size": "large";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 94;
+                    "unit": "px";
+                  };
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "type": "multiline";
+          "size": "medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 82;
+                    "unit": "px";
+                  };
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x3";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/text-input.mjs
+++ b/packages/rootage/__generated__/components/text-input.mjs
@@ -1,0 +1,2 @@
+import artifact from "./text-input.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/toggle-button.d.ts
+++ b/packages/rootage/__generated__/components/toggle-button.d.ts
@@ -1,0 +1,642 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "toggle-button";
+    "name": "Toggle Button";
+  };
+  "data": {
+    "id": "toggle-button";
+    "name": "Toggle Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "colorDuration": {
+              "type": "duration";
+            };
+            "colorTimingFunction": {
+              "type": "cubicBezier";
+            };
+            "color": {
+              "type": "color";
+            };
+            "minHeight": {
+              "type": "dimension";
+            };
+            "cornerRadius": {
+              "type": "dimension";
+            };
+            "gap": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "paddingY": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+          };
+        };
+        "prefixIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "suffixIcon": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "progressCircle": {
+          "properties": {
+            "trackColor": {
+              "type": "color";
+            };
+            "rangeColor": {
+              "type": "color";
+            };
+            "size": {
+              "type": "dimension";
+            };
+            "thickness": {
+              "type": "dimension";
+            };
+          };
+        };
+      };
+      "variants": {
+        "variant": {
+          "values": {
+            "brandSolid": {
+              "description": "브랜드 컬러로 강조된 스타일입니다.";
+            };
+            "neutralWeak": {
+              "description": "기본적인 토글 스타일입니다.";
+            };
+          };
+          "defaultValue": "brandSolid";
+        };
+        "size": {
+          "values": {
+            "xsmall": {};
+            "small": {};
+          };
+          "defaultValue": "xsmall";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "colorDuration": {
+                  "type": "duration";
+                  "value": "$duration.color-transition";
+                };
+                "colorTimingFunction": {
+                  "type": "cubicBezier";
+                  "value": "$timing-function.easing";
+                };
+              };
+              "label": {
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "brandSolid";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-solid";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "progressCircle": {
+                "trackColor": {
+                  "type": "color";
+                  "value": "$color.palette.static-white-alpha-300";
+                };
+                "rangeColor": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-solid-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "progressCircle": {
+                "trackColor": {
+                  "type": "color";
+                  "value": "$color.palette.gray-500";
+                };
+                "rangeColor": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "loading",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.brand-solid-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+              "loading",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "variant": "neutralWeak";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "progressCircle": {
+                "trackColor": {
+                  "type": "color";
+                  "value": "$color.palette.gray-500";
+                };
+                "rangeColor": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "progressCircle": {
+                "trackColor": {
+                  "type": "color";
+                  "value": "$color.palette.gray-500";
+                };
+                "rangeColor": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+              "pressed",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.disabled";
+                };
+              };
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "prefixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+              "suffixIcon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "loading",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "selected",
+              "loading",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.neutral-weak-pressed";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "xsmall";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x8";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x1_5";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+              };
+              "progressCircle": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 14;
+                    "unit": "px";
+                  };
+                };
+                "thickness": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "size": "small";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "minHeight": {
+                  "type": "dimension";
+                  "value": "$dimension.x9";
+                };
+                "cornerRadius": {
+                  "type": "dimension";
+                  "value": "$radius.full";
+                };
+                "gap": {
+                  "type": "dimension";
+                  "value": "$dimension.x1";
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+                "paddingY": {
+                  "type": "dimension";
+                  "value": "$dimension.x2";
+                };
+              };
+              "prefixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "suffixIcon": {
+                "size": {
+                  "type": "dimension";
+                  "value": "$dimension.x3_5";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+              };
+              "progressCircle": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 14;
+                    "unit": "px";
+                  };
+                };
+                "thickness": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 2;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/toggle-button.mjs
+++ b/packages/rootage/__generated__/components/toggle-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./toggle-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/top-navigation-icon-button.d.ts
+++ b/packages/rootage/__generated__/components/top-navigation-icon-button.d.ts
@@ -1,0 +1,140 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "top-navigation-icon-button";
+    "name": "Top Navigation Icon Button";
+  };
+  "data": {
+    "id": "top-navigation-icon-button";
+    "name": "Top Navigation Icon Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+          };
+        };
+        "icon": {
+          "properties": {
+            "size": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+          };
+        };
+      };
+      "variants": {
+        "tone": {
+          "values": {
+            "layer": {};
+            "transparent": {};
+          };
+          "defaultValue": "layer";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 44;
+                    "unit": "px";
+                  };
+                };
+              };
+              "icon": {
+                "size": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 24;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "layer";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "transparent";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "icon": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/top-navigation-icon-button.mjs
+++ b/packages/rootage/__generated__/components/top-navigation-icon-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./top-navigation-icon-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/top-navigation-text-button.d.ts
+++ b/packages/rootage/__generated__/components/top-navigation-text-button.d.ts
@@ -1,0 +1,226 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "top-navigation-text-button";
+    "name": "Top Navigation Text Button";
+  };
+  "data": {
+    "id": "top-navigation-text-button";
+    "name": "Top Navigation Text Button";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "maxWidth": {
+              "type": "dimension";
+              "description": "버튼 레이블이 길어졌을 때 ellipsis 말줄임을 시작할 최대 너비입니다. Top Navigation main slot이 충분한 공간을 차지할 수 있도록 하기 위해 폰트 스케일링의 영향을 받지 않는 px 값을 사용합니다.";
+            };
+            "height": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+          };
+        };
+        "label": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "maxFontSizeScale": {
+              "type": "number";
+            };
+            "minFontSizeScale": {
+              "type": "number";
+            };
+            "maxLineHeightScale": {
+              "type": "number";
+            };
+            "minLineHeightScale": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {
+        "tone": {
+          "values": {
+            "layer": {};
+            "transparent": {};
+          };
+          "defaultValue": "layer";
+        };
+        "theme": {
+          "values": {
+            "ios": {};
+            "android": {};
+          };
+          "defaultValue": "ios";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {};
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 44;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x2_5";
+                };
+              };
+              "label": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+                "maxFontSizeScale": {
+                  "type": "number";
+                  "value": 1.2;
+                };
+                "minFontSizeScale": {
+                  "type": "number";
+                  "value": 1;
+                };
+                "maxLineHeightScale": {
+                  "type": "number";
+                  "value": 1.2;
+                };
+                "minLineHeightScale": {
+                  "type": "number";
+                  "value": 1;
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "layer";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "transparent";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+          {
+            "states": readonly [
+              "disabled",
+            ];
+            "slots": {
+              "label": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.disabled";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "theme": "ios";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "maxWidth": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 96;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "theme": "android";
+        };
+        "definitions": readonly [];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/top-navigation-text-button.mjs
+++ b/packages/rootage/__generated__/components/top-navigation-text-button.mjs
@@ -1,0 +1,2 @@
+import artifact from "./top-navigation-text-button.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/top-navigation.d.ts
+++ b/packages/rootage/__generated__/components/top-navigation.d.ts
@@ -1,0 +1,439 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "top-navigation";
+    "name": "Top Navigation";
+  };
+  "data": {
+    "id": "top-navigation";
+    "name": "Top Navigation";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "height": {
+              "type": "dimension";
+            };
+            "paddingX": {
+              "type": "dimension";
+            };
+            "color": {
+              "type": "color";
+            };
+            "gradient": {
+              "type": "gradient";
+            };
+            "bleedBottom": {
+              "type": "dimension";
+              "description": "gradient가 표시될 때 하단 아래로 gradient가 확장되는 길이입니다.";
+            };
+          };
+        };
+        "left": {
+          "properties": {};
+          "description": "왼쪽 영역입니다. 일반적으로 뒤로가기/닫기 Top Navigation Icon Button이 위치합니다.";
+        };
+        "main": {
+          "properties": {
+            "paddingLeft": {
+              "type": "dimension";
+            };
+          };
+          "description": "title과 subtitle을 포함하는 영역입니다.";
+        };
+        "right": {
+          "properties": {};
+          "description": "오른쪽 영역입니다. 일반적으로 Top Navigation Icon Button 또는 Top Navigation Text Button이 위치합니다.";
+        };
+        "title": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "maxFontSizeScale": {
+              "type": "number";
+            };
+            "minFontSizeScale": {
+              "type": "number";
+            };
+            "maxLineHeightScale": {
+              "type": "number";
+            };
+            "minLineHeightScale": {
+              "type": "number";
+            };
+          };
+        };
+        "subtitle": {
+          "properties": {
+            "color": {
+              "type": "color";
+            };
+            "fontSize": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "maxFontSizeScale": {
+              "type": "number";
+            };
+            "minFontSizeScale": {
+              "type": "number";
+            };
+            "maxLineHeightScale": {
+              "type": "number";
+            };
+            "minLineHeightScale": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {
+        "theme": {
+          "values": {
+            "ios": {};
+            "android": {};
+          };
+          "defaultValue": "ios";
+        };
+        "tone": {
+          "values": {
+            "layer": {
+              "description": "color를 $color.bg.layer-basement 등으로 변경하여 사용할 수 있습니다.";
+            };
+            "transparent": {};
+          };
+          "defaultValue": "layer";
+        };
+        "gradient": {
+          "values": {
+            "false": {
+              "description": "false로 사용하는 것을 권장하지 않습니다. gradient 없이 사용하면 Top Navigation의 콘텐츠 가독성을 직접 확보해야 합니다. 스크린 배경 색상이 Top Navigation에 보이기를 원하는 경우 tone=layer를 사용하세요.";
+            };
+            "true": {};
+          };
+          "defaultValue": "false";
+          "description": "tone=transparent일 때만 동작합니다.";
+        };
+        "titleLayout": {
+          "values": {
+            "titleOnly": {};
+            "withSubtitle": {};
+          };
+          "defaultValue": "titleOnly";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {
+          "theme": "ios";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 44;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "theme": "android";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "height": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 56;
+                    "unit": "px";
+                  };
+                };
+                "paddingX": {
+                  "type": "dimension";
+                  "value": "$dimension.x4";
+                };
+              };
+              "main": {
+                "paddingLeft": {
+                  "type": "dimension";
+                  "value": {
+                    "value": 16;
+                    "unit": "px";
+                  };
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "layer";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.bg.layer-default";
+                };
+              };
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral";
+                };
+              };
+              "subtitle": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.fg.neutral-muted";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "transparent";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "title": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+              "subtitle": {
+                "color": {
+                  "type": "color";
+                  "value": "$color.palette.static-white";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "transparent";
+          "gradient": "false";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "color": {
+                  "type": "color";
+                  "value": "#00000000";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "tone": "transparent";
+          "gradient": "true";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "gradient": {
+                  "type": "gradient";
+                  "value": readonly [
+                    {
+                      "color": "#00000059";
+                      "position": 0;
+                    },
+                    {
+                      "color": "#00000000";
+                      "position": 1;
+                    },
+                  ];
+                };
+                "bleedBottom": {
+                  "type": "dimension";
+                  "value": "$dimension.x5";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "titleLayout": "titleOnly";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "title": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t6";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t6";
+                };
+                "maxFontSizeScale": {
+                  "type": "number";
+                  "value": 1.2;
+                };
+                "minFontSizeScale": {
+                  "type": "number";
+                  "value": 1;
+                };
+                "maxLineHeightScale": {
+                  "type": "number";
+                  "value": 1.2;
+                };
+                "minLineHeightScale": {
+                  "type": "number";
+                  "value": 1;
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "titleLayout": "withSubtitle";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "title": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "maxFontSizeScale": {
+                  "type": "number";
+                  "value": 1.2;
+                };
+                "minFontSizeScale": {
+                  "type": "number";
+                  "value": 1;
+                };
+                "maxLineHeightScale": {
+                  "type": "number";
+                  "value": 1.2;
+                };
+                "minLineHeightScale": {
+                  "type": "number";
+                  "value": 1;
+                };
+              };
+              "subtitle": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t2";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t2";
+                };
+                "maxFontSizeScale": {
+                  "type": "number";
+                  "value": 1.2;
+                };
+                "minFontSizeScale": {
+                  "type": "number";
+                  "value": 1;
+                };
+                "maxLineHeightScale": {
+                  "type": "number";
+                  "value": 1.2;
+                };
+                "minLineHeightScale": {
+                  "type": "number";
+                  "value": 1;
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/top-navigation.mjs
+++ b/packages/rootage/__generated__/components/top-navigation.mjs
@@ -1,0 +1,2 @@
+import artifact from "./top-navigation.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/components/typography.d.ts
+++ b/packages/rootage/__generated__/components/typography.d.ts
@@ -1,0 +1,2675 @@
+declare const artifact: {
+  "kind": "ComponentSpec";
+  "metadata": {
+    "id": "typography";
+    "name": "Typography";
+  };
+  "data": {
+    "id": "typography";
+    "name": "Typography";
+    "schema": {
+      "slots": {
+        "root": {
+          "properties": {
+            "fontSize": {
+              "type": "dimension";
+            };
+            "lineHeight": {
+              "type": "dimension";
+            };
+            "fontWeight": {
+              "type": "number";
+            };
+          };
+        };
+      };
+      "variants": {
+        "textStyle": {
+          "values": {
+            "screenTitle": {
+              "description": "화면에 크게 표시되는 주요 제목이나 타이틀에 사용합니다.";
+            };
+            "articleBody": {
+              "description": "게시물이나 콘텐츠 중심 섹션의 본문 텍스트에 사용합니다.";
+            };
+            "articleNote": {
+              "description": "주석, 참고 사항 및 상세 리스트 등 부가 정보에 사용하며, 일반 본문 텍스트에는 사용하지 않습니다.";
+            };
+            "t1Regular": {};
+            "t1Medium": {};
+            "t1Bold": {};
+            "t2Regular": {};
+            "t2Medium": {};
+            "t2Bold": {};
+            "t3Regular": {};
+            "t3Medium": {};
+            "t3Bold": {};
+            "t4Regular": {};
+            "t4Medium": {};
+            "t4Bold": {};
+            "t5Regular": {};
+            "t5Medium": {};
+            "t5Bold": {};
+            "t6Regular": {};
+            "t6Medium": {};
+            "t6Bold": {};
+            "t7Regular": {};
+            "t7Medium": {};
+            "t7Bold": {};
+            "t8Regular": {};
+            "t8Medium": {};
+            "t8Bold": {};
+            "t9Regular": {};
+            "t9Medium": {};
+            "t9Bold": {};
+            "t10Regular": {};
+            "t10Medium": {};
+            "t10Bold": {};
+            "t11Regular": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+            };
+            "t11Medium": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+            };
+            "t11Bold": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+            };
+            "t12Regular": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+            };
+            "t12Medium": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+            };
+            "t12Bold": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+            };
+            "t13Regular": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+            };
+            "t13Medium": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+            };
+            "t13Bold": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+            };
+            "t14Regular": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+            };
+            "t14Medium": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+            };
+            "t14Bold": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+            };
+            "t1StaticRegular": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t1StaticMedium": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t1StaticBold": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t2StaticRegular": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t2StaticMedium": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t2StaticBold": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t3StaticRegular": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t3StaticMedium": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t3StaticBold": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t4StaticRegular": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t4StaticMedium": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t4StaticBold": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t5StaticRegular": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t5StaticMedium": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t5StaticBold": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t6StaticRegular": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t6StaticMedium": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t6StaticBold": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t7StaticRegular": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t7StaticMedium": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t7StaticBold": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t8StaticRegular": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t8StaticMedium": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t8StaticBold": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t9StaticRegular": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t9StaticMedium": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t9StaticBold": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t10StaticRegular": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t10StaticMedium": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t10StaticBold": {
+              "description": "폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t11StaticRegular": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t11StaticMedium": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t11StaticBold": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t12StaticRegular": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t12StaticMedium": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t12StaticBold": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t13StaticRegular": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t13StaticMedium": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t13StaticBold": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t14StaticRegular": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t14StaticMedium": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+            "t14StaticBold": {
+              "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 static text size와 static line height 토큰을 사용합니다.";
+            };
+          };
+          "defaultValue": "screenTitle";
+        };
+      };
+    };
+    "definitions": readonly [
+      {
+        "variants": {
+          "textStyle": "screenTitle";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t10";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t10";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "articleBody";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t6";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "articleNote";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t1Regular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t1";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t1";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t1Medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t1";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t1";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t1Bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t1";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t1";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t2Regular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t2";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t2";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t2Medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t2";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t2";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t2Bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t2";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t2";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t3Regular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t3Medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t3Bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t4Regular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t4Medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t4Bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t5Regular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t5Medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t5Bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t6Regular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t6";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t6";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t6Medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t6";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t6";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t6Bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t6";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t6";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t7Regular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t7";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t7";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t7Medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t7";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t7";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t7Bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t7";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t7";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t8Regular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t8";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t8";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t8Medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t8";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t8";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t8Bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t8";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t8";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t9Regular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t9";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t9";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t9Medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t9";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t9";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t9Bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t9";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t9";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t10Regular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t10";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t10";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t10Medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t10";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t10";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t10Bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t10";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t10";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t11Regular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t11";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t11";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t11Medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t11";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t11";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t11Bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t11";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t11";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t12Regular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t12";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t12";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t12Medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t12";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t12";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t12Bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t12";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t12";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t13Regular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t13";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t13";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t13Medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t13";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t13";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t13Bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t13";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t13";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t14Regular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t14";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t14";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t14Medium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t14";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t14";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t14Bold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t14";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t14";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t1StaticRegular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t1-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t1-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t1StaticMedium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t1-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t1-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t1StaticBold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t1-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t1-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t2StaticRegular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t2-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t2-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t2StaticMedium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t2-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t2-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t2StaticBold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t2-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t2-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t3StaticRegular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t3StaticMedium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t3StaticBold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t3-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t3-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t4StaticRegular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t4StaticMedium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t4StaticBold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t4-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t4-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t5StaticRegular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t5StaticMedium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t5StaticBold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t5-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t5-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t6StaticRegular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t6-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t6-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t6StaticMedium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t6-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t6-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t6StaticBold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t6-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t6-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t7StaticRegular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t7-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t7-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t7StaticMedium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t7-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t7-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t7StaticBold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t7-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t7-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t8StaticRegular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t8-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t8-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t8StaticMedium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t8-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t8-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t8StaticBold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t8-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t8-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t9StaticRegular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t9-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t9-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t9StaticMedium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t9-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t9-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t9StaticBold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t9-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t9-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t10StaticRegular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t10-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t10-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t10StaticMedium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t10-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t10-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t10StaticBold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t10-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t10-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t11StaticRegular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t11-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t11-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t11StaticMedium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t11-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t11-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t11StaticBold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t11-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t11-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t12StaticRegular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t12-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t12-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t12StaticMedium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t12-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t12-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t12StaticBold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t12-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t12-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t13StaticRegular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t13-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t13-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t13StaticMedium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t13-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t13-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t13StaticBold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t13-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t13-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t14StaticRegular";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t14-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t14-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.regular";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t14StaticMedium";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t14-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t14-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.medium";
+                };
+              };
+            };
+          },
+        ];
+      },
+      {
+        "variants": {
+          "textStyle": "t14StaticBold";
+        };
+        "definitions": readonly [
+          {
+            "states": readonly [
+              "enabled",
+            ];
+            "slots": {
+              "root": {
+                "fontSize": {
+                  "type": "dimension";
+                  "value": "$font-size.t14-static";
+                };
+                "lineHeight": {
+                  "type": "dimension";
+                  "value": "$line-height.t14-static";
+                };
+                "fontWeight": {
+                  "type": "number";
+                  "value": "$font-weight.bold";
+                };
+              };
+            };
+          },
+        ];
+      },
+    ];
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/components/typography.mjs
+++ b/packages/rootage/__generated__/components/typography.mjs
@@ -1,0 +1,2 @@
+import artifact from "./typography.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/dimension.d.ts
+++ b/packages/rootage/__generated__/dimension.d.ts
@@ -1,0 +1,276 @@
+declare const artifact: {
+  "kind": "Tokens";
+  "metadata": {
+    "id": "dimension";
+    "name": "Dimension";
+  };
+  "data": {
+    "collection": "global";
+    "tokens": {
+      "$dimension.x0_5": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 2;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.x1": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 4;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.x1_5": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 6;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.x2": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 8;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.x2_5": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 10;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.x3": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 12;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.x3_5": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 14;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.x4": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 16;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.x4_5": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 18;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.x5": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 20;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.x6": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 24;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.x7": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 28;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.x8": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 32;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.x9": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 36;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.x10": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 40;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.x12": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 48;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.x13": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 52;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.x14": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 56;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.x16": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 64;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$dimension.spacing-x.between-chips": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": "$dimension.x2";
+          };
+        };
+        "description": "Chip 사이의 수평 간격에 사용합니다.";
+      };
+      "$dimension.spacing-x.global-gutter": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": "$dimension.x4";
+          };
+        };
+        "description": "화면 전체에 적용되는 기본 수평 padding 값입니다.";
+      };
+      "$dimension.spacing-y.component-default": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": "$dimension.x3";
+          };
+        };
+        "description": "컴포넌트 간 수직 간격 토큰이 정의되지 않은 컴포넌트 사이의 수직 간격에 사용합니다.";
+      };
+      "$dimension.spacing-y.nav-to-title": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": "$dimension.x5";
+          };
+        };
+        "description": "Top Navigation과 Page Title 사이의 간격입니다.";
+      };
+      "$dimension.spacing-y.screen-bottom": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": "$dimension.x14";
+          };
+        };
+        "description": "화면 하단의 여백입니다.";
+      };
+      "$dimension.spacing-y.between-text": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": "$dimension.x1_5";
+          };
+        };
+        "description": "텍스트 요소 간의 수직 간격입니다.";
+      };
+    };
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/dimension.mjs
+++ b/packages/rootage/__generated__/dimension.mjs
@@ -1,0 +1,2 @@
+import artifact from "./dimension.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/duration.d.ts
+++ b/packages/rootage/__generated__/duration.d.ts
@@ -1,0 +1,96 @@
+declare const artifact: {
+  "kind": "Tokens";
+  "metadata": {
+    "id": "duration";
+    "name": "Duration";
+    "lastUpdated": "25-11-18";
+  };
+  "data": {
+    "collection": "global";
+    "tokens": {
+      "$duration.d1": {
+        "values": {
+          "default": {
+            "type": "duration";
+            "value": {
+              "value": 50;
+              "unit": "ms";
+            };
+          };
+        };
+      };
+      "$duration.d2": {
+        "values": {
+          "default": {
+            "type": "duration";
+            "value": {
+              "value": 100;
+              "unit": "ms";
+            };
+          };
+        };
+      };
+      "$duration.d3": {
+        "values": {
+          "default": {
+            "type": "duration";
+            "value": {
+              "value": 150;
+              "unit": "ms";
+            };
+          };
+        };
+      };
+      "$duration.d4": {
+        "values": {
+          "default": {
+            "type": "duration";
+            "value": {
+              "value": 200;
+              "unit": "ms";
+            };
+          };
+        };
+      };
+      "$duration.d5": {
+        "values": {
+          "default": {
+            "type": "duration";
+            "value": {
+              "value": 250;
+              "unit": "ms";
+            };
+          };
+        };
+      };
+      "$duration.d6": {
+        "values": {
+          "default": {
+            "type": "duration";
+            "value": {
+              "value": 300;
+              "unit": "ms";
+            };
+          };
+        };
+      };
+      "$duration.color-transition": {
+        "values": {
+          "default": {
+            "type": "duration";
+            "value": "$duration.d3";
+          };
+        };
+      };
+      "$duration.pressed-scale": {
+        "values": {
+          "default": {
+            "type": "duration";
+            "value": "$duration.d3";
+          };
+        };
+      };
+    };
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/duration.mjs
+++ b/packages/rootage/__generated__/duration.mjs
@@ -1,0 +1,2 @@
+import artifact from "./duration.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/font-size.d.ts
+++ b/packages/rootage/__generated__/font-size.d.ts
@@ -1,0 +1,339 @@
+declare const artifact: {
+  "kind": "Tokens";
+  "metadata": {
+    "id": "font-size";
+    "name": "Font Size";
+  };
+  "data": {
+    "collection": "global";
+    "tokens": {
+      "$font-size.t1": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 0.6875;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$font-size.t2": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 0.75;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$font-size.t3": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 0.8125;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$font-size.t4": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 0.875;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$font-size.t5": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 1;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$font-size.t6": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 1.125;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$font-size.t7": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 1.25;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$font-size.t8": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 1.375;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$font-size.t9": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 1.5;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$font-size.t10": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 1.625;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$font-size.t11": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 1.75;
+              "unit": "rem";
+            };
+          };
+        };
+        "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+      };
+      "$font-size.t12": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 2;
+              "unit": "rem";
+            };
+          };
+        };
+        "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+      };
+      "$font-size.t13": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 2.5;
+              "unit": "rem";
+            };
+          };
+        };
+        "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+      };
+      "$font-size.t14": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 3;
+              "unit": "rem";
+            };
+          };
+        };
+        "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+      };
+      "$font-size.t1-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 11;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$font-size.t2-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 12;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$font-size.t3-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 13;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$font-size.t4-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 14;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$font-size.t5-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 16;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$font-size.t6-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 18;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$font-size.t7-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 20;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$font-size.t8-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 22;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$font-size.t9-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 24;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$font-size.t10-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 26;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$font-size.t11-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 28;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$font-size.t12-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 32;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$font-size.t13-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 40;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$font-size.t14-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 48;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+    };
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/font-size.mjs
+++ b/packages/rootage/__generated__/font-size.mjs
@@ -1,0 +1,2 @@
+import artifact from "./font-size.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/font-weight.d.ts
+++ b/packages/rootage/__generated__/font-weight.d.ts
@@ -1,0 +1,37 @@
+declare const artifact: {
+  "kind": "Tokens";
+  "metadata": {
+    "id": "font-weight";
+    "name": "Font Weight";
+  };
+  "data": {
+    "collection": "global";
+    "tokens": {
+      "$font-weight.regular": {
+        "values": {
+          "default": {
+            "type": "number";
+            "value": 400;
+          };
+        };
+      };
+      "$font-weight.medium": {
+        "values": {
+          "default": {
+            "type": "number";
+            "value": 500;
+          };
+        };
+      };
+      "$font-weight.bold": {
+        "values": {
+          "default": {
+            "type": "number";
+            "value": 700;
+          };
+        };
+      };
+    };
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/font-weight.mjs
+++ b/packages/rootage/__generated__/font-weight.mjs
@@ -1,0 +1,2 @@
+import artifact from "./font-weight.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/gradient.d.ts
+++ b/packages/rootage/__generated__/gradient.d.ts
@@ -1,0 +1,248 @@
+declare const artifact: {
+  "kind": "Tokens";
+  "metadata": {
+    "id": "gradient";
+    "name": "Gradient";
+    "lastUpdated": "26-01-14";
+  };
+  "data": {
+    "collection": "color";
+    "tokens": {
+      "$gradient.glow-magic": {
+        "values": {
+          "theme-light": {
+            "type": "gradient";
+            "value": readonly [
+              {
+                "color": "#fef6f7";
+                "position": 0;
+              },
+              {
+                "color": "#fef0e7";
+                "position": 0.8;
+              },
+              {
+                "color": "#f9f7f5";
+                "position": 1;
+              },
+            ];
+          };
+          "theme-dark": {
+            "type": "gradient";
+            "value": readonly [
+              {
+                "color": "#2d252d";
+                "position": 0;
+              },
+              {
+                "color": "#3a312b";
+                "position": 0.8;
+              },
+              {
+                "color": "#333232";
+                "position": 1;
+              },
+            ];
+          };
+        };
+        "description": "반짝이는 것처럼 느껴지는 배경에 쓰이는 ai 컬러입니다.";
+      };
+      "$gradient.glow-magic-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "gradient";
+            "value": readonly [
+              {
+                "color": "#fbf0f2";
+                "position": 0;
+              },
+              {
+                "color": "#ffe8db";
+                "position": 0.8;
+              },
+              {
+                "color": "#f5f2ef";
+                "position": 1;
+              },
+            ];
+          };
+          "theme-dark": {
+            "type": "gradient";
+            "value": readonly [
+              {
+                "color": "#3e333e";
+                "position": 0;
+              },
+              {
+                "color": "#51453e";
+                "position": 0.8;
+              },
+              {
+                "color": "#434242";
+                "position": 1;
+              },
+            ];
+          };
+        };
+        "description": "반짝이는 것처럼 느껴지는 배경에 쓰이는 ai 컬러의 pressed컬러입니다.";
+      };
+      "$gradient.highlight-magic": {
+        "values": {
+          "theme-light": {
+            "type": "gradient";
+            "value": readonly [
+              {
+                "color": "#ff6600";
+                "position": 0.2;
+              },
+              {
+                "color": "#d25aca";
+                "position": 1;
+              },
+            ];
+          };
+          "theme-dark": {
+            "type": "gradient";
+            "value": readonly [
+              {
+                "color": "#ff6600";
+                "position": 0.2;
+              },
+              {
+                "color": "#d25aca";
+                "position": 1;
+              },
+            ];
+          };
+        };
+        "description": "아이콘 및 shape 영역에서 AI 기능을 표현할 때 사용하는 컬러입니다.";
+      };
+      "$gradient.highlight-magic-pressed": {
+        "values": {
+          "theme-light": {
+            "type": "gradient";
+            "value": readonly [
+              {
+                "color": "#e14f00";
+                "position": 0.2;
+              },
+              {
+                "color": "#ae58bf";
+                "position": 1;
+              },
+            ];
+          };
+          "theme-dark": {
+            "type": "gradient";
+            "value": readonly [
+              {
+                "color": "#ff9e65";
+                "position": 0.2;
+              },
+              {
+                "color": "#e89bee";
+                "position": 1;
+              },
+            ];
+          };
+        };
+        "description": "";
+      };
+      "$gradient.shimmer-magic": {
+        "values": {
+          "theme-light": {
+            "type": "gradient";
+            "value": readonly [
+              {
+                "color": "#fff9f500";
+                "position": 0;
+              },
+              {
+                "color": "#fff9f5cc";
+                "position": 0.46;
+              },
+              {
+                "color": "#fff9f5cc";
+                "position": 0.54;
+              },
+              {
+                "color": "#fff9f500";
+                "position": 1;
+              },
+            ];
+          };
+          "theme-dark": {
+            "type": "gradient";
+            "value": readonly [
+              {
+                "color": "#fff9f500";
+                "position": 0;
+              },
+              {
+                "color": "#fff9f51a";
+                "position": 0.46;
+              },
+              {
+                "color": "#fff9f51a";
+                "position": 0.54;
+              },
+              {
+                "color": "#fff9f500";
+                "position": 1;
+              },
+            ];
+          };
+        };
+        "description": "Skeleton AI shimmer";
+      };
+      "$gradient.shimmer-neutral": {
+        "values": {
+          "theme-light": {
+            "type": "gradient";
+            "value": readonly [
+              {
+                "color": "#ffffff00";
+                "position": 0;
+              },
+              {
+                "color": "#ffffffab";
+                "position": 0.46;
+              },
+              {
+                "color": "#ffffffab";
+                "position": 0.54;
+              },
+              {
+                "color": "#ffffff00";
+                "position": 1;
+              },
+            ];
+          };
+          "theme-dark": {
+            "type": "gradient";
+            "value": readonly [
+              {
+                "color": "#ffffff00";
+                "position": 0;
+              },
+              {
+                "color": "#ffffff1a";
+                "position": 0.46;
+              },
+              {
+                "color": "#ffffff1a";
+                "position": 0.54;
+              },
+              {
+                "color": "#ffffff00";
+                "position": 1;
+              },
+            ];
+          };
+        };
+        "description": "Skeleton shimmer";
+      };
+    };
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/gradient.mjs
+++ b/packages/rootage/__generated__/gradient.mjs
@@ -1,0 +1,2 @@
+import artifact from "./gradient.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/index.d.ts
+++ b/packages/rootage/__generated__/index.d.ts
@@ -1,0 +1,334 @@
+declare const artifact: {
+  "name": "Rootage";
+  "version": "2.3.0";
+  "resources": readonly [
+    {
+      "path": "/collections.json";
+    },
+    {
+      "path": "/color.json";
+    },
+    {
+      "path": "/components/accordion-item.json";
+    },
+    {
+      "path": "/components/accordion.json";
+    },
+    {
+      "path": "/components/action-button.json";
+    },
+    {
+      "path": "/components/action-chip.json";
+    },
+    {
+      "path": "/components/action-sheet-close-button.json";
+    },
+    {
+      "path": "/components/action-sheet-item.json";
+    },
+    {
+      "path": "/components/action-sheet.json";
+    },
+    {
+      "path": "/components/alert-dialog.json";
+    },
+    {
+      "path": "/components/attachment-input-dropzone.json";
+    },
+    {
+      "path": "/components/attachment-input-item-action-button.json";
+    },
+    {
+      "path": "/components/attachment-input-item-remove-button.json";
+    },
+    {
+      "path": "/components/attachment-input-item.json";
+    },
+    {
+      "path": "/components/attachment-input-trigger.json";
+    },
+    {
+      "path": "/components/attachment-input.json";
+    },
+    {
+      "path": "/components/avatar-stack.json";
+    },
+    {
+      "path": "/components/avatar.json";
+    },
+    {
+      "path": "/components/badge.json";
+    },
+    {
+      "path": "/components/bottom-sheet-close-button.json";
+    },
+    {
+      "path": "/components/bottom-sheet-handle.json";
+    },
+    {
+      "path": "/components/bottom-sheet.json";
+    },
+    {
+      "path": "/components/callout.json";
+    },
+    {
+      "path": "/components/checkbox-group.json";
+    },
+    {
+      "path": "/components/checkbox.json";
+    },
+    {
+      "path": "/components/checkmark.json";
+    },
+    {
+      "path": "/components/chip-tablist.json";
+    },
+    {
+      "path": "/components/chip.json";
+    },
+    {
+      "path": "/components/content-placeholder.json";
+    },
+    {
+      "path": "/components/contextual-floating-button.json";
+    },
+    {
+      "path": "/components/control-chip.json";
+    },
+    {
+      "path": "/components/dialog-close-button.json";
+    },
+    {
+      "path": "/components/dialog.json";
+    },
+    {
+      "path": "/components/divider.json";
+    },
+    {
+      "path": "/components/extended-action-sheet-close-button.json";
+    },
+    {
+      "path": "/components/extended-action-sheet-item.json";
+    },
+    {
+      "path": "/components/extended-action-sheet.json";
+    },
+    {
+      "path": "/components/extended-fab.json";
+    },
+    {
+      "path": "/components/fab.json";
+    },
+    {
+      "path": "/components/field-label.json";
+    },
+    {
+      "path": "/components/field.json";
+    },
+    {
+      "path": "/components/floating-action-button.json";
+    },
+    {
+      "path": "/components/help-bubble.json";
+    },
+    {
+      "path": "/components/identity-placeholder.json";
+    },
+    {
+      "path": "/components/image-frame-floater.json";
+    },
+    {
+      "path": "/components/image-frame-indicator.json";
+    },
+    {
+      "path": "/components/image-frame-reaction-button.json";
+    },
+    {
+      "path": "/components/image-frame.json";
+    },
+    {
+      "path": "/components/inline-banner.json";
+    },
+    {
+      "path": "/components/input-button.json";
+    },
+    {
+      "path": "/components/link-content.json";
+    },
+    {
+      "path": "/components/list-header.json";
+    },
+    {
+      "path": "/components/list-item.json";
+    },
+    {
+      "path": "/components/manner-temp-badge.json";
+    },
+    {
+      "path": "/components/manner-temp.json";
+    },
+    {
+      "path": "/components/menu-item.json";
+    },
+    {
+      "path": "/components/menu-sheet-close-button.json";
+    },
+    {
+      "path": "/components/menu-sheet-item.json";
+    },
+    {
+      "path": "/components/menu-sheet.json";
+    },
+    {
+      "path": "/components/menu.json";
+    },
+    {
+      "path": "/components/notification-badge.json";
+    },
+    {
+      "path": "/components/page-banner.json";
+    },
+    {
+      "path": "/components/progress-circle.json";
+    },
+    {
+      "path": "/components/quantity-picker-button.json";
+    },
+    {
+      "path": "/components/quantity-picker.json";
+    },
+    {
+      "path": "/components/radio-group.json";
+    },
+    {
+      "path": "/components/radio.json";
+    },
+    {
+      "path": "/components/radiomark.json";
+    },
+    {
+      "path": "/components/reaction-button.json";
+    },
+    {
+      "path": "/components/scroll-fog.json";
+    },
+    {
+      "path": "/components/segmented-control-indicator.json";
+    },
+    {
+      "path": "/components/segmented-control-item.json";
+    },
+    {
+      "path": "/components/segmented-control.json";
+    },
+    {
+      "path": "/components/select-box-checkmark.json";
+    },
+    {
+      "path": "/components/select-box-group.json";
+    },
+    {
+      "path": "/components/select-box.json";
+    },
+    {
+      "path": "/components/select-item.json";
+    },
+    {
+      "path": "/components/select-trigger.json";
+    },
+    {
+      "path": "/components/select.json";
+    },
+    {
+      "path": "/components/side-panel-close-button.json";
+    },
+    {
+      "path": "/components/side-panel.json";
+    },
+    {
+      "path": "/components/skeleton.json";
+    },
+    {
+      "path": "/components/slider-thumb.json";
+    },
+    {
+      "path": "/components/slider-tick.json";
+    },
+    {
+      "path": "/components/slider.json";
+    },
+    {
+      "path": "/components/snackbar.json";
+    },
+    {
+      "path": "/components/switch.json";
+    },
+    {
+      "path": "/components/switchmark.json";
+    },
+    {
+      "path": "/components/tab.json";
+    },
+    {
+      "path": "/components/tablist.json";
+    },
+    {
+      "path": "/components/tag-group-item.json";
+    },
+    {
+      "path": "/components/tag-group.json";
+    },
+    {
+      "path": "/components/text-button.json";
+    },
+    {
+      "path": "/components/text-input.json";
+    },
+    {
+      "path": "/components/toggle-button.json";
+    },
+    {
+      "path": "/components/top-navigation-icon-button.json";
+    },
+    {
+      "path": "/components/top-navigation-text-button.json";
+    },
+    {
+      "path": "/components/top-navigation.json";
+    },
+    {
+      "path": "/components/typography.json";
+    },
+    {
+      "path": "/dimension.json";
+    },
+    {
+      "path": "/duration.json";
+    },
+    {
+      "path": "/font-size.json";
+    },
+    {
+      "path": "/font-weight.json";
+    },
+    {
+      "path": "/gradient.json";
+    },
+    {
+      "path": "/line-height.json";
+    },
+    {
+      "path": "/radius.json";
+    },
+    {
+      "path": "/scale.json";
+    },
+    {
+      "path": "/shadow.json";
+    },
+    {
+      "path": "/timing-function.json";
+    },
+  ];
+};
+export default artifact;

--- a/packages/rootage/__generated__/index.mjs
+++ b/packages/rootage/__generated__/index.mjs
@@ -1,0 +1,2 @@
+import artifact from "./index.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/line-height.d.ts
+++ b/packages/rootage/__generated__/line-height.d.ts
@@ -1,0 +1,339 @@
+declare const artifact: {
+  "kind": "Tokens";
+  "metadata": {
+    "id": "line-height";
+    "name": "Line Height";
+  };
+  "data": {
+    "collection": "global";
+    "tokens": {
+      "$line-height.t1": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 0.9375;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$line-height.t2": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 1;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$line-height.t3": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 1.125;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$line-height.t4": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 1.1875;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$line-height.t5": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 1.375;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$line-height.t6": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 1.5;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$line-height.t7": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 1.6875;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$line-height.t8": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 1.875;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$line-height.t9": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 2;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$line-height.t10": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 2.1875;
+              "unit": "rem";
+            };
+          };
+        };
+      };
+      "$line-height.t11": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 2.375;
+              "unit": "rem";
+            };
+          };
+        };
+        "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+      };
+      "$line-height.t12": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 2.625;
+              "unit": "rem";
+            };
+          };
+        };
+        "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+      };
+      "$line-height.t13": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 3.25;
+              "unit": "rem";
+            };
+          };
+        };
+        "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+      };
+      "$line-height.t14": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 3.75;
+              "unit": "rem";
+            };
+          };
+        };
+        "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다.";
+      };
+      "$line-height.t1-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 15;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$line-height.t2-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 16;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$line-height.t3-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 18;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$line-height.t4-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 19;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$line-height.t5-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 22;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$line-height.t6-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 24;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$line-height.t7-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 27;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$line-height.t8-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 30;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$line-height.t9-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 32;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$line-height.t10-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 35;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$line-height.t11-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 38;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$line-height.t12-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 42;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$line-height.t13-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 52;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+      "$line-height.t14-static": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 60;
+              "unit": "px";
+            };
+          };
+        };
+        "description": "`sm` breakpoint 이상에서만 사용하는 것을 권장합니다. 폰트 스케일링에 반응하지 않도록 px로 정의되었습니다.";
+      };
+    };
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/line-height.mjs
+++ b/packages/rootage/__generated__/line-height.mjs
@@ -1,0 +1,2 @@
+import artifact from "./line-height.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/radius.d.ts
+++ b/packages/rootage/__generated__/radius.d.ts
@@ -1,0 +1,134 @@
+declare const artifact: {
+  "kind": "Tokens";
+  "metadata": {
+    "id": "radius";
+    "name": "Radius";
+  };
+  "data": {
+    "collection": "global";
+    "tokens": {
+      "$radius.r0_5": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 2;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$radius.r1": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 4;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$radius.r1_5": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 6;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$radius.r2": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 8;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$radius.r2_5": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 10;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$radius.r3": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 12;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$radius.r3_5": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 14;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$radius.r4": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 16;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$radius.r5": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 20;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$radius.r6": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 24;
+              "unit": "px";
+            };
+          };
+        };
+      };
+      "$radius.full": {
+        "values": {
+          "default": {
+            "type": "dimension";
+            "value": {
+              "value": 9999;
+              "unit": "px";
+            };
+          };
+        };
+      };
+    };
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/radius.mjs
+++ b/packages/rootage/__generated__/radius.mjs
@@ -1,0 +1,2 @@
+import artifact from "./radius.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/scale.d.ts
+++ b/packages/rootage/__generated__/scale.d.ts
@@ -1,0 +1,49 @@
+declare const artifact: {
+  "kind": "Tokens";
+  "metadata": {
+    "id": "scale";
+    "name": "Scale";
+  };
+  "data": {
+    "collection": "motion";
+    "tokens": {
+      "$scale.s95": {
+        "values": {
+          "preferred": {
+            "type": "number";
+            "value": 0.95;
+          };
+          "reduced": {
+            "type": "number";
+            "value": 1;
+          };
+        };
+      };
+      "$scale.s97": {
+        "values": {
+          "preferred": {
+            "type": "number";
+            "value": 0.97;
+          };
+          "reduced": {
+            "type": "number";
+            "value": 1;
+          };
+        };
+      };
+      "$scale.s98": {
+        "values": {
+          "preferred": {
+            "type": "number";
+            "value": 0.98;
+          };
+          "reduced": {
+            "type": "number";
+            "value": 1;
+          };
+        };
+      };
+    };
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/scale.mjs
+++ b/packages/rootage/__generated__/scale.mjs
@@ -1,0 +1,2 @@
+import artifact from "./scale.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/shadow.d.ts
+++ b/packages/rootage/__generated__/shadow.d.ts
@@ -1,0 +1,171 @@
+declare const artifact: {
+  "kind": "Tokens";
+  "metadata": {
+    "id": "shadow";
+    "name": "Shadow";
+    "lastUpdated": "26-01-06";
+  };
+  "data": {
+    "collection": "color";
+    "tokens": {
+      "$shadow.s1": {
+        "values": {
+          "theme-light": {
+            "type": "shadow";
+            "value": readonly [
+              {
+                "color": "#00000014";
+                "offsetX": {
+                  "value": 0;
+                  "unit": "px";
+                };
+                "offsetY": {
+                  "value": 1;
+                  "unit": "px";
+                };
+                "blur": {
+                  "value": 4;
+                  "unit": "px";
+                };
+                "spread": {
+                  "value": 0;
+                  "unit": "px";
+                };
+              },
+            ];
+          };
+          "theme-dark": {
+            "type": "shadow";
+            "value": readonly [
+              {
+                "color": "#00000080";
+                "offsetX": {
+                  "value": 0;
+                  "unit": "px";
+                };
+                "offsetY": {
+                  "value": 1;
+                  "unit": "px";
+                };
+                "blur": {
+                  "value": 4;
+                  "unit": "px";
+                };
+                "spread": {
+                  "value": 0;
+                  "unit": "px";
+                };
+              },
+            ];
+          };
+        };
+      };
+      "$shadow.s2": {
+        "values": {
+          "theme-light": {
+            "type": "shadow";
+            "value": readonly [
+              {
+                "color": "#0000001a";
+                "offsetX": {
+                  "value": 0;
+                  "unit": "px";
+                };
+                "offsetY": {
+                  "value": 2;
+                  "unit": "px";
+                };
+                "blur": {
+                  "value": 10;
+                  "unit": "px";
+                };
+                "spread": {
+                  "value": 0;
+                  "unit": "px";
+                };
+              },
+            ];
+          };
+          "theme-dark": {
+            "type": "shadow";
+            "value": readonly [
+              {
+                "color": "#000000ad";
+                "offsetX": {
+                  "value": 0;
+                  "unit": "px";
+                };
+                "offsetY": {
+                  "value": 2;
+                  "unit": "px";
+                };
+                "blur": {
+                  "value": 10;
+                  "unit": "px";
+                };
+                "spread": {
+                  "value": 0;
+                  "unit": "px";
+                };
+              },
+            ];
+          };
+        };
+      };
+      "$shadow.s3": {
+        "values": {
+          "theme-light": {
+            "type": "shadow";
+            "value": readonly [
+              {
+                "color": "#0000001f";
+                "offsetX": {
+                  "value": 0;
+                  "unit": "px";
+                };
+                "offsetY": {
+                  "value": 4;
+                  "unit": "px";
+                };
+                "blur": {
+                  "value": 16;
+                  "unit": "px";
+                };
+                "spread": {
+                  "value": 0;
+                  "unit": "px";
+                };
+              },
+            ];
+          };
+          "theme-dark": {
+            "type": "shadow";
+            "value": readonly [
+              {
+                "color": "#000000cc";
+                "offsetX": {
+                  "value": 0;
+                  "unit": "px";
+                };
+                "offsetY": {
+                  "value": 4;
+                  "unit": "px";
+                };
+                "blur": {
+                  "value": 16;
+                  "unit": "px";
+                };
+                "spread": {
+                  "value": 0;
+                  "unit": "px";
+                };
+              },
+            ];
+          };
+        };
+        "description": "화면의 다른 요소들보다 가장 높은 계층에 위치할 때 사용됩니다.";
+      };
+    };
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/shadow.mjs
+++ b/packages/rootage/__generated__/shadow.mjs
@@ -1,0 +1,2 @@
+import artifact from "./shadow.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/__generated__/timing-function.d.ts
+++ b/packages/rootage/__generated__/timing-function.d.ts
@@ -1,0 +1,104 @@
+declare const artifact: {
+  "kind": "Tokens";
+  "metadata": {
+    "id": "timing-function";
+    "name": "Timing Function";
+  };
+  "data": {
+    "collection": "global";
+    "tokens": {
+      "$timing-function.linear": {
+        "values": {
+          "default": {
+            "type": "cubicBezier";
+            "value": readonly [
+              0,
+              0,
+              1,
+              1,
+            ];
+          };
+        };
+      };
+      "$timing-function.easing": {
+        "values": {
+          "default": {
+            "type": "cubicBezier";
+            "value": readonly [
+              0.35,
+              0,
+              0.35,
+              1,
+            ];
+          };
+        };
+      };
+      "$timing-function.enter": {
+        "values": {
+          "default": {
+            "type": "cubicBezier";
+            "value": readonly [
+              0,
+              0,
+              0.15,
+              1,
+            ];
+          };
+        };
+      };
+      "$timing-function.exit": {
+        "values": {
+          "default": {
+            "type": "cubicBezier";
+            "value": readonly [
+              0.35,
+              0,
+              1,
+              1,
+            ];
+          };
+        };
+      };
+      "$timing-function.enter-expressive": {
+        "values": {
+          "default": {
+            "type": "cubicBezier";
+            "value": readonly [
+              0.03,
+              0.4,
+              0.1,
+              1,
+            ];
+          };
+        };
+      };
+      "$timing-function.exit-expressive": {
+        "values": {
+          "default": {
+            "type": "cubicBezier";
+            "value": readonly [
+              0.35,
+              0,
+              0.95,
+              0.55,
+            ];
+          };
+        };
+      };
+      "$timing-function.pressed-scale": {
+        "values": {
+          "default": {
+            "type": "cubicBezier";
+            "value": readonly [
+              0,
+              0,
+              0.15,
+              1,
+            ];
+          };
+        };
+      };
+    };
+  };
+};
+export default artifact;

--- a/packages/rootage/__generated__/timing-function.mjs
+++ b/packages/rootage/__generated__/timing-function.mjs
@@ -1,0 +1,2 @@
+import artifact from "./timing-function.json" with { type: "json" };
+export default artifact;

--- a/packages/rootage/package.json
+++ b/packages/rootage/package.json
@@ -8,7 +8,7 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "rootage:generate": "bun rootage json-schema ./components && bun rootage json ./__generated__ && bun rootage json-ts ./__generated__"
+    "rootage:generate": "bun rootage json-schema ./components && bun rootage json-ts ./__generated__"
   },
   "main": "package.json",
   "files": [

--- a/packages/rootage/package.json
+++ b/packages/rootage/package.json
@@ -8,13 +8,15 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "rootage:generate": "bun rootage json-schema ./components && bun rootage json ./__generated__"
+    "rootage:generate": "bun rootage json-schema ./components && bun rootage json ./__generated__ && bun rootage json-ts ./__generated__"
   },
   "main": "package.json",
   "files": [
     "*.yaml",
     "components/*.yaml",
     "__generated__/**/*.json",
+    "__generated__/**/*.mjs",
+    "__generated__/**/*.d.ts",
     "LICENSE",
     "NOTICE"
   ],
@@ -23,7 +25,19 @@
     "./package.json": "./package.json",
     "./index.json": "./__generated__/index.json",
     "./components/*.json": "./__generated__/components/*.json",
-    "./*.json": "./__generated__/*.json"
+    "./*.json": "./__generated__/*.json",
+    "./index": {
+      "types": "./__generated__/index.d.ts",
+      "import": "./__generated__/index.mjs"
+    },
+    "./components/*": {
+      "types": "./__generated__/components/*.d.ts",
+      "import": "./__generated__/components/*.mjs"
+    },
+    "./*": {
+      "types": "./__generated__/*.d.ts",
+      "import": "./__generated__/*.mjs"
+    }
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Rootage가 내보내는 JSON 아티팩트마다 `.mjs` + `.d.ts` 한 쌍을 함께 생성합니다.
확장자를 뗀 경로로 import하면 같은 데이터를, 값이 뭉개지지 않은 채로 읽을 수 있어요.

## 왜 필요한가요

TypeScript는 `.json`을 import할 때 값을 그대로 기억하지 않고 "문자열이다" 정도만 남깁니다.
그래서 Rootage 스펙이 담고 있던 정보 — 이 값이 어떤 토큰을 가리키는지(`$radius.r5`),
어떤 enum 값이 선택됐는지 — 가 recipe에 닿기 전에 사라져요. `definitions`처럼 엔트리마다
모양이 다른 배열은 통째로 하나의 유니온이 돼서, 특정 항목을 꺼내는 것부터 막힙니다.

억지로 꺼내면 `any`가 되는데, 이건 그냥 실패하는 것보다 나쁩니다. `any`에 걸어둔 검사는
전부 통과하면서 실제로는 아무것도 확인해주지 않으니까요.

`.d.ts`를 나란히 두면 TypeScript가 그 선언을 대신 읽습니다. 데이터는 여전히 JSON 한 벌이고,
타입만 정확해져요.

## 무엇이 가능해지나요

Rootage에 얼마 전 추가된 `enum` 프로퍼티 타입(#1881)은 CSS로 옮길 수 없는 결정을 담습니다.
정렬이나 아이콘 위치 같은 것들이요. 이런 값은 커스텀 프로퍼티가 될 수 없어서
`@seed-design/css` 산출물에서는 빠지고, 쓰려는 recipe는 Rootage 스펙을 직접 읽는 수밖에
없습니다.

`menu-sheet-item`이 그 자리에서 기다리고 있어요. 스펙의 `labelAlign=left`와
`labelAlign=center`는 `enabled: {}`로 비어 있고, recipe는 그게 무슨 뜻인지 손으로 적어둔
상태입니다. 둘 사이에 연결이 없어요.

스펙이 `label.textAlign: enum [leading, center]`를 선언하면, 고를 수 있는 값 목록이
그대로 타입으로 넘어옵니다.

```ts
import spec from "@seed-design/rootage-artifacts/components/menu-sheet-item";

type LabelTextAlign =
  (typeof spec.data.schema.slots.label.properties.textAlign.values)[number];
//   ^? "leading" | "center"

const labelAlign = (align: LabelTextAlign) =>
  match(align)
    .with("leading", () => ({ content: { textAlign: "start" } }))
    .with("center", () => ({ root: { justifyContent: "center" },
                             content: { alignItems: "center" } }))
    .exhaustive();
```

여기서 얻는 건 짧은 코드가 아니라 알람입니다. Rootage에 값이 하나 늘어나면 이 자리에서
컴파일이 멈춰서, 그게 화면에서 어떤 모양이어야 하는지 누군가 정하기 전까지 넘어가지 않아요.
지금은 같은 변경이 조용히 지나가고, recipe만 스펙과 다른 말을 하게 됩니다.

enum 값은 `start` 같은 CSS 단어가 아니라 `leading`처럼 플랫폼 중립 어휘로 둡니다. 위
예시에서 보이듯 값 하나가 CSS 속성 여러 개로 퍼지기 때문에 Rootage가 번역까지 대신할 수
없고, CSS 어휘를 고르면 Rootage 포맷 자체가 웹 쪽으로 기울어요.

## 이번 PR에 없는 것

아직 `enum`을 쓰는 스펙이 없어서 소비하는 코드도 없습니다. 첫 스펙을 넣는 건 Rootage가
배포하는 JSON이 바뀌는 일이라 따로 다루고, 이 PR은 그때까지 독립적으로 머지할 수 있는
준비만 담았어요.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 교환 데이터를 위한 TypeScript 선언 파일(`.d.ts`)과 모듈 파일(`.mjs`)을 생성할 수 있습니다.
  * 새로운 CLI 명령으로 JSON, TypeScript 선언 및 모듈 파일을 함께 생성할 수 있습니다.
  * 생성된 타입에서 문자열, 숫자, 불리언, 배열, 객체 등의 리터럴 값이 정확히 반영됩니다.
  * JSON 모듈을 기본 내보내기로 재사용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->