### PR TITLE
docs(ai-integration): align Docs MCP page with @seed-design/docs-mcp 0.7

### DIFF
--- a/docs/content/ai-integration/(mcp)/docs-mcp.mdx
+++ b/docs/content/ai-integration/(mcp)/docs-mcp.mdx
@@ -17,6 +17,9 @@ description: AI Agent가 SEED 문서에 직접 접근할 수 있는 MCP 서버�
 
 Figma 연결 없이 독립적으로 실행되며, SEED를 사용하는 프로젝트에서 AI 도구의 문서 이해도를 높일 수 있습니다.
 
+문서는 `section` + `path`로 주소가 정해집니다. 처음에는 `discover_seed_docs`로 섹션·카테고리 맵을
+확인한 뒤, `list_docs` / `get_doc`로 필요한 문서만 가져오세요.
+
 ## 설치
 
 <Tabs items={['Claude Code', 'Codex CLI', 'Gemini CLI', 'Cursor', 'Claude Desktop']}>
@@ -56,17 +59,28 @@ codex mcp add seed-docs -- npx -y @seed-design/docs-mcp
 
 <Tab value="Cursor">
 
+프로젝트 루트의 `.cursor/mcp.json`에 다음을 추가합니다:
+
 ```json
 {
   "mcpServers": {
     "seed-docs": {
+      "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@seed-design/docs-mcp"],
-      "type": "stdio"
+      "args": ["-y", "@seed-design/docs-mcp"]
     }
   }
 }
 ```
