### PR TITLE
feat(mcp): support export_node_as_image in REST mode

### DIFF
--- a/.changeset/smooth-donkeys-repeat.md
+++ b/.changeset/smooth-donkeys-repeat.md
@@ -1,0 +1,9 @@
+---
+"@seed-design/mcp": minor
+---
+
+`export_node_as_image`가 Figma 앱과 웹소켓 서버 없이 REST 모드에서도 작동하도록 업데이트합니다.
+
+- `format` 파라미터에서 주요 LLM 도구가 이미지로 판단하지 않는 `PDF`를 제거합니다.
+- `format` 파라미터에서 `SVG`를 제거합니다.
+- `scale` 파라미터의 스키마를 Figma REST API 제약에 맞춰 0.01 이상 4 이하로 제한합니다.

--- a/docs/content/ai-integration/(mcp)/figma-mcp.mdx
+++ b/docs/content/ai-integration/(mcp)/figma-mcp.mdx
@@ -327,6 +327,7 @@ Figma URL 또는 `fileKey` + `nodeId`를 전달하면 REST API로, `nodeId`만 �
 | `get_node_react_code`           | 레이어의 React 코드를 생성합니다.             |
 | `get_component_info`            | 컴포넌트의 key와 속성 정의를 반환합니다.      |
 | `find_nodes`                   | 하위 레이어를 이름(정규식)으로 검색하여 ID 목록을 반환합니다. |
+| `export_node_as_image`          | 레이어를 이미지(PNG, JPG)로 렌더링해 반환합니다. |
 | `retrieve_color_variable_names` | SEED 색상 변수 이름 목록을 반환합니다. |
 
 ### WebSocket 전용
@@ -337,7 +338,6 @@ Figma 플러그인과 통신이 필요합니다. `websocket` 또는 `all` 모드
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | `get_selection`        | 현재 선택한 레이어의 ID를 반환합니다.                                                                                              |
 | `get_document_info`    | 현재 열린 Figma 문서의 정보를 반환합니다.                                                                                          |
-| `export_node_as_image` | 레이어를 이미지(PNG, JPG, SVG, PDF)로 내보냅니다.                                                                                  |
 | `add_annotations`      | 레이어에 [Annotation](https://help.figma.com/hc/en-us/articles/20774752502935-Add-measurements-and-annotate-designs)을 추가합니다. |
 | `get_annotations`      | 레이어의 Annotation을 가져옵니다.                                                                                                  |
 | `join_channel`         | 특정 채널에 참가합니다.                                                                                                            |

--- a/packages/mcp/AGENTS.md
+++ b/packages/mcp/AGENTS.md
@@ -30,7 +30,7 @@
 ## 파일 작성 컨벤션
 
 - `src/tools.ts`: MCP 도구 정의 및 핸들러 (`registerTools`, `registerEditingTools`)
-- `src/tools-helpers.ts`: 도구 공통 헬퍼 (`fetchNodeData`, `fetchMultipleNodesData`, `ToolMode`)
+- `src/tools-helpers.ts`: 도구 공통 헬퍼 (`fetchNodeData`, `fetchMultipleNodesData`, `fetchNodeImage`, `ToolMode`)
 - `src/figma-rest-client.ts`: Figma REST API 클라이언트
 - `src/websocket.ts`: Figma Plugin WebSocket 클라이언트
 - `src/responses.ts`: 응답 포맷팅 유틸리티

--- a/packages/mcp/src/figma-rest-client.ts
+++ b/packages/mcp/src/figma-rest-client.ts
@@ -1,8 +1,13 @@
 import { Api as FigmaApi } from "figma-api";
-import type { GetFileNodesResponse } from "@figma/rest-api-spec";
+import type { GetFileNodesResponse, GetImagesQueryParams } from "@figma/rest-api-spec";
 
 export interface FigmaRestClient {
   getFileNodes(fileKey: string, nodeIds: string[]): Promise<GetFileNodesResponse>;
+  getNodeImageUrl(
+    fileKey: string,
+    nodeId: string,
+    options: Pick<GetImagesQueryParams, "format" | "scale">,
+  ): Promise<string>;
 }
 
 export function createFigmaRestClient(personalAccessToken: string): FigmaRestClient {
@@ -13,6 +18,23 @@ export function createFigmaRestClient(personalAccessToken: string): FigmaRestCli
       const response = await api.getFileNodes({ file_key: fileKey }, { ids: nodeIds.join(",") });
 
       return response;
+    },
+
+    async getNodeImageUrl(fileKey, nodeId, { format, scale }) {
+      const response = await api.getImages({ file_key: fileKey }, { ids: nodeId, format, scale });
+
+      // The `images` map is keyed by the requested id, but Figma normalizes `:` to `-` in some
+      // responses, so a direct lookup can miss even though exactly one node was requested.
+      const imageUrl = response.images[nodeId] ?? Object.values(response.images)[0];
+
+      // Figma documents a null entry as "rendering of that specific node has failed", either
+      // because the id does not exist or because the node has no renderable components.
+      if (!imageUrl)
+        throw new Error(
+          `Figma failed to render node ${nodeId}. Either the node does not exist in file ${fileKey}, or it has nothing renderable.`,
+        );
+
+      return imageUrl;
     },
   };
 }

