### PR TITLE
refactor(qvism-preset): derive breakpoints and token CSS selectors from rootage collections

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -542,7 +542,7 @@
         "@seed-design/rootage-core": "0.0.0",
       },
       "devDependencies": {
-        "@seed-design/rootage-artifacts": "workspace:*",
+        "@seed-design/rootage-artifacts": "2.3.0",
         "csstype": "^3.1.3",
       },
     },

--- a/bun.lock
+++ b/bun.lock
@@ -478,6 +478,7 @@
       },
       "devDependencies": {
         "@lynx-js/types": "^3.7.0",
+        "@seed-design/rootage-artifacts": "2.3.0",
       },
     },
     "packages/lynx-react": {

--- a/packages/lynx-qvism-preset/package.json
+++ b/packages/lynx-qvism-preset/package.json
@@ -34,6 +34,7 @@
     "lightningcss": "^1.29.3"
   },
   "devDependencies": {
-    "@lynx-js/types": "^3.7.0"
+    "@lynx-js/types": "^3.7.0",
+    "@seed-design/rootage-artifacts": "2.3.0"
   }
 }

--- a/packages/lynx-qvism-preset/src/seed-css.ts
+++ b/packages/lynx-qvism-preset/src/seed-css.ts
@@ -1,8 +1,19 @@
+import type collections from "@seed-design/rootage-artifacts/collections";
 import { css, type AST } from "@seed-design/rootage-core";
 
 type TokenDeclaration = AST.TokenDeclaration;
 type TokenLit = AST.TokenLit;
 type ValueLit = AST.ValueLit;
+
+/**
+ * Every collection rootage declares, mapped to the selector or at-rule each of
+ * its modes is emitted under.
+ */
+type Selectors = {
+  [C in (typeof collections.data)[number] as C["name"]]: {
+    [M in C["modes"][number]["id"]]: string | null;
+  };
+};
 
 /**
  * Creates a SEED-specific declaration function with Lynx font units.
@@ -86,6 +97,8 @@ export default function generateSeedCss(
 :root.seed-color-mode-dark-only,
 .seed-color-mode-dark-only`,
       },
+      // Lynx has no responsive support, so every viewport mode opts out.
+      "viewport-width": { base: null, sm: null, md: null, lg: null, xl: null },
       motion: {
         preferred: ":root",
         // Lynx does not evaluate `@media (prefers-reduced-motion: reduce)`, so a
@@ -93,7 +106,7 @@ export default function generateSeedCss(
         // out of emission entirely, so motion scales always apply under `:root`.
         reduced: null,
       },
-    },
+    } satisfies Selectors,
     customDeclaration: createSeedDeclaration(),
   };
 

--- a/packages/qvism-preset/package.json
+++ b/packages/qvism-preset/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@seed-design/rootage-artifacts": "workspace:*",
+    "@seed-design/rootage-artifacts": "2.3.0",
     "csstype": "^3.1.3"
   }
 }

--- a/packages/qvism-preset/src/seed-css.ts
+++ b/packages/qvism-preset/src/seed-css.ts
@@ -9,13 +9,6 @@ type ValueLit = AST.ValueLit;
 /**
  * Every collection rootage declares, mapped to the selector or at-rule each of
  * its modes is emitted under.
- *
- * `getTokenCss` throws on a mode it finds no mapping for, so a rootage change
- * already fails the build — but only once the generator runs, and only for the
- * missing half. Restating the shape here moves that to compile time and also
- * catches the direction the runtime cannot see: a collection or mode name that
- * exists here and nowhere in rootage is simply never read, so the throw lands on
- * the entry that was spelled correctly.
  */
 type Selectors = {
   [C in (typeof collections.data)[number] as C["name"]]: {
@@ -117,9 +110,6 @@ export default function generateSeedCss(
 :root[data-seed-color-mode="dark-only"],
 :root [data-seed-color-mode="dark-only"]`,
       },
-      // Spelled out rather than mapped over `breakpointValues`: `Object.fromEntries`
-      // widens to an index signature, which `satisfies` rejects for want of the
-      // named keys.
       "viewport-width": {
         base: ":root",
         sm: breakpoints.up("sm"),

--- a/packages/qvism-preset/src/seed-css.ts
+++ b/packages/qvism-preset/src/seed-css.ts
@@ -1,9 +1,27 @@
+import collections from "@seed-design/rootage-artifacts/collections";
 import { css, type AST } from "@seed-design/rootage-core";
-import { breakpointValues } from "./utils/breakpoint";
+import { breakpoints } from "./utils/breakpoint";
 
 type TokenDeclaration = AST.TokenDeclaration;
 type TokenLit = AST.TokenLit;
 type ValueLit = AST.ValueLit;
+
+/**
+ * Every collection rootage declares, mapped to the selector or at-rule each of
+ * its modes is emitted under.
+ *
+ * `getTokenCss` throws on a mode it finds no mapping for, so a rootage change
+ * already fails the build — but only once the generator runs, and only for the
+ * missing half. Restating the shape here moves that to compile time and also
+ * catches the direction the runtime cannot see: a collection or mode name that
+ * exists here and nowhere in rootage is simply never read, so the throw lands on
+ * the entry that was spelled correctly.
+ */
+type Selectors = {
+  [C in (typeof collections.data)[number] as C["name"]]: {
+    [M in C["modes"][number]["id"]]: string | null;
+  };
+};
 
 /**
  * Creates a SEED-specific declaration function with platform-aware font scaling
@@ -99,17 +117,21 @@ export default function generateSeedCss(
 :root[data-seed-color-mode="dark-only"],
 :root [data-seed-color-mode="dark-only"]`,
       },
-      "viewport-width": Object.fromEntries(
-        Object.entries(breakpointValues).map(([breakpoint, value]) => [
-          breakpoint,
-          value !== 0 ? `@media (min-width: ${value}px)` : ":root",
-        ]),
-      ),
+      // Spelled out rather than mapped over `breakpointValues`: `Object.fromEntries`
+      // widens to an index signature, which `satisfies` rejects for want of the
+      // named keys.
+      "viewport-width": {
+        base: ":root",
+        sm: breakpoints.up("sm"),
+        md: breakpoints.up("md"),
+        lg: breakpoints.up("lg"),
+        xl: breakpoints.up("xl"),
+      },
       motion: {
         preferred: ":root",
         reduced: "@media (prefers-reduced-motion: reduce)",
       },
-    },
+    } satisfies Selectors,
     customDeclaration: createSeedDeclaration(prefix), // Pass prefix to declaration factory
   };
 

