### PR TITLE
feat(release): add multi-lane release workflow

### DIFF
--- a/.github/release/AGENTS.md
+++ b/.github/release/AGENTS.md
@@ -1,0 +1,18 @@
+# .github/release
+
+## 디렉토리 개요
+
+`dev`·`minor`·`major` 릴리즈 레인의 정적 설정과 중앙 운영 상태를 관리한다. 실제 판단과 변경 로직은 `scripts/release`에 두고 GitHub Actions가 이 설정을 읽어 실행한다.
+
+## 파일 작성 컨벤션
+
+- JSON 설정 파일은 `schemaVersion`과 로컬 `$schema` 참조를 포함한다. 대응하는 `*.schema.json`은 Draft 2020-12로 작성하고 모든 객체에 `additionalProperties: false`를 둔다.
+- 설정 구조를 변경할 때 TypeScript 타입, 런타임 파서, JSON Schema, 테스트를 함께 갱신한다.
+- `lanes.json`에는 레인의 불변 정책을, `control.json`에는 PR을 통해 변경하는 운영 상태만 둔다.
+- branch·package별 중복 설정 파일을 추가하지 않고 세 레인의 차이는 `lanes` map으로 표현한다.
+
+## 코드 작성 컨벤션
+
+- 일반 PR은 `control.json`, `.changeset/config.json`, `.changeset/pre.json`을 변경하지 않는다.
+- production 활성화와 freeze를 포함한 상태 변경은 반드시 자동화가 만든 PR로 반영한다.
+- DES-2201 계약이 준비되지 않은 상태에서는 `mode`를 `production`으로 변경하지 않는다.

--- a/.github/release/control.json
+++ b/.github/release/control.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "./control.schema.json",
+  "schemaVersion": 1,
+  "mode": "dry-run",
+  "rootageContractReady": false,
+  "freeze": null
+}

--- a/.github/release/control.schema.json
+++ b/.github/release/control.schema.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SEED Design 릴리즈 운영 상태",
+  "description": "릴리즈 실행 모드, Rootage 계약 준비 상태, stable 승격 freeze를 정의한다.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "schemaVersion", "mode", "rootageContractReady", "freeze"],
+  "properties": {
+    "$schema": {
+      "description": "이 설정 파일을 검증하는 로컬 JSON Schema 경로다.",
+      "const": "./control.schema.json"
+    },
+    "schemaVersion": {
+      "description": "릴리즈 운영 상태 형식의 버전이다. 파서가 지원하는 버전과 일치해야 한다.",
+      "const": 1
+    },
+    "mode": {
+      "description": "dry-run은 검증만 수행하고 production은 실제 npm·Rootage 게시를 허용한다.",
+      "enum": ["dry-run", "production"]
+    },
+    "rootageContractReady": {
+      "description": "DES-2201의 불변 Rootage 게시 계약이 production 사용 가능한 상태인지 나타낸다.",
+      "type": "boolean"
+    },
+    "freeze": {
+      "description": "진행 중인 stable 승격 상태다. 승격이 없으면 null이다.",
+      "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/freeze" }]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "mode": { "const": "production" } },
+        "required": ["mode"]
+      },
+      "then": {
+        "properties": { "rootageContractReady": { "const": true } }
+      }
+    }
+  ],
+  "$defs": {
+    "freeze": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["promotionLane", "candidateSha", "phase", "frozenLanes", "startedAt"],
+      "properties": {
+        "promotionLane": {
+          "description": "stable로 승격할 prerelease 레인이다.",
+          "enum": ["minor", "major"]
+        },
+        "candidateSha": {
+          "description": "승격 대상으로 고정한 레인 HEAD의 40자리 Git commit SHA다.",
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "phase": {
+          "description": "승격 작업의 현재 단계다.",
+          "enum": ["frozen", "integrating", "rebuilding"]
+        },
+        "frozenLanes": {
+          "description": "승격 완료 전 일반 PR merge와 prerelease publish를 차단할 레인 목록이다.",
+          "type": "array",
+          "items": {
+            "enum": ["minor", "major"]
+          },
+          "uniqueItems": true
+        },
+        "startedAt": {
+          "description": "승격 freeze를 시작한 RFC 3339 시각이다.",
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "promotionLane": { "const": "minor" } },
+            "required": ["promotionLane"]
+          },
+          "then": {
+            "properties": { "frozenLanes": { "const": ["minor"] } }
+          }
+        },
+        {
+          "if": {
+            "properties": { "promotionLane": { "const": "major" } },
+            "required": ["promotionLane"]
+          },
+          "then": {
+            "properties": { "frozenLanes": { "const": ["minor", "major"] } }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.github/release/lanes.json
+++ b/.github/release/lanes.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "./lanes.schema.json",
+  "schemaVersion": 1,
+  "repository": "daangn/seed-design",
+  "maintainerTeam": "design-system",
+  "protectedDistTags": ["latest", "stable"],
+  "lanes": {
+    "dev": {
+      "bump": "patch",
+      "prerelease": false,
+      "sources": []
+    },
+    "minor": {
+      "bump": "minor",
+      "prerelease": true,
+      "sources": ["dev"]
+    },
+    "major": {
+      "bump": "major",
+      "prerelease": true,
+      "sources": ["dev", "minor"]
+    }
+  },
+  "sync": {
+    "activation": null,
+    "reconcileCron": "*/10 * * * *",
+    "conflictAlertHours": 24
+  }
+}

--- a/.github/release/lanes.schema.json
+++ b/.github/release/lanes.schema.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SEED Design 릴리즈 레인 설정",
+  "description": "dev, minor, major 고정 레인의 버전 정책과 동기화 그래프를 정의한다.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schemaVersion",
+    "repository",
+    "maintainerTeam",
+    "protectedDistTags",
+    "lanes",
+    "sync"
+  ],
+  "properties": {
+    "$schema": {
+      "description": "이 설정 파일을 검증하는 로컬 JSON Schema 경로다.",
+      "const": "./lanes.schema.json"
+    },
+    "schemaVersion": {
+      "description": "릴리즈 레인 설정 형식의 버전이다. 파서가 지원하는 버전과 일치해야 한다.",
+      "const": 1
+    },
+    "repository": {
+      "description": "릴리즈 자동화가 동작하는 GitHub 저장소의 owner/name이다.",
+      "const": "daangn/seed-design"
+    },
+    "maintainerTeam": {
+      "description": "동기화 충돌과 장기 대기 알림을 받을 GitHub 팀 이름이다.",
+      "type": "string",
+      "minLength": 1
+    },
+    "protectedDistTags": {
+      "description": "prerelease tag로 사용할 수 없도록 보호하는 npm dist-tag 목록이다.",
+      "type": "array",
+      "minItems": 2,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9-]{0,31}$"
+      },
+      "allOf": [{ "contains": { "const": "latest" } }, { "contains": { "const": "stable" } }]
+    },
+    "lanes": {
+      "description": "고정 릴리즈 레인별 bump, prerelease 여부, 상위 동기화 source를 정의한다.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["dev", "minor", "major"],
+      "properties": {
+        "dev": {
+          "description": "일상 변경을 patch stable로 배포하는 기본 레인이다.",
+          "$ref": "#/$defs/devLane"
+        },
+        "minor": {
+          "description": "dev 변경을 받아 minor prerelease를 만드는 레인이다.",
+          "$ref": "#/$defs/minorLane"
+        },
+        "major": {
+          "description": "dev와 minor 변경을 받아 major prerelease를 만드는 레인이다.",
+          "$ref": "#/$defs/majorLane"
+        }
+      }
+    },
+    "sync": {
+      "description": "레인 간 PR 동기화 reconciler의 활성화와 실행 정책이다.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["activation", "reconcileCron", "conflictAlertHours"],
+      "properties": {
+        "activation": {
+          "description": "동기화 대상으로 인정할 merge의 시작 시각이다. null이면 동기화를 비활성화한다.",
+          "oneOf": [{ "type": "null" }, { "type": "string", "format": "date-time" }]
+        },
+        "reconcileCron": {
+          "description": "누락된 동기화 이벤트를 재조회하는 GitHub Actions cron 표현식이다.",
+          "type": "string",
+          "minLength": 1
+        },
+        "conflictAlertHours": {
+          "description": "충돌 Draft PR이 이 시간 이상 열려 있을 때 담당자에게 다시 알린다.",
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    }
+  },
+  "$defs": {
+    "devLane": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bump", "prerelease", "sources"],
+      "properties": {
+        "bump": {
+          "description": "이 레인 PR의 직접 changeset에 요구하는 bump다.",
+          "const": "patch"
+        },
+        "prerelease": {
+          "description": "이 레인이 prerelease 상태를 사용하는지 나타낸다.",
+          "const": false
+        },
+        "sources": { "description": "이 레인으로 변경을 전달하는 하위 레인 목록이다.", "const": [] }
+      }
+    },
+    "minorLane": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bump", "prerelease", "sources"],
+      "properties": {
+        "bump": {
+          "description": "이 레인 PR의 직접 changeset에 요구하는 bump다.",
+          "const": "minor"
+        },
+        "prerelease": {
+          "description": "이 레인이 prerelease 상태를 사용하는지 나타낸다.",
+          "const": true
+        },
+        "sources": {
+          "description": "이 레인으로 변경을 전달하는 하위 레인 목록이다.",
+          "const": ["dev"]
+        }
+      }
+    },
+    "majorLane": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bump", "prerelease", "sources"],
+      "properties": {
+        "bump": {
+          "description": "이 레인 PR의 직접 changeset에 요구하는 bump다.",
+          "const": "major"
+        },
+        "prerelease": {
+          "description": "이 레인이 prerelease 상태를 사용하는지 나타낸다.",
+          "const": true
+        },
+        "sources": {
+          "description": "이 레인으로 변경을 전달하는 하위 레인 목록이다.",
+          "const": ["dev", "minor"]
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/release-activation.yml
+++ b/.github/workflows/release-activation.yml
@@ -1,0 +1,46 @@
+name: Release automation activation
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: "Activation step"
+        required: true
+        type: choice
+        options: [enable-sync, enable-production]
+
+concurrency:
+  group: release-activation
+  cancel-in-progress: false
+
+jobs:
+  create-pr:
+    name: Create activation PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+      - name: Apply activation state
+        run: bun scripts/release/cli.ts activation --operation "${{ inputs.operation }}"
+      - name: Create activation PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPERATION: ${{ inputs.operation }}
+        run: |
+          BRANCH="release-freeze/activation-${OPERATION}-${GITHUB_RUN_ID}"
+          git switch -c "$BRANCH"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/release/lanes.json .github/release/control.json
+          git commit -m "chore(release): ${OPERATION}"
+          git push origin "$BRANCH"
+          MARKER=$(bun scripts/release/cli.ts marker --type freeze --lane dev --tag "$OPERATION")
+          gh pr create --base dev --head "$BRANCH" --title "chore(release): ${OPERATION}" --body "$MARKER"

--- a/.github/workflows/release-bootstrap.yml
+++ b/.github/workflows/release-bootstrap.yml
@@ -1,0 +1,91 @@
+name: Release lanes bootstrap
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: release-bootstrap
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Verify clean stable baseline
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+      - name: Require DES-2201 and a clean dev baseline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          test "$(jq -r '.rootageContractReady' .github/release/control.json)" = "true"
+          test "$(jq -r '.mode' .github/release/control.json)" = "dry-run"
+          test "$(jq -r '.freeze' .github/release/control.json)" = "null"
+          CHANGESETS=$(rg --files .changeset -g '*.md' | rg -v '^.changeset/README.md$' || true)
+          test -z "$CHANGESETS"
+          OPEN_VERSION_PR=$(gh pr list --state open --base dev --head changeset-release/dev --json number --jq '.[0].number')
+          test -z "$OPEN_VERSION_PR"
+
+  create-branches:
+    name: Create and protect fixed lanes
+    needs: preflight
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: dev
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+      - name: Create branches from the same dev SHA
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_ADMIN_TOKEN }}
+        run: bun scripts/release/bootstrap.ts
+
+  configure:
+    name: Configure ${{ matrix.lane }} beta lane
+    needs: create-branches
+    strategy:
+      matrix:
+        lane: [minor, major]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ matrix.lane }}
+          fetch-depth: 0
+      - uses: ./.github/actions/setup
+      - name: Configure baseBranch and enter beta
+        env:
+          LANE: ${{ matrix.lane }}
+        run: |
+          jq --arg lane "$LANE" '.baseBranch = $lane' .changeset/config.json > /tmp/changeset-config.json
+          cp /tmp/changeset-config.json .changeset/config.json
+          bun changeset pre enter beta
+      - name: Create bootstrap PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LANE: ${{ matrix.lane }}
+        run: |
+          BRANCH="release-rebuild/bootstrap-${LANE}-${GITHUB_RUN_ID}"
+          git switch -c "$BRANCH"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .changeset/config.json .changeset/pre.json
+          git commit -m "chore(release): bootstrap ${LANE} beta lane"
+          git push origin "$BRANCH"
+          MARKER=$(bun scripts/release/cli.ts marker --type rebuild --lane "$LANE" --targetLane "$LANE" --tag beta)
+          gh pr create --base "$LANE" --head "$BRANCH" --title "chore(release): bootstrap ${LANE} beta lane" --body "$MARKER"

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -1,0 +1,45 @@
+name: Release automation E2E
+
+on:
+  pull_request:
+    paths:
+      - ".github/release/**"
+      - ".github/workflows/release-*.yml"
+      - ".github/workflows/rootage-release-contract.yml"
+      - "scripts/release/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify release automation without production writes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup
+
+      - name: Verify release unit and integration scenarios
+        run: bun test scripts/release
+
+      - name: Generate all tracked artifacts
+        run: bun generate:all
+
+      - name: Run repository test suite
+        run: bun test:all
+
+      - name: Re-run generation and require a clean diff
+        run: |
+          bun generate:all
+          git diff --exit-code
+
+      - name: Build and package Rootage without publishing
+        run: bun scripts/release/dry-run.ts

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1,104 +1,98 @@
-name: Release
+name: Release Version PR
 
 on:
   push:
-    branches:
-      - main
-      - dev
+    branches: [dev, minor, major]
     paths:
       - "packages/**"
       - "docs/**"
       - ".changeset/**"
+      - ".github/release/**"
       - ".github/workflows/release-packages.yml"
       - ".github/actions/setup/action.yml"
+      - "scripts/release/**"
   workflow_dispatch:
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: release-version-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
-  release:
-    name: Release Seed Design Packages
+  version:
+    name: Update Version Packages PR
+    if: contains(fromJSON('["dev", "minor", "major"]'), github.ref_name)
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
       pull-requests: write
-      packages: read
-      id-token: write
 
     steps:
-      - name: Checkout Repo
+      - name: Checkout lane
         uses: actions/checkout@v6
         with:
-          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
-
-      - uses: actions/setup-node@v6 # this is faster than `bun install -g npm@latest`
-        with:
-          node-version: "24"
 
       - uses: ./.github/actions/setup
 
-      - name: 릴리즈 Pull Request를 만들거나 패키지를 배포해요
-        id: changesets
-        uses: changesets/action@v1
+      - name: Create or update Version Packages PR
+        id: version
+        uses: changesets/action@3841a0683d3cfa6dae0f9bb335290003010fe3f0 # v1.9.0
         with:
-          publish: bun release
-          version: bun version
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: bun scripts/release/version.ts
+          commit: "chore(release): version packages"
           title: "release: version packages"
+          branch: ${{ github.ref_name }}
+
+      - name: Mark trusted Version Packages PR
+        if: steps.version.outputs.pullRequestNumber
+        uses: actions/github-script@v9
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
-          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
-
-      - name: 릴리즈 PR이 만들어지거나 업데이트된 경우 해당 PR의 base 브랜치를 체크아웃해요
-        if: steps.changesets.outputs.published == 'false' && steps.changesets.outputs.hasChangesets == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+          PR_NUMBER: ${{ steps.version.outputs.pullRequestNumber }}
+          LANE: ${{ github.ref_name }}
         with:
