### PR TITLE
feat(mcp): support get_annotations in REST mode

### DIFF
--- a/.changeset/tidy-jars-collect.md
+++ b/.changeset/tidy-jars-collect.md
@@ -1,0 +1,12 @@
+---
+"@seed-design/mcp": major
+---
+
+`get_annotations`가 Figma 앱과 웹소켓 서버 없이 REST 모드에서도 작동하도록 업데이트하고, 누락되던 Annotation을 반환하도록 고칩니다.
+
+- Figma URL 또는 `fileKey` + `nodeId`를 전달하면 REST API로 동작합니다.
+- 응답 구조가 `{ annotations: [{ nodeId, labelMarkdowns }] }`에서 `{ nodes: [{ nodeId, annotations }] }`로 변경됩니다. `annotations`의 각 항목은 `label`, `labelMarkdown`, `properties`, `category`를 담습니다. 이 응답을 읽는 프롬프트가 있다면 새 구조에 맞게 수정해야 합니다.
+- 조회 대상 레이어 자신에 붙은 Annotation이 결과에서 빠지던 문제를 수정합니다. 이제 대상 레이어와 그 하위 레이어를 모두 반환합니다.
+- Text, Rectangle처럼 하위 레이어를 가질 수 없는 레이어를 조회하면 오류가 나던 문제를 수정합니다.
+- Annotation 카테고리를 `category: { id, label, color, isPreset }`으로 풀어서 반환합니다. 이전에는 카테고리 정보가 아예 없었습니다.
+- REST 모드로 받은 Annotation에는 서식이 제거된 평문 `label`만 담깁니다. Figma에서 작성한 마크다운 원문 `labelMarkdown`과 `category`는 웹소켓 모드에서만 제공됩니다.

--- a/.changeset/tidy-jars-collect.md
+++ b/.changeset/tidy-jars-collect.md
@@ -7,3 +7,4 @@
 - 조회 대상 레이어 자신에 붙은 Annotation이 결과에서 빠지던 문제를 수정합니다.
 - Text, Rectangle처럼 하위 레이어를 가질 수 없는 레이어를 조회하면 오류가 나던 문제를 수정합니다.
 - Annotation 카테고리를 `category: { id, label, color, isPreset }`으로 반환합니다.
+- Annotation이 붙은 레이어의 `name`, `type`, 그리고 조회 대상부터 해당 레이어까지의 상위 레이어 정보를 `path`로 반환합니다.

--- a/.changeset/tidy-jars-collect.md
+++ b/.changeset/tidy-jars-collect.md
@@ -1,12 +1,9 @@
 ---
-"@seed-design/mcp": major
+"@seed-design/mcp": minor
 ---
 
-`get_annotations`가 Figma 앱과 웹소켓 서버 없이 REST 모드에서도 작동하도록 업데이트하고, 누락되던 Annotation을 반환하도록 고칩니다.
+`get_annotations`가 Figma 앱과 웹소켓 서버 없이 REST 모드에서도 작동하도록 업데이트하고, 반환 결과를 개선합니다.
 
-- Figma URL 또는 `fileKey` + `nodeId`를 전달하면 REST API로 동작합니다.
-- 응답 구조가 `{ annotations: [{ nodeId, labelMarkdowns }] }`에서 `{ nodes: [{ nodeId, annotations }] }`로 변경됩니다. `annotations`의 각 항목은 `label`, `labelMarkdown`, `properties`, `category`를 담습니다. 이 응답을 읽는 프롬프트가 있다면 새 구조에 맞게 수정해야 합니다.
-- 조회 대상 레이어 자신에 붙은 Annotation이 결과에서 빠지던 문제를 수정합니다. 이제 대상 레이어와 그 하위 레이어를 모두 반환합니다.
+- 조회 대상 레이어 자신에 붙은 Annotation이 결과에서 빠지던 문제를 수정합니다.
 - Text, Rectangle처럼 하위 레이어를 가질 수 없는 레이어를 조회하면 오류가 나던 문제를 수정합니다.
-- Annotation 카테고리를 `category: { id, label, color, isPreset }`으로 풀어서 반환합니다. 이전에는 카테고리 정보가 아예 없었습니다.
-- REST 모드로 받은 Annotation에는 서식이 제거된 평문 `label`만 담깁니다. Figma에서 작성한 마크다운 원문 `labelMarkdown`과 `category`는 웹소켓 모드에서만 제공됩니다.
+- Annotation 카테고리를 `category: { id, label, color, isPreset }`으로 반환합니다.

--- a/docs/content/ai-integration/(mcp)/figma-mcp.mdx
+++ b/docs/content/ai-integration/(mcp)/figma-mcp.mdx
@@ -329,6 +329,7 @@ Figma URL 또는 `fileKey` + `nodeId`를 전달하면 REST API로, `nodeId`만 �
 | `find_nodes`                   | 하위 레이어를 이름(정규식)으로 검색하여 ID 목록을 반환합니다. |
 | `export_node_as_image`          | 레이어를 이미지(PNG, JPG)로 렌더링해 반환합니다. |
 | `export_node_as_svg`            | 레이어를 SVG 마크업(텍스트)으로 반환합니다. |