--- a/packages/qvism-preset/src/seed-css.ts
+++ b/packages/qvism-preset/src/seed-css.ts
@@ -1,4 +1,4 @@
-import collections from "@seed-design/rootage-artifacts/collections";
+import type collections from "@seed-design/rootage-artifacts/collections";
 import { css, type AST } from "@seed-design/rootage-core";
 import { breakpoints } from "./utils/breakpoint";
 

--- a/packages/qvism-preset/src/utils/breakpoint.ts
+++ b/packages/qvism-preset/src/utils/breakpoint.ts
@@ -2,7 +2,7 @@
 // since qvism-preset cannot depend on @seed-design/css (css is generated from qvism-preset)
 // the names now come from rootage; only the pixel values are still duplicated
 
-import collections from "@seed-design/rootage-artifacts/collections";
+import type collections from "@seed-design/rootage-artifacts/collections";
 
 /**
  * Rootage declares which breakpoints exist, as the modes of its `viewport-width`

--- a/packages/qvism-preset/src/utils/breakpoint.ts
+++ b/packages/qvism-preset/src/utils/breakpoint.ts
@@ -1,15 +1,8 @@
-// Duplicated from packages/css/breakpoints/index.mjs
+// the pixel values are duplicated from packages/css/breakpoints/index.mjs
 // since qvism-preset cannot depend on @seed-design/css (css is generated from qvism-preset)
-// the names now come from rootage; only the pixel values are still duplicated
 
 import type collections from "@seed-design/rootage-artifacts/collections";
 
-/**
- * Rootage declares which breakpoints exist, as the modes of its `viewport-width`
- * collection; it carries no pixel values, so those stay here. The `satisfies`
- * below is what ties the two together — adding, removing or renaming a mode in
- * rootage fails this file until the values follow.
- */
 type Breakpoint = Extract<
   (typeof collections.data)[number],
   { name: "viewport-width" }

--- a/packages/qvism-preset/src/utils/breakpoint.ts
+++ b/packages/qvism-preset/src/utils/breakpoint.ts
@@ -1,6 +1,19 @@
 // Duplicated from packages/css/breakpoints/index.mjs
 // since qvism-preset cannot depend on @seed-design/css (css is generated from qvism-preset)
-// might derive breakpoint names from rootage later
+// the names now come from rootage; only the pixel values are still duplicated
+
+import collections from "@seed-design/rootage-artifacts/collections";
+
+/**
+ * Rootage declares which breakpoints exist, as the modes of its `viewport-width`
+ * collection; it carries no pixel values, so those stay here. The `satisfies`
+ * below is what ties the two together — adding, removing or renaming a mode in
+ * rootage fails this file until the values follow.
+ */
+type Breakpoint = Extract<
+  (typeof collections.data)[number],
+  { name: "viewport-width" }
+>["modes"][number]["id"];
 
 export const breakpointValues = {
   base: 0,
@@ -8,9 +21,9 @@ export const breakpointValues = {
   md: 768,
   lg: 1280,
   xl: 1440,
-} as const;
+} as const satisfies Record<Breakpoint, number>;
 
-type NonBaseBreakpoint = Exclude<keyof typeof breakpointValues, "base">;
+type NonBaseBreakpoint = Exclude<Breakpoint, "base">;
 
 export const breakpoints = {
   up: <T extends NonBaseBreakpoint>(name: T) =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **개선**
  - 반응형 화면에 사용되는 뷰포트별 브레이크포인트 기준을 표준화했습니다.
  - 화면 너비별 스타일 설정의 일관성과 검증을 강화해 다양한 기기에서 안정적인 레이아웃을 제공합니다.
  - 뷰포트 크기에 따른 스타일 적용을 명확히 정비해 화면 전환 시 표시 품질을 개선했습니다.
  - 지원되지 않는 화면 크기 설정이 잘못 생성되지 않도록 관련 출력을 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->