-          ref: changeset-release/${{ github.ref_name }}
-
-      - name: 배포 전인 경우 rootage json 파일의 버전을 @seed-design/rootage-artifacts 버전에 맞춰요
-        if: steps.changesets.outputs.published == 'false' && steps.changesets.outputs.hasChangesets == 'true'
-        run: |
-          bun install --frozen-lockfile
-          bun rootage:build
-          bun install # link
-          bun rootage:generate
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add packages/rootage/__generated__
-          git commit -m "Update rootage generated json to match new package version" || echo "No changes to commit"
-          git push
-
-      - name: 배포된 버전을 가져와요
-        id: get-package-versions
-        if: steps.changesets.outputs.published == 'true'
-        run: |
-          PACKAGE_VERSIONS=$(echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -c 'map({name: .name, value: .version}) | from_entries')
-          echo "packageVersions=$PACKAGE_VERSIONS" >> $GITHUB_OUTPUT
-
-      - name: rootage-artifacts가 배포된 경우 Slack에 알려요
-        if: steps.changesets.outputs.published == 'true' && contains(fromJson(steps.changesets.outputs.publishedPackages || '[]').*.name, '@seed-design/rootage-artifacts')
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            text: "새 Rootage 버전이 배포되었어요."
-            blocks:
-              - type: "header"
-                text:
-                  type: "plain_text"
-                  text: "새 Rootage 버전이 배포되었어요: v${{ fromJson(steps.get-package-versions.outputs.packageVersions || '{}')['@seed-design/rootage-artifacts'] }}"
-              - type: "section"
-                text:
-                  type: "plain_text"
-                  text: "문서 빌드까지는 시간이 조금 더 걸릴 수 있어요."
-              - type: "actions"
-                elements:
-                  - type: "button"
-                    style: "primary"
-                    text:
-                      type: "plain_text"
-                      text: "Changelog"
-                    url: "https://seed-design.io/react/updates/changelog"
+          script: |
+            const { stdout } = await exec.getExecOutput("bun", [
+              "scripts/release/cli.ts",
+              "marker",
+              "--type", "version",
+              "--lane", process.env.LANE,
+            ]);
+            const marker = stdout.trim();
+            const pull = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number(process.env.PR_NUMBER),
+            });
+            const bodyWithoutOldMarker = (pull.data.body ?? "").replace(
+              /<!-- seed-release:\{[^\n]+\} -->\n*/g,
+              "",
+            );
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number(process.env.PR_NUMBER),
+              body: `${marker}\n\n${bodyWithoutOldMarker}`,
+            });
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.PR_NUMBER),
+              labels: ["release:version"],
+            }).catch(async (error) => {
+              if (error.status !== 404 && error.status !== 422) throw error;
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: "release:version",
+                color: "8250df",
+                description: "Version Packages PR generated by release automation",
+              });
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: Number(process.env.PR_NUMBER),
+                labels: ["release:version"],
+              });
+            });

--- a/.github/workflows/release-pr-validation.yml
+++ b/.github/workflows/release-pr-validation.yml
@@ -1,0 +1,36 @@
+name: Release lane PR validation
+
+on:
+  pull_request:
+    branches: [dev, minor, major]
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate release lane
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR merge ref
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup
+
+      - name: Validate changesets and automation identity
+        id: release-validation
+        run: bun scripts/release/cli.ts validate-pr --event "$GITHUB_EVENT_PATH"
+
+      - name: Test release automation
+        run: bun test scripts/release
+
+      - name: Run full trusted sync gate
+        if: steps.release-validation.outputs.type == 'sync'
+        run: |
+          bun generate:all
+          bun test:all
+          bun generate:all
+          git diff --exit-code

--- a/.github/workflows/release-promotion.yml
+++ b/.github/workflows/release-promotion.yml
@@ -1,0 +1,130 @@
+name: Release stable promotion
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: "Promotion operation"
+        required: true
+        type: choice
+        options: [start, integrate, rebuild, finish]
+      lane:
+        description: "Promotion lane"
+        required: true
+        type: choice
+        options: [minor, major]
+      rebuild-lane:
+        description: "Lane to rebuild from latest dev"
+        required: false
+        type: choice
+        options: [minor, major]
+
+concurrency:
+  group: release-promotion
+  cancel-in-progress: false
+
+jobs:
+  state-pr:
+    name: Create promotion state PR
+    if: inputs.operation == 'start' || inputs.operation == 'finish'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout dev control plane
+        uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+
+      - name: Ensure no pending state PR exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "$(gh pr list --state open --base dev --search 'head:release-freeze/' --json number --jq '.[0].number')" ]; then
+            echo "A promotion state PR is already open."
+            exit 1
+          fi
+
+      - name: Resolve candidate SHA
+        id: candidate
+        env:
+          LANE: ${{ inputs.lane }}
+        run: |
+          git fetch origin "$LANE"
+          echo "sha=$(git rev-parse "origin/$LANE")" >> "$GITHUB_OUTPUT"
+
+      - name: Update control state
+        run: bun scripts/release/cli.ts promotion --lane "${{ inputs.lane }}" --phase "${{ inputs.operation }}" --candidate-sha "${{ steps.candidate.outputs.sha }}"
+
+      - name: Create control-state PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LANE: ${{ inputs.lane }}
+          OPERATION: ${{ inputs.operation }}
+        run: |
+          BRANCH="release-freeze/${LANE}-${OPERATION}-${GITHUB_RUN_ID}"
+          git switch -c "$BRANCH"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/release/control.json
+          git commit -m "chore(release): ${OPERATION} ${LANE} promotion"
+          git push origin "$BRANCH"
+          MARKER=$(bun scripts/release/cli.ts marker --type freeze --lane dev --targetLane "$LANE" --tag "$OPERATION")
+          gh pr create --base dev --head "$BRANCH" --title "chore(release): ${OPERATION} ${LANE} promotion" --body "$MARKER"
+
+  integrate:
+    name: Integrate stable lane into dev
+    if: inputs.operation == 'integrate'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+      - name: Create stable integration PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RECONCILE_MODE: integration
+          SOURCE_LANE: ${{ inputs.lane }}
+          TARGET_LANE: dev
+        run: bun scripts/release/reconcile-worker.ts
+
+  rebuild:
+    name: Rebuild lane from latest dev
+    if: inputs.operation == 'rebuild'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Require rebuild lane
+        if: inputs.rebuild-lane == ''
+        run: exit 1
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.rebuild-lane }}
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+      - name: Create rebuild PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RECONCILE_MODE: rebuild
+          SOURCE_LANE: dev
+          TARGET_LANE: ${{ inputs.rebuild-lane }}
+        run: bun scripts/release/reconcile-worker.ts

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,182 @@
+name: Release publish
+
+on:
+  pull_request_target:
+    branches: [dev, minor, major]
+    types: [closed]
+  schedule:
+    - cron: "7,27,47 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: release-publish
+  cancel-in-progress: false
+
+jobs:
+  select:
+    name: Select oldest approved Version Packages PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    outputs:
+      found: ${{ steps.queue.outputs.found }}
+      number: ${{ steps.queue.outputs.number }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+      - name: Reconcile the durable publish queue
+        id: queue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun scripts/release/publish-queue.ts
+
+  authorize:
+    name: Authorize Version Packages merge
+    needs: select
+    if: needs.select.outputs.found == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      mode: ${{ steps.authorize.outputs.mode }}
+      lane: ${{ steps.authorize.outputs.lane }}
+      merge-sha: ${{ steps.authorize.outputs.mergeSha }}
+      base-sha: ${{ steps.authorize.outputs.baseSha }}
+      number: ${{ steps.authorize.outputs.number }}
+    steps:
+      - name: Checkout trusted dev control plane
+        uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+      - name: Authorize human-approved Version Packages PR
+        id: authorize
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun scripts/release/authorize-publish-pr.ts "${{ needs.select.outputs.number }}"
+
+  dry-run:
+    name: Version, build and package dry-run
+    needs: authorize
+    if: needs.authorize.outputs.mode == 'dry-run'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout exact merged commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.authorize.outputs.merge-sha }}
+          fetch-depth: 0
+      - uses: ./.github/actions/setup
+      - name: Plan versions without registry writes
+        run: bun scripts/release/publish-plan.ts "${{ needs.authorize.outputs.lane }}"
+      - name: Run real build and packaging code
+        run: bun scripts/release/dry-run.ts
+
+  publish-npm:
+    name: Publish npm packages
+    needs: authorize
+    if: needs.authorize.outputs.mode == 'production'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    outputs:
+      rootage-version: ${{ steps.plan.outputs.rootageVersion }}
+      rootage-integrity: ${{ steps.rootage.outputs.integrity }}
+      stable: ${{ steps.plan.outputs.stable }}
+    steps:
+      - name: Checkout exact merged commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.authorize.outputs.merge-sha }}
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      - uses: ./.github/actions/setup
+      - name: Verify monotonic versions and recovery plan
+        id: plan
+        run: bun scripts/release/publish-plan.ts "${{ needs.authorize.outputs.lane }}"
+      - name: Publish missing versions from the approved commit
+        run: bun release
+      - name: Resolve published Rootage integrity
+        id: rootage
+        run: bun scripts/release/rootage-input.ts "${{ steps.plan.outputs.rootageVersion }}"
+      - name: Push package tags
+        run: git push --follow-tags
+
+  publish-rootage:
+    name: Publish immutable Rootage artifacts
+    needs: publish-npm
+    if: needs.publish-npm.outputs.rootage-version != ''
+    uses: ./.github/workflows/rootage-release-contract.yml
+    with:
+      version: ${{ needs.publish-npm.outputs.rootage-version }}
+      npm-integrity: ${{ needs.publish-npm.outputs.rootage-integrity }}
+      stable: ${{ needs.publish-npm.outputs.stable == 'true' }}
+    secrets: inherit
+
+  record:
+    name: Record successful queue item
+    needs: [authorize, dry-run, publish-npm, publish-rootage]
+    if: >-
+      always() &&
+      !failure() &&
+      !cancelled() &&
+      (needs.dry-run.result == 'success' || needs.publish-npm.result == 'success') &&
+      (needs.publish-rootage.result == 'success' || needs.publish-rootage.result == 'skipped')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: dev
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+      - name: Persist idempotent publish result
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISH_PR_NUMBER: ${{ needs.authorize.outputs.number }}
+          PUBLISH_MERGE_SHA: ${{ needs.authorize.outputs.merge-sha }}
+          PUBLISH_STATUS: ${{ needs.authorize.outputs.mode }}
+        run: bun scripts/release/record-publish.ts
+      - name: Drain the next FIFO item
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run release-publish.yml
+
+  notify-failure:
+    name: Notify release failure
+    needs: [authorize, dry-run, publish-npm, publish-rootage]
+    if: failure()
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions: {}
+    steps:
+      - name: Notify Slack without changing the release result
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "Rootage release failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/release-sync-alert.yml
+++ b/.github/workflows/release-sync-alert.yml
@@ -1,0 +1,37 @@
+name: Release sync conflict alert
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+jobs:
+  alert:
+    name: Alert stale synchronization conflicts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: dev
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+      - name: Find and comment on stale conflicts
+        id: conflicts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun scripts/release/sync-alert.ts
+      - name: Notify Slack
+        if: steps.conflicts.outputs.count != '0'
+        continue-on-error: true
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "Rootage release sync conflicts need attention: ${{ steps.conflicts.outputs.urls }}"

--- a/.github/workflows/release-sync-merge.yml
+++ b/.github/workflows/release-sync-merge.yml
@@ -1,0 +1,28 @@
+name: Release sync trusted merge
+
+on:
+  workflow_run:
+    workflows: ["Release lane PR validation"]
+    types: [completed]
+
+jobs:
+  merge:
+    name: Revalidate and merge trusted sync PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout trusted dev workflow
+        uses: actions/checkout@v6
+        with:
+          ref: dev
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+
+      - name: Verify immutable automation diff and merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun scripts/release/sync-merge.ts