+
+Cursor GUI는 셸 프로필의 `PATH`를 물려받지 않습니다. macOS에서는 종종
+`/usr/bin:/bin:/usr/sbin:/sbin`만 보이므로, nvm·fnm·Volta·Homebrew로 설치한 Node라면
+위 설정에서 `npx`를 찾지 못해 서버가 MCP 목록에 **아예 나타나지 않을 수** 있습니다.
+그 경우 `command`를 Node/`npx`의 절대 경로로 바꾸거나, Node를 찾은 뒤 `npx`를 실행하는
+작은 셸 스크립트를 `command`로 지정하세요.
+
+프로젝트 MCP는 Cursor **Settings → MCP**(또는 Customize → MCP)에서 활성화·승인이 필요합니다.
+토글이 꺼져 있으면 `createClient` 시도 자체가 로그에 남지 않습니다.
 
 [Cursor MCP에 대해 자세히 알아보기](https://docs.cursor.com/context/model-context-protocol)
 
@@ -93,198 +107,87 @@ codex mcp add seed-docs -- npx -y @seed-design/docs-mcp
 
 ## 사용 가능한 도구
 
+`@seed-design/docs-mcp@0.7.0` 기준으로 노출되는 도구입니다. 도구 표면은 마이너 버전에서
+바뀔 수 있으니, 연결 직후 `discover_seed_docs`로 실제 맵을 확인하세요.
+
 ### Discovery
 
-#### `discover_tools`
+#### `discover_seed_docs`
 
-사용 가능한 모든 도구를 탐색하고 각 도구의 용도를 확인합니다. MCP 서버에 처음 연결했을 때 호출하면 유용합니다.
+사용 가능한 섹션과 카테고리 맵을 반환합니다. `list_docs` / `get_doc`를 쓰기 전에 먼저 호출하세요.
 
-**파라미터:**
-| 이름 | 타입 | 설명 |
-|------|------|------|
-| `query` | string (선택) | 도구를 필터링할 검색어 (예: 'installation', 'component') |
-| `category` | string (선택) | 카테고리 필터 (`discovery`, `react`, `breeze`, `design-guidelines`, `rootage`, `icons`) |
+**파라미터:** 없음
 
 **예시:**
 ```
-discover_tools({ query: "component" })
+discover_seed_docs()
 ```
 
 ---
 
-### React Components
+### Documents
 
-#### `list_react_components`
+#### `list_docs`
 
-사용 가능한 모든 SEED React 컴포넌트 목록을 반환합니다.
-
-**파라미터:** 없음
-
-**예시 응답:**
-```
-Found 45 React components:
-
-- ActionButton (action-button)
-- AlertDialog (alert-dialog)
-- Avatar (avatar)
-- Badge (badge)
-...
-```
-
-#### `get_react_component`
-
-특정 React 컴포넌트의 상세 문서를 반환합니다. 설치 방법, props, 사용 예시가 포함됩니다.
+특정 섹션의 문서 목록을 반환합니다. 응답의 `path`를 `get_doc`에 넘깁니다.
 
 **파라미터:**
 | 이름 | 타입 | 설명 |
 |------|------|------|
-| `componentName` | string | 컴포넌트 이름 (kebab-case, 예: `action-button`, `text-field`) |
+| `section` | string | `react`, `docs`, `breeze`, `ai-integration`, `lynx` |
+| `category` | string (선택) | 예: `components`, `foundation`, `getting-started` |
 
 **예시:**
 ```
-get_react_component({ componentName: "action-button" })
+list_docs({ section: "react", category: "components" })
 ```
 
-#### `get_react_changelog`
+#### `get_doc`
 
-SEED React 패키지의 변경 이력을 반환합니다. 버전 업그레이드 시 변경 사항을 확인할 때 유용합니다.
-
-**파라미터:** 없음
-
----
-
-### React 섹션별 도구
-
-React 문서의 각 섹션에 접근하는 도구들입니다. 각 섹션마다 `list_*`와 `get_*` 도구가 제공됩니다.
-
-| 섹션 | list 도구 | get 도구 | 설명 |
-|------|-----------|----------|------|
-| Getting Started | `list_react_getting_started` | `get_react_getting_started` | 설치, CLI, 스타일링 설정 |
-| Stackflow | `list_react_stackflow` | `get_react_stackflow` | Stackflow 통합 가이드 |
-| Developer Tools | `list_react_developer_tools` | `get_react_developer_tools` | Codemod, Figma 통합 |
-| Migration | `list_react_migration` | `get_react_migration` | 마이그레이션 가이드 |
-| AI Integration | `list_react_ai_integration` | `get_react_ai_integration` | AI 도구 통합 |
-| Updates | `list_react_updates` | `get_react_updates` | 버전 업데이트 정보 |
-
-#### 사용 예시
-
-먼저 `list_*` 도구로 사용 가능한 문서를 확인합니다:
-
-```
-list_react_getting_started()
-```
-
-응답:
-```
-# SEED React - Getting Started Topics
-
-- Installation - Vite (path: installation/vite)
-- Installation - Manual (path: installation/manual)
-- CLI - Commands (path: cli/commands)
-- CLI - Configuration (path: cli/configuration)
-- Styling - Theming (path: styling/theming)
-- Styling - Tailwind CSS (path: styling/tailwind-css)
-```
-
-원하는 문서의 `path`를 사용해 상세 내용을 가져옵니다:
-
-```
-get_react_getting_started({ path: "installation/vite" })
-```
-
----
-
-### Breeze
-
-Breeze는 프로젝트에 바로 사용할 수 있는 유틸리티 UI 컴포넌트 모음입니다.
-
-#### `list_breeze_components`
-
-사용 가능한 Breeze 컴포넌트 목록을 반환합니다.
-
-**파라미터:** 없음
-
-**예시 응답:**
-```
-Found 1 Breeze components:
-
-- AnimateNumber (animate-number)
-```
-
-#### `get_breeze_component`
-
-특정 Breeze 컴포넌트의 상세 문서를 반환합니다.
+한 문서의 전체 내용을 반환합니다.
 
 **파라미터:**
 | 이름 | 타입 | 설명 |
 |------|------|------|
-| `componentName` | string | 컴포넌트 이름 (kebab-case, 예: `animate-number`) |
+| `section` | string | `react`, `docs`, `breeze`, `ai-integration`, `lynx` |
+| `path` | string | 예: `components/action-button`, `getting-started/styling/tailwind-css` |
 
 **예시:**
 ```
-get_breeze_component({ componentName: "animate-number" })
+get_doc({ section: "react", path: "components/action-button" })
+get_doc({ section: "docs", path: "foundation/color" })
 ```
 
----
+#### `get_full_docs`
 
-### Design Guidelines
-
-컴포넌트의 디자인 가이드라인 문서에 접근합니다. 해부도(anatomy), 속성, 사용 권장사항 등이 포함됩니다.
-
-#### `list_docs_components`
-
-디자인 가이드라인이 있는 컴포넌트 목록을 반환합니다.
-
-**파라미터:** 없음
-
-**예시 응답:**
-```
-Found 25 component design guidelines:
-
-- ActionButton (action-button)
-- Avatar (avatar)
-- BottomSheet (bottom-sheet)
-...
-```
-
-#### `get_docs_component`
-
-특정 컴포넌트의 디자인 가이드라인을 반환합니다.
+한 섹션의 문서를 한꺼번에 반환합니다. 컨텍스트가 커지므로 가능하면 `get_doc`을 우선하세요.
 
 **파라미터:**
 | 이름 | 타입 | 설명 |
 |------|------|------|
-| `componentName` | string | 컴포넌트 이름 (kebab-case, 예: `action-button`) |
+| `section` | string | `react`, `docs`, `breeze`, `ai-integration`, `lynx` |
 
 **예시:**
 ```
-get_docs_component({ componentName: "action-button" })
+get_full_docs({ section: "ai-integration" })
 ```
 
 ---
 
 ### Rootage
 
-SEED의 Rootage 스펙(디자인 토큰 및 컴포넌트 스펙의 원본 JSON 데이터)에 접근합니다.
-
 #### `get_rootage`
 
-Rootage 리소스를 반환합니다. 경로 없이 호출하면 사용 가능한 모든 리소스 목록을 반환합니다.
+SEED Rootage 스펙(토큰·컴포넌트 JSON)을 반환합니다. `path` 없이 호출하면 인덱스입니다.
 
 **파라미터:**
 | 이름 | 타입 | 설명 |
 |------|------|------|
-| `path` | string (선택) | 리소스 경로 (예: `/color.json`, `/components/action-button.json`) |
+| `path` | string (선택) | 예: `/color.json`, `/components/action-button.json` |
 
 **예시:**
-
-리소스 목록 조회:
 ```
 get_rootage()
-```
-
-특정 리소스 조회:
-```
 get_rootage({ path: "/components/action-button.json" })
 ```
 
@@ -327,18 +230,6 @@ list_icons({ type: "monochrome", variant: "line", limit: 20 })
 search_icons({ query: "화살표" })
 ```
 
-**예시 응답:**
-```
-Found 15 icons matching "화살표":
-View in browser: https://seed-design.io/foundations/iconography/library?search=화살표
-
-- icon_arrow_left_line [monochrome] (line)
-  Matched: arrow, 화살표, left
-- icon_arrow_right_line [monochrome] (line)
-  Matched: arrow, 화살표, right
-...
-```
-
 #### `get_icon_details`
 
 특정 아이콘의 상세 정보와 React 컴포넌트 import 문을 반환합니다.
@@ -351,28 +242,6 @@ View in browser: https://seed-design.io/foundations/iconography/library?search=�
 **예시:**
 ```
 get_icon_details({ iconName: "icon_arrow_left_line" })
-```
-
-**예시 응답:**
-```markdown
-# icon_arrow_left_line
-
-**Type:** monochrome
-**Variant:** line
-**Keywords:** arrow, left, back, 화살표, 왼쪽
-
-## Usage
-
-### React
-\`\`\`tsx
-import { IconArrowLeftLine } from "@karrotmarket/react-monochrome-icon"
-
-<IconArrowLeftLine />
-\`\`\`
-
-## Documentation
-
-View this icon: https://seed-design.io/foundations/iconography/library?icon=icon_arrow_left_line
 ```
 
 ---


### PR DESCRIPTION
The published page still described the pre-0.7 per-topic tools (discover_tools, list_react_components, …). Agents following it call names that no longer exist. Document the section/path surface that 0.7.0 actually exposes, and note Cursor GUI PATH pitfalls with bare npx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * MCP 사용 안내에 `section` 및 `path` 기반 문서 조회 절차를 추가했습니다.
  * Cursor 설정 예시에 `type: "stdio"`를 반영하고, PATH 상속 문제와 MCP 활성화·승인 절차를 설명했습니다.
  * 제공 도구 목록, 버전 기준, 매개변수 및 사용 예시를 최신화했습니다.
  * 아이콘 검색 및 상세 정보 관련 예시 응답을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->