### PR TITLE
docs(progress-circle): fix static white preview background fill

### DIFF
--- a/docs/examples/react/progress-circle/static-white.tsx
+++ b/docs/examples/react/progress-circle/static-white.tsx
@@ -5,9 +5,8 @@ export default function ProgressCircleStaticWhite() {
     <div
       style={{
         display: "flex",
-        flex: 1,
-        width: "100vw",
-        height: "300px",
+        width: "100%",
+        minHeight: "200px",
         alignItems: "center",
         justifyContent: "center",
         background: "black",


### PR DESCRIPTION
## Summary
- Progress Circle docs "Static White" preview showed only a thin black bar instead of a full black background.
- Root cause: the example used `flex: 1` (flex-basis 0) inside an auto-height column flex parent, so `height: 300px` did not take effect and the box collapsed to the circle size; `width: 100vw` also overflowed the preview panel.
- Fix: use `width: 100%` + `minHeight: 200px`, remove `flex: 1` / `100vw`.

<img width="1659" height="978" alt="image" src="https://github.com/user-attachments/assets/3161b12d-810a-4ef2-a940-9a14042d8acd" />
<img width="1670" height="1175" alt="image" src="https://github.com/user-attachments/assets/c71b342d-d999-4773-a3af-6bed26ff665e" />


## Test plan
- [ ] Open Progress Circle docs → Static White preview
- [ ] Confirm the preview area fills with black and the white circle is centered
- [ ] Confirm other Progress Circle examples are unchanged

Related: https://seed-design.io/react/components/progress-circle


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 진행률 원형 표시 예제의 컨테이너 레이아웃을 개선했습니다.
  * 화면 너비에 맞게 표시되며, 최소 높이를 유지하도록 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->