### PR TITLE
feat(docs): add copy-link action to the LLMS.txt dropdown

### DIFF
--- a/docs/components/page-actions.tsx
+++ b/docs/components/page-actions.tsx
@@ -2,6 +2,7 @@
 
 import { IconChevronDownLine, IconSquare2StackedLine } from "@karrotmarket/react-monochrome-icon";
 import { IconSeedArrow } from "@/components/icon-seed-arrow";
+import { IconLink } from "@/components/icons/IconLink";
 import {
   DocsMenuContent,
   DocsMenuGroup,
@@ -36,12 +37,20 @@ function LLMOptionsContent({ markdownUrl }: { markdownUrl: string }) {
   const [isLoading, setLoading] = useState(false);
   const adapter = useSnackbarAdapter();
 
-  const showCopiedSnackbar = () => {
+  const showCopiedSnackbar = (message: string) => {
     adapter.create({
       timeout: 2000,
       onClose: () => {},
-      render: () => <Snackbar message="복사되었습니다" />,
+      render: () => <Snackbar message={message} />,
     });
+  };
+
+  // markdownUrl은 루트 상대 경로(`/llms/...`)라 그대로 복사하면 붙여넣는 쪽에서 못 연다.
+  const handleCopyUrlClick = async () => {
+    setOpen(false);
+
+    await navigator.clipboard.writeText(new URL(markdownUrl, window.location.href).href);
+    showCopiedSnackbar("링크가 복사되었습니다");
   };
 
   const handleCopyClick = async () => {
@@ -50,7 +59,7 @@ function LLMOptionsContent({ markdownUrl }: { markdownUrl: string }) {
     const cached = cache.get(markdownUrl);
     if (cached) {
       await navigator.clipboard.writeText(cached);
-      showCopiedSnackbar();
+      showCopiedSnackbar("내용이 복사되었습니다");
       return;
     }
 
@@ -62,7 +71,7 @@ function LLMOptionsContent({ markdownUrl }: { markdownUrl: string }) {
 
       cache.set(markdownUrl, content);
       await navigator.clipboard.writeText(content);
-      showCopiedSnackbar();
+      showCopiedSnackbar("내용이 복사되었습니다");
     } finally {
       setLoading(false);
     }
@@ -83,8 +92,15 @@ function LLMOptionsContent({ markdownUrl }: { markdownUrl: string }) {
       <DocsMenuContent>
         <DocsMenuGroup>
           <DocsMenuItem
+            label="링크 복사"
+            suffixIcon={<IconLink />}
+            onClick={() => {
+              void handleCopyUrlClick();
+            }}
+          />
+          <DocsMenuItem
             disabled={isLoading}
-            label="복사하기"
+            label="내용 복사"
             suffixIcon={<IconSquare2StackedLine />}
             onClick={() => {
               void handleCopyClick();


### PR DESCRIPTION
## 배경

문서 페이지 우상단 `LLMS.txt` 드롭다운에 **복사하기**(본문 마크다운 fetch → 클립보드)와 **열기** 두 항목만 있었다. 정작 LLM에 붙여넣을 때 가장 자주 필요한 건 llms.txt 주소 자체인데, 그걸 얻으려면 열기로 새 탭을 띄운 뒤 주소창에서 직접 복사해야 했다.

## 변경

**링크 복사 / 내용 복사 / 열기** 3항목 구성으로 바꿨다.


| 항목 | 동작 |
|---|---|
| 링크 복사 | 해당 페이지 llms.txt의 **절대 URL** 복사 (예: `https://v3.seed-design.io/llms/foundations/color.txt`) |
| 내용 복사 | 기존 `복사하기`. 로직·캐시·`isLoading` 그대로, 라벨만 변경 |
| 열기 | 기존 그대로 |

- `markdownUrl`이 루트 상대 경로(`/llms/...`)라 `new URL(markdownUrl, window.location.href).href`로 절대화한다.
- 아이콘은 이미 레포에 있는 `IconLink`(체인 글리프) 재사용 — `@karrotmarket/react-monochrome-icon`에 링크 글리프가 없다.
- 스낵바를 동작별로 분리했다. 링크는 `updates` 공유 버튼과 같은 "링크가 복사되었습니다" 문구를 쓴다.

`docs`는 private 패키지라 changeset은 없다.

## 검증

dev 서버에서 `/foundations/color` 드롭다운을 직접 확인했다.

- 메뉴 3항목이 링크 복사 / 내용 복사 / 열기 순서로 렌더, 아이콘 3개 모두 16px
- 링크 복사 → 클립보드에 `http://localhost:3007/llms/foundations/color.txt` (절대 URL)
- 스낵바 "링크가 복사되었습니다" 노출
- `bun docs:test` 98 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 페이지 액션 메뉴에서 현재 페이지의 URL을 클립보드에 복사할 수 있습니다.
  * URL 복사와 Markdown 내용 복사를 별도 메뉴로 제공합니다.
  * 각 복사 동작에 맞는 스낵바 안내 메시지를 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->