+| `get_annotations`               | 레이어와 그 하위 레이어의 [Annotation](https://help.figma.com/hc/en-us/articles/20774752502935-Add-measurements-and-annotate-designs)을 가져옵니다. |
 | `retrieve_color_variable_names` | SEED 색상 변수 이름 목록을 반환합니다. |
 
 ### WebSocket 전용
@@ -340,7 +341,6 @@ Figma 플러그인과 통신이 필요합니다. `websocket` 또는 `all` 모드
 | `get_selection`        | 현재 선택한 레이어의 ID를 반환합니다.                                                                                              |
 | `get_document_info`    | 현재 열린 Figma 문서의 정보를 반환합니다.                                                                                          |
 | `add_annotations`      | 레이어에 [Annotation](https://help.figma.com/hc/en-us/articles/20774752502935-Add-measurements-and-annotate-designs)을 추가합니다. |
-| `get_annotations`      | 레이어의 Annotation을 가져옵니다.                                                                                                  |
 | `join_channel`         | 특정 채널에 참가합니다.                                                                                                            |
 
 <Accordions type="single">

--- a/packages/mcp/AGENTS.md
+++ b/packages/mcp/AGENTS.md
@@ -37,9 +37,12 @@
 - `src/prompts.ts`: LLM 프롬프트 템플릿
 - `src/config.ts`: MCP 설정 (`McpConfig`)
 - `src/bin/`: 실행 엔트리포인트
+- `scripts/`: 배포에 포함되지 않는 개발용 스크립트 (`package.json`의 `files`에서 제외). `probe-transports.ts`가 도구 헬퍼를 REST/WebSocket 양쪽으로 실행해 결과를 비교한다.
 
 ## 코드 작성 컨벤션
 
 - `packages/figma`의 `createRestNormalizer`, `figma`(codegen), `react`(codegen)를 import해서 사용
 - `createPluginNormalizer`는 사용하지 않는다 — Plugin 환경이 아니므로 Plugin API 호출 불가
 - 도구 파라미터는 `ToolMode`에 따라 스키마가 동적으로 결정됨 (`getSingleNodeParamsSchema`, `getMultiNodeParamsSchema`)
+- **hybrid 도구를 추가·수정하면 REST와 WebSocket 양쪽을 실행해 결과를 비교한다.** 한쪽만 고쳐도 타입은 통과하고 다른 쪽이 조용히 어긋난다. 검증 절차(검증 대상 선정, 플러그인 재빌드·리로드, relay 기동, 비교 기준)는 `verify-figma-mcp-transports` 스킬에 있다 — WebSocket 확인은 Figma 데스크톱 앱 조작이 필요해 사람 없이는 끝낼 수 없으므로, 코드를 읽고 "맞을 것"으로 갈음하지 않는다.
+- WebSocket 경로에만 존재하는 필드(`labelMarkdown`, `category` 등)를 추가할 때는 `ToolAnnotation`처럼 optional로 두고, REST가 왜 못 주는지 타입 옆에 남긴다. 두 경로가 같은 개념을 다른 이름으로 부르는 경우(페이지가 Plugin API에선 `PAGE`, REST에선 `CANVAS`)도 마찬가지다.

--- a/packages/mcp/scripts/probe-transports.ts
+++ b/packages/mcp/scripts/probe-transports.ts
@@ -1,0 +1,239 @@
+/**
+ * Runs one MCP tool helper over both transports and diffs the two answers.
+ *
+ * Usage:
+ *   bun packages/mcp/scripts/probe-transports.ts \
+ *     --probe <tool> --transport both \
+ *     --file-key <key> --node-id <id>
+ *
+ * `--file-key` falls back to `SEED_MCP_PROBE_FILE_KEY`.
+ *
+ * To cover a new tool, add an entry to `PROBES` below: point `run` at the helper the tool's
+ * handler already calls (never at the REST/WebSocket API directly — the helper *is* what is under
+ * test), and list in `ignore` the fields only one transport can produce. What belongs in `ignore`
+ * and what must be reported instead is decided by the `verify-figma-mcp-transports` skill.
+ */
+import { parseArgs } from "node:util";
+import { v4 as uuidv4 } from "uuid";
+import WebSocket from "ws";
+import { createFigmaRestClient } from "../src/figma-rest-client";
+import { fetchNodeAnnotations, type ToolContext } from "../src/tools-helpers";
+import type { FigmaCommand } from "../src/types";
+
+interface Probe {
+  run: (params: { fileKey: string; nodeId: string }, context: ToolContext) => Promise<unknown>;
+  ignore: readonly string[];
+}
+
+// A Map rather than an object literal so the `--probe` argument can look one up without a cast.
+const PROBES = new Map<string, Probe>([
+  [
+    "get_annotations",
+    {
+      run: (params, context) => fetchNodeAnnotations(params, context),
+      // The REST endpoint serializes neither the authored markdown nor the annotation's category.
+      ignore: ["labelMarkdown", "category"],
+    },
+  ],
+]);
+
+// The plugin UI joins this channel unconditionally, so there is nothing for a caller to configure.
+const CHANNEL = "local-default";
+
+const { values } = parseArgs({
+  options: {
+    probe: { type: "string" },
+    transport: { type: "string", default: "both" },
+    "file-key": { type: "string" },
+    "node-id": { type: "string" },
+    port: { type: "string", default: "3055" },
+    timeout: { type: "string", default: "30000" },
+  },
+});
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(2);
+}
+
+const known = [...PROBES.keys()].join(", ");
+const probeName = values.probe ?? fail(`--probe is required (one of: ${known})`);
+const probe = PROBES.get(probeName) ?? fail(`unknown probe "${probeName}" (one of: ${known})`);
+
+const transport = values.transport;
+if (transport !== "rest" && transport !== "websocket" && transport !== "both") {
+  fail(`--transport must be rest, websocket, or both (got "${transport}")`);
+}
+
+// No file is baked in: which document exercises a tool's edge cases depends on the tool and on what
+// the person running this can open. `SEED_MCP_PROBE_FILE_KEY` is the convenience for repeat runs.
+const fileKey =
+  values["file-key"] ??
+  process.env["SEED_MCP_PROBE_FILE_KEY"] ??
+  fail("--file-key is required (or set SEED_MCP_PROBE_FILE_KEY)");
+const nodeId = values["node-id"] ?? fail("--node-id is required");
+const params = { fileKey, nodeId };
+
+/**
+ * A one-shot stand-in for `src/websocket.ts`. The real client auto-joins on `open` without exposing
+ * anything to await and reconnects forever, so a script built on it can neither know when it is
+ * safe to send nor exit on its own.
+ */
+function createProbeClient(port: number, timeoutMs: number) {
+  const pending = new Map<
+    string,
+    {
+      resolve: (value: unknown) => void;
+      reject: (reason: Error) => void;
+      timer: ReturnType<typeof setTimeout>;
+    }
+  >();
+
+  const ws = new WebSocket(`ws://localhost:${port}`);
+
+  ws.on("message", (raw) => {
+    const frame: unknown = JSON.parse(String(raw));
+    if (typeof frame !== "object" || frame === null || !("message" in frame)) return;
+
+    // The relay's join acknowledgement arrives twice, once as a bare string.
+    const message = frame.message;
+    if (typeof message !== "object" || message === null || !("id" in message)) return;
+
+    const id = message.id;
+    if (typeof id !== "string") return;
+
+    const request = pending.get(id);
+    if (!request) return;
+
+    // `handleMessage` in the relay broadcasts to every client in the channel *including the
+    // sender*, so the request this script just sent comes straight back with a matching id. Only a
+    // reply carries `result` or `error`; requiring one is how `websocket.ts` avoids resolving on
+    // its own echo, and dropping this guard is the classic way to make a probe "pass" instantly.
+    const error = "error" in message ? message.error : undefined;
+    const hasResult = "result" in message;
+    if (error === undefined && !hasResult) return;
+
+    clearTimeout(request.timer);
+    pending.delete(id);
+
+    if (error !== undefined) {
+      request.reject(new Error(String(error)));
+      return;
+    }
+
+    request.resolve("result" in message ? message.result : undefined);
+  });
+
+  function sendCommand(command: FigmaCommand, commandParams: unknown = {}) {
+    return new Promise<unknown>((resolve, reject) => {
+      const id = uuidv4();
+      const payload =
+        typeof commandParams === "object" && commandParams !== null ? commandParams : {};
+
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(
+          new Error(
+            `"${command}" timed out after ${timeoutMs}ms — the relay is up but nothing answered. Is the plugin running and connected?`,
+          ),
+        );
+      }, timeoutMs);
+
+      pending.set(id, { resolve, reject, timer });
+
+      ws.send(
+        JSON.stringify({
+          id,
+          type: command === "join" ? "join" : "message",
+          channel: CHANNEL,
+          message: { id, command, params: { ...payload, commandId: id } },
+        }),
+      );
+    });
+  }
+
+  const ready = new Promise<void>((resolve, reject) => {
+    ws.on("error", reject);
+    ws.on("open", () => {
+      sendCommand("join", { channel: CHANNEL }).then(() => resolve(), reject);
+    });
+  });
+
+  return { ready, sendCommand, close: () => ws.close() };
+}
+
+async function runRest() {
+  const personalAccessToken =
+    process.env["FIGMA_PERSONAL_ACCESS_TOKEN"] ?? fail("FIGMA_PERSONAL_ACCESS_TOKEN is not set");
+
+  return probe.run(params, {
+    restClient: createFigmaRestClient(personalAccessToken),
+    sendCommandToFigma: null,
+    mode: "rest",
+  });
+}
+
+async function runWebSocket() {
+  const client = createProbeClient(Number(values.port), Number(values.timeout));
+  await client.ready;
+
+  try {
+    // `mode` is load-bearing, not decoration: `resolveRestClient` hands back the context's REST
+    // client for any mode but "websocket", and every helper prefers REST once it holds a client and
+    // a fileKey. A stray client here would run REST twice and report a false pass.
+    return await probe.run(params, {
+      restClient: null,
+      sendCommandToFigma: client.sendCommand,
+      mode: "websocket",
+    });
+  } finally {
+    client.close();
+  }
+}
+
+/** Drops transport-only fields and sorts keys so the comparison survives differing key order. */
+function normalize(value: unknown, ignore: readonly string[]): unknown {
+  if (Array.isArray(value)) return value.map((item) => normalize(item, ignore));
+
+  if (value === null || typeof value !== "object") return value;
+
+  // Annotated rather than inferred: `Object.entries` widens its values to `any` for a bare object.
+  const entries: [string, unknown][] = Object.entries(value);
+
+  return Object.fromEntries(
+    entries
+      .filter(([key]) => !ignore.includes(key))
+      .map(([key, item]) => [key, normalize(item, ignore)] as const)
+      .sort(([a], [b]) => a.localeCompare(b)),
+  );
+}
+
+if (transport === "rest") {
+  console.log(JSON.stringify(await runRest(), null, 2));
+  process.exit(0);
+}
+
+if (transport === "websocket") {
+  console.log(JSON.stringify(await runWebSocket(), null, 2));
+  process.exit(0);
+}
+
+const rest = await runRest();
+const websocket = await runWebSocket();
+
+const restNormalized = JSON.stringify(normalize(rest, probe.ignore), null, 2);
+const websocketNormalized = JSON.stringify(normalize(websocket, probe.ignore), null, 2);
+
+if (restNormalized === websocketNormalized) {
+  console.log(`✓ ${probeName} ${fileKey}/${nodeId}: transports agree on every shared field`);
+  console.log(`  ignored (transport-only): ${probe.ignore.join(", ") || "none"}`);
+  process.exit(0);
+}
+
+console.error(`✗ ${probeName} ${fileKey}/${nodeId}: transports disagree`);
+console.error(`\n--- REST (normalized) ---\n${restNormalized}`);
+console.error(`\n--- WebSocket (normalized) ---\n${websocketNormalized}`);
+console.error(
+  "\nA difference is not automatically a bug. Classify the field first — see the `verify-figma-mcp-transports` skill. Only a value one transport cannot produce at all belongs in this probe's `ignore`; anything the two sides merely render differently is reported, not silenced.",
+);
+process.exit(1);

