### PR TITLE
refactor(release): use app token for lane bootstrap

### DIFF
--- a/.github/workflows/release-bootstrap.yml
+++ b/.github/workflows/release-bootstrap.yml
@@ -35,7 +35,7 @@ jobs:
           test -z "$OPEN_VERSION_PR"
 
   create-branches:
-    name: Create and protect fixed lanes
+    name: Create fixed lanes
     needs: preflight
     runs-on: ubuntu-latest
     permissions:
@@ -47,10 +47,30 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.13"
+      - name: Create Daangn Bud installation token
+        id: bud-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.DAANGN_BUD_CLIENT_ID }}
+          private-key: ${{ secrets.DAANGN_BUD_PRIVATE_KEY }}
+          permission-contents: write
       - name: Create branches from the same dev SHA
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_ADMIN_TOKEN }}
+          GH_TOKEN: ${{ steps.bud-token.outputs.token }}
         run: bun scripts/release/bootstrap.ts
+      - name: Summarize manual protection setup
+        run: |
+          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          ## 수동 branch protection 설정 필요
+
+          `dev`, `minor`, `major`에 다음 보호 규칙을 설정한 뒤 bootstrap PR을 merge합니다.
+
+          - Require branches to be up to date before merging
+          - Required status check: `Validate release lane`
+          - Require conversation resolution before merging
+          - Block force pushes
+          - Block branch deletion
+          EOF
 
   configure:
     name: Configure ${{ matrix.lane }} beta lane

--- a/.github/workflows/release-bootstrap.yml
+++ b/.github/workflows/release-bootstrap.yml
@@ -47,16 +47,9 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.13"
-      - name: Create Daangn Bud installation token
-        id: bud-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.DAANGN_BUD_CLIENT_ID }}
-          private-key: ${{ secrets.DAANGN_BUD_PRIVATE_KEY }}
-          permission-contents: write
       - name: Create branches from the same dev SHA
         env:
-          GH_TOKEN: ${{ steps.bud-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_BOOTSTRAP_TOKEN }}
         run: bun scripts/release/bootstrap.ts
       - name: Summarize manual protection setup
         run: |

--- a/.github/workflows/release-pr-validation.yml
+++ b/.github/workflows/release-pr-validation.yml
@@ -25,9 +25,6 @@ jobs:
         id: release-validation
         run: bun scripts/release/cli.ts validate-pr --event "$GITHUB_EVENT_PATH"
 
-      - name: Test release automation
-        run: bun test scripts/release
-
       - name: Run full trusted sync gate
         if: steps.release-validation.outputs.type == 'sync'
         run: |

--- a/TECH.md
+++ b/TECH.md
@@ -239,6 +239,8 @@ export const Checkbox = { Root, Control, HiddenInput, ... };
 - `minor`·`major`의 `enter`·`retag`·`exit`와 stable 승격은 보호 브랜치를 직접 수정하지 않고 PR로 수행한다.
 - 레인 동기화는 원본 일반 PR의 최종 diff만 target별 FIFO로 전달하며, 충돌이나 사람 수정이 있으면 자동 merge를 중단한다.
 - `control.json`의 기본값은 `dry-run`이다. DES-2201의 불변 Rootage 게시 계약과 bootstrap E2E가 완료되기 전에는 production으로 전환하지 않는다.
+- 레인 bootstrap은 `DAANGN_BUD_CLIENT_ID`와 `DAANGN_BUD_PRIVATE_KEY`로 발급한 Daangn Bud installation token을 사용해 `minor`·`major` 브랜치만 생성한다.
+- `dev`·`minor`·`major`의 branch protection은 bootstrap 실행 후 저장소 관리자가 수동으로 설정한다. 세 레인 모두 최신 base 반영, `Validate release lane` 필수 검사, 대화 해결을 요구하고 force push와 삭제를 차단한다.
 
 ---
 