--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -1,0 +1,62 @@
+name: Release lane synchronization
+
+on:
+  pull_request_target:
+    branches: [dev, minor, major]
+    types: [closed]
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+jobs:
+  prepare:
+    name: Read synchronization control
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      enabled: ${{ steps.control.outputs.enabled }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: dev
+      - id: control
+        run: |
+          if [ "$(jq -r '.sync.activation' .github/release/lanes.json)" = "null" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  drain:
+    name: Drain ${{ matrix.target }} FIFO queue
+    needs: prepare
+    if: needs.prepare.outputs.enabled == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [minor, major]
+    concurrency:
+      group: release-sync-${{ matrix.target }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout target lane
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ matrix.target }}
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+
+      - name: Apply the oldest unprocessed source PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_LANE: ${{ matrix.target }}
+        run: bun scripts/release/sync-worker.ts

--- a/.github/workflows/release-transition.yml
+++ b/.github/workflows/release-transition.yml
@@ -1,0 +1,79 @@
+name: Release prerelease transition
+
+on:
+  workflow_dispatch:
+    inputs:
+      lane:
+        description: "Pre-release lane"
+        required: true
+        type: choice
+        options: [minor, major]
+      command:
+        description: "State transition"
+        required: true
+        type: choice
+        options: [enter, retag, exit]
+      tag:
+        description: "Pre-release tag for enter or retag"
+        required: false
+        default: beta
+        type: string
+
+concurrency:
+  group: release-transition-${{ inputs.lane }}
+  cancel-in-progress: false
+
+jobs:
+  create-pr:
+    name: Create transition PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout selected lane
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.lane }}
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup
+
+      - name: Reject an equivalent open transition
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LANE: ${{ inputs.lane }}
+          COMMAND: ${{ inputs.command }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          MATCH=$(gh pr list --state open --base "$LANE" --json body --jq ".[] | select(.body | contains(\"\\\"type\\\":\\\"transition\\\"\") and contains(\"\\\"command\\\":\\\"$COMMAND\\\"\") and contains(\"\\\"tag\\\":\\\"$TAG\\\"\")) | .body" || true)
+          if [ -n "$MATCH" ]; then
+            echo "Equivalent transition PR is already open."
+            exit 1
+          fi
+
+      - name: Apply transition
+        id: transition
+        run: bun scripts/release/cli.ts transition --lane "${{ inputs.lane }}" --command "${{ inputs.command }}" --tag "${{ inputs.tag }}"
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LANE: ${{ inputs.lane }}
+          COMMAND: ${{ inputs.command }}
+          TAG: ${{ steps.transition.outputs.tag }}
+        run: |
+          BRANCH="release-transition/${LANE}/${COMMAND}-${GITHUB_RUN_ID}"
+          git switch -c "$BRANCH"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .changeset/pre.json
+          git commit -m "chore(release): ${COMMAND} ${LANE} prerelease"
+          git push origin "$BRANCH"
+          MARKER=$(bun scripts/release/cli.ts marker --type transition --lane "$LANE" --command "$COMMAND" --tag "${TAG:-beta}")
+          PR_URL=$(gh pr create --base "$LANE" --head "$BRANCH" --title "chore(release): ${COMMAND} ${LANE} prerelease" --body "$MARKER")
+          PR_NUMBER=${PR_URL##*/}
+          gh api "repos/${GITHUB_REPOSITORY}/labels" -f name="release:transition" -f color="1f883d" -f description="Changesets prerelease state transition" >/dev/null 2>&1 || true
+          gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" -f labels[]="release:transition" >/dev/null

--- a/.github/workflows/rootage-release-contract.yml
+++ b/.github/workflows/rootage-release-contract.yml
@@ -1,0 +1,54 @@
+name: Rootage release contract
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Exact @seed-design/rootage-artifacts version"
+        required: true
+        type: string
+      stable:
+        description: "Whether to update the stable pointer after verification"
+        required: true
+        type: boolean
+      npm-integrity:
+        description: "Integrity from the published npm tarball"
+        required: true
+        type: string
+    outputs:
+      manifest-sha:
+        description: "SHA-256 of the immutable completion manifest"
+        value: ${{ jobs.unavailable.outputs.manifest-sha }}
+      file-count:
+        description: "Number of verified Rootage JSON files"
+        value: ${{ jobs.unavailable.outputs.file-count }}
+      pointer-before:
+        description: "Stable pointer before compare-and-set"
+        value: ${{ jobs.unavailable.outputs.pointer-before }}
+      pointer-after:
+        description: "Stable pointer after compare-and-set"
+        value: ${{ jobs.unavailable.outputs.pointer-after }}
+
+jobs:
+  unavailable:
+    name: Require DES-2201
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      manifest-sha: ${{ steps.contract.outputs.manifest-sha }}
+      file-count: ${{ steps.contract.outputs.file-count }}
+      pointer-before: ${{ steps.contract.outputs.pointer-before }}
+      pointer-after: ${{ steps.contract.outputs.pointer-after }}
+    steps:
+      - name: Fail closed until immutable serving is implemented
+        id: contract
+        run: |
+          {
+            echo "manifest-sha="
+            echo "file-count=0"
+            echo "pointer-before="
+            echo "pointer-after="
+          } >> "$GITHUB_OUTPUT"
+          echo "DES-2201 must replace this contract before production activation."
+          echo "Requested version: ${{ inputs.version }}, integrity: ${{ inputs.npm-integrity }}, stable: ${{ inputs.stable }}"
+          exit 1

--- a/TECH.md
+++ b/TECH.md
@@ -231,6 +231,15 @@ export const Checkbox = { Root, Control, HiddenInput, ... };
 - `bun version` - 버전 업데이트
 - `bun release` - 배포
 
+### 릴리즈 레인 자동화
+
+- `dev`는 patch stable, `minor`는 minor pre-release, `major`는 major pre-release 레인이다.
+- 레인 정책은 `.github/release/lanes.json`, 운영 모드와 승격 freeze는 `.github/release/control.json`에서 관리한다. 각 파일은 같은 디렉토리의 Draft 2020-12 JSON Schema를 `$schema`로 참조한다.
+- 일반 PR은 read-only 검증만 수행하고 Version Packages PR의 사람 merge만 게시 승인이 된다.
+- `minor`·`major`의 `enter`·`retag`·`exit`와 stable 승격은 보호 브랜치를 직접 수정하지 않고 PR로 수행한다.
+- 레인 동기화는 원본 일반 PR의 최종 diff만 target별 FIFO로 전달하며, 충돌이나 사람 수정이 있으면 자동 merge를 중단한다.
+- `control.json`의 기본값은 `dry-run`이다. DES-2201의 불변 Rootage 게시 계약과 bootstrap E2E가 완료되기 전에는 production으로 전환하지 않는다.
+
 ---
 
 ## 환경 변수

--- a/scripts/release/AGENTS.md
+++ b/scripts/release/AGENTS.md
@@ -1,0 +1,18 @@
+# scripts/release
+
+## 디렉토리 개요
+
+Rootage 릴리즈 레인의 검증, 동기화, 게시 승인, 승격을 구현하는 Bun TypeScript 모듈이다. `.github/workflows`는 얇은 실행 계층으로 유지하고 재사용 가능한 판단은 이 폴더에 둔다.
+
+## 파일 작성 컨벤션
+
+- 파일명은 역할을 나타내는 kebab-case를 사용하고 테스트는 `*.test.ts`로 같은 폴더에 둔다.
+- 공통 타입은 `types.ts`, GitHub REST 경계는 `github.ts`, CLI 진입점은 역할별 파일로 분리한다.
+- barrel file은 만들지 않고 필요한 모듈을 직접 import한다.
+
+## 코드 작성 컨벤션
+
+- 외부 입력은 config·marker parser에서 검증한 뒤 domain 타입으로 변환한다.
+- PR diff 계산, queue 정렬, SemVer 비교처럼 중요한 판단은 순수 함수로 분리하고 단위 테스트를 작성한다.
+- `pull_request_target`에서 fork head를 checkout하지 않으며 write 작업은 신뢰 marker와 head/base 관계를 다시 검증한다.
+- npm·Rootage 쓰기는 승인된 Version Packages merge commit에서만 실행하고 dry-run은 production credential을 사용하지 않는다.

--- a/scripts/release/authorize-publish-pr.ts
+++ b/scripts/release/authorize-publish-pr.ts
@@ -1,0 +1,48 @@
+import { appendFile } from "node:fs/promises";
+import { GitHubClient, type GitHubPullRequest } from "./github";
+import { parseMarker } from "./marker";
+import { authorizePublish } from "./publish";
+import { isLaneName, parseReleaseControl } from "./config";
+
+const token = process.env.GH_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY;
+const number = Number(Bun.argv[2]);
+if (!token || !repository || !Number.isInteger(number)) {
+  throw new Error("GitHub workflow 환경과 PR 번호가 필요합니다.");
+}
+
+const client = new GitHubClient(repository, token);
+const pull = await client.request<GitHubPullRequest>(`/repos/${repository}/pulls/${number}`);
+if (!pull.merged_at || !pull.merge_commit_sha || !pull.merged_by) {
+  throw new Error(`PR #${number}은 merge된 PR이 아닙니다.`);
+}
+if (!isLaneName(pull.base.ref)) throw new Error(`${pull.base.ref}은 릴리즈 레인이 아닙니다.`);
+
+const gitShow = Bun.spawn(["git", "show", "origin/dev:.github/release/control.json"], {
+  stdout: "pipe",
+  stderr: "inherit",
+});
+const controlText = await new Response(gitShow.stdout).text();
+if ((await gitShow.exited) !== 0) throw new Error("dev release control을 읽지 못했습니다.");
+const control = parseReleaseControl(JSON.parse(controlText));
+const mode = authorizePublish(
+  parseMarker(pull.body ?? ""),
+  pull.merged_by.login,
+  pull.base.ref,
+  pull.head.ref,
+  control,
+);
+
+const outputPath = process.env.GITHUB_OUTPUT;
+if (outputPath) {
+  await appendFile(
+    outputPath,
+    `${[
+      `mode=${mode}`,
+      `lane=${pull.base.ref}`,
+      `mergeSha=${pull.merge_commit_sha}`,
+      `baseSha=${pull.base.sha}`,
+      `number=${pull.number}`,
+    ].join("\n")}\n`,
+  );
+}

--- a/scripts/release/bootstrap.ts
+++ b/scripts/release/bootstrap.ts
@@ -1,0 +1,50 @@
+import { GitHubClient } from "./github";
+import { loadReleaseControl } from "./config";
+
+interface GitReference {
+  ref: string;
+  object: { sha: string };
+}
+
+const token = process.env.GH_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY;
+if (!token || !repository)
+  throw new Error("RELEASE_ADMIN_TOKEN과 GitHub 저장소 정보가 필요합니다.");
+
+const control = await loadReleaseControl();
+if (control.mode !== "dry-run" || !control.rootageContractReady || control.freeze) {
+  throw new Error("DES-2201 계약이 준비된 dry-run·비승격 상태에서만 bootstrap할 수 있습니다.");
+}
+
+const client = new GitHubClient(repository, token);
+const dev = await client.request<GitReference>(`/repos/${repository}/git/ref/heads/dev`);
+for (const lane of ["dev", "minor", "major"] as const) {
+  if (lane !== "dev") {
+    try {
+      await client.request<GitReference>(`/repos/${repository}/git/ref/heads/${lane}`);
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.includes("404")) throw error;
+      await client.request(`/repos/${repository}/git/refs`, {
+        method: "POST",
+        body: JSON.stringify({ ref: `refs/heads/${lane}`, sha: dev.object.sha }),
+      });
+    }
+  }
+  await client.request(`/repos/${repository}/branches/${lane}/protection`, {
+    method: "PUT",
+    body: JSON.stringify({
+      required_status_checks: { strict: true, contexts: ["Validate release lane"] },
+      enforce_admins: false,
+      required_pull_request_reviews: null,
+      restrictions: null,
+      required_linear_history: false,
+      allow_force_pushes: false,
+      allow_deletions: false,
+      block_creations: false,
+      required_conversation_resolution: true,
+      lock_branch: false,
+      allow_fork_syncing: false,
+    }),
+  });
+}
+console.log(`minor와 major를 dev@${dev.object.sha}에서 생성하고 세 레인을 보호했습니다.`);

--- a/scripts/release/changesets.ts
+++ b/scripts/release/changesets.ts
@@ -1,0 +1,66 @@
+import { readFile } from "node:fs/promises";
+import { parse } from "yaml";
+import { isBumpType } from "./config";
+import type { BumpType, ChangesetEntry, LaneName } from "./types";
+
+const frontmatterPattern = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+
+export async function parseChangesetFile(file: string): Promise<ChangesetEntry> {
+  const content = await readFile(file, "utf8");
+  const match = content.match(frontmatterPattern);
+  if (!match?.[1]) throw new Error(`${file}: Changeset frontmatter를 찾을 수 없습니다.`);
+
+  const frontmatter = parse(match[1]);
+  if (typeof frontmatter !== "object" || frontmatter === null || Array.isArray(frontmatter)) {
+    throw new Error(`${file}: Changeset release 목록이 객체가 아닙니다.`);
+  }
+
+  const releases = Object.entries(frontmatter).map(([name, type]) => {
+    if (typeof type !== "string" || !isBumpType(type)) {
+      throw new Error(`${file}: ${name}의 bump '${String(type)}'를 지원하지 않습니다.`);
+    }
+    return { name, type };
+  });
+  if (releases.length === 0) throw new Error(`${file}: release 항목이 없습니다.`);
+
+  return { file, releases };
+}
+
+export interface ChangesetValidation {
+  warnings: string[];
+  errors: string[];
+  entries: ChangesetEntry[];
+}
+
+export async function validateChangesets(
+  files: string[],
+  lane: LaneName,
+  expected: BumpType,
+): Promise<ChangesetValidation> {
+  const changesetFiles = files.filter((file) => {
+    const normalized = file.replaceAll("\\", "/");
+    return (
+      /(^|\/)\.changeset\/[^/]+\.md$/.test(normalized) &&
+      !normalized.endsWith("/.changeset/README.md")
+    );
+  });
+  if (changesetFiles.length === 0) {
+    return {
+      entries: [],
+      errors: [],
+      warnings: [`${lane} 대상 PR에 changeset이 없습니다.`],
+    };
+  }
+
+  const entries = await Promise.all(changesetFiles.map(parseChangesetFile));
+  const errors = entries.flatMap((entry) =>
+    entry.releases
+      .filter((release) => release.type !== expected)
+      .map(
+        (release) =>
+          `${entry.file}: ${release.name}은 ${lane} 레인에서 ${expected}여야 하지만 ${release.type}입니다.`,
+      ),
+  );
+
+  return { entries, errors, warnings: [] };
+}

--- a/scripts/release/cli.ts
+++ b/scripts/release/cli.ts
@@ -1,0 +1,289 @@
+import { appendFile, readFile, writeFile } from "node:fs/promises";
+import { authorizePublish } from "./publish";
+import { isLaneName, loadLaneConfig, parseReleaseControl } from "./config";
+import { validateChangesets } from "./changesets";
+import { encodeMarker, parseMarker, validateGeneratedPr } from "./marker";
+import { applyTransition, planTransition, readPreState } from "./transition";
+import type {
+  GeneratedPrType,
+  LaneName,
+  PullRequestIdentity,
+  ReleaseMarker,
+  TransitionCommand,
+} from "./types";
+import { generatedPrTypes } from "./types";
+
+interface PullRequestEvent {
+  repository: { full_name: string };
+  pull_request: {
+    body: string | null;
+    merged_by?: { login: string } | null;
+    user: { login: string };
+    base: { ref: string; repo: { full_name: string } };
+    head: { ref: string; sha: string; repo: { full_name: string } | null };
+  };
+}
+
+function parseArguments(argv: string[]): { command: string; values: Map<string, string> } {
+  const [command = "help", ...rest] = argv;
+  const values = new Map<string, string>();
+  for (let index = 0; index < rest.length; index += 2) {
+    const key = rest[index];
+    const value = rest[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error(`인자를 해석할 수 없습니다: ${rest.slice(index).join(" ")}`);
+    }
+    values.set(key.slice(2), value);
+  }
+  return { command, values };
+}
+
+function required(values: Map<string, string>, key: string): string {
+  const value = values.get(key);
+  if (!value) throw new Error(`--${key} 인자가 필요합니다.`);
+  return value;
+}
+
+async function run(command: string[]): Promise<string> {
+  const child = Bun.spawn(command, { stdout: "pipe", stderr: "pipe" });
+  const stdout = await new Response(child.stdout).text();
+  const stderr = await new Response(child.stderr).text();
+  const exitCode = await child.exited;
+  if (exitCode !== 0) throw new Error(`${command.join(" ")} 실패:\n${stderr}`);
+  return stdout.trim();
+}
+
+async function readEvent(path: string): Promise<PullRequestEvent> {
+  return JSON.parse(await readFile(path, "utf8")) as PullRequestEvent;
+}
+
+function identityFromEvent(event: PullRequestEvent): PullRequestIdentity {
+  return {
+    author: event.pull_request.user.login,
+    body: event.pull_request.body ?? "",
+    baseRef: event.pull_request.base.ref,
+    headRef: event.pull_request.head.ref,
+    baseRepository: event.pull_request.base.repo.full_name,
+    headRepository: event.pull_request.head.repo?.full_name ?? "",
+  };
+}
+
+async function changedFiles(baseRef: string, diffFilter?: string): Promise<string[]> {
+  const filter = diffFilter ? [`--diff-filter=${diffFilter}`] : [];
+  const output = await run(["git", "diff", "--name-only", ...filter, `origin/${baseRef}...HEAD`]);
+  return output ? output.split("\n") : [];
+}
+
+async function writeSummary(lines: string[]): Promise<void> {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) await appendFile(summaryPath, `${lines.join("\n")}\n`);
+}
+
+async function writeOutput(values: Record<string, string>): Promise<void> {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  await appendFile(
+    outputPath,
+    `${Object.entries(values)
+      .map(([key, value]) => `${key}=${value}`)
+      .join("\n")}\n`,
+  );
+}
+
+async function releaseControlFromDev(): Promise<ReturnType<typeof parseReleaseControl>> {
+  const raw = await run(["git", "show", "origin/dev:.github/release/control.json"]);
+  return parseReleaseControl(JSON.parse(raw));
+}
+
+async function validatePr(values: Map<string, string>): Promise<void> {
+  const event = await readEvent(required(values, "event"));
+  const lane = event.pull_request.base.ref;
+  if (!isLaneName(lane)) throw new Error(`${lane}은 릴리즈 레인이 아닙니다.`);
+
+  const config = await loadLaneConfig();
+  const generated = validateGeneratedPr(identityFromEvent(event));
+  if (generated) {
+    await writeSummary([
+      "## 릴리즈 PR 검증",
+      "",
+      `- 유형: \`${generated.type}\``,
+      `- 레인: \`${lane}\``,
+      "- 자동화 생성 주체와 head/base 관계를 확인했습니다.",
+    ]);
+    await writeOutput({ generated: "true", type: generated.type, lane });
+    return;
+  }
+
+  const control = await releaseControlFromDev();
+  if (control.freeze?.frozenLanes.includes(lane as Exclude<LaneName, "dev">)) {
+    throw new Error(`${lane} 레인은 stable 승격 재구성이 끝날 때까지 merge가 동결됐습니다.`);
+  }
+
+  const files = await changedFiles(lane);
+  const protectedChanges = files.filter((file) =>
+    [".changeset/config.json", ".changeset/pre.json", ".github/release/control.json"].includes(
+      file,
+    ),
+  );
+  if (protectedChanges.length > 0) {
+    throw new Error(
+      `일반 PR은 레인 상태 파일을 변경할 수 없습니다: ${protectedChanges.join(", ")}`,
+    );
+  }
+  const deletedChangesets = (await changedFiles(lane, "D")).filter(
+    (file) => file.startsWith(".changeset/") && file.endsWith(".md"),
+  );
+  if (deletedChangesets.length > 0) {
+    throw new Error(`일반 PR은 changeset을 삭제할 수 없습니다: ${deletedChangesets.join(", ")}`);
+  }
+  const result = await validateChangesets(files, lane, config.lanes[lane].bump);
+  for (const warning of result.warnings) console.log(`::warning::${warning}`);
+  await writeSummary([
+    "## 릴리즈 PR 검증",
+    "",
+    `- 레인: \`${lane}\``,
+    `- 요구 bump: \`${config.lanes[lane].bump}\``,
+    `- changeset: ${result.entries.length}개`,
+    ...result.warnings.map((warning) => `- 경고: ${warning}`),
+    ...result.errors.map((error) => `- 오류: ${error}`),
+  ]);
+  if (result.errors.length > 0) throw new Error(result.errors.join("\n"));
+  await writeOutput({ generated: "false", lane });
+}
+
+function asGeneratedPrType(value: string): GeneratedPrType {
+  if (!generatedPrTypes.includes(value as GeneratedPrType)) {
+    throw new Error(`지원하지 않는 PR 유형입니다: ${value}`);
+  }
+  return value as GeneratedPrType;
+}
+
+async function marker(values: Map<string, string>): Promise<void> {
+  const lane = required(values, "lane");
+  if (!isLaneName(lane)) throw new Error(`지원하지 않는 레인입니다: ${lane}`);
+  const type = asGeneratedPrType(required(values, "type"));
+  const result: ReleaseMarker = { schemaVersion: 1, type, lane };
+  const optionalString = [
+    "sourceRepository",
+    "targetLane",
+    "patchSha256",
+    "expectedHeadSha",
+    "command",
+    "tag",
+  ] as const;
+  for (const key of optionalString) {
+    const value = values.get(key);
+    if (value) Object.assign(result, { [key]: value });
+  }
+  const sourcePr = values.get("sourcePr");
+  if (sourcePr) result.sourcePr = Number(sourcePr);
+  console.log(encodeMarker(result));
+}
+
+async function transition(values: Map<string, string>): Promise<void> {
+  const lane = required(values, "lane");
+  if (!isLaneName(lane)) throw new Error(`지원하지 않는 레인입니다: ${lane}`);
+  const command = required(values, "command") as TransitionCommand;
+  if (!["enter", "retag", "exit"].includes(command)) {
+    throw new Error(`지원하지 않는 상태 전환입니다: ${command}`);
+  }
+  const config = await loadLaneConfig();
+  const plan = planTransition(
+    lane,
+    command,
+    values.get("tag"),
+    await readPreState(),
+    config.protectedDistTags,
+  );
+  await applyTransition(plan);
+  await writeOutput({ lane, command, tag: plan.tag ?? "" });
+}
+
+async function authorize(values: Map<string, string>): Promise<void> {
+  const event = await readEvent(required(values, "event"));
+  const baseRef = event.pull_request.base.ref;
+  if (!isLaneName(baseRef)) throw new Error(`${baseRef}은 릴리즈 레인이 아닙니다.`);
+  const control = await releaseControlFromDev();
+  const mode = authorizePublish(
+    parseMarker(event.pull_request.body ?? ""),
+    event.pull_request.merged_by?.login ?? "",
+    baseRef,
+    event.pull_request.head.ref,
+    control,
+  );
+  await writeOutput({ mode, lane: baseRef, headSha: event.pull_request.head.sha });
+  await writeSummary([
+    "## 게시 승인 검증",
+    "",
+    `- 레인: \`${baseRef}\``,
+    `- 실행 모드: \`${mode}\``,
+    `- 승인자: \`${event.pull_request.merged_by?.login ?? "없음"}\``,
+  ]);
+}
+
+async function promotion(values: Map<string, string>): Promise<void> {
+  const lane = required(values, "lane");
+  if (lane !== "minor" && lane !== "major") throw new Error("승격 레인은 minor 또는 major입니다.");
+  const phase = required(values, "phase");
+  const control = await releaseControlFromDev();
+  if (phase === "start") {
+    if (control.freeze)
+      throw new Error(`${control.freeze.promotionLane} 승격이 이미 진행 중입니다.`);
+    const candidateSha = required(values, "candidate-sha");
+    control.freeze = {
+      promotionLane: lane,
+      candidateSha,
+      phase: "frozen",
+      frozenLanes: lane === "major" ? ["minor", "major"] : ["minor"],
+      startedAt: new Date().toISOString(),
+    };
+  } else if (phase === "integrating" || phase === "rebuilding") {
+    if (!control.freeze || control.freeze.promotionLane !== lane) {
+      throw new Error(`${lane} 승격 상태가 없습니다.`);
+    }
+    control.freeze.phase = phase;
+  } else if (phase === "finish") {
+    if (!control.freeze || control.freeze.promotionLane !== lane) {
+      throw new Error(`${lane} 승격 상태가 없습니다.`);
+    }
+    control.freeze = null;
+  } else {
+    throw new Error(`지원하지 않는 승격 단계입니다: ${phase}`);
+  }
+  await writeFile(".github/release/control.json", `${JSON.stringify(control, null, 2)}\n`);
+}
+
+async function activation(values: Map<string, string>): Promise<void> {
+  const operation = required(values, "operation");
+  const control = await releaseControlFromDev();
+  const config = await loadLaneConfig();
+  if (operation === "enable-sync") {
+    if (config.sync.activation) throw new Error("동기화가 이미 활성화되어 있습니다.");
+    config.sync.activation = new Date().toISOString();
+    await writeFile(".github/release/lanes.json", `${JSON.stringify(config, null, 2)}\n`);
+    return;
+  }
+  if (operation === "enable-production") {
+    if (!config.sync.activation) throw new Error("동기화를 먼저 활성화해야 합니다.");
+    if (!control.rootageContractReady) throw new Error("DES-2201 계약이 준비되지 않았습니다.");
+    if (control.freeze) throw new Error("승격 중에는 production을 활성화할 수 없습니다.");
+    if (control.mode === "production") throw new Error("production이 이미 활성화되어 있습니다.");
+    control.mode = "production";
+    await writeFile(".github/release/control.json", `${JSON.stringify(control, null, 2)}\n`);
+    return;
+  }
+  throw new Error(`지원하지 않는 activation 작업입니다: ${operation}`);
+}
+
+async function main(): Promise<void> {
+  const { command, values } = parseArguments(Bun.argv.slice(2));
+  if (command === "validate-pr") return validatePr(values);
+  if (command === "marker") return marker(values);
+  if (command === "transition") return transition(values);
+  if (command === "authorize-publish") return authorize(values);
+  if (command === "promotion") return promotion(values);
+  if (command === "activation") return activation(values);
+  throw new Error(`지원하지 않는 명령입니다: ${command}`);
+}
+
+await main();

