### PR TITLE
feat(mcp): add export_node_as_svg for SVG markup as text

### DIFF
--- a/.changeset/eager-moons-attend.md
+++ b/.changeset/eager-moons-attend.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/figma-extractor": patch
+---
+
+`figma-api` 의존성을 업데이트합니다.

--- a/.changeset/olive-eels-shave.md
+++ b/.changeset/olive-eels-shave.md
@@ -2,12 +2,9 @@
 "@seed-design/mcp": minor
 ---
 
-레이어를 SVG 마크업으로 받는 `export_node_as_svg` 툴을 추가합니다.
+특정 레이어의 SVG 마크업을 받아오는 `export_node_as_svg` 툴을 추가합니다. `export_node_as_image`의 format `SVG` 파라미터를 대체합니다.
 
-`export_node_as_image`에서 빠진 SVG를 별도 툴로 분리했습니다. SVG를 이미지 응답으로 내려주면 주요 LLM 도구가 렌더하지 못하고 조용히 버리기 때문에, 텍스트로 반환해야 에이전트가 실제로 읽을 수 있습니다. path 데이터나 viewBox 원본이 필요한 벡터 아트워크에 쓰세요. REST 모드와 WebSocket 모드 양쪽에서 동작합니다.
+- REST 및 WebSocket 모드 모두에서 사용할 수 있습니다.
+- `outlineText` 파라미터를 사용하여 텍스트 레이어를 vector path로 변환할지 정합니다. Figma API 기본값은 `true`지만 이 도구의 기본값은 응답 크기 최적화를 위해 `false`입니다.
 
-`outlineText`는 텍스트를 vector path로 변환할지 정합니다. Figma 기본값은 `true`지만 이 툴은 `false`를 기본으로 씁니다. 텍스트가 `<text>`로 남아야 응답이 작고 읽을 수 있기 때문입니다. Figma와 픽셀 단위로 같아야 할 때만 `true`로 지정하세요.
-
-WebSocket 모드에서는 Figma 플러그인도 최신 버전이어야 합니다.
-
-REST 모드가 `outlineText`를 제대로 전달하려면 `figma-api` 2.1.4-beta 이상이 필요해 의존성을 올렸습니다. 그 이전 버전은 값이 `false`인 쿼리 파라미터를 요청에서 빠뜨립니다.
+`figma-api` 의존성을 업데이트합니다.

--- a/.changeset/olive-eels-shave.md
+++ b/.changeset/olive-eels-shave.md
@@ -1,0 +1,11 @@
+---
+"@seed-design/mcp": minor
+---
+
+레이어를 SVG 마크업으로 받는 `export_node_as_svg` 툴을 추가합니다.
+
+`export_node_as_image`에서 빠진 SVG를 별도 툴로 분리했습니다. SVG를 이미지 응답으로 내려주면 주요 LLM 도구가 렌더하지 못하고 조용히 버리기 때문에, 텍스트로 반환해야 에이전트가 실제로 읽을 수 있습니다. path 데이터나 viewBox 원본이 필요한 벡터 아트워크에 쓰세요. REST 모드와 WebSocket 모드 양쪽에서 동작합니다.
+
+`outlineText`는 텍스트를 vector path로 변환할지 정합니다. Figma 기본값은 `true`지만 이 툴은 `false`를 기본으로 씁니다. 텍스트가 `<text>`로 남아야 응답이 작고 읽을 수 있기 때문입니다. Figma와 픽셀 단위로 같아야 할 때만 `true`로 지정하세요.
+
+WebSocket 모드에서는 Figma 플러그인도 최신 버전이어야 합니다.

--- a/.changeset/olive-eels-shave.md
+++ b/.changeset/olive-eels-shave.md
@@ -9,3 +9,5 @@
 `outlineText`는 텍스트를 vector path로 변환할지 정합니다. Figma 기본값은 `true`지만 이 툴은 `false`를 기본으로 씁니다. 텍스트가 `<text>`로 남아야 응답이 작고 읽을 수 있기 때문입니다. Figma와 픽셀 단위로 같아야 할 때만 `true`로 지정하세요.
 
 WebSocket 모드에서는 Figma 플러그인도 최신 버전이어야 합니다.
+
+REST 모드가 `outlineText`를 제대로 전달하려면 `figma-api` 2.1.4-beta 이상이 필요해 의존성을 올렸습니다. 그 이전 버전은 값이 `false`인 쿼리 파라미터를 요청에서 빠뜨립니다.

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/bun": "^1.3.8",
         "bunchee": "^6.5.1",
