### PR TITLE
fix(figma-extractor)!: upgrade cosmiconfig to 10 for TypeScript 7 support

### DIFF
--- a/.changeset/brave-jars-sing.md
+++ b/.changeset/brave-jars-sing.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/figma-extractor": patch
+---
+
+내부 의존성 `cosmiconfig`를 10으로 올려 TypeScript 7 환경에서 `figma-extractor.config.ts`를 불러오지 못하던 문제를 수정합니다.

--- a/.changeset/brave-jars-sing.md
+++ b/.changeset/brave-jars-sing.md
@@ -2,4 +2,4 @@
 "@seed-design/figma-extractor": major
 ---
 
-(BREAKING CHANGE: Node.js를 22.18 이상 또는 24 이상으로 업그레이드해야 합니다.) 내부 의존성 `cosmiconfig`를 10으로 올려 TypeScript 7 환경에서 `figma-extractor.config.ts`를 불러오지 못하던 문제를 수정합니다.
+내부 의존성 `cosmiconfig`를 10으로 올려 TypeScript 7 환경에서 `figma-extractor.config.ts`를 불러오지 못하던 문제를 수정합니다. Node.js를 22.18 이상 또는 24 이상으로 업그레이드해야 합니다.

--- a/.changeset/brave-jars-sing.md
+++ b/.changeset/brave-jars-sing.md
@@ -1,5 +1,5 @@
 ---
-"@seed-design/figma-extractor": patch
+"@seed-design/figma-extractor": major
 ---
 
-내부 의존성 `cosmiconfig`를 10으로 올려 TypeScript 7 환경에서 `figma-extractor.config.ts`를 불러오지 못하던 문제를 수정합니다.
+(BREAKING CHANGE: Node.js를 22.18 이상 또는 24 이상으로 업그레이드해야 합니다.) 내부 의존성 `cosmiconfig`를 10으로 올려 TypeScript 7 환경에서 `figma-extractor.config.ts`를 불러오지 못하던 문제를 수정합니다.

--- a/bun.lock
+++ b/bun.lock
@@ -146,7 +146,7 @@
         "@figma/rest-api-spec": "0.27.0",
         "cac": "^7.0.0",
         "change-case": "^5.4.4",
-        "cosmiconfig": "^9.0.0",
+        "cosmiconfig": "^10.0.0",
         "dotenv": "^17.0.0",
         "es-toolkit": "^1.35.0",
         "figma-api": "^2.1.2-beta",
@@ -6812,6 +6812,8 @@
     "@seed-design/figma-contrast-checker/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "@seed-design/figma-extractor/@figma/rest-api-spec": ["@figma/rest-api-spec@0.27.0", "", {}, "sha512-jRGYwBLdybit9X7puOmztx8XUt1dq9a7jtBO2KEK4OrxP8GKGX5yY2+efV/XNRHnqTbzFue0qdZklSBs/EaGNw=="],
+
+    "@seed-design/figma-extractor/cosmiconfig": ["cosmiconfig@10.0.0", "", { "dependencies": { "env-paths": "^2.2.1", "js-yaml": "^4.1.0" } }, "sha512-RYs2EfrIoS16yh6j/MLgF753u5rROFFw3XGjcJXM4UQJm1iGXX7gKNyk4O/bCkyfi9Qfo+fVdd3FrnviZv830g=="],
 
     "@seed-design/figma-extractor/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 

--- a/ecosystem/figma-extractor/package.json
+++ b/ecosystem/figma-extractor/package.json
@@ -7,6 +7,9 @@
     "directory": "ecosystem/figma-extractor"
   },
   "license": "Apache-2.0",
+  "engines": {
+    "node": "^22.18 || >= 24"
+  },
   "scripts": {
     "build": "bun build.mjs && tsc",
     "lint:publish": "bun publint"
@@ -33,7 +36,7 @@
     "@figma/rest-api-spec": "0.27.0",
     "cac": "^7.0.0",
     "change-case": "^5.4.4",
-    "cosmiconfig": "^9.0.0",
+    "cosmiconfig": "^10.0.0",
     "dotenv": "^17.0.0",
     "es-toolkit": "^1.35.0",
     "figma-api": "^2.1.2-beta",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * TypeScript 7 환경에서 Figma Extractor 설정 파일이 정상적으로 로드되지 않던 문제를 수정했습니다.
  * 최신 개발 환경에서 설정 파일을 보다 안정적으로 불러올 수 있습니다.

* **호환성**
  * 이번 버전은 Node.js 22.18 이상 또는 Node.js 24 이상이 필요합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->