--- a/scripts/release/config.ts
+++ b/scripts/release/config.ts
@@ -1,0 +1,216 @@
+import { readFile } from "node:fs/promises";
+import type {
+  BumpType,
+  LaneConfig,
+  LaneDefinition,
+  LaneName,
+  ReleaseControl,
+  ReleaseFreeze,
+} from "./types";
+import { bumpTypes, laneNames } from "./types";
+
+const laneSet = new Set<string>(laneNames);
+const bumpSet = new Set<string>(bumpTypes);
+const tagPattern = /^[a-z][a-z0-9-]{0,31}$/;
+const shaPattern = /^[0-9a-f]{40}$/;
+
+const lanePolicy: Record<LaneName, LaneDefinition> = {
+  dev: { bump: "patch", prerelease: false, sources: [] },
+  minor: { bump: "minor", prerelease: true, sources: ["dev"] },
+  major: { bump: "major", prerelease: true, sources: ["dev", "minor"] },
+};
+
+function assertObject(value: unknown, label: string): asserts value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label}이 객체가 아닙니다.`);
+  }
+}
+
+function assertExactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+  label: string,
+): void {
+  const actual = Object.keys(value);
+  const missing = expected.filter((key) => !actual.includes(key));
+  const unknown = actual.filter((key) => !expected.includes(key));
+  if (missing.length > 0 || unknown.length > 0) {
+    throw new Error(
+      `${label} 키가 스키마와 다릅니다. 누락: ${missing.join(", ") || "없음"}, 알 수 없음: ${unknown.join(", ") || "없음"}`,
+    );
+  }
+}
+
+function isDateTime(value: string): boolean {
+  return value.includes("T") && Number.isFinite(Date.parse(value));
+}
+
+export function isLaneName(value: string): value is LaneName {
+  return laneSet.has(value);
+}
+
+export function isBumpType(value: string): value is BumpType {
+  return bumpSet.has(value);
+}
+
+function assertLaneDefinition(value: unknown, lane: LaneName): asserts value is LaneDefinition {
+  assertObject(value, `${lane} 레인 설정`);
+  assertExactKeys(value, ["bump", "prerelease", "sources"], `${lane} 레인 설정`);
+
+  if (typeof value.bump !== "string" || !isBumpType(value.bump)) {
+    throw new Error(`${lane} 레인의 bump 설정이 올바르지 않습니다.`);
+  }
+  if (typeof value.prerelease !== "boolean" || !Array.isArray(value.sources)) {
+    throw new Error(`${lane} 레인의 prerelease 또는 sources 설정이 올바르지 않습니다.`);
+  }
+  if (!value.sources.every((source) => typeof source === "string" && isLaneName(source))) {
+    throw new Error(`${lane} 레인의 source에 알 수 없는 레인이 있습니다.`);
+  }
+  const expected = lanePolicy[lane];
+  if (
+    value.bump !== expected.bump ||
+    value.prerelease !== expected.prerelease ||
+    JSON.stringify(value.sources) !== JSON.stringify(expected.sources)
+  ) {
+    throw new Error(`${lane} 레인 정책이 고정 스키마와 다릅니다.`);
+  }
+}
+
+export function parseLaneConfig(value: unknown): LaneConfig {
+  assertObject(value, "릴리즈 레인 설정");
+  assertExactKeys(
+    value,
+    [
+      "$schema",
+      "schemaVersion",
+      "repository",
+      "maintainerTeam",
+      "protectedDistTags",
+      "lanes",
+      "sync",
+    ],
+    "릴리즈 레인 설정",
+  );
+
+  if (value.$schema !== "./lanes.schema.json") {
+    throw new Error("릴리즈 레인 JSON Schema 참조가 올바르지 않습니다.");
+  }
+  if (value.schemaVersion !== 1 || value.repository !== "daangn/seed-design") {
+    throw new Error("지원하지 않는 릴리즈 레인 설정입니다.");
+  }
+  if (
+    typeof value.maintainerTeam !== "string" ||
+    value.maintainerTeam.length === 0 ||
+    !Array.isArray(value.protectedDistTags) ||
+    !value.protectedDistTags.every((tag) => typeof tag === "string" && tagPattern.test(tag)) ||
+    new Set(value.protectedDistTags).size !== value.protectedDistTags.length ||
+    !value.protectedDistTags.includes("latest") ||
+    !value.protectedDistTags.includes("stable")
+  ) {
+    throw new Error("maintainer 또는 보호 dist-tag 설정이 올바르지 않습니다.");
+  }
+  assertObject(value.lanes, "레인 정의");
+  assertExactKeys(value.lanes, laneNames, "레인 정의");
+  const dev = value.lanes.dev;
+  const minor = value.lanes.minor;
+  const major = value.lanes.major;
+  assertLaneDefinition(dev, "dev");
+  assertLaneDefinition(minor, "minor");
+  assertLaneDefinition(major, "major");
+
+  assertObject(value.sync, "동기화 설정");
+  assertExactKeys(value.sync, ["activation", "reconcileCron", "conflictAlertHours"], "동기화 설정");
+  if (
+    (value.sync.activation !== null &&
+      (typeof value.sync.activation !== "string" || !isDateTime(value.sync.activation))) ||
+    typeof value.sync.reconcileCron !== "string" ||
+    value.sync.reconcileCron.length === 0 ||
+    !Number.isInteger(value.sync.conflictAlertHours) ||
+    Number(value.sync.conflictAlertHours) < 1
+  ) {
+    throw new Error("동기화 설정 값이 올바르지 않습니다.");
+  }
+
+  return {
+    $schema: "./lanes.schema.json",
+    schemaVersion: 1,
+    repository: "daangn/seed-design",
+    maintainerTeam: value.maintainerTeam,
+    protectedDistTags: value.protectedDistTags as string[],
+    lanes: { dev, minor, major },
+    sync: {
+      activation: value.sync.activation as string | null,
+      reconcileCron: value.sync.reconcileCron,
+      conflictAlertHours: value.sync.conflictAlertHours as number,
+    },
+  };
+}
+
+function assertReleaseFreeze(value: unknown): asserts value is ReleaseFreeze {
+  assertObject(value, "승격 freeze");
+  assertExactKeys(
+    value,
+    ["promotionLane", "candidateSha", "phase", "frozenLanes", "startedAt"],
+    "승격 freeze",
+  );
+  const promotionLane = value.promotionLane;
+  const expectedFrozenLanes = promotionLane === "minor" ? ["minor"] : ["minor", "major"];
+  if (
+    (promotionLane !== "minor" && promotionLane !== "major") ||
+    typeof value.candidateSha !== "string" ||
+    !shaPattern.test(value.candidateSha) ||
+    !["frozen", "integrating", "rebuilding"].includes(String(value.phase)) ||
+    !Array.isArray(value.frozenLanes) ||
+    JSON.stringify(value.frozenLanes) !== JSON.stringify(expectedFrozenLanes) ||
+    typeof value.startedAt !== "string" ||
+    !isDateTime(value.startedAt)
+  ) {
+    throw new Error("승격 freeze 설정이 스키마와 다릅니다.");
+  }
+}
+
+export function parseReleaseControl(value: unknown): ReleaseControl {
+  assertObject(value, "릴리즈 제어 설정");
+  assertExactKeys(
+    value,
+    ["$schema", "schemaVersion", "mode", "rootageContractReady", "freeze"],
+    "릴리즈 제어 설정",
+  );
+
+  if (value.$schema !== "./control.schema.json") {
+    throw new Error("릴리즈 제어 JSON Schema 참조가 올바르지 않습니다.");
+  }
+  if (
+    value.schemaVersion !== 1 ||
+    typeof value.mode !== "string" ||
+    !["dry-run", "production"].includes(value.mode)
+  ) {
+    throw new Error("지원하지 않는 릴리즈 제어 설정입니다.");
+  }
+  if (typeof value.rootageContractReady !== "boolean") {
+    throw new Error("Rootage 계약 준비 상태가 없습니다.");
+  }
+  if (value.mode === "production" && !value.rootageContractReady) {
+    throw new Error("DES-2201 계약 없이 production 상태를 선언할 수 없습니다.");
+  }
+  if (value.freeze !== null) {
+    assertReleaseFreeze(value.freeze);
+  }
+  return {
+    $schema: "./control.schema.json",
+    schemaVersion: 1,
+    mode: value.mode as ReleaseControl["mode"],
+    rootageContractReady: value.rootageContractReady,
+    freeze: value.freeze,
+  };
+}
+
+export async function loadLaneConfig(path = ".github/release/lanes.json"): Promise<LaneConfig> {
+  return parseLaneConfig(JSON.parse(await readFile(path, "utf8")));
+}
+
+export async function loadReleaseControl(
+  path = ".github/release/control.json",
+): Promise<ReleaseControl> {
+  return parseReleaseControl(JSON.parse(await readFile(path, "utf8")));
+}

--- a/scripts/release/dry-run.ts
+++ b/scripts/release/dry-run.ts
@@ -1,0 +1,37 @@
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { sha256 } from "./sync";
+
+async function run(command: string[], cwd = process.cwd()): Promise<void> {
+  console.log(`$ ${command.join(" ")}`);
+  const child = Bun.spawn(command, { cwd, stdout: "inherit", stderr: "inherit" });
+  const exitCode = await child.exited;
+  if (exitCode !== 0) throw new Error(`${command.join(" ")} 명령이 ${exitCode}로 실패했습니다.`);
+}
+
+const temporaryDirectory = await mkdtemp(join(tmpdir(), "seed-release-dry-run-"));
+try {
+  await run(["bun", "packages:build"]);
+  await run(["bun", "rootage:build"]);
+  await run(["bun", "rootage:generate"]);
+  await run(["bun", "pm", "pack", "--destination", temporaryDirectory], "packages/rootage");
+
+  const archives = (await readdir(temporaryDirectory)).sort();
+  if (archives.length !== 1)
+    throw new Error(`Rootage archive가 1개여야 합니다: ${archives.join(", ")}`);
+  const archive = Bun.file(join(temporaryDirectory, archives[0]));
+  const checksum = sha256(new Uint8Array(await archive.arrayBuffer()));
+  const result = { archive: archives[0], bytes: archive.size, sha256: checksum };
+  console.log(JSON.stringify(result, null, 2));
+
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) {
+    await Bun.write(
+      summaryPath,
+      `## Rootage dry-run\n\n- archive: \`${result.archive}\`\n- bytes: ${result.bytes}\n- sha256: \`${checksum}\`\n`,
+    );
+  }
+} finally {
+  await rm(temporaryDirectory, { recursive: true, force: true });
+}