--- a/packages/mcp/src/tools-helpers.ts
+++ b/packages/mcp/src/tools-helpers.ts
@@ -1,4 +1,4 @@
-import type { GetFileNodesResponse } from "@figma/rest-api-spec";
+import type { GetFileNodesResponse, GetImagesQueryParams } from "@figma/rest-api-spec";
 import type { FigmaRestClient } from "./figma-rest-client";
 import { createFigmaRestClient } from "./figma-rest-client";
 import type { FigmaWebSocketClient } from "./websocket";
@@ -98,6 +98,68 @@ export async function fetchMultipleNodesData(
     );
 
     return results;
+  }
+
+  throw new Error(
+    "No connection available. Provide figmaUrl/fileKey with personalAccessToken or FIGMA_PERSONAL_ACCESS_TOKEN, or use WebSocket mode with Figma Plugin.",
+  );
+}
+
+export const IMAGE_FORMATS = ["PNG", "JPG"] as const;
+
+export type ImageFormat = (typeof IMAGE_FORMATS)[number];
+
+/**
+ * The plugin names formats in upper case and the REST API in lower case, so every format needs
+ * both spellings plus the MIME type the tool reports back.
+ */
+const IMAGE_FORMAT = {
+  PNG: { restFormat: "png", mimeType: "image/png" },
+  JPG: { restFormat: "jpg", mimeType: "image/jpeg" },
+} as const satisfies Record<
+  ImageFormat,
+  { restFormat: NonNullable<GetImagesQueryParams["format"]>; mimeType: string }
+>;
+
+export async function fetchNodeImage(
+  params: {
+    fileKey?: string;
+    nodeId: string;
+    personalAccessToken?: string;
+    format: ImageFormat;
+    scale: number;
+  },
+  context: ToolContext,
+) {
+  const { fileKey, nodeId, personalAccessToken, format, scale } = params;
+  const { restFormat, mimeType } = IMAGE_FORMAT[format];
+  const restClient = resolveRestClient(personalAccessToken, context);
+  const { sendCommandToFigma } = context;
+
+  if (restClient && fileKey) {
+    const imageUrl = await restClient.getNodeImageUrl(fileKey, nodeId, {
+      format: restFormat,
+      scale,
+    });
+    const response = await fetch(imageUrl);
+
+    if (!response.ok)
+      throw new Error(`Image download failed: ${response.status} ${response.statusText}`);
+
+    return {
+      base64: Buffer.from(await response.arrayBuffer()).toString("base64"),
+      mimeType,
+    };
+  }
+
+  if (sendCommandToFigma) {
+    const result = (await sendCommandToFigma("export_node_as_image", {
+      nodeId,
+      format,
+      scale,
+    })) as { base64: string };
+
+    return { base64: result.base64, mimeType };
   }
 
   throw new Error(

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -21,7 +21,10 @@ import {
   createToolContext,
   fetchMultipleNodesData,
   fetchNodeData,
+  fetchNodeImage,
+  IMAGE_FORMATS,
   requireWebSocket,
+  type ImageFormat,
   type ToolMode,
 } from "./tools-helpers";
 import type { FigmaWebSocketClient } from "./websocket";
@@ -368,6 +371,36 @@ export function registerTools(
     },
   );
 
+  // Export Node as Image Tool (REST API + WebSocket)
+  server.registerTool(
+    "export_node_as_image",
+    {
+      description: getSingleNodeDescription(
+        "Render a Figma node as an image and return it inline. Use it to see what a node actually looks like, e.g. to compare generated UI against the design.",
+        mode,
+      ),
+      inputSchema: singleNodeParamsSchema.extend({
+        format: z.enum(IMAGE_FORMATS).default("PNG").describe("Export format"),
+        scale: z.number().min(0.01).max(4).default(1).describe("Render scale between 0.01 and 4"),
+      }),
+    },
+    async (
+      params: z.infer<typeof singleNodeBaseSchema> & { format: ImageFormat; scale: number },
+    ) => {
+      try {
+        const { fileKey, nodeId, personalAccessToken } = resolveSingleNodeParams(params);
+        const { base64, mimeType } = await fetchNodeImage(
+          { fileKey, nodeId, personalAccessToken, format: params.format, scale: params.scale },
+          context,
+        );
+
+        return formatImageResponse(base64, mimeType);
+      } catch (error) {
+        return formatErrorResponse("export_node_as_image", error);
+      }
+    },
+  );
+
   // Utility Tools (No Figma connection required)
 
   // Retrieve Color Variable Names Tool
@@ -516,34 +549,6 @@ export function registerTools(
           return formatObjectResponse(result);
         } catch (error) {
           return formatErrorResponse("get_annotations", error);
-        }
-      },
-    );
-
-    // Export Node as Image Tool
-    server.registerTool(
-      "export_node_as_image",
-      {
-        description: "Export a node as an image from Figma (WebSocket mode only)",
-        inputSchema: z.object({
-          nodeId: z.string().describe("The ID of the node to export"),
-          format: z.enum(["PNG", "JPG", "SVG", "PDF"]).optional().describe("Export format"),
-          scale: z.number().positive().optional().describe("Export scale"),
-        }),
-      },
-      async ({ nodeId, format, scale }) => {
-        try {
-          requireWebSocket(context);
-          const result = await context.sendCommandToFigma("export_node_as_image", {
-            nodeId,
-            format: format || "PNG",
-            scale: scale || 1,
-          });
-
-          const typedResult = result as { base64: string; mimeType: string };
-          return formatImageResponse(typedResult.base64, typedResult.mimeType || "image/png");
-        } catch (error) {
-          return formatErrorResponse("export_node_as_image", error);
         }
       },
     );