--- a/packages/mcp/src/tools-helpers.ts
+++ b/packages/mcp/src/tools-helpers.ts
@@ -229,6 +229,23 @@ export interface ToolAnnotation extends Annotation {
 
 export interface AnnotatedNode {
   nodeId: string;
+  name: string;
+  /**
+   * Kept as `string` rather than `Node["type"]`: the WebSocket path answers in the Plugin API's
+   * vocabulary, which calls a page `PAGE` where REST calls it `CANVAS`, so neither union covers
+   * both transports.
+   */
+  type: string;
+  /**
+   * Ancestors between the queried node and this one, outermost first, and empty on the queried
+   * node itself. Relative rather than absolute because REST returns only the requested subtree,
+   * leaving nothing above it to name.
+   *
+   * Carries `id` because layer names are not unique — a page routinely repeats `Label` or `Slot`
+   * across hundreds of nodes — so the names alone read as a breadcrumb but cannot address the
+   * ancestor a caller wants to act on.
+   */
+  path: { id: string; name: string }[];
   annotations: ToolAnnotation[];
 }
 
@@ -239,19 +256,27 @@ export interface AnnotatedNode {
 function collectAnnotatedNodes(root: Node) {
   const collected: AnnotatedNode[] = [];
 
-  const visit = (node: Node) => {
+  const visit = (node: Node, path: AnnotatedNode["path"]) => {
     if ("annotations" in node && node.annotations && node.annotations.length > 0) {
-      collected.push({ nodeId: node.id, annotations: node.annotations });
+      collected.push({
+        nodeId: node.id,
+        name: node.name,
+        type: node.type,
+        path,
+        annotations: node.annotations,
+      });
     }
 
     if (!("children" in node)) return;
 
+    const childPath = [...path, { id: node.id, name: node.name }];
+
     for (const child of node.children) {
-      visit(child);
+      visit(child, childPath);
     }
   };
 
-  visit(root);
+  visit(root, []);
 
   return collected;
 }

--- a/packages/mcp/src/tools-helpers.ts
+++ b/packages/mcp/src/tools-helpers.ts
@@ -1,4 +1,9 @@
-import type { GetFileNodesResponse, GetImagesQueryParams } from "@figma/rest-api-spec";
+import type {
+  Annotation,
+  GetFileNodesResponse,
+  GetImagesQueryParams,
+  Node,
+} from "@figma/rest-api-spec";
 import type { FigmaRestClient } from "./figma-rest-client";
 import { createFigmaRestClient } from "./figma-rest-client";
 import type { FigmaWebSocketClient } from "./websocket";
@@ -200,6 +205,80 @@ export async function fetchNodeSvg(
     })) as { svg: string };
 
     return result.svg;
+  }
+
+  throw new Error(
+    "No connection available. Provide figmaUrl/fileKey with personalAccessToken or FIGMA_PERSONAL_ACCESS_TOKEN, or use WebSocket mode with Figma Plugin.",
+  );
+}
+
+/**
+ * `labelMarkdown` and `category` are absent from `Annotation` because the REST endpoint serializes
+ * neither the authored markdown nor the annotation's category; only the plugin, and therefore only
+ * the WebSocket path, can read them.
+ */
+export interface ToolAnnotation extends Annotation {
+  labelMarkdown?: string;
+  category?: {
+    id: string;
+    label: string;
+    color: string;
+    isPreset: boolean;
+  };
+}
+
+export interface AnnotatedNode {
+  nodeId: string;
+  annotations: ToolAnnotation[];
+}
+
+/**
+ * Mirrors the plugin's traversal — the queried node first, then everything under it — so both
+ * transports answer the same question.
+ */
+function collectAnnotatedNodes(root: Node) {
+  const collected: AnnotatedNode[] = [];
+
+  const visit = (node: Node) => {
+    if ("annotations" in node && node.annotations && node.annotations.length > 0) {
+      collected.push({ nodeId: node.id, annotations: node.annotations });
+    }
+
+    if (!("children" in node)) return;
+
+    for (const child of node.children) {
+      visit(child);
+    }
+  };
+
+  visit(root);
+
+  return collected;
+}
+
+export async function fetchNodeAnnotations(
+  params: { fileKey?: string; nodeId: string; personalAccessToken?: string },
+  context: ToolContext,
+): Promise<AnnotatedNode[]> {
+  const { fileKey, nodeId, personalAccessToken } = params;
+  const restClient = resolveRestClient(personalAccessToken, context);
+  const { sendCommandToFigma } = context;
+
+  if (restClient && fileKey) {
+    const response = await restClient.getFileNodes(fileKey, [nodeId]);
+    const nodeData = response.nodes[nodeId];
+
+    if (!nodeData) throw new Error(`Node ${nodeId} not found in file ${fileKey}`);
+
+    return collectAnnotatedNodes(nodeData.document);
+  }
+
+  if (sendCommandToFigma) {
+    const result = (await sendCommandToFigma("get_annotations", { nodeId })) as {
+      nodes: AnnotatedNode[];
+    };
+
+    return result.nodes;
   }
 
   throw new Error(

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -19,6 +19,7 @@ import type { FigmaRestClient } from "./figma-rest-client";
 import {
   createToolContext,
   fetchMultipleNodesData,
+  fetchNodeAnnotations,
   fetchNodeData,
   fetchNodeImage,
   fetchNodeSvg,
@@ -122,6 +123,17 @@ function getSingleNodeDescription(baseDescription: string, mode: ToolMode): stri
     case "all":
       return `${baseDescription} Provide either: (1) figmaUrl (e.g., https://www.figma.com/design/ABC/Name?node-id=0-1), (2) fileKey + nodeId, or (3) nodeId only for WebSocket mode.`;
   }
+}
+
+function getAnnotationsDescription(mode: ToolMode): string {
+  const description = getSingleNodeDescription(
+    "Get annotations on a node and on every node under it in Figma.",
+    mode,
+  );
+
+  if (mode === "websocket") return description;
+
+  return `${description} Annotations read over REST carry only \`label\`, the plain-text rendering — markdown authored in Figma is flattened. \`labelMarkdown\`, holding the authored source, and \`category\` are only present on the WebSocket path.`;
 }
 
 function getMultiNodeDescription(baseDescription: string, mode: ToolMode): string {
@@ -574,28 +586,26 @@ export function registerTools(
         }
       },
     );