--- a/scripts/release/github.ts
+++ b/scripts/release/github.ts
@@ -1,0 +1,77 @@
+export interface GitHubPullRequest {
+  number: number;
+  body: string | null;
+  draft: boolean;
+  merged_at: string | null;
+  merge_commit_sha: string | null;
+  created_at: string;
+  user: { login: string };
+  merged_by?: { login: string } | null;
+  base: { ref: string; sha: string; repo: { full_name: string } };
+  head: { ref: string; sha: string; repo: { full_name: string } | null };
+}
+
+export class GitHubClient {
+  readonly repository: string;
+  readonly token: string;
+
+  constructor(repository: string, token: string) {
+    this.repository = repository;
+    this.token = token;
+  }
+
+  async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const response = await fetch(`https://api.github.com${path}`, {
+      ...init,
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${this.token}`,
+        "x-github-api-version": "2022-11-28",
+        ...init.headers,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(
+        `GitHub API ${init.method ?? "GET"} ${path} 실패: ${response.status} ${await response.text()}`,
+      );
+    }
+    return (await response.json()) as T;
+  }
+
+  async paginate<T>(path: string): Promise<T[]> {
+    const results: T[] = [];
+    for (let page = 1; ; page += 1) {
+      const separator = path.includes("?") ? "&" : "?";
+      const current = await this.request<T[]>(`${path}${separator}per_page=100&page=${page}`);
+      results.push(...current);
+      if (current.length < 100) return results;
+    }
+  }
+
+  async comment(issue: number, body: string): Promise<void> {
+    await this.request(`/repos/${this.repository}/issues/${issue}/comments`, {
+      method: "POST",
+      body: JSON.stringify({ body }),
+    });
+  }
+
+  async ensureLabel(name: string, color: string, description: string): Promise<void> {
+    const encoded = encodeURIComponent(name);
+    const response = await fetch(
+      `https://api.github.com/repos/${this.repository}/labels/${encoded}`,
+      {
+        headers: {
+          accept: "application/vnd.github+json",
+          authorization: `Bearer ${this.token}`,
+          "x-github-api-version": "2022-11-28",
+        },
+      },
+    );
+    if (response.ok) return;
+    if (response.status !== 404) throw new Error(`label 조회 실패: ${response.status}`);
+    await this.request(`/repos/${this.repository}/labels`, {
+      method: "POST",
+      body: JSON.stringify({ name, color, description }),
+    });
+  }
+}

--- a/scripts/release/marker.ts
+++ b/scripts/release/marker.ts
@@ -1,0 +1,47 @@
+import type { GeneratedPrType, PullRequestIdentity, ReleaseMarker } from "./types";
+import { generatedPrTypes, laneNames } from "./types";
+
+const prefixByType: Record<GeneratedPrType, string> = {
+  version: "changeset-release/",
+  transition: "release-transition/",
+  sync: "release-sync/",
+  freeze: "release-freeze/",
+  integration: "release-integration/",
+  rebuild: "release-rebuild/",
+};
+
+const markerPattern = /<!-- seed-release:(\{[^\n]+\}) -->/;
+
+export function encodeMarker(marker: ReleaseMarker): string {
+  return `<!-- seed-release:${JSON.stringify(marker)} -->`;
+}
+
+export function parseMarker(body: string): ReleaseMarker | null {
+  const match = body.match(markerPattern);
+  if (!match?.[1]) return null;
+
+  try {
+    const marker = JSON.parse(match[1]) as Partial<ReleaseMarker>;
+    if (
+      marker.schemaVersion !== 1 ||
+      !generatedPrTypes.includes(marker.type as GeneratedPrType) ||
+      !laneNames.includes(marker.lane as ReleaseMarker["lane"])
+    ) {
+      return null;
+    }
+    return marker as ReleaseMarker;
+  } catch {
+    return null;
+  }
+}
+
+export function validateGeneratedPr(identity: PullRequestIdentity): ReleaseMarker | null {
+  const marker = parseMarker(identity.body);
+  if (!marker) return null;
+  if (identity.author !== "github-actions[bot]") return null;
+  if (identity.headRepository !== identity.baseRepository) return null;
+  if (identity.baseRef !== marker.lane) return null;
+  if (!identity.headRef.startsWith(prefixByType[marker.type])) return null;
+  if (marker.type === "sync" && marker.targetLane !== marker.lane) return null;
+  return marker;
+}

--- a/scripts/release/publish-plan.ts
+++ b/scripts/release/publish-plan.ts
@@ -1,0 +1,138 @@
+import { appendFile, readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { assertStableVersionsAdvance, parseSemver } from "./publish";
+import { isLaneName, parseReleaseControl } from "./config";
+
+interface PackageManifest {
+  name?: string;
+  version?: string;
+  private?: boolean;
+}
+
+interface RegistryDocument {
+  versions?: Record<string, unknown>;
+  "dist-tags"?: Record<string, string>;
+}
+
+async function run(command: string[]): Promise<string> {
+  const child = Bun.spawn(command, { stdout: "pipe", stderr: "pipe" });
+  const stdout = await new Response(child.stdout).text();
+  const stderr = await new Response(child.stderr).text();
+  const exitCode = await child.exited;
+  if (exitCode !== 0) throw new Error(`${command.join(" ")} 실패:\n${stderr}`);
+  return stdout.trim();
+}
+
+async function registryDocument(name: string): Promise<RegistryDocument | null> {
+  const response = await fetch(`https://registry.npmjs.org/${encodeURIComponent(name)}`, {
+    headers: { accept: "application/json" },
+  });
+  if (response.status === 404) return null;
+  if (!response.ok) throw new Error(`${name} registry 조회 실패: ${response.status}`);
+  return (await response.json()) as RegistryDocument;
+}
+
+async function changedPackages(): Promise<Array<{ name: string; version: string; path: string }>> {
+  const parent = await run(["git", "rev-parse", "HEAD^"]);
+  const output = await run(["git", "diff", "--name-only", parent, "HEAD", "--", "**/package.json"]);
+  const paths = output ? output.split("\n") : [];
+  const packages = await Promise.all(
+    paths.map(async (path) => {
+      const manifest = JSON.parse(await readFile(path, "utf8")) as PackageManifest;
+      if (manifest.private || !manifest.name || !manifest.version) return null;
+      return { name: manifest.name, version: manifest.version, path: dirname(path) };
+    }),
+  );
+  return packages.filter((item): item is NonNullable<typeof item> => item !== null);
+}
+
+const lane = Bun.argv[2] ?? "";
+if (!isLaneName(lane)) throw new Error(`지원하지 않는 릴리즈 레인입니다: ${lane}`);
+
+const packages = await changedPackages();
+const registryEntries = await Promise.all(
+  packages.map(async (item) => [item.name, await registryDocument(item.name)] as const),
+);
+const registry = Object.fromEntries(registryEntries);
+const missing = packages.filter((item) => !registry[item.name]?.versions?.[item.version]);
+const stable = packages.filter((item) => parseSemver(item.version).prerelease.length === 0);
+const prerelease = packages.filter((item) => parseSemver(item.version).prerelease.length > 0);
+
+if (lane === "dev" && prerelease.length > 0) {
+  throw new Error(
+    `dev에서 pre-release package를 게시할 수 없습니다: ${prerelease.map((item) => item.name).join(", ")}`,
+  );
+}
+if (stable.length > 0 && prerelease.length > 0) {
+  throw new Error("한 Version Packages PR에서 stable과 pre-release를 함께 게시할 수 없습니다.");
+}
+const control = parseReleaseControl(
+  JSON.parse(await run(["git", "show", "origin/dev:.github/release/control.json"])),
+);
+if (
+  control.freeze?.frozenLanes.includes(lane as Exclude<typeof lane, "dev">) &&
+  prerelease.length > 0
+) {
+  throw new Error(`${lane} 레인은 stable 승격 중이므로 pre-release publish를 할 수 없습니다.`);
+}
+if (
+  control.freeze &&
+  stable.length > 0 &&
+  lane !== "dev" &&
+  control.freeze.promotionLane !== lane
+) {
+  throw new Error(
+    `${control.freeze.promotionLane} 승격 중에는 ${lane} stable을 게시할 수 없습니다.`,
+  );
+}
+if (stable.length > 0) {
+  const stableMissing = stable.filter((item) => !registry[item.name]?.versions?.[item.version]);
+  assertStableVersionsAdvance(
+    Object.fromEntries(stableMissing.map((item) => [item.name, item.version])),
+    Object.fromEntries(
+      stableMissing.map((item) => [item.name, registry[item.name]?.["dist-tags"]?.latest ?? null]),
+    ),
+  );
+}
+
+const rootage = packages.find((item) => item.name === "@seed-design/rootage-artifacts");
+const result = {
+  lane,
+  stable: stable.length > 0,
+  packages,
+  missing,
+  rootageVersion: rootage?.version ?? "",
+};
+console.log(JSON.stringify(result, null, 2));
+
+const outputPath = process.env.GITHUB_OUTPUT;
+if (outputPath) {
+  await appendFile(
+    outputPath,
+    `${[
+      `stable=${result.stable}`,
+      `missingCount=${missing.length}`,
+      `rootageVersion=${result.rootageVersion}`,
+      `packages=${JSON.stringify(packages)}`,
+    ].join("\n")}\n`,
+  );
+}
+
+const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+if (summaryPath) {
+  await appendFile(
+    summaryPath,
+    [
+      "## 게시 계획",
+      "",
+      `- 레인: \`${lane}\``,
+      `- 유형: ${result.stable ? "stable" : "pre-release"}`,
+      `- 대상 package: ${packages.length}개`,
+      `- 아직 게시되지 않은 package: ${missing.length}개`,
+      `- Rootage: ${result.rootageVersion || "변경 없음"}`,
+      "",
+      ...packages.map((item) => `- \`${item.name}@${item.version}\``),
+      "",
+    ].join("\n"),
+  );
+}

--- a/scripts/release/publish-queue.ts
+++ b/scripts/release/publish-queue.ts
@@ -1,0 +1,57 @@
+import { appendFile } from "node:fs/promises";
+import { GitHubClient, type GitHubPullRequest } from "./github";
+import { parseMarker } from "./marker";
+
+interface IssueComment {
+  body: string | null;
+}
+
+const token = process.env.GH_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY;
+if (!token || !repository) throw new Error("GitHub workflow 환경이 필요합니다.");
+const client = new GitHubClient(repository, token);
+
+const pulls = (
+  await Promise.all(
+    ["dev", "minor", "major"].map((lane) =>
+      client.paginate<GitHubPullRequest>(
+        `/repos/${repository}/pulls?state=closed&base=${lane}&sort=updated&direction=asc`,
+      ),
+    ),
+  )
+)
+  .flat()
+  .filter((pull) => {
+    const marker = parseMarker(pull.body ?? "");
+    return Boolean(pull.merged_at && pull.merge_commit_sha && marker?.type === "version");
+  })
+  .sort((left, right) => {
+    const byDate = (left.merged_at ?? "").localeCompare(right.merged_at ?? "");
+    return byDate === 0 ? left.number - right.number : byDate;
+  });
+
+let selected: GitHubPullRequest | null = null;
+for (const pull of pulls) {
+  const comments = await client.paginate<IssueComment>(
+    `/repos/${repository}/issues/${pull.number}/comments`,
+  );
+  const key = pull.merge_commit_sha ?? "";
+  const processed = comments.some((comment) =>
+    comment.body?.includes(`<!-- seed-release-publish:${key}:`),
+  );
+  if (!processed) {
+    selected = pull;
+    break;
+  }
+}
+
+const outputPath = process.env.GITHUB_OUTPUT;
+if (outputPath) {
+  await appendFile(
+    outputPath,
+    selected ? `found=true\nnumber=${selected.number}\n` : "found=false\nnumber=\n",
+  );
+}
+console.log(
+  selected ? `게시 queue에서 PR #${selected.number}을 선택했습니다.` : "게시 queue가 비었습니다.",
+);

--- a/scripts/release/publish.ts
+++ b/scripts/release/publish.ts
@@ -1,0 +1,95 @@
+import type { LaneName, ReleaseControl, ReleaseMarker } from "./types";
+
+export interface Semver {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+}
+
+export function parseSemver(value: string): Semver {
+  const match = value.match(
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z.-]+)?$/,
+  );
+  if (!match) throw new Error(`유효하지 않은 SemVer입니다: ${value}`);
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4]?.split(".") ?? [],
+  };
+}
+
+function compareIdentifier(left: string, right: string): number {
+  const leftNumber = /^\d+$/.test(left) ? Number(left) : null;
+  const rightNumber = /^\d+$/.test(right) ? Number(right) : null;
+  if (leftNumber !== null && rightNumber !== null) return leftNumber - rightNumber;
+  if (leftNumber !== null) return -1;
+  if (rightNumber !== null) return 1;
+  return left.localeCompare(right);
+}
+
+export function compareSemver(leftValue: string, rightValue: string): number {
+  const left = parseSemver(leftValue);
+  const right = parseSemver(rightValue);
+  for (const key of ["major", "minor", "patch"] as const) {
+    if (left[key] !== right[key]) return left[key] - right[key];
+  }
+  if (left.prerelease.length === 0 || right.prerelease.length === 0) {
+    return right.prerelease.length - left.prerelease.length;
+  }
+  const length = Math.max(left.prerelease.length, right.prerelease.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = left.prerelease[index];
+    const rightPart = right.prerelease[index];
+    if (leftPart === undefined) return -1;
+    if (rightPart === undefined) return 1;
+    const compared = compareIdentifier(leftPart, rightPart);
+    if (compared !== 0) return compared;
+  }
+  return 0;
+}
+
+export function assertStableVersionsAdvance(
+  planned: Record<string, string>,
+  latest: Record<string, string | null>,
+): void {
+  const invalid = Object.entries(planned).filter(([name, version]) => {
+    const current = latest[name];
+    return current !== null && current !== undefined && compareSemver(version, current) <= 0;
+  });
+  if (invalid.length > 0) {
+    throw new Error(
+      invalid
+        .map(
+          ([name, version]) => `${name}@${version}은 npm latest ${latest[name]}보다 높지 않습니다.`,
+        )
+        .join("\n"),
+    );
+  }
+}
+
+export function authorizePublish(
+  marker: ReleaseMarker | null,
+  mergedBy: string,
+  baseLane: LaneName,
+  headRef: string,
+  control: ReleaseControl,
+): "dry-run" | "production" {
+  if (!marker || marker.type !== "version" || marker.lane !== baseLane) {
+    throw new Error("신뢰할 수 있는 Version Packages PR marker가 없습니다.");
+  }
+  if (headRef !== `changeset-release/${baseLane}`) {
+    throw new Error("Version Packages PR의 head/base 관계가 올바르지 않습니다.");
+  }
+  if (!mergedBy || mergedBy.endsWith("[bot]")) {
+    throw new Error("Version Packages PR은 사람이 merge해야 publish할 수 있습니다.");
+  }
+  if (control.freeze?.phase === "frozen" && baseLane === "dev") {
+    throw new Error("stable 승격 중에는 dev patch publish가 중단됩니다.");
+  }
+  if (control.mode === "production" && !control.rootageContractReady) {
+    throw new Error("DES-2201 Rootage 게시 계약이 준비되지 않아 production publish를 막았습니다.");
+  }
+  return control.mode;
+}