-        "figma-api": "^2.1.2-beta",
+        "figma-api": "2.1.4-beta",
         "knip": "^6.0.0",
         "publint": "^0.3.12",
         "typescript": "^6.0.3",
@@ -120,7 +120,7 @@
         "chalk": "^5.3.0",
         "chromatic": "^17.0.0",
         "concurrently": "^9.2.1",
-        "figma-api": "^2.1.2-beta",
+        "figma-api": "2.1.4-beta",
         "flat-cache": "^6.1.19",
         "gray-matter": "^4.0.3",
         "mdast-util-mdx-jsx": "^3.2.0",
@@ -149,7 +149,7 @@
         "cosmiconfig": "^9.0.0",
         "dotenv": "^17.0.0",
         "es-toolkit": "^1.35.0",
-        "figma-api": "^2.1.2-beta",
+        "figma-api": "2.1.4-beta",
         "fs-extra": "^11.3.0",
         "zod": "^3.24.3",
       },
@@ -514,7 +514,7 @@
         "@modelcontextprotocol/server": "^2.0.0",
         "@seed-design/figma": "2.1.0",
         "cac": "^7.0.0",
-        "figma-api": "^2.1.2-beta",
+        "figma-api": "2.1.4-beta",
         "uuid": "^14.0.0",
         "ws": "^8.18.1",
         "yargs": "^18.0.0",
@@ -3692,7 +3692,7 @@
 
     "adm-zip": ["adm-zip@0.5.16", "", {}, "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ=="],
 
-    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
@@ -3774,7 +3774,7 @@
 
     "aws4": ["aws4@1.13.2", "", {}, "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="],
 