-
-    // Get Annotations Tool
-    server.registerTool(
-      "get_annotations",
-      {
-        description: "Get annotations for a specific node in Figma (WebSocket mode only)",
-        inputSchema: z.object({
-          nodeId: z.string().describe("The ID of the node to get annotations for"),
-        }),
-      },
-      async ({ nodeId }) => {
-        try {
-          requireWebSocket(context);
-          const result = await context.sendCommandToFigma("get_annotations", { nodeId });
-
-          return formatObjectResponse(result);
-        } catch (error) {
-          return formatErrorResponse("get_annotations", error);
-        }
-      },
-    );
   }
+
+  // Get Annotations Tool (REST API + WebSocket)
+  server.registerTool(
+    "get_annotations",
+    {
+      description: getAnnotationsDescription(mode),
+      inputSchema: singleNodeParamsSchema,
+    },
+    async (params: z.infer<typeof singleNodeBaseSchema>) => {
+      try {
+        const { fileKey, nodeId, personalAccessToken } = resolveSingleNodeParams(params);
+        const nodes = await fetchNodeAnnotations({ fileKey, nodeId, personalAccessToken }, context);
+
+        return formatObjectResponse({ nodes });
+      } catch (error) {
+        return formatErrorResponse("get_annotations", error);
+      }
+    },
+  );
 }
 
 function collectMatchingNodes(

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -127,7 +127,7 @@ function getSingleNodeDescription(baseDescription: string, mode: ToolMode): stri
 
 function getAnnotationsDescription(mode: ToolMode): string {
   const description = getSingleNodeDescription(
-    "Get annotations on a node and on every node under it in Figma.",
+    "Get annotations on a node and on every node under it in Figma. Each result carries the annotated node's `name` and `type`, plus `path`: the `{ id, name }` of every ancestor between the queried node and it, outermost first.",
     mode,
   );
 

--- a/patches/@figma%2Frest-api-spec@0.36.0.patch
+++ b/patches/@figma%2Frest-api-spec@0.36.0.patch
@@ -1,8 +1,71 @@
 diff --git a/dist/api_types.ts b/dist/api_types.ts
-index 77e3e617772cd586c26cee2d3ab1e788a98c78eb..b5cbe196234f1cfa67862d99bcb7616c0bfeea75 100644
+index 77e3e617772cd586c26cee2d3ab1e788a98c78eb..61ccdbed54549914532e964d5f846d1e9bc08ed4 100644
 --- a/dist/api_types.ts
 +++ b/dist/api_types.ts
-@@ -853,6 +853,7 @@ export type Node =
+@@ -797,7 +797,61 @@ export type DevStatusTrait = {
+   }
+ }
+ 
+-export type AnnotationsTrait = object
++export type AnnotationsTrait = {
++  /**
++   * An array of annotations displaying notes and pinned properties of nodes. Figma's REST docs cap
++   * this at one, but the endpoint does serialize every annotation a node carries.
++   */
++  annotations?: Annotation[]
++}
++
++/**
++ * A note and pinned properties left on a node.
++ */
++export type Annotation = {
++  /**
++   * Plain text only. The Plugin API stores the authored markdown separately as `labelMarkdown`,
++   * which this endpoint does not return, so formatting is flattened to newlines here.
++   */
++  label?: string
++
++  properties?: AnnotationProperty[]
++}
++
++/**
++ * A pinned property in an Annotation.
++ */
++export type AnnotationProperty = {
++  /**
++   * The type of the property, as a string enum.
++   */
++  type:
++    | 'width'
++    | 'height'
++    | 'maxWidth'
++    | 'minWidth'
++    | 'maxHeight'
++    | 'minHeight'
++    | 'fills'
++    | 'strokes'
++    | 'effects'
++    | 'strokeWeight'
++    | 'cornerRadius'
++    | 'textStyleId'
++    | 'textAlignHorizontal'
++    | 'fontFamily'
++    | 'fontStyle'
++    | 'fontSize'
++    | 'fontWeight'
++    | 'lineHeight'
++    | 'letterSpacing'
++    | 'itemSpacing'
++    | 'padding'
++    | 'layoutMode'
++    | 'alignItems'
++    | 'opacity'
++    | 'mainComponent'
++}
+ 
+ export type TransformModifiersTrait = object
+ 
+@@ -853,6 +907,7 @@ export type Node =
    | SectionNode
    | ShapeWithTextNode
    | SliceNode
@@ -10,7 +73,7 @@ index 77e3e617772cd586c26cee2d3ab1e788a98c78eb..b5cbe196234f1cfa67862d99bcb7616c
    | StarNode
    | StickyNode
    | TableNode
-@@ -926,6 +927,7 @@ export type SubcanvasNode =
+@@ -926,6 +981,7 @@ export type SubcanvasNode =
    | SectionNode
    | ShapeWithTextNode
    | SliceNode
@@ -18,7 +81,7 @@ index 77e3e617772cd586c26cee2d3ab1e788a98c78eb..b5cbe196234f1cfa67862d99bcb7616c
    | StarNode
    | StickyNode
    | TableNode
-@@ -1141,6 +1143,14 @@ export type InstanceNode = {
+@@ -1141,6 +1197,14 @@ export type InstanceNode = {
    overrides: Overrides[]
  } & FrameTraits
  
@@ -33,7 +96,7 @@ index 77e3e617772cd586c26cee2d3ab1e788a98c78eb..b5cbe196234f1cfa67862d99bcb7616c
  export type EmbedNode = {
    /**
     * The type of this node, represented by the string literal "EMBED"
-@@ -2407,7 +2417,7 @@ export type TextPathTypeStyle = {
+@@ -2407,7 +2471,7 @@ export type TextPathTypeStyle = {
  /**
   * Component property type.
   */
@@ -42,7 +105,7 @@ index 77e3e617772cd586c26cee2d3ab1e788a98c78eb..b5cbe196234f1cfa67862d99bcb7616c
  
  /**
   * Instance swap preferred value.
-@@ -2436,7 +2446,7 @@ export type ComponentPropertyDefinition = {
+@@ -2436,7 +2500,7 @@ export type ComponentPropertyDefinition = {
    /**
     * Initial value of this property for instances.
     */
@@ -51,7 +114,7 @@ index 77e3e617772cd586c26cee2d3ab1e788a98c78eb..b5cbe196234f1cfa67862d99bcb7616c
  
    /**
     * All possible values for this property. Only exists on VARIANT properties.
-@@ -2461,7 +2471,7 @@ export type ComponentProperty = {
+@@ -2461,7 +2525,7 @@ export type ComponentProperty = {
    /**
     * Value of the property for this component instance.
     */

--- a/skills/verify-figma-mcp-transports/SKILL.md
+++ b/skills/verify-figma-mcp-transports/SKILL.md
@@ -64,7 +64,7 @@ Build everything that does not need a person, so the person is interrupted exact
 1. Build the plugin. Editing the source without rebuilding leaves Figma reading the old `dist`.
 
    ```bash
-   cd tools/figma-mcp && bun run build
+   bun --filter figma-mcp build
    ```
 
 2. Start the relay in the background (`Bash` with `run_in_background: true`).
@@ -89,7 +89,7 @@ Then ask with **AskUserQuestion**. Do not write the question into chat and conti
 
 Spell out what to do and why each step matters; without the reason people skip the reload. Refer to the file by the key Phase 1 actually used. If they open a different file the two transports answer about different documents, and that difference gets reported as a code bug.
 
-```
+```text
 WebSocket side is ready. Two things in Figma:
 
 1. Quit the plugin and run it again — dist was just rebuilt, and a running

--- a/skills/verify-figma-mcp-transports/SKILL.md
+++ b/skills/verify-figma-mcp-transports/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: verify-figma-mcp-transports
+description: Run a Figma MCP tool over both the REST and WebSocket transports and diff the two answers, so a change to one path cannot silently drift from the other. Use after editing `packages/mcp/src/tools.ts`, `src/tools-helpers.ts`, or `tools/figma-mcp/src/main/commands/*`. Also triggers on "verify both transports", "compare REST and WebSocket output", "check the plugin path still matches", "transport 검증", "REST랑 WebSocket 비교해줘", "플러그인이랑 REST 결과 같은지 확인".
+---
+
+# Verify Figma MCP Transports
+
+A Figma MCP tool answers the same question over two paths: **REST** (personal access token) and **WebSocket** (the Figma plugin). Fixing one and not the other still typechecks, so the drift is silent. Run both and compare mechanically.
+
+For where the two paths diverge in this package, read `packages/mcp/AGENTS.md`.
+
+> [!IMPORTANT]
+> Run this skill **on the main thread**. Phase 3 is a hard stop that waits on a person, and a subagent has nobody to ask — it will pass itself.
+
+## Prerequisites
+
+- `FIGMA_PERSONAL_ACCESS_TOKEN` is set. If not, stop at Phase 0 and ask for it.
+- The Figma desktop app is installed.
+- The tool under test is registered in `PROBES` in the probe script. If it isn't, register it first — see the header comment in that file.
+
+## Phase 0: Decide what to inspect
+
+Both transports need a target, so this comes before any probing — REST in Phase 1 already needs it.
+
+**Derive the criteria yourself; do not ask the person to invent them.** Read the diff you just made and work out which edge cases it touches. Then ask for a layer that exercises those specific cases. You know what changed; the person only knows their files.
+
+Concretely: name the shape you need, not the node. "A frame containing a layer with two or more annotations, and a text layer with none" is answerable. "Give me a layer URL" is not — it hands your job to someone who can't do it.
+
+Start from this checklist and cut what your change doesn't touch:
+
+| Cover | Why |
+|---|---|
+| The queried node itself carrying a value | Catches a traversal that skips its own root |
+| A descendant carrying a value | The recursive collection path |
+| A leaf (no `children`) | Whether a non-container node throws |
+| A page (`CANVAS` / `PAGE`) | The plugin-only `loadAsync` path, plus the type-vocabulary difference |
+| A node inside a component instance | IDs composed as `I<a>;<b>;<c>` |
+
+The last two apply to every tool. The rest apply only when the tool walks a tree.
+
+Ask with **AskUserQuestion**, and ask for a **layer URL** — `parseFigmaUrl` takes the file key and node id straight out of it, so nobody has to read ids off a canvas.
+
+If the same file gets reused across runs, put its key in `SEED_MCP_PROBE_FILE_KEY` and pass only `--node-id` afterwards.
+
+## Phase 1: REST alone (no person needed)
+
+REST needs nothing but the token, so **finish it without asking anyone.**
+
+```bash
+bun packages/mcp/scripts/probe-transports.ts \
+  --probe <tool> \
+  --transport rest \
+  --file-key <key> \
+  --node-id <id>
+```
+
+- The script calls the same helper the tool handler calls. Never reach past it to the REST API directly — that tests Figma, not the tool.
+- If this fails, do not move on to WebSocket prep. Calling a person in to help debug a broken REST path spends their time on your bug.
+
+## Phase 2: Prepare WebSocket (up to the human boundary)
+
+Build everything that does not need a person, so the person is interrupted exactly once.
+
+1. Build the plugin. Editing the source without rebuilding leaves Figma reading the old `dist`.
+
+   ```bash
+   cd tools/figma-mcp && bun run build
+   ```
+
+2. Start the relay in the background (`Bash` with `run_in_background: true`).
+
+   ```bash
+   bun packages/mcp/bin/index.mjs socket
+   ```
+
+   Wait for `WebSocket server running on port 3055`. If the port is already held, ask whether to reuse that process — never kill something you did not start.
+
+## Phase 3: Hand off (hard stop)
+
+Only a person can drive the Figma desktop app. There is no way around this step.
+
+**Before asking, confirm all of these.** If any is false, go back to Phase 2 — the person gets called once.
+
+- [ ] `tools/figma-mcp/dist` was just rebuilt
+- [ ] The relay is listening on 3055
+- [ ] Phase 1 passed
+
+Then ask with **AskUserQuestion**. Do not write the question into chat and continue — that is not a stop.
+
+Spell out what to do and why each step matters; without the reason people skip the reload. Refer to the file by the key Phase 1 actually used. If they open a different file the two transports answer about different documents, and that difference gets reported as a code bug.
+
+```
+WebSocket side is ready. Two things in Figma:
+
+1. Quit the plugin and run it again — dist was just rebuilt, and a running
+   instance keeps answering with the old code.
+2. Open the file from Phase 1 (<key>) and hit Connect in the plugin.
+   Port 3055, channel is fixed to local-default, so there is nothing to type.
+```
+
+Offer three options:
+
+| Option | Next |
+|---|---|
+| `Ready` | Phase 4 |
+| `Show me how to reload the plugin` | Explain, then ask again |
+| `Stop` | Clean up the relay, report Phase 1 only |
+
+## Phase 4: Probe and compare
+
+1. **Do not take "ready" at face value.** Check the relay log for `New client connected` first. If it is missing, ask again rather than probing into a void — an unconnected run yields a 30-second timeout that reads like a plugin bug.
+
+2. Run both and diff:
+
+   ```bash
+   bun packages/mcp/scripts/probe-transports.ts \
+     --probe <tool> \
+     --transport both \
+     --file-key <key> \
+     --node-id <id>
+   ```
+
+3. **The exit code decides whether anything differs — not whether it is a bug.** Do not read the output and conclude it "looks the same"; 0 means the transports agree on every compared field. A 1 prints the disagreement, which you then classify with the table below before calling it a bug.
+
+4. Run every node you chose in Phase 0. One passing node is not a pass.
+
+## Phase 5: Report and clean up
+
+- Report pass/fail per node, and for any failure which field differed and how.
+- Record which file and nodes you used. Without that nobody can reproduce the result.
+- **Terminate only a relay you started in Phase 2.** If you reused one that was already running, leave it.
+
+## Four ways the transports diverge
+
+Comparing is not "the whole payload matches". Sort each field into one of four classes.
+
+| Class | Handling |
+|---|---|
+| **Must match** | The default. A difference is a bug. |
+| **Transport-only** | Only one side can produce it. Add it to the probe's `ignore`. |
+| **Different vocabulary** | Both name the same thing differently — a page is `PAGE` to the Plugin API and `CANVAS` to REST. **Report it; never add it to `ignore`.** Ignoring the field buries real type bugs along with it. |
+| **Same field, different rendering** | Both sides return the field, but the values differ because each is produced by different Figma machinery — whitespace, escaping, ordering, precision. Figma does not document these and they can turn up anywhere. **Report it and let a person judge.** |
+
+The last class is the one to be careful with. It is tempting to make it go away by normalising the value before comparing, but a difference you have seen once is an observation, not a rule — you do not know what Figma actually does in the cases you have not hit. Encoding a guess turns the probe into something that confidently passes payloads that genuinely differ, which is worse than the red X it replaces. Leave the value alone, report the difference, and record what was decided wherever this tool's behaviour is tracked — not in this skill, which must stay tool-agnostic.
+
+When you add a field, classify it first, and edit `ignore` only for the transport-only case. That list is the single source of truth for a tool's parity contract, so no values are copied into this document.
+
+## Do not
+
+- Guess a WebSocket result, reuse an earlier run, or backfill it from REST. A timeout is reported as a timeout.
+- Treat "I read the code and it looks right" as verification. Executing is the entire point of this skill.
+- Move to Phase 4 without an answer from the person.
+- Call a failure "an environment problem" up front. Gather evidence in order: relay log, then whether the plugin connected, then probe output.
+
+## Finding things
+
+Paths move; exported names rarely do. Search for the symbol rather than opening a path:
+
+| To find | Search for |
+|---|---|
+| The probe implementation and each tool's `ignore` list | `PROBES` |
+| The relay protocol the probe imitates | `sendCommandToFigma` |
+| The relay itself, including the echo-to-sender behaviour | `broadcastToChannel` |
+| The channel the plugin joins | `local-default` |

--- a/tools/figma-mcp/src/main/commands/annotation.ts
+++ b/tools/figma-mcp/src/main/commands/annotation.ts
@@ -60,6 +60,18 @@ export interface ResolvedAnnotation extends Omit<Annotation, "categoryId"> {
 
 export interface AnnotatedNode {
   nodeId: string;
+  name: string;
+  type: BaseNode["type"];
+  /**
+   * Ancestors between the queried node and this one, outermost first, and empty on the queried
+   * node itself. Relative rather than absolute so it matches what the REST path can build from its
+   * subtree-only response.
+   *
+   * Carries `id` because layer names are not unique — a page routinely repeats `Label` or `Slot`
+   * across hundreds of nodes — so the names alone read as a breadcrumb but cannot address the
+   * ancestor a caller wants to act on.
+   */
+  path: { id: string; name: string }[];
   annotations: ResolvedAnnotation[];
 }
 
@@ -118,25 +130,30 @@ async function collectAnnotatedNodes(root: BaseNode) {
     return { ...annotation, ...(category && { category }) };
   };
 
-  const visit = async (node: BaseNode) => {
+  const visit = async (node: BaseNode, path: AnnotatedNode["path"]) => {
     // `documentAccess: "dynamic-page"` keeps a page's children unavailable until it is loaded.
     if (node.type === "PAGE") await node.loadAsync();
 
     if ("annotations" in node && node.annotations.length > 0) {
       collected.push({
         nodeId: node.id,
+        name: node.name,
+        type: node.type,
+        path,
         annotations: await Promise.all(node.annotations.map(resolveAnnotation)),
       });
     }
 
     if (!("children" in node)) return;
 
+    const childPath = [...path, { id: node.id, name: node.name }];
+
     for (const child of node.children) {
-      await visit(child);
+      await visit(child, childPath);
     }
   };
 
-  await visit(root);
+  await visit(root, []);
 
   return collected;
 }

--- a/tools/figma-mcp/src/main/commands/annotation.ts
+++ b/tools/figma-mcp/src/main/commands/annotation.ts
@@ -47,9 +47,20 @@ export async function addAnnotations(params: AddAnnotationsParams) {
   };
 }
 
-export interface GetAnnotation {
+export interface ResolvedAnnotationCategory {
+  id: string;
+  label: string;
+  color: AnnotationCategoryColor;
+  isPreset: boolean;
+}
+
+export interface ResolvedAnnotation extends Omit<Annotation, "categoryId"> {
+  category?: ResolvedAnnotationCategory;
+}
+
+export interface AnnotatedNode {
   nodeId: string;
-  labelMarkdowns: string[];
+  annotations: ResolvedAnnotation[];
 }
 
 export interface GetAnnotationsParams {
@@ -57,10 +68,80 @@ export interface GetAnnotationsParams {
 }
 
 export interface GetAnnotationsResult {
-  annotations: GetAnnotation[];
+  nodes: AnnotatedNode[];
 }
 
-// Get annotations under given node id
+/**
+ * An `AnnotationCategory` carries `remove`/`setColor`/`setLabel`, so it has to be copied field by
+ * field to survive the JSON hop to the MCP server.
+ */
+function createCategoryResolver() {
+  const resolved = new Map<string, ResolvedAnnotationCategory | undefined>();
+
+  return async (categoryId: string) => {
+    // A whole subtree usually shares a handful of categories, so each id is looked up once.
+    if (!resolved.has(categoryId)) {
+      const category = await figma.annotations.getAnnotationCategoryByIdAsync(categoryId);
+
+      resolved.set(
+        categoryId,
+        category
+          ? {
+              id: category.id,
+              label: category.label,
+              color: category.color,
+              isPreset: category.isPreset,
+            }
+          : undefined,
+      );
+    }
+
+    return resolved.get(categoryId);
+  };
+}
+
+/**
+ * Deliberately not `node.findAll`: it skips the node it is called on, and it only exists on
+ * container nodes even though leaf nodes such as TEXT and RECTANGLE carry annotations too. Asking
+ * about a frame whose own annotation is the only one would come back empty, and asking about a
+ * TEXT node would throw.
+ */
+async function collectAnnotatedNodes(root: BaseNode) {
+  const collected: AnnotatedNode[] = [];
+  const resolveCategory = createCategoryResolver();
+
+  const resolveAnnotation = async ({ categoryId, ...annotation }: Annotation) => {
+    if (!categoryId) return annotation;
+
+    const category = await resolveCategory(categoryId);
+
+    return { ...annotation, ...(category && { category }) };
+  };
+
+  const visit = async (node: BaseNode) => {
+    // `documentAccess: "dynamic-page"` keeps a page's children unavailable until it is loaded.
+    if (node.type === "PAGE") await node.loadAsync();
+
+    if ("annotations" in node && node.annotations.length > 0) {
+      collected.push({
+        nodeId: node.id,
+        annotations: await Promise.all(node.annotations.map(resolveAnnotation)),
+      });
+    }
+
+    if (!("children" in node)) return;
+
+    for (const child of node.children) {
+      await visit(child);
+    }
+  };
+
+  await visit(root);
+
+  return collected;
+}
+
+// Get annotations on the given node and every node under it
 export async function getAnnotations(params: GetAnnotationsParams) {
   const { nodeId } = params;
 
@@ -69,20 +150,7 @@ export async function getAnnotations(params: GetAnnotationsParams) {
     throw new Error(`Node not found: ${nodeId}`);
   }
 
-  if (!("findAll" in node)) {
-    throw new Error(`Node does not support findAll: ${nodeId}`);
-  }
-
-  const nodeWithAnnotations = node.findAll(
-    (node) => "annotations" in node && node.annotations.length > 0,
-  ) as Array<SceneNode & AnnotationsMixin>;
-
-  const annotations = nodeWithAnnotations.map((node) => ({
-    nodeId: node.id,
-    labelMarkdowns: node.annotations.map((annotation) => annotation.labelMarkdown),
-  }));
-
   return {
-    annotations,
+    nodes: await collectAnnotatedNodes(node),
   };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Figma 주석 조회를 REST API와 WebSocket 모드에서 지원합니다.
  * 지정한 레이어와 모든 하위 레이어의 주석을 노드별로 확인할 수 있습니다.
  * 노드 이름, 유형, 계층 경로와 주석 정보를 제공합니다.
  * 주석 카테고리의 ID, 이름, 색상 및 프리셋 여부를 제공합니다.
  * REST 모드에서는 텍스트 레이블을, WebSocket 모드에서는 서식 및 카테고리 정보를 제공합니다.

* **버그 수정**
  * 대상 레이어의 주석이 누락되던 문제를 수정했습니다.
  * 하위 레이어가 없거나 주석이 없는 레이어 조회 오류를 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->