--- a/scripts/release/reconcile-worker.ts
+++ b/scripts/release/reconcile-worker.ts
@@ -1,0 +1,165 @@
+import { readFile, rm, writeFile } from "node:fs/promises";
+import { GitHubClient, type GitHubPullRequest } from "./github";
+import { encodeMarker } from "./marker";
+import { protectedLaneFiles, sha256 } from "./sync";
+import { isLaneName, parseReleaseControl } from "./config";
+import type { LaneName } from "./types";
+
+const mode = process.env.RECONCILE_MODE;
+const sourceValue = process.env.SOURCE_LANE;
+const targetValue = process.env.TARGET_LANE;
+const tokenValue = process.env.GH_TOKEN;
+const repositoryValue = process.env.GITHUB_REPOSITORY;
+if (
+  (mode !== "integration" && mode !== "rebuild") ||
+  !sourceValue ||
+  !targetValue ||
+  !isLaneName(sourceValue) ||
+  !isLaneName(targetValue) ||
+  !tokenValue ||
+  !repositoryValue
+) {
+  throw new Error("RECONCILE_MODE, SOURCE_LANE, TARGET_LANE과 GitHub 환경이 필요합니다.");
+}
+if (mode === "integration" && targetValue !== "dev") {
+  throw new Error("stable integration 대상은 dev여야 합니다.");
+}
+if (mode === "rebuild" && (sourceValue !== "dev" || targetValue === "dev")) {
+  throw new Error("rebuild는 dev에서 minor 또는 major로 진행합니다.");
+}
+
+const source: LaneName = sourceValue;
+const target: LaneName = targetValue;
+const token = tokenValue;
+const repository = repositoryValue;
+const client = new GitHubClient(repository, token);
+
+async function run(
+  command: string[],
+  allowFailure = false,
+): Promise<{ code: number; output: string }> {
+  const child = Bun.spawn(command, { stdout: "pipe", stderr: "pipe" });
+  const stdout = await new Response(child.stdout).text();
+  const stderr = await new Response(child.stderr).text();
+  const code = await child.exited;
+  if (code !== 0 && !allowFailure) {
+    throw new Error(`${command.join(" ")} 실패:\n${stdout}\n${stderr}`);
+  }
+  return { code, output: `${stdout}${stderr}`.trim() };
+}
+
+async function applyPatch(patchPath: string): Promise<boolean> {
+  const applied = await run(["git", "apply", "--3way", "--whitespace=nowarn", patchPath], true);
+  if (applied.code === 0) return false;
+
+  await run(["git", "reset", "--hard", "HEAD"]);
+  await run(["git", "apply", "--reject", "--whitespace=nowarn", patchPath], true);
+  const rejects = Array.from(new Bun.Glob("**/*.rej").scanSync({ cwd: process.cwd(), dot: true }));
+  await Promise.all(rejects.map((file) => rm(file, { force: true })));
+  return true;
+}
+
+const branch = `release-${mode}/${source}-to-${target}-${process.env.GITHUB_RUN_ID ?? Date.now()}`;
+await run(["git", "fetch", "origin", source, target, "dev"]);
+await run(["git", "switch", "-c", branch]);
+
+let patch: string;
+if (mode === "integration") {
+  const mergeBase = (await run(["git", "merge-base", `origin/${source}`, "origin/dev"])).output;
+  patch = (
+    await run([
+      "git",
+      "diff",
+      "--binary",
+      mergeBase,
+      `origin/${source}`,
+      "--",
+      ".",
+      ":(exclude).changeset/config.json",
+      ":(exclude).changeset/pre.json",
+      ":(exclude).github/release/control.json",
+    ])
+  ).output;
+} else {
+  patch = (
+    await run([
+      "git",
+      "diff",
+      "--binary",
+      `origin/${target}`,
+      "origin/dev",
+      "--",
+      ".",
+      ":(exclude).changeset/config.json",
+      ":(exclude).changeset/pre.json",
+    ])
+  ).output;
+}
+
+const patchPath = `/tmp/seed-release-${mode}-${source}-${target}.diff`;
+await Bun.write(patchPath, patch);
+const conflict = await applyPatch(patchPath);
+
+if (mode === "integration") {
+  const control = parseReleaseControl(
+    JSON.parse(await readFile(".github/release/control.json", "utf8")),
+  );
+  if (!control.freeze || control.freeze.promotionLane !== source) {
+    throw new Error(`${source} 승격 freeze 상태가 없습니다.`);
+  }
+  control.freeze.phase = "integrating";
+  await writeFile(".github/release/control.json", `${JSON.stringify(control, null, 2)}\n`);
+} else {
+  const changesetConfig = JSON.parse(await readFile(".changeset/config.json", "utf8")) as Record<
+    string,
+    unknown
+  >;
+  changesetConfig.baseBranch = target;
+  await writeFile(".changeset/config.json", `${JSON.stringify(changesetConfig, null, 2)}\n`);
+  await rm(".changeset/pre.json", { force: true });
+}
+
+for (const file of mode === "integration" ? protectedLaneFiles.slice(0, 2) : []) {
+  await run(["git", "restore", "--source=HEAD", "--staged", "--worktree", "--", file], true);
+}
+await run(["git", "add", "--all"]);
+const diff = await run(["git", "diff", "--cached", "--quiet"], true);
+if (diff.code === 0) throw new Error(`${mode} 결과가 no-op입니다.`);
+
+await run(["git", "config", "user.name", "github-actions[bot]"]);
+await run(["git", "config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"]);
+await run(["git", "commit", "-m", `chore(release): ${mode} ${source} to ${target}`]);
+await run(["git", "push", "origin", branch]);
+const headSha = (await run(["git", "rev-parse", "HEAD"])).output;
+const marker = encodeMarker({
+  schemaVersion: 1,
+  type: mode,
+  lane: target,
+  sourceRepository: repository,
+  targetLane: target,
+  patchSha256: sha256(patch),
+  expectedHeadSha: headSha,
+});
+const result = await client.request<GitHubPullRequest>(`/repos/${repository}/pulls`, {
+  method: "POST",
+  body: JSON.stringify({
+    title: `chore(release): ${mode} ${source} to ${target}`,
+    head: branch,
+    base: target,
+    body: `${marker}\n\n${source}의 검증된 stable 결과를 ${target}에 반영합니다.${
+      conflict ? "\n\n자동 적용 충돌이 있어 Draft로 생성했습니다. @daangn/design-system" : ""
+    }`,
+    draft: conflict,
+  }),
+});
+const label = conflict ? "release:reconcile-conflict" : `release:${mode}`;
+await client.ensureLabel(
+  label,
+  conflict ? "d1242f" : "bf8700",
+  "Stable integration or lane rebuild",
+);
+await client.request(`/repos/${repository}/issues/${result.number}/labels`, {
+  method: "POST",
+  body: JSON.stringify({ labels: [label] }),
+});
+console.log(`${mode} PR #${result.number}을 생성했습니다.`);

--- a/scripts/release/record-publish.ts
+++ b/scripts/release/record-publish.ts
@@ -1,0 +1,16 @@
+import { GitHubClient } from "./github";
+
+const token = process.env.GH_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY;
+const number = Number(process.env.PUBLISH_PR_NUMBER);
+const mergeSha = process.env.PUBLISH_MERGE_SHA;
+const status = process.env.PUBLISH_STATUS;
+if (!token || !repository || !Number.isInteger(number) || !mergeSha || !status) {
+  throw new Error("게시 결과 기록에 필요한 환경이 없습니다.");
+}
+
+const client = new GitHubClient(repository, token);
+await client.comment(
+  number,
+  `<!-- seed-release-publish:${mergeSha}:${status} -->\n게시 queue가 이 Version Packages PR을 \`${status}\`로 처리했습니다.\n\nRun: ${process.env.GITHUB_SERVER_URL}/${repository}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+);

--- a/scripts/release/release.test.ts
+++ b/scripts/release/release.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseLaneConfig, parseReleaseControl } from "./config";
+import { parseChangesetFile, validateChangesets } from "./changesets";
+import { encodeMarker, parseMarker, validateGeneratedPr } from "./marker";
+import { assertStableVersionsAdvance, authorizePublish, compareSemver } from "./publish";
+import { idempotencyKey, isProcessed, sha256, sortSyncCandidates, syncTargets } from "./sync";
+import { planTransition, validatePrereleaseTag } from "./transition";
+import type { LaneConfig, PullRequestIdentity, ReleaseControl, ReleaseMarker } from "./types";
+
+const temporaryDirectories: string[] = [];
+
+function expectPropertyDescriptions(schema: Record<string, unknown>): void {
+  const properties = schema.properties;
+  if (typeof properties === "object" && properties !== null && !Array.isArray(properties)) {
+    for (const [name, definition] of Object.entries(properties)) {
+      expect(definition).toBeObject();
+      const property = definition as Record<string, unknown>;
+      expect(typeof property.description, `${name} 필드 description`).toBe("string");
+      expectPropertyDescriptions(property);
+    }
+  }
+
+  const definitions = schema.$defs;
+  if (typeof definitions === "object" && definitions !== null && !Array.isArray(definitions)) {
+    for (const definition of Object.values(definitions)) {
+      expectPropertyDescriptions(definition as Record<string, unknown>);
+    }
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+const config: LaneConfig = {
+  $schema: "./lanes.schema.json",
+  schemaVersion: 1,
+  repository: "daangn/seed-design",
+  maintainerTeam: "design-system",
+  protectedDistTags: ["latest", "stable"],
+  lanes: {
+    dev: { bump: "patch", prerelease: false, sources: [] },
+    minor: { bump: "minor", prerelease: true, sources: ["dev"] },
+    major: { bump: "major", prerelease: true, sources: ["dev", "minor"] },
+  },
+  sync: { activation: null, reconcileCron: "*/10 * * * *", conflictAlertHours: 24 },
+};
+
+const control: ReleaseControl = {
+  $schema: "./control.schema.json",
+  schemaVersion: 1,
+  mode: "dry-run",
+  rootageContractReady: false,
+  freeze: null,
+};
+
+describe("릴리즈 설정", () => {
+  test("세 고정 레인을 읽는다", () => {
+    expect(parseLaneConfig(config)).toEqual(config);
+    expect(parseReleaseControl(control)).toEqual(control);
+  });
+
+  test("알 수 없는 bump를 거부한다", () => {
+    const invalid = {
+      ...config,
+      lanes: {
+        ...config.lanes,
+        dev: { ...config.lanes.dev, bump: "banana" },
+      },
+    };
+    expect(() => parseLaneConfig(invalid)).toThrow("bump");
+  });
+
+  test("실제 설정이 명시적인 로컬 JSON Schema를 참조한다", async () => {
+    const cases = [
+      [".github/release/lanes.json", ".github/release/lanes.schema.json"],
+      [".github/release/control.json", ".github/release/control.schema.json"],
+    ] as const;
+
+    for (const [configPath, schemaPath] of cases) {
+      const actual = JSON.parse(await readFile(configPath, "utf8")) as Record<string, unknown>;
+      const schema = JSON.parse(await readFile(schemaPath, "utf8")) as Record<string, unknown>;
+      expect(actual.$schema).toBe(`./${schemaPath.split("/").at(-1)}`);
+      expect(schema.$schema).toBe("https://json-schema.org/draft/2020-12/schema");
+      expect(schema.additionalProperties).toBe(false);
+      expect(schema.required).toContain("$schema");
+      expectPropertyDescriptions(schema);
+    }
+
+    expect(parseLaneConfig(JSON.parse(await readFile(cases[0][0], "utf8")))).toBeTruthy();
+    expect(parseReleaseControl(JSON.parse(await readFile(cases[1][0], "utf8")))).toBeTruthy();
+  });
+
+  test("알 수 없는 키와 잘못된 freeze 조합을 거부한다", () => {
+    expect(() => parseLaneConfig({ ...config, typo: true })).toThrow("알 수 없음");
+    expect(() =>
+      parseReleaseControl({
+        ...control,
+        freeze: {
+          promotionLane: "major",
+          candidateSha: "a".repeat(40),
+          phase: "frozen",
+          frozenLanes: ["major"],
+          startedAt: "2026-08-05T00:00:00.000Z",
+        },
+      }),
+    ).toThrow("스키마");
+  });
+});
+
+describe("Changeset 검증", () => {
+  test("frontmatter의 package와 bump를 읽는다", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "changeset-test-"));
+    temporaryDirectories.push(directory);
+    const file = join(directory, "valid.md");
+    await writeFile(file, '---\n"@seed-design/rootage-artifacts": minor\n---\n\n설명\n');
+    expect(await parseChangesetFile(file)).toEqual({
+      file,
+      releases: [{ name: "@seed-design/rootage-artifacts", type: "minor" }],
+    });
+  });
+
+  test("레인과 다른 직접 bump를 모두 보고한다", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "changeset-test-"));
+    temporaryDirectories.push(directory);
+    const changesetDirectory = join(directory, ".changeset");
+    await mkdir(changesetDirectory);
+    const file = join(changesetDirectory, "invalid.md");
+    await writeFile(file, '---\n"@seed-design/css": patch\n"@seed-design/react": major\n---\n');
+    const result = await validateChangesets([file], "minor", "minor");
+    expect(result.errors).toHaveLength(2);
+  });
+
+  test("changeset이 없으면 실패 대신 경고한다", async () => {
+    const result = await validateChangesets(["packages/react/src/index.ts"], "dev", "patch");
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+  });
+});
+
+describe("자동화 PR marker", () => {
+  const marker: ReleaseMarker = {
+    schemaVersion: 1,
+    type: "sync",
+    lane: "major",
+    targetLane: "major",
+    sourceRepository: "daangn/seed-design",
+    sourcePr: 42,
+    patchSha256: "abc",
+  };
+  const identity: PullRequestIdentity = {
+    author: "github-actions[bot]",
+    body: encodeMarker(marker),
+    baseRef: "major",
+    headRef: "release-sync/dev-42-to-major",
+    baseRepository: "daangn/seed-design",
+    headRepository: "daangn/seed-design",
+  };
+
+  test("marker를 왕복하고 신뢰 조건을 검사한다", () => {
+    expect(parseMarker(encodeMarker(marker))).toEqual(marker);
+    expect(validateGeneratedPr(identity)).toEqual(marker);
+  });
+
+  test("fork와 사람 작성 PR은 예외 처리하지 않는다", () => {
+    expect(validateGeneratedPr({ ...identity, headRepository: "fork/seed-design" })).toBeNull();
+    expect(validateGeneratedPr({ ...identity, author: "person" })).toBeNull();
+  });
+});
+
+describe("pre-release 상태 전환", () => {
+  const preState = {
+    mode: "pre" as const,
+    tag: "alpha",
+    initialVersions: {},
+    changesets: [],
+  };
+
+  test("기본 beta 진입과 retag를 계획한다", () => {
+    expect(planTransition("minor", "enter", undefined, null, config.protectedDistTags).tag).toBe(
+      "beta",
+    );
+    expect(planTransition("major", "retag", "rc", preState, config.protectedDistTags).tag).toBe(
+      "rc",
+    );
+  });
+
+  test("중복 상태와 stable tag를 거부한다", () => {
+    expect(() => planTransition("major", "enter", "beta", preState, [])).toThrow("이미");
+    expect(() => validatePrereleaseTag("latest", config.protectedDistTags)).toThrow("보호");
+    expect(() => planTransition("minor", "retag", "alpha", preState, [])).toThrow("이미");
+  });
+
+  test("dev와 잘못된 exit를 거부한다", () => {
+    expect(() => planTransition("dev", "enter", "beta", null, [])).toThrow("dev");
+    expect(() => planTransition("minor", "exit", undefined, null, [])).toThrow("아닙니다");
+  });
+});
+
+describe("동기화 queue", () => {
+  test("major의 두 유입 경로를 merge 시각과 PR 번호로 정렬한다", () => {
+    const sorted = sortSyncCandidates([
+      {
+        number: 12,
+        mergedAt: "2026-08-05T02:00:00Z",
+        baseRef: "minor",
+        mergeCommitSha: "b",
+        author: "b",
+      },
+      {
+        number: 11,
+        mergedAt: "2026-08-05T02:00:00Z",
+        baseRef: "dev",
+        mergeCommitSha: "a",
+        author: "a",
+      },
+      {
+        number: 10,
+        mergedAt: "2026-08-05T01:00:00Z",
+        baseRef: "dev",
+        mergeCommitSha: "c",
+        author: "c",
+      },
+    ]);
+    expect(sorted.map((candidate) => candidate.number)).toEqual([10, 11, 12]);
+    expect(syncTargets(config, "dev")).toEqual(["minor", "major"]);
+    expect(syncTargets(config, "minor")).toEqual(["major"]);
+  });
+
+  test("idempotency key와 marker를 일관되게 판정한다", () => {
+    const marker: ReleaseMarker = {
+      schemaVersion: 1,
+      type: "sync",
+      lane: "major",
+      targetLane: "major",
+      sourceRepository: "daangn/seed-design",
+      sourcePr: 7,
+    };
+    expect(idempotencyKey("daangn/seed-design", 7, "major")).toBe("daangn/seed-design#7->major");
+    expect(isProcessed(marker, "daangn/seed-design", 7, "major")).toBe(true);
+    expect(sha256("same")).toBe(sha256("same"));
+  });
+});
+
+describe("게시 승인과 버전 단조 증가", () => {
+  const marker: ReleaseMarker = { schemaVersion: 1, type: "version", lane: "dev" };
+
+  test("SemVer stable과 prerelease를 비교한다", () => {
+    expect(compareSemver("2.0.0", "2.0.0-beta.3")).toBeGreaterThan(0);
+    expect(compareSemver("2.0.1", "2.0.0")).toBeGreaterThan(0);
+    expect(compareSemver("2.0.0-beta.2", "2.0.0-beta.10")).toBeLessThan(0);
+  });
+
+  test("latest 이하 stable version을 거부한다", () => {
+    expect(() =>
+      assertStableVersionsAdvance(
+        { "@seed-design/rootage-artifacts": "2.3.0" },
+        { "@seed-design/rootage-artifacts": "2.3.0" },
+      ),
+    ).toThrow("높지 않습니다");
+    expect(() =>
+      assertStableVersionsAdvance(
+        { "@seed-design/rootage-artifacts": "2.3.1" },
+        { "@seed-design/rootage-artifacts": "2.3.0" },
+      ),
+    ).not.toThrow();
+  });
+
+  test("사람이 merge한 Version PR만 dry-run 게시를 승인한다", () => {
+    expect(authorizePublish(marker, "maintainer", "dev", "changeset-release/dev", control)).toBe(
+      "dry-run",
+    );
+    expect(() =>
+      authorizePublish(marker, "github-actions[bot]", "dev", "changeset-release/dev", control),
+    ).toThrow("사람");
+  });
+
+  test("승격 freeze 중 dev publish를 막고 통합 단계에서 재개한다", () => {
+    const frozen: ReleaseControl = {
+      ...control,
+      freeze: {
+        promotionLane: "major",
+        candidateSha: "a".repeat(40),
+        phase: "frozen",
+        frozenLanes: ["minor", "major"],
+        startedAt: "2026-08-05T00:00:00Z",
+      },
+    };
+    expect(() =>
+      authorizePublish(marker, "maintainer", "dev", "changeset-release/dev", frozen),
+    ).toThrow("중단");
+    expect(
+      authorizePublish(marker, "maintainer", "dev", "changeset-release/dev", {
+        ...frozen,
+        freeze: frozen.freeze ? { ...frozen.freeze, phase: "integrating" } : null,
+      }),
+    ).toBe("dry-run");
+  });
+
+  test("DES-2201 계약 없이 production을 거부한다", () => {
+    expect(() =>
+      authorizePublish(marker, "maintainer", "dev", "changeset-release/dev", {
+        ...control,
+        mode: "production",
+      }),
+    ).toThrow("DES-2201");
+  });
+});

--- a/scripts/release/rootage-input.ts
+++ b/scripts/release/rootage-input.ts
@@ -1,0 +1,28 @@
+import { appendFile } from "node:fs/promises";
+
+interface RegistryDocument {
+  versions?: Record<string, { dist?: { integrity?: string } }>;
+}
+
+const version = Bun.argv[2] ?? "";
+const outputPath = process.env.GITHUB_OUTPUT;
+if (!version) {
+  if (outputPath) await appendFile(outputPath, "integrity=\n");
+  process.exit(0);
+}
+
+let integrity = "";
+for (let attempt = 1; attempt <= 12; attempt += 1) {
+  const response = await fetch("https://registry.npmjs.org/%40seed-design%2Frootage-artifacts", {
+    headers: { accept: "application/json" },
+  });
+  if (response.ok) {
+    const document = (await response.json()) as RegistryDocument;
+    integrity = document.versions?.[version]?.dist?.integrity ?? "";
+    if (integrity) break;
+  }
+  if (attempt < 12) await Bun.sleep(5_000);
+}
+if (!integrity) throw new Error(`Rootage ${version}의 npm integrity를 확인하지 못했습니다.`);
+if (outputPath) await appendFile(outputPath, `integrity=${integrity}\n`);
+console.log(`@seed-design/rootage-artifacts@${version}: ${integrity}`);

--- a/scripts/release/sync-alert.ts
+++ b/scripts/release/sync-alert.ts
@@ -1,0 +1,44 @@
+import { appendFile } from "node:fs/promises";
+import { GitHubClient, type GitHubPullRequest } from "./github";
+import { loadLaneConfig } from "./config";
+import { parseMarker } from "./marker";
+
+interface IssueComment {
+  body: string | null;
+}
+
+const token = process.env.GH_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY;
+if (!token || !repository) throw new Error("GitHub workflow 환경이 필요합니다.");
+
+const client = new GitHubClient(repository, token);
+const config = await loadLaneConfig();
+const threshold = Date.now() - config.sync.conflictAlertHours * 60 * 60 * 1000;
+const pulls = await client.paginate<GitHubPullRequest>(
+  `/repos/${repository}/pulls?state=open&sort=created&direction=asc`,
+);
+const stale = pulls.filter((pull) => {
+  const marker = parseMarker(pull.body ?? "");
+  return marker?.type === "sync" && pull.draft && Date.parse(pull.created_at) <= threshold;
+});
+
+const alerted: string[] = [];
+for (const pull of stale) {
+  const comments = await client.paginate<IssueComment>(
+    `/repos/${repository}/issues/${pull.number}/comments`,
+  );
+  if (comments.some((comment) => comment.body?.includes("<!-- seed-release-sync-alert -->"))) {
+    continue;
+  }
+  await client.comment(
+    pull.number,
+    `<!-- seed-release-sync-alert -->\n동기화 충돌이 ${config.sync.conflictAlertHours}시간 이상 해결되지 않았습니다. @${pull.user.login} @daangn/${config.maintainerTeam}`,
+  );
+  alerted.push(`https://github.com/${repository}/pull/${pull.number}`);
+}
+
+const outputPath = process.env.GITHUB_OUTPUT;
+if (outputPath) {
+  await appendFile(outputPath, `count=${alerted.length}\nurls=${alerted.join(", ")}\n`);
+}
+console.log(alerted.length > 0 ? alerted.join("\n") : "새 장기 충돌 알림이 없습니다.");