-    "axios": ["axios@1.15.0", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q=="],
+    "axios": ["axios@1.19.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.6", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw=="],
 
     "b4a": ["b4a@1.7.3", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q=="],
 
@@ -4428,7 +4428,7 @@
 
     "fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
-    "figma-api": ["figma-api@2.1.2-beta", "", { "dependencies": { "@figma/rest-api-spec": "^0.27.0", "axios": "^1.13.5" } }, "sha512-5p5CIqnxa0ynLC5B2ZItHG1Byp2b64YzHw6Uz4CheogDFWmzGrzb53y8Bu0rU2fq1UdAqYxScvZ3jKotmCIwgg=="],
+    "figma-api": ["figma-api@2.1.4-beta", "", { "dependencies": { "@figma/rest-api-spec": "^0.27.0", "axios": "^1.15.2" } }, "sha512-lWb7w/5boGR0fPVlkF+CMlbG8CAczl1bE6tnH7i0Uh2TmDbwLSWms0ASzSqo7GjsUynHnCbMj0tPpeBTKOQF/Q=="],
 
     "figma-mcp": ["figma-mcp@workspace:tools/figma-mcp"],
 
@@ -4474,7 +4474,7 @@
 
     "focus-lock": ["focus-lock@1.3.6", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg=="],
 
-    "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
+    "follow-redirects": ["follow-redirects@1.16.0", "", { "peerDependencies": { "debug": "*" }, "optionalPeers": ["debug"] }, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
@@ -4692,7 +4692,7 @@
 
     "https-browserify": ["https-browserify@1.0.0", "", {}, "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg=="],
 
-    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "human-id": ["human-id@4.1.2", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-v/J+4Z/1eIJovEBdlV5TYj1IR+ZiohcYGRY+qN/oC9dAfKzVT023N/Bgw37hrKCoVRBvk3bqyzpr2PP5YeTMSg=="],
 
@@ -6702,6 +6702,8 @@
 
     "@rsbuild/plugin-check-syntax/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
+    "@rsdoctor/core/axios": ["axios@1.15.0", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q=="],
+
     "@rsdoctor/core/enhanced-resolve": ["enhanced-resolve@5.12.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ=="],
 
     "@rsdoctor/core/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
@@ -6888,6 +6890,8 @@
 
     "asn1.js/bn.js": ["bn.js@4.12.2", "", {}, "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="],
 
+    "axios/form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
+
     "babel-loader/find-cache-dir": ["find-cache-dir@4.0.0", "", { "dependencies": { "common-path-prefix": "^3.0.0", "pkg-dir": "^7.0.0" } }, "sha512-9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg=="],
 
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -7034,6 +7038,8 @@
 
     "fumadocs-ui/shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
 
+    "get-it/follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
+
     "get-uri/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "get-uri/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
@@ -7071,6 +7077,10 @@
     "htmlparser2/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 
     "http-proxy/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
+    "http-proxy/follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
+
+    "http-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "http-proxy-middleware/is-plain-obj": ["is-plain-obj@3.0.0", "", {}, "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA=="],
 
@@ -7526,6 +7536,8 @@
 
     "@rsbuild/plugin-check-syntax/htmlparser2/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
+    "@rsdoctor/core/axios/follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
+
     "@rsdoctor/sdk/open/define-lazy-prop": ["define-lazy-prop@2.0.0", "", {}, "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="],
 
     "@rushstack/node-core-library/ajv-formats/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
@@ -7677,6 +7689,8 @@
     "@vue/language-core/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "archiver-utils/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "axios/form-data/hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "babel-loader/find-cache-dir/pkg-dir": ["pkg-dir@7.0.0", "", { "dependencies": { "find-up": "^6.3.0" } }, "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA=="],
 
@@ -7868,6 +7882,8 @@
 
     "isomorphic-dompurify/jsdom/html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
 
+    "isomorphic-dompurify/jsdom/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
     "isomorphic-dompurify/jsdom/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "isomorphic-dompurify/jsdom/tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
@@ -7999,6 +8015,8 @@
     "sanity/jsdom/data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
 
     "sanity/jsdom/html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
+
+    "sanity/jsdom/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "sanity/jsdom/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
@@ -8224,6 +8242,8 @@
 
     "inquirer/@inquirer/prompts/@inquirer/select/@inquirer/figures": ["@inquirer/figures@1.0.15", "", {}, "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g=="],
 
+    "isomorphic-dompurify/jsdom/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "isomorphic-dompurify/jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "isomorphic-dompurify/jsdom/tough-cookie/tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
@@ -8277,6 +8297,8 @@
     "rollup-plugin-visualizer/open/wsl-utils/is-wsl": ["is-wsl@3.1.0", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw=="],
 
     "sanity/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "sanity/jsdom/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "sanity/jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 

--- a/docs/content/ai-integration/(mcp)/figma-mcp.mdx
+++ b/docs/content/ai-integration/(mcp)/figma-mcp.mdx
@@ -328,6 +328,7 @@ Figma URL 또는 `fileKey` + `nodeId`를 전달하면 REST API로, `nodeId`만 �
 | `get_component_info`            | 컴포넌트의 key와 속성 정의를 반환합니다.      |
 | `find_nodes`                   | 하위 레이어를 이름(정규식)으로 검색하여 ID 목록을 반환합니다. |
 | `export_node_as_image`          | 레이어를 이미지(PNG, JPG)로 렌더링해 반환합니다. |
+| `export_node_as_svg`            | 레이어를 SVG 마크업(텍스트)으로 반환합니다. |
 | `retrieve_color_variable_names` | SEED 색상 변수 이름 목록을 반환합니다. |
 
 ### WebSocket 전용

--- a/docs/package.json
+++ b/docs/package.json
@@ -110,7 +110,7 @@
     "chalk": "^5.3.0",
     "chromatic": "^17.0.0",
     "concurrently": "^9.2.1",
-    "figma-api": "^2.1.2-beta",
+    "figma-api": "2.1.4-beta",
     "flat-cache": "^6.1.19",
     "gray-matter": "^4.0.3",
     "mdast-util-mdx-jsx": "^3.2.0",

--- a/ecosystem/figma-extractor/package.json
+++ b/ecosystem/figma-extractor/package.json
@@ -36,7 +36,7 @@
     "cosmiconfig": "^9.0.0",
     "dotenv": "^17.0.0",
     "es-toolkit": "^1.35.0",
-    "figma-api": "^2.1.2-beta",
+    "figma-api": "2.1.4-beta",
     "fs-extra": "^11.3.0",
     "zod": "^3.24.3"
   },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/bun": "^1.3.8",
     "bunchee": "^6.5.1",
-    "figma-api": "^2.1.2-beta",
+    "figma-api": "2.1.4-beta",
     "knip": "^6.0.0",
     "publint": "^0.3.12",
     "typescript": "^6.0.3",

--- a/packages/mcp/AGENTS.md
+++ b/packages/mcp/AGENTS.md
@@ -30,7 +30,7 @@
 ## 파일 작성 컨벤션
 
 - `src/tools.ts`: MCP 도구 정의 및 핸들러 (`registerTools`, `registerEditingTools`)
-- `src/tools-helpers.ts`: 도구 공통 헬퍼 (`fetchNodeData`, `fetchMultipleNodesData`, `fetchNodeImage`, `ToolMode`)
+- `src/tools-helpers.ts`: 도구 공통 헬퍼 (`fetchNodeData`, `fetchMultipleNodesData`, `fetchNodeImage`, `fetchNodeSvg`, `ToolMode`)
 - `src/figma-rest-client.ts`: Figma REST API 클라이언트
 - `src/websocket.ts`: Figma Plugin WebSocket 클라이언트
 - `src/responses.ts`: 응답 포맷팅 유틸리티

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -37,7 +37,7 @@
     "@modelcontextprotocol/server": "^2.0.0",
     "@seed-design/figma": "2.1.0",
     "cac": "^7.0.0",
-    "figma-api": "^2.1.2-beta",
+    "figma-api": "2.1.4-beta",
     "uuid": "^14.0.0",
     "ws": "^8.18.1",
     "yargs": "^18.0.0",

--- a/packages/mcp/src/figma-rest-client.ts
+++ b/packages/mcp/src/figma-rest-client.ts
@@ -1,9 +1,5 @@
-import { API_DOMAIN, API_VER, Api as FigmaApi } from "figma-api";
-import type {
-  GetFileNodesResponse,
-  GetImagesQueryParams,
-  GetImagesResponse,
-} from "@figma/rest-api-spec";
+import { Api as FigmaApi } from "figma-api";
+import type { GetFileNodesResponse, GetImagesQueryParams } from "@figma/rest-api-spec";
 
 export interface FigmaRestClient {
   getFileNodes(fileKey: string, nodeIds: string[]): Promise<GetFileNodesResponse>;
@@ -25,22 +21,9 @@ export function createFigmaRestClient(personalAccessToken: string): FigmaRestCli
     },
 
     async getNodeImageUrl(fileKey, nodeId, options) {
-      // `api.getImages` builds its query with figma-api's `toQueryParams`, which keeps an entry
-      // only when the value is truthy — so `svg_outline_text: false` is dropped and Figma applies
-      // its own default of `true`. Building the query here and going through the underlying
-      // `request` keeps the auth headers and error handling while serializing falsy values.
-      const query = new URLSearchParams({
-        ids: nodeId,
-        ...Object.fromEntries(
-          Object.entries(options)
-            .filter(([_, value]) => value !== undefined)
-            .map(([key, value]) => [key, String(value)]),
-        ),
-      });
-
-      const response = await api.request<GetImagesResponse>(
-        `${API_DOMAIN}/${API_VER}/images/${fileKey}?${query}`,
-      );
+      // Needs figma-api >= 2.1.4-beta: earlier releases drop a falsy query param, which silently
+      // turned `svg_outline_text: false` into Figma's own default of `true`.
+      const response = await api.getImages({ file_key: fileKey }, { ids: nodeId, ...options });
 
       // The `images` map is keyed by the requested id, but Figma normalizes `:` to `-` in some
       // responses, so a direct lookup can miss even though exactly one node was requested.

--- a/packages/mcp/src/figma-rest-client.ts
+++ b/packages/mcp/src/figma-rest-client.ts
@@ -6,7 +6,7 @@ export interface FigmaRestClient {
   getNodeImageUrl(
     fileKey: string,
     nodeId: string,
-    options: Pick<GetImagesQueryParams, "format" | "scale">,
+    options: Omit<GetImagesQueryParams, "ids">,
   ): Promise<string>;
 }
 
@@ -20,8 +20,8 @@ export function createFigmaRestClient(personalAccessToken: string): FigmaRestCli
       return response;
     },
 
-    async getNodeImageUrl(fileKey, nodeId, { format, scale }) {
-      const response = await api.getImages({ file_key: fileKey }, { ids: nodeId, format, scale });
+    async getNodeImageUrl(fileKey, nodeId, options) {
+      const response = await api.getImages({ file_key: fileKey }, { ids: nodeId, ...options });
 
       // The `images` map is keyed by the requested id, but Figma normalizes `:` to `-` in some
       // responses, so a direct lookup can miss even though exactly one node was requested.

--- a/packages/mcp/src/figma-rest-client.ts
+++ b/packages/mcp/src/figma-rest-client.ts
@@ -1,5 +1,9 @@
-import { Api as FigmaApi } from "figma-api";
-import type { GetFileNodesResponse, GetImagesQueryParams } from "@figma/rest-api-spec";
+import { API_DOMAIN, API_VER, Api as FigmaApi } from "figma-api";
+import type {
+  GetFileNodesResponse,
+  GetImagesQueryParams,
+  GetImagesResponse,
+} from "@figma/rest-api-spec";
 
 export interface FigmaRestClient {
   getFileNodes(fileKey: string, nodeIds: string[]): Promise<GetFileNodesResponse>;
@@ -21,7 +25,22 @@ export function createFigmaRestClient(personalAccessToken: string): FigmaRestCli
     },
 
     async getNodeImageUrl(fileKey, nodeId, options) {
-      const response = await api.getImages({ file_key: fileKey }, { ids: nodeId, ...options });
+      // `api.getImages` builds its query with figma-api's `toQueryParams`, which keeps an entry
+      // only when the value is truthy — so `svg_outline_text: false` is dropped and Figma applies
+      // its own default of `true`. Building the query here and going through the underlying
+      // `request` keeps the auth headers and error handling while serializing falsy values.
+      const query = new URLSearchParams({
+        ids: nodeId,
+        ...Object.fromEntries(
+          Object.entries(options)
+            .filter(([_, value]) => value !== undefined)
+            .map(([key, value]) => [key, String(value)]),
+        ),
+      });
+
+      const response = await api.request<GetImagesResponse>(
+        `${API_DOMAIN}/${API_VER}/images/${fileKey}?${query}`,
+      );
 
       // The `images` map is keyed by the requested id, but Figma normalizes `:` to `-` in some
       // responses, so a direct lookup can miss even though exactly one node was requested.

--- a/packages/mcp/src/tools-helpers.ts
+++ b/packages/mcp/src/tools-helpers.ts
@@ -167,6 +167,46 @@ export async function fetchNodeImage(
   );
 }
 
+export async function fetchNodeSvg(
+  params: {
+    fileKey?: string;
+    nodeId: string;
+    personalAccessToken?: string;
+    outlineText: boolean;
+  },
+  context: ToolContext,
+) {
+  const { fileKey, nodeId, personalAccessToken, outlineText } = params;
+  const restClient = resolveRestClient(personalAccessToken, context);
+  const { sendCommandToFigma } = context;
+
+  if (restClient && fileKey) {
+    const svgUrl = await restClient.getNodeImageUrl(fileKey, nodeId, {
+      format: "svg",
+      svg_outline_text: outlineText,
+    });
+    const response = await fetch(svgUrl);
+
+    if (!response.ok)
+      throw new Error(`SVG download failed: ${response.status} ${response.statusText}`);
+
+    return await response.text();
+  }
+
+  if (sendCommandToFigma) {
+    const result = (await sendCommandToFigma("export_node_as_svg", {
+      nodeId,
+      outlineText,
+    })) as { svg: string };
+
+    return result.svg;
+  }
+
+  throw new Error(
+    "No connection available. Provide figmaUrl/fileKey with personalAccessToken or FIGMA_PERSONAL_ACCESS_TOKEN, or use WebSocket mode with Figma Plugin.",
+  );
+}
+
 export function requireWebSocket(context: ToolContext): asserts context is ToolContext & {
   sendCommandToFigma: NonNullable<ToolContext["sendCommandToFigma"]>;
 } {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -22,6 +22,7 @@ import {
   fetchMultipleNodesData,
   fetchNodeData,
   fetchNodeImage,
+  fetchNodeSvg,
   IMAGE_FORMATS,
   requireWebSocket,
   type ImageFormat,
@@ -298,7 +299,7 @@ export function registerTools(
     "get_node_react_code",
     {
       description: getSingleNodeDescription(
-        "Get the React code for a specific node in Figma.",
+        "Get the React code for a specific node in Figma. Vectors that match the Karrot icon packs come back as React icon component names.",
         mode,
       ),
       inputSchema: singleNodeParamsSchema,
@@ -397,6 +398,48 @@ export function registerTools(
         return formatImageResponse(base64, mimeType);
       } catch (error) {
         return formatErrorResponse("export_node_as_image", error);
+      }
+    },
+  );
+
+  // Export Node as SVG Tool (REST API + WebSocket)
+  server.registerTool(
+    "export_node_as_svg",
+    {
+      description: getSingleNodeDescription(
+        "Export a Figma node as SVG markup and return it as text. Use it when you need the vector source itself — path data, viewBox, fill — to put into code. A whole screen frame runs to tens of thousands of tokens and may be cut short by the client, so target the smallest node that holds the artwork.",
+        mode,
+      ),
+      inputSchema: singleNodeParamsSchema.extend({
+        outlineText: z
+          .boolean()
+          .default(false)
+          .describe(
+            "Render text as vector paths instead of <text> elements. Figma defaults this to true; this tool defaults to false so the text stays readable and the output stays small. Set it to true only when the SVG has to match Figma exactly regardless of the viewer's font rendering.",
+          ),
+      }),
+    },
+    async (params: z.infer<typeof singleNodeBaseSchema> & { outlineText: boolean }) => {
+      try {
+        const { fileKey, nodeId, personalAccessToken } = resolveSingleNodeParams(params);
+        const svg = await fetchNodeSvg(
+          { fileKey, nodeId, personalAccessToken, outlineText: params.outlineText },
+          context,
+        );
+
+        return formatTextResponse(svg);
+      } catch (error) {
+        // Plugin builds that predate this command reject with `Unknown command`, which reads as a
+        // server bug unless the stale plugin is named as the cause.
+        if (error instanceof Error && error.message.includes("Unknown command"))
+          return formatErrorResponse(
+            "export_node_as_svg",
+            new Error(
+              `${error.message}. The connected Figma plugin is too old for this tool — update it, or pass fileKey + personalAccessToken to go through the REST API instead.`,
+            ),
+          );
+
+        return formatErrorResponse("export_node_as_svg", error);
       }
     },
   );

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -37,6 +37,7 @@ export type FigmaCommand =
   | "get_node_info"
   | "get_nodes_info"
   | "export_node_as_image"
+  | "export_node_as_svg"
   | "join"
   | "clone_node"
   | "add_annotations"

--- a/tools/figma-mcp/src/main/command-handler.ts
+++ b/tools/figma-mcp/src/main/command-handler.ts
@@ -8,6 +8,7 @@ import {
   addAnnotations,
   cloneNode,
   exportNodeAsImage,
+  exportNodeAsSvg,
   getAnnotations,
   getDocumentInfo,
   getNodeInfo,
@@ -86,6 +87,9 @@ async function executeCommand(command: string, params: any): Promise<any> {
 
     case "export_node_as_image":
       return await exportNodeAsImage(params);
+
+    case "export_node_as_svg":
+      return await exportNodeAsSvg(params);
 
     case "clone_node":
       return await cloneNode(params);

--- a/tools/figma-mcp/src/main/commands/export.ts
+++ b/tools/figma-mcp/src/main/commands/export.ts
@@ -73,3 +73,45 @@ export async function exportNodeAsImage(params: ExportNodeParams): Promise<Expor
     );
   }
 }
+
+export interface ExportNodeSvgParams {
+  nodeId: string;
+  outlineText?: boolean;
+}
+
+export interface ExportNodeSvgResult {
+  id: string;
+  svg: string;
+}
+
+export async function exportNodeAsSvg(params: ExportNodeSvgParams): Promise<ExportNodeSvgResult> {
+  const { nodeId, outlineText = false } = params || {};
+
+  if (!nodeId) {
+    throw new Error("Node ID is required");
+  }
+
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node) {
+    throw new Error(`Node not found with ID: ${nodeId}`);
+  }
+
+  if (!("exportAsync" in node)) {
+    throw new Error(`Node does not support export: ${nodeId}`);
+  }
+
+  try {
+    // `SVG_STRING` resolves to a string rather than the `Uint8Array` every other format returns,
+    // so there is no base64 round trip here.
+    const svg = await node.exportAsync({ format: "SVG_STRING", svgOutlineText: outlineText });
+
+    return {
+      id: node.id,
+      svg,
+    };
+  } catch (error) {
+    throw new Error(
+      `Error exporting node as SVG: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 특정 Figma 레이어를 SVG 마크업으로 내보내는 `export_node_as_svg` 도구를 추가했습니다.
  * REST API와 WebSocket 모드를 지원합니다.
  * `outlineText` 옵션으로 텍스트를 벡터 경로로 변환할 수 있습니다.

* **문서**
  * SVG 내보내기 도구를 공통 도구 목록에 반영했습니다.

* **기타**
  * 관련 패키지의 패치 릴리스와 API 연동 업데이트를 기록했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->