--- a/TECH.md
+++ b/TECH.md
@@ -239,7 +239,7 @@ export const Checkbox = { Root, Control, HiddenInput, ... };
 - `minor`·`major`의 `enter`·`retag`·`exit`와 stable 승격은 보호 브랜치를 직접 수정하지 않고 PR로 수행한다.
 - 레인 동기화는 원본 일반 PR의 최종 diff만 target별 FIFO로 전달하며, 충돌이나 사람 수정이 있으면 자동 merge를 중단한다.
 - `control.json`의 기본값은 `dry-run`이다. DES-2201의 불변 Rootage 게시 계약과 bootstrap E2E가 완료되기 전에는 production으로 전환하지 않는다.
-- 레인 bootstrap은 `DAANGN_BUD_CLIENT_ID`와 `DAANGN_BUD_PRIVATE_KEY`로 발급한 Daangn Bud installation token을 사용해 `minor`·`major` 브랜치만 생성한다.
+- 레인 bootstrap은 Daangn Bud 도입 전까지 `Contents: write`만 가진 임시 fine-grained PAT를 `RELEASE_BOOTSTRAP_TOKEN` 저장소 시크릿으로 받아 `minor`·`major` 브랜치만 생성한다.
 - `dev`·`minor`·`major`의 branch protection은 bootstrap 실행 후 저장소 관리자가 수동으로 설정한다. 세 레인 모두 최신 base 반영, `Validate release lane` 필수 검사, 대화 해결을 요구하고 force push와 삭제를 차단한다.
 
 ---