--- a/tools/figma-mcp/src/main/commands/export.ts
+++ b/tools/figma-mcp/src/main/commands/export.ts
@@ -1,7 +1,22 @@
 import { customBase64Encode } from "../utils/base64";
 
+const MIME_TYPE = {
+  PNG: "image/png",
+  JPG: "image/jpeg",
+} as const;
+
+function resolveFormat(format: unknown): keyof typeof MIME_TYPE {
+  // `@seed-design/mcp` releases before 2.2 offered SVG and PDF, which this command never honoured
+  // — it always exported PNG. Those clients label the response from their own request, so handing
+  // them real SVG bytes would leave the payload contradicting its `mimeType`.
+  if (format === "JPG") return "JPG";
+
+  return "PNG";
+}
+
 export interface ExportNodeParams {
   nodeId: string;
+  format?: string;
   scale?: number;
 }
 
@@ -13,6 +28,7 @@ export interface ExportNodeResult {
 
 export async function exportNodeAsImage(params: ExportNodeParams): Promise<ExportNodeResult> {
   const { nodeId, scale = 1 } = params || {};
+  const format = resolveFormat(params?.format);
 
   if (!nodeId) {
     throw new Error("Node ID is required");
@@ -26,7 +42,7 @@ export async function exportNodeAsImage(params: ExportNodeParams): Promise<Expor
   try {
     // Create export settings
     const settings: ExportSettings = {
-      format: "PNG",
+      format,
       constraint: {
         type: "SCALE",
         value: scale,
@@ -43,15 +59,13 @@ export async function exportNodeAsImage(params: ExportNodeParams): Promise<Expor
 
     const bytes = await exportableNode.exportAsync(settings);
 
-    const mimeType = "image/png";
-
     // Encode to base64
     const base64 = customBase64Encode(bytes);
 
     return {
       id: node.id,
       base64,
-      mimeType,
+      mimeType: MIME_TYPE[format],
     };
   } catch (error) {
     throw new Error(


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * `export_node_as_image`가 REST 및 WebSocket 방식에서 모두 지원됩니다.
  * 노드를 PNG 또는 JPG 이미지로 내보낼 수 있습니다.
  * 이미지 배율을 0.01~4 범위에서 지정할 수 있습니다.
  * 이미지 내보내기 결과가 표준 이미지 응답으로 제공됩니다.

* **변경 사항**
  * 이미지 내보내기 형식에서 PDF와 SVG 지원이 제거되었습니다.

* **문서**
  * 공통 도구 목록에 이미지 내보내기 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->