--- a/scripts/release/sync-merge.ts
+++ b/scripts/release/sync-merge.ts
@@ -1,0 +1,72 @@
+import { GitHubClient, type GitHubPullRequest } from "./github";
+import { validateGeneratedPr } from "./marker";
+
+interface WorkflowRunEvent {
+  workflow_run: {
+    conclusion: string;
+    pull_requests: Array<{ number: number }>;
+  };
+}
+
+interface PullCommit {
+  author: { login: string } | null;
+  commit: { author: { email: string | null } };
+}
+
+const token = process.env.GH_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY;
+const eventPath = process.env.GITHUB_EVENT_PATH;
+if (!token || !repository || !eventPath) throw new Error("GitHub workflow 환경이 필요합니다.");
+
+const event = (await Bun.file(eventPath).json()) as WorkflowRunEvent;
+if (event.workflow_run.conclusion !== "success") {
+  console.log("검증 workflow가 성공하지 않아 자동 merge하지 않습니다.");
+  process.exit(0);
+}
+const pullNumber = event.workflow_run.pull_requests[0]?.number;
+if (!pullNumber) {
+  console.log("연결된 PR이 없어 종료합니다.");
+  process.exit(0);
+}
+
+const client = new GitHubClient(repository, token);
+const pull = await client.request<GitHubPullRequest>(`/repos/${repository}/pulls/${pullNumber}`);
+const marker = validateGeneratedPr({
+  author: pull.user.login,
+  body: pull.body ?? "",
+  baseRef: pull.base.ref,
+  headRef: pull.head.ref,
+  baseRepository: pull.base.repo.full_name,
+  headRepository: pull.head.repo?.full_name ?? "",
+});
+if (!marker || marker.type !== "sync" || pull.draft) {
+  console.log("신뢰된 ready sync PR이 아니므로 자동 merge하지 않습니다.");
+  process.exit(0);
+}
+if (!marker.expectedHeadSha || marker.expectedHeadSha !== pull.head.sha) {
+  console.log("자동 생성 이후 head가 변경되어 수동 리뷰로 전환합니다.");
+  process.exit(0);
+}
+
+const commits = await client.paginate<PullCommit>(
+  `/repos/${repository}/pulls/${pullNumber}/commits`,
+);
+const hasHumanCommit = commits.some(
+  (commit) =>
+    commit.author?.login !== "github-actions[bot]" &&
+    commit.commit.author.email !== "41898282+github-actions[bot]@users.noreply.github.com",
+);
+if (hasHumanCommit) {
+  console.log("사람 commit이 있어 자동 merge하지 않습니다.");
+  process.exit(0);
+}
+
+await client.request(`/repos/${repository}/pulls/${pullNumber}/merge`, {
+  method: "PUT",
+  body: JSON.stringify({
+    sha: pull.head.sha,
+    merge_method: "squash",
+    commit_title: `chore(release): sync #${marker.sourcePr} to ${marker.targetLane}`,
+  }),
+});
+console.log(`sync PR #${pullNumber}을 merge했습니다.`);