--- a/scripts/release/bootstrap.ts
+++ b/scripts/release/bootstrap.ts
@@ -9,7 +9,7 @@ interface GitReference {
 const token = process.env.GH_TOKEN;
 const repository = process.env.GITHUB_REPOSITORY;
 if (!token || !repository)
-  throw new Error("Daangn Bud installation token과 GitHub 저장소 정보가 필요합니다.");
+  throw new Error("릴리즈 bootstrap token과 GitHub 저장소 정보가 필요합니다.");
 
 const control = await loadReleaseControl();
 if (control.mode !== "dry-run" || !control.rootageContractReady || control.freeze) {

--- a/scripts/release/bootstrap.ts
+++ b/scripts/release/bootstrap.ts
@@ -9,7 +9,7 @@ interface GitReference {
 const token = process.env.GH_TOKEN;
 const repository = process.env.GITHUB_REPOSITORY;
 if (!token || !repository)
-  throw new Error("RELEASE_ADMIN_TOKEN과 GitHub 저장소 정보가 필요합니다.");
+  throw new Error("Daangn Bud installation token과 GitHub 저장소 정보가 필요합니다.");
 
 const control = await loadReleaseControl();
 if (control.mode !== "dry-run" || !control.rootageContractReady || control.freeze) {
@@ -18,33 +18,15 @@ if (control.mode !== "dry-run" || !control.rootageContractReady || control.freez
 
 const client = new GitHubClient(repository, token);
 const dev = await client.request<GitReference>(`/repos/${repository}/git/ref/heads/dev`);
-for (const lane of ["dev", "minor", "major"] as const) {
-  if (lane !== "dev") {
-    try {
-      await client.request<GitReference>(`/repos/${repository}/git/ref/heads/${lane}`);
-    } catch (error) {
-      if (!(error instanceof Error) || !error.message.includes("404")) throw error;
-      await client.request(`/repos/${repository}/git/refs`, {
-        method: "POST",
-        body: JSON.stringify({ ref: `refs/heads/${lane}`, sha: dev.object.sha }),
-      });
-    }
+for (const lane of ["minor", "major"] as const) {
+  try {
+    await client.request<GitReference>(`/repos/${repository}/git/ref/heads/${lane}`);
+  } catch (error) {
+    if (!(error instanceof Error) || !error.message.includes("404")) throw error;
+    await client.request(`/repos/${repository}/git/refs`, {
+      method: "POST",
+      body: JSON.stringify({ ref: `refs/heads/${lane}`, sha: dev.object.sha }),
+    });
   }
-  await client.request(`/repos/${repository}/branches/${lane}/protection`, {
-    method: "PUT",
-    body: JSON.stringify({
-      required_status_checks: { strict: true, contexts: ["Validate release lane"] },
-      enforce_admins: false,
-      required_pull_request_reviews: null,
-      restrictions: null,
-      required_linear_history: false,
-      allow_force_pushes: false,
-      allow_deletions: false,
-      block_creations: false,
-      required_conversation_resolution: true,
-      lock_branch: false,
-      allow_fork_syncing: false,
-    }),
-  });
 }
-console.log(`minor와 major를 dev@${dev.object.sha}에서 생성하고 세 레인을 보호했습니다.`);
+console.log(`minor와 major를 dev@${dev.object.sha}에서 생성했습니다.`);

--- a/scripts/release/workflow-security.test.ts
+++ b/scripts/release/workflow-security.test.ts
@@ -85,16 +85,15 @@ describe("릴리즈 workflow 권한 경계", () => {
     expect(parsed.every((item) => Object.keys(item.jobs).length > 0)).toBe(true);
   });
 
-  test("bootstrap은 Daangn Bud로 브랜치만 생성하고 보호 규칙은 수동 설정한다", async () => {
+  test("bootstrap token은 브랜치만 생성하고 보호 규칙은 수동 설정한다", async () => {
     const [bootstrapWorkflow, bootstrapScript] = await Promise.all([
       readFile(".github/workflows/release-bootstrap.yml", "utf8"),
       readFile("scripts/release/bootstrap.ts", "utf8"),
     ]);
 
-    expect(bootstrapWorkflow).toContain("actions/create-github-app-token@v3");
-    expect(bootstrapWorkflow).toContain("vars.DAANGN_BUD_CLIENT_ID");
-    expect(bootstrapWorkflow).toContain("secrets.DAANGN_BUD_PRIVATE_KEY");
+    expect(bootstrapWorkflow).toContain("secrets.RELEASE_BOOTSTRAP_TOKEN");
     expect(bootstrapWorkflow).not.toContain("RELEASE_ADMIN_TOKEN");
+    expect(bootstrapWorkflow).not.toContain("permission-administration");
     expect(bootstrapScript).not.toContain("/protection");
   });
 

--- a/scripts/release/workflow-security.test.ts
+++ b/scripts/release/workflow-security.test.ts
@@ -85,6 +85,19 @@ describe("릴리즈 workflow 권한 경계", () => {
     expect(parsed.every((item) => Object.keys(item.jobs).length > 0)).toBe(true);
   });
 
+  test("bootstrap은 Daangn Bud로 브랜치만 생성하고 보호 규칙은 수동 설정한다", async () => {
+    const [bootstrapWorkflow, bootstrapScript] = await Promise.all([
+      readFile(".github/workflows/release-bootstrap.yml", "utf8"),
+      readFile("scripts/release/bootstrap.ts", "utf8"),
+    ]);
+
+    expect(bootstrapWorkflow).toContain("actions/create-github-app-token@v3");
+    expect(bootstrapWorkflow).toContain("vars.DAANGN_BUD_CLIENT_ID");
+    expect(bootstrapWorkflow).toContain("secrets.DAANGN_BUD_PRIVATE_KEY");
+    expect(bootstrapWorkflow).not.toContain("RELEASE_ADMIN_TOKEN");
+    expect(bootstrapScript).not.toContain("/protection");
+  });
+
   test("DES-2201 계약은 승인된 소스와 production 환경에서만 R2를 갱신한다", async () => {
     const contract = await readFile(".github/workflows/rootage-release-contract.yml", "utf8");
     expect(contract).toContain("environment: rootage-production");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **변경 사항**
  * 릴리스 브랜치 부트스트랩이 전용 보안 토큰을 사용하도록 개선되었습니다.
  * `minor` 및 `major` 브랜치가 없으면 최신 `dev` 기준으로 자동 생성됩니다.
  * 브랜치 보호 규칙은 부트스트랩 후 수동 설정하며, 필요한 설정이 요약 안내에 표시됩니다.

* **문서**
  * 릴리스 브랜치 생성 및 보호 규칙 설정 절차를 업데이트했습니다.

* **테스트**
  * 릴리스 자동화의 토큰 사용과 보안 조건을 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->