--- a/scripts/release/sync-worker.ts
+++ b/scripts/release/sync-worker.ts
@@ -1,0 +1,242 @@
+import { rm } from "node:fs/promises";
+import { GitHubClient, type GitHubPullRequest } from "./github";
+import { encodeMarker, parseMarker } from "./marker";
+import { idempotencyKey, protectedLaneFiles, sha256, sortSyncCandidates } from "./sync";
+import { isLaneName, parseLaneConfig } from "./config";
+import type { LaneName, SyncCandidate } from "./types";
+
+interface IssueComment {
+  body: string | null;
+  author_association: string;
+  user: { login: string };
+}
+
+const tokenValue = process.env.GH_TOKEN;
+const repositoryValue = process.env.GITHUB_REPOSITORY;
+const targetValue = process.env.TARGET_LANE;
+if (
+  !tokenValue ||
+  !repositoryValue ||
+  !targetValue ||
+  !isLaneName(targetValue) ||
+  targetValue === "dev"
+) {
+  throw new Error("GH_TOKEN, GITHUB_REPOSITORY, TARGET_LANE(minor|major)가 필요합니다.");
+}
+const token = tokenValue;
+const repository = repositoryValue;
+const target: Exclude<LaneName, "dev"> = targetValue;
+const config = parseLaneConfig(
+  JSON.parse((await run(["git", "show", "origin/dev:.github/release/lanes.json"])).output),
+);
+if (!config.sync.activation) {
+  console.log("동기화 activation이 설정되지 않아 안전하게 종료합니다.");
+  process.exit(0);
+}
+const activation = config.sync.activation;
+const client = new GitHubClient(repository, token);
+
+async function run(
+  command: string[],
+  allowFailure = false,
+): Promise<{ code: number; output: string }> {
+  const child = Bun.spawn(command, { stdout: "pipe", stderr: "pipe" });
+  const stdout = await new Response(child.stdout).text();
+  const stderr = await new Response(child.stderr).text();
+  const code = await child.exited;
+  if (code !== 0 && !allowFailure) {
+    throw new Error(`${command.join(" ")} 실패:\n${stdout}\n${stderr}`);
+  }
+  return { code, output: `${stdout}${stderr}`.trim() };
+}
+
+function isGeneralPullRequest(pr: GitHubPullRequest): boolean {
+  if (!pr.merged_at || !pr.merge_commit_sha) return false;
+  if (parseMarker(pr.body ?? "")) return false;
+  return ![
+    "changeset-release/",
+    "release-transition/",
+    "release-sync/",
+    "release-freeze/",
+    "release-integration/",
+    "release-rebuild/",
+  ].some((prefix) => pr.head.ref.startsWith(prefix));
+}
+
+async function sourcePullRequests(source: LaneName): Promise<GitHubPullRequest[]> {
+  const pulls = await client.paginate<GitHubPullRequest>(
+    `/repos/${repository}/pulls?state=closed&base=${source}&sort=updated&direction=asc`,
+  );
+  return pulls.filter(
+    (pull) => pull.merged_at && pull.merged_at >= activation && isGeneralPullRequest(pull),
+  );
+}
+
+async function comments(pr: number): Promise<IssueComment[]> {
+  return client.paginate<IssueComment>(`/repos/${repository}/issues/${pr}/comments`);
+}
+
+function syncRecord(body: string | null, key: string): boolean {
+  return body?.includes(`<!-- seed-release-sync:${key}:`) ?? false;
+}
+
+async function hasSkip(pr: GitHubPullRequest, key: string): Promise<boolean> {
+  const allComments = await comments(pr.number);
+  const existingRecord = allComments.some((comment) => syncRecord(comment.body, key));
+  if (existingRecord) return true;
+
+  const command = allComments.find((comment) => {
+    const body = comment.body ?? "";
+    const trusted = ["OWNER", "MEMBER", "COLLABORATOR"].includes(comment.author_association);
+    const targetsLane = body.includes("/release-sync skip") && body.includes(`target=${target}`);
+    const hasReason = /reason=\S+/.test(body);
+    const hasEvidence = /evidence=(?:#\d+|[0-9a-f]{7,40})\b/.test(body);
+    return trusted && targetsLane && hasReason && hasEvidence;
+  });
+  if (!command) return false;
+
+  await client.comment(
+    pr.number,
+    `<!-- seed-release-sync:${key}:skipped -->\n${target} 동기화를 @${command.user.login}의 승인된 skip 요청으로 건너뜁니다.`,
+  );
+  return true;
+}
+
+async function existingPull(branch: string): Promise<GitHubPullRequest | null> {
+  const owner = repository.split("/")[0];
+  const pulls = await client.paginate<GitHubPullRequest>(
+    `/repos/${repository}/pulls?state=all&head=${owner}:${encodeURIComponent(branch)}`,
+  );
+  return pulls[0] ?? null;
+}
+
+async function hasOpenSyncPull(): Promise<boolean> {
+  const pulls = await client.paginate<GitHubPullRequest>(
+    `/repos/${repository}/pulls?state=open&base=${target}`,
+  );
+  return pulls.some((pull) => parseMarker(pull.body ?? "")?.type === "sync");
+}
+
+const sourcePulls = (
+  await Promise.all(config.lanes[target].sources.map((source) => sourcePullRequests(source)))
+).flat();
+const candidates = sortSyncCandidates(
+  sourcePulls.map(
+    (pull): SyncCandidate => ({
+      number: pull.number,
+      mergedAt: pull.merged_at ?? "",
+      baseRef: pull.base.ref as LaneName,
+      mergeCommitSha: pull.merge_commit_sha ?? "",
+      author: pull.user.login,
+    }),
+  ),
+);
+
+if (await hasOpenSyncPull()) {
+  console.log(`${target}에 열린 sync PR이 있어 FIFO queue를 유지합니다.`);
+  process.exit(0);
+}
+
+let selected: {
+  candidate: SyncCandidate;
+  pull: GitHubPullRequest;
+  key: string;
+  branch: string;
+} | null = null;
+for (const candidate of candidates) {
+  const pull = sourcePulls.find((item) => item.number === candidate.number);
+  if (!pull) continue;
+  const key = idempotencyKey(repository, candidate.number, target);
+  const branch = `release-sync/${candidate.baseRef}-${candidate.number}-to-${target}`;
+  if ((await existingPull(branch)) || (await hasSkip(pull, key))) continue;
+  selected = { candidate, pull, key, branch };
+  break;
+}
+
+if (!selected) {
+  console.log(`${target}에 전달할 미처리 PR이 없습니다.`);
+  process.exit(0);
+}
+
+const patchResponse = await fetch(
+  `https://api.github.com/repos/${repository}/pulls/${selected.candidate.number}`,
+  {
+    headers: {
+      accept: "application/vnd.github.diff",
+      authorization: `Bearer ${token}`,
+      "x-github-api-version": "2022-11-28",
+    },
+  },
+);
+if (!patchResponse.ok) throw new Error(`PR diff 조회 실패: ${patchResponse.status}`);
+const patch = await patchResponse.text();
+const patchHash = sha256(patch);
+const patchPath = `/tmp/seed-release-sync-${selected.candidate.number}-${target}.diff`;
+await Bun.write(patchPath, patch);
+
+await run(["git", "switch", "-c", selected.branch]);
+let conflict = false;
+const applied = await run(["git", "apply", "--3way", "--whitespace=nowarn", patchPath], true);
+if (applied.code !== 0) {
+  conflict = true;
+  await run(["git", "reset", "--hard", "HEAD"]);
+  await run(["git", "apply", "--reject", "--whitespace=nowarn", patchPath], true);
+  const rejects = Array.from(new Bun.Glob("**/*.rej").scanSync({ cwd: process.cwd(), dot: true }));
+  await Promise.all(rejects.map((file) => rm(file, { force: true })));
+}
+
+for (const file of protectedLaneFiles) {
+  await run(["git", "restore", "--source=HEAD", "--staged", "--worktree", "--", file], true);
+}
+await run(["git", "add", "--all"]);
+const diff = await run(["git", "diff", "--cached", "--quiet"], true);
+if (diff.code === 0 && !conflict) {
+  await client.comment(
+    selected.candidate.number,
+    `<!-- seed-release-sync:${selected.key}:no-op -->\n${target}에는 최종 diff가 이미 반영되어 있어 no-op으로 기록합니다.`,
+  );
+  console.log(`${selected.key}: no-op`);
+  process.exit(0);
+}
+
+await run(["git", "config", "user.name", "github-actions[bot]"]);
+await run(["git", "config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"]);
+await run([
+  "git",
+  "commit",
+  ...(diff.code === 0 ? ["--allow-empty"] : []),
+  "-m",
+  `chore(release): sync #${selected.candidate.number} to ${target}`,
+]);
+await run(["git", "push", "origin", selected.branch]);
+const expectedHeadSha = (await run(["git", "rev-parse", "HEAD"])).output;
+const marker = encodeMarker({
+  schemaVersion: 1,
+  type: "sync",
+  lane: target,
+  targetLane: target,
+  sourceRepository: repository,
+  sourcePr: selected.candidate.number,
+  patchSha256: patchHash,
+  expectedHeadSha,
+});
+const conflictMessage = conflict
+  ? `\n\n자동 적용 중 충돌이 발생했습니다. 충돌 marker와 reject 파일은 커밋하지 않았습니다. @${selected.candidate.author} @${config.maintainerTeam}`
+  : "";
+const created = await client.request<GitHubPullRequest>(`/repos/${repository}/pulls`, {
+  method: "POST",
+  body: JSON.stringify({
+    title: `chore(release): sync #${selected.candidate.number} to ${target}`,
+    head: selected.branch,
+    base: target,
+    body: `${marker}\n\nIdempotency key: \`${selected.key}\`\n\nSource: #${selected.candidate.number}${conflictMessage}`,
+    draft: conflict,
+  }),
+});
+const label = conflict ? "release:sync-conflict" : "release:sync";
+await client.ensureLabel(label, conflict ? "d1242f" : "0969da", "Release lane synchronization");
+await client.request(`/repos/${repository}/issues/${created.number}/labels`, {
+  method: "POST",
+  body: JSON.stringify({ labels: [label] }),
+});
+console.log(`${selected.key}: PR #${created.number} 생성`);

--- a/scripts/release/sync.ts
+++ b/scripts/release/sync.ts
@@ -1,0 +1,43 @@
+import { createHash } from "node:crypto";
+import type { LaneConfig, LaneName, ReleaseMarker, SyncCandidate } from "./types";
+
+export function syncTargets(config: LaneConfig, source: LaneName): LaneName[] {
+  return Object.entries(config.lanes)
+    .filter(([, definition]) => definition.sources.includes(source))
+    .map(([lane]) => lane as LaneName);
+}
+
+export function idempotencyKey(repository: string, sourcePr: number, targetLane: LaneName): string {
+  return `${repository}#${sourcePr}->${targetLane}`;
+}
+
+export function sortSyncCandidates(candidates: SyncCandidate[]): SyncCandidate[] {
+  return [...candidates].sort((left, right) => {
+    const byDate = left.mergedAt.localeCompare(right.mergedAt);
+    return byDate === 0 ? left.number - right.number : byDate;
+  });
+}
+
+export function sha256(content: string | Uint8Array): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+export function isProcessed(
+  marker: ReleaseMarker,
+  repository: string,
+  sourcePr: number,
+  targetLane: LaneName,
+): boolean {
+  return (
+    marker.type === "sync" &&
+    marker.sourceRepository === repository &&
+    marker.sourcePr === sourcePr &&
+    marker.targetLane === targetLane
+  );
+}
+
+export const protectedLaneFiles = [
+  ".changeset/config.json",
+  ".changeset/pre.json",
+  ".github/release/control.json",
+] as const;

--- a/scripts/release/transition.ts
+++ b/scripts/release/transition.ts
@@ -1,0 +1,85 @@
+import { readFile, writeFile } from "node:fs/promises";
+import type { LaneName, TransitionCommand } from "./types";
+
+interface PreState {
+  mode: "pre" | "exit";
+  tag: string;
+  initialVersions: Record<string, string>;
+  changesets: string[];
+}
+
+export interface TransitionPlan {
+  command: TransitionCommand;
+  lane: Exclude<LaneName, "dev">;
+  tag?: string;
+  bunCommand?: string[];
+}
+
+export function validatePrereleaseTag(tag: string, protectedTags: string[]): string {
+  const normalized = tag.trim().toLowerCase();
+  if (!/^[a-z][a-z0-9-]{0,31}$/.test(normalized)) {
+    throw new Error(
+      "pre-release tag는 영문 소문자로 시작하는 1~32자의 영문·숫자·하이픈이어야 합니다.",
+    );
+  }
+  if (protectedTags.includes(normalized)) {
+    throw new Error(`'${normalized}'은 stable용으로 보호된 dist-tag입니다.`);
+  }
+  return normalized;
+}
+
+export function planTransition(
+  lane: LaneName,
+  command: TransitionCommand,
+  tag: string | undefined,
+  preState: PreState | null,
+  protectedTags: string[],
+): TransitionPlan {
+  if (lane === "dev") throw new Error("dev 레인은 pre-release 상태 전환을 지원하지 않습니다.");
+
+  if (command === "enter") {
+    const nextTag = validatePrereleaseTag(tag ?? "beta", protectedTags);
+    if (preState) throw new Error(`${lane} 레인은 이미 '${preState.tag}' pre-release 상태입니다.`);
+    return {
+      command,
+      lane,
+      tag: nextTag,
+      bunCommand: ["bun", "changeset", "pre", "enter", nextTag],
+    };
+  }
+
+  if (!preState || preState.mode !== "pre") {
+    throw new Error(`${lane} 레인은 pre-release 상태가 아닙니다.`);
+  }
+
+  if (command === "retag") {
+    const nextTag = validatePrereleaseTag(tag ?? "beta", protectedTags);
+    if (preState.tag === nextTag)
+      throw new Error(`${lane} 레인은 이미 '${nextTag}' tag를 사용합니다.`);
+    return { command, lane, tag: nextTag };
+  }
+
+  return { command, lane, bunCommand: ["bun", "changeset", "pre", "exit"] };
+}
+
+export async function readPreState(path = ".changeset/pre.json"): Promise<PreState | null> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) return null;
+  return JSON.parse(await readFile(path, "utf8")) as PreState;
+}
+
+export async function applyTransition(plan: TransitionPlan): Promise<void> {
+  if (plan.command === "retag") {
+    const state = await readPreState();
+    if (!state || !plan.tag) throw new Error("retag에 필요한 pre-release 상태가 없습니다.");
+    state.tag = plan.tag;
+    await writeFile(".changeset/pre.json", `${JSON.stringify(state, null, 2)}\n`);
+    return;
+  }
+
+  if (!plan.bunCommand) throw new Error("실행할 Changesets 명령이 없습니다.");
+  const child = Bun.spawn(plan.bunCommand, { stdout: "inherit", stderr: "inherit" });
+  const exitCode = await child.exited;
+  if (exitCode !== 0)
+    throw new Error(`Changesets 상태 전환이 종료 코드 ${exitCode}로 실패했습니다.`);
+}

--- a/scripts/release/types.ts
+++ b/scripts/release/types.ts
@@ -1,0 +1,86 @@
+export const laneNames = ["dev", "minor", "major"] as const;
+export const bumpTypes = ["patch", "minor", "major"] as const;
+export const generatedPrTypes = [
+  "version",
+  "transition",
+  "sync",
+  "freeze",
+  "integration",
+  "rebuild",
+] as const;
+
+export type LaneName = (typeof laneNames)[number];
+export type BumpType = (typeof bumpTypes)[number];
+export type GeneratedPrType = (typeof generatedPrTypes)[number];
+export type TransitionCommand = "enter" | "retag" | "exit";
+
+export interface LaneDefinition {
+  bump: BumpType;
+  prerelease: boolean;
+  sources: LaneName[];
+}
+
+export interface LaneConfig {
+  $schema: "./lanes.schema.json";
+  schemaVersion: 1;
+  repository: string;
+  maintainerTeam: string;
+  protectedDistTags: string[];
+  lanes: Record<LaneName, LaneDefinition>;
+  sync: {
+    activation: string | null;
+    reconcileCron: string;
+    conflictAlertHours: number;
+  };
+}
+
+export interface ReleaseFreeze {
+  promotionLane: Exclude<LaneName, "dev">;
+  candidateSha: string;
+  phase: "frozen" | "integrating" | "rebuilding";
+  frozenLanes: Exclude<LaneName, "dev">[];
+  startedAt: string;
+}
+
+export interface ReleaseControl {
+  $schema: "./control.schema.json";
+  schemaVersion: 1;
+  mode: "dry-run" | "production";
+  rootageContractReady: boolean;
+  freeze: ReleaseFreeze | null;
+}
+
+export interface ReleaseMarker {
+  schemaVersion: 1;
+  type: GeneratedPrType;
+  lane: LaneName;
+  sourceRepository?: string;
+  sourcePr?: number;
+  targetLane?: LaneName;
+  patchSha256?: string;
+  expectedHeadSha?: string;
+  command?: TransitionCommand;
+  tag?: string;
+}
+
+export interface PullRequestIdentity {
+  author: string;
+  body: string;
+  baseRef: string;
+  headRef: string;
+  baseRepository: string;
+  headRepository: string;
+}
+
+export interface ChangesetEntry {
+  file: string;
+  releases: Array<{ name: string; type: BumpType }>;
+}
+
+export interface SyncCandidate {
+  number: number;
+  mergedAt: string;
+  baseRef: LaneName;
+  mergeCommitSha: string;
+  author: string;
+}

--- a/scripts/release/version.ts
+++ b/scripts/release/version.ts
@@ -1,0 +1,13 @@
+async function run(command: string[]): Promise<void> {
+  console.log(`$ ${command.join(" ")}`);
+  const child = Bun.spawn(command, { stdout: "inherit", stderr: "inherit" });
+  const exitCode = await child.exited;
+  if (exitCode !== 0) throw new Error(`${command.join(" ")} 명령이 ${exitCode}로 실패했습니다.`);
+}
+
+export {};
+
+await run(["bun", "version"]);
+await run(["bun", "rootage:build"]);
+await run(["bun", "install"]);
+await run(["bun", "rootage:generate"]);

--- a/scripts/release/workflow-security.test.ts
+++ b/scripts/release/workflow-security.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { parse } from "yaml";
+
+interface WorkflowJob {
+  permissions?: Record<string, string> | string;
+  steps?: Array<{ uses?: string; with?: Record<string, string> }>;
+}
+
+interface Workflow {
+  permissions?: Record<string, string> | string;
+  jobs: Record<string, WorkflowJob>;
+}
+
+async function workflow(path: string): Promise<Workflow> {
+  return parse(await readFile(path, "utf8")) as Workflow;
+}
+
+describe("릴리즈 workflow 권한 경계", () => {
+  test("일반 PR 검증은 read-only다", async () => {
+    const validation = await workflow(".github/workflows/release-pr-validation.yml");
+    expect(validation.permissions).toEqual({ contents: "read" });
+    expect(validation.jobs.validate.permissions).toBeUndefined();
+  });
+
+  test("npm publish job만 OIDC를 가진다", async () => {
+    const publish = await workflow(".github/workflows/release-publish.yml");
+    const oidcJobs = Object.entries(publish.jobs)
+      .filter(
+        ([, job]) => typeof job.permissions === "object" && job.permissions["id-token"] === "write",
+      )
+      .map(([name]) => name);
+    expect(oidcJobs).toEqual(["publish-npm"]);
+  });
+
+  test("pull_request_target control workflow는 PR head를 checkout하지 않는다", async () => {
+    const workflows = await Promise.all([
+      workflow(".github/workflows/release-publish.yml"),
+      workflow(".github/workflows/release-sync.yml"),
+    ]);
+    const untrustedHeadRef = ["$", "{{ github.event.pull_request.head.sha }}"].join("");
+    for (const candidate of workflows) {
+      for (const job of Object.values(candidate.jobs)) {
+        for (const step of job.steps ?? []) {
+          if (step.uses?.startsWith("actions/checkout@")) {
+            expect(step.with?.ref).not.toBe(untrustedHeadRef);
+          }
+        }
+      }
+    }
+  });
+
+  test("모든 release workflow YAML을 읽을 수 있다", async () => {
+    const paths = [
+      ".github/workflows/release-packages.yml",
+      ".github/workflows/release-pr-validation.yml",
+      ".github/workflows/release-transition.yml",
+      ".github/workflows/release-publish.yml",
+      ".github/workflows/release-sync.yml",
+      ".github/workflows/release-sync-merge.yml",
+      ".github/workflows/release-sync-alert.yml",
+      ".github/workflows/release-promotion.yml",
+      ".github/workflows/release-e2e.yml",
+      ".github/workflows/release-bootstrap.yml",
+      ".github/workflows/release-activation.yml",
+      ".github/workflows/rootage-release-contract.yml",
+    ];
+    const parsed = await Promise.all(paths.map(workflow));
+    expect(parsed.every((item) => Object.keys(item.jobs).length > 0)).toBe(true);
+  });
+
+  test("DES-2201 계약은 production 활성화 전에 fail-closed다", async () => {
+    const contract = await readFile(".github/workflows/rootage-release-contract.yml", "utf8");
+    expect(contract).toContain("DES-2201 must replace this contract");
+    expect(contract).toContain("exit 1");
+  });
+});


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * dev·minor·major 릴리스 레인 기반의 버전 관리 및 동기화 자동화를 추가했습니다.
  * 릴리스 활성화, 프리릴리스 전환, 안정 버전 승격, 게시 과정을 수동 또는 자동으로 실행할 수 있습니다.
  * FIFO 방식의 릴리스 PR 처리와 충돌 감지·알림을 지원합니다.
  * 프로덕션 게시 전 검증 및 dry-run 패키징을 제공합니다.

* **검증 및 안정성**
  * 릴리스 설정, 변경셋, 버전, 동결 상태와 게시 조건을 자동 검증합니다.
  * 릴리스 워크플로와 권한에 대한 자동화 테스트를 추가했습니다.

* **문서**
  * 릴리스 운영 정책과 관련 작성 규칙을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->