### PR TITLE
feat(release): automate Rootage contract activation

### DIFF
--- a/.github/workflows/release-activation.yml
+++ b/.github/workflows/release-activation.yml
@@ -7,7 +7,7 @@ on:
         description: "Activation step"
         required: true
         type: choice
-        options: [enable-sync, enable-production]
+        options: [enable-rootage-contract, enable-sync, enable-production]
 
 concurrency:
   group: release-activation

--- a/scripts/release/activation.test.ts
+++ b/scripts/release/activation.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { applyActivation } from "./activation";
+import type { LaneConfig, ReleaseControl } from "./types";
+
+const config: LaneConfig = {
+  $schema: "./lanes.schema.json",
+  schemaVersion: 1,
+  repository: "daangn/seed-design",
+  maintainerTeam: "design-system",
+  protectedDistTags: ["latest", "stable"],
+  lanes: {
+    dev: { bump: "patch", prerelease: false, sources: [] },
+    minor: { bump: "minor", prerelease: true, sources: ["dev"] },
+    major: { bump: "major", prerelease: true, sources: ["dev", "minor"] },
+  },
+  sync: { activation: null, reconcileCron: "*/10 * * * *", conflictAlertHours: 24 },
+};
+
+const control: ReleaseControl = {
+  $schema: "./control.schema.json",
+  schemaVersion: 1,
+  mode: "dry-run",
+  rootageContractReady: false,
+  freeze: null,
+};
+
+describe("릴리즈 자동화 활성화", () => {
+  test("Rootage 계약 준비 상태를 활성화한다", () => {
+    const result = applyActivation(
+      "enable-rootage-contract",
+      control,
+      config,
+      "2026-08-07T00:00:00.000Z",
+    );
+
+    expect(result.changed).toBe("control");
+    expect(result.control.rootageContractReady).toBe(true);
+    expect(control.rootageContractReady).toBe(false);
+  });
+
+  test("Rootage 계약 준비 상태의 중복 활성화를 거부한다", () => {
+    expect(() =>
+      applyActivation(
+        "enable-rootage-contract",
+        { ...control, rootageContractReady: true },
+        config,
+        "2026-08-07T00:00:00.000Z",
+      ),
+    ).toThrow("이미 준비");
+  });
+
+  test("동기화와 Rootage 계약 준비 후에만 production을 활성화한다", () => {
+    expect(() =>
+      applyActivation("enable-production", control, config, "2026-08-07T00:00:00.000Z"),
+    ).toThrow("동기화를 먼저");
+
+    const activatedConfig = {
+      ...config,
+      sync: { ...config.sync, activation: "2026-08-07T00:00:00.000Z" },
+    };
+    expect(() =>
+      applyActivation("enable-production", control, activatedConfig, "2026-08-07T00:00:00.000Z"),
+    ).toThrow("DES-2201 계약");
+
+    const result = applyActivation(
+      "enable-production",
+      { ...control, rootageContractReady: true },
+      activatedConfig,
+      "2026-08-07T00:00:00.000Z",
+    );
+    expect(result.control.mode).toBe("production");
+  });
+});

--- a/scripts/release/activation.ts
+++ b/scripts/release/activation.ts
@@ -1,0 +1,48 @@
+import type { LaneConfig, ReleaseControl } from "./types";
+
+export type ActivationOperation = "enable-rootage-contract" | "enable-sync" | "enable-production";
+
+export interface ActivationResult {
+  config: LaneConfig;
+  control: ReleaseControl;
+  changed: "config" | "control";
+}
+
+export function applyActivation(
+  operation: string,
+  control: ReleaseControl,
+  config: LaneConfig,
+  activatedAt: string,
+): ActivationResult {
+  if (operation === "enable-rootage-contract") {
+    if (control.rootageContractReady) throw new Error("Rootage 계약이 이미 준비되어 있습니다.");
+    return {
+      config,
+      control: { ...control, rootageContractReady: true },
+      changed: "control",
+    };
+  }
+
+  if (operation === "enable-sync") {
+    if (config.sync.activation) throw new Error("동기화가 이미 활성화되어 있습니다.");
+    return {
+      config: { ...config, sync: { ...config.sync, activation: activatedAt } },
+      control,
+      changed: "config",
+    };
+  }
+
+  if (operation === "enable-production") {
+    if (!config.sync.activation) throw new Error("동기화를 먼저 활성화해야 합니다.");
+    if (!control.rootageContractReady) throw new Error("DES-2201 계약이 준비되지 않았습니다.");
+    if (control.freeze) throw new Error("승격 중에는 production을 활성화할 수 없습니다.");
+    if (control.mode === "production") throw new Error("production이 이미 활성화되어 있습니다.");
+    return {
+      config,
+      control: { ...control, mode: "production" },
+      changed: "control",
+    };
+  }
+
+  throw new Error(`지원하지 않는 activation 작업입니다: ${operation}`);
+}

--- a/scripts/release/cli.ts
+++ b/scripts/release/cli.ts
@@ -1,4 +1,5 @@
 import { appendFile, readFile, writeFile } from "node:fs/promises";
+import { applyActivation } from "./activation";
 import { authorizePublish } from "./publish";
 import { isLaneName, loadLaneConfig, parseReleaseControl } from "./config";
 import { validateChangesets } from "./changesets";
@@ -266,22 +267,12 @@ async function activation(values: Map<string, string>): Promise<void> {
   const operation = required(values, "operation");
   const control = await releaseControlFromDev();
   const config = await loadLaneConfig();
-  if (operation === "enable-sync") {
-    if (config.sync.activation) throw new Error("동기화가 이미 활성화되어 있습니다.");
-    config.sync.activation = new Date().toISOString();
-    await writeFile(".github/release/lanes.json", `${JSON.stringify(config, null, 2)}\n`);
-    return;
-  }
-  if (operation === "enable-production") {
-    if (!config.sync.activation) throw new Error("동기화를 먼저 활성화해야 합니다.");
-    if (!control.rootageContractReady) throw new Error("DES-2201 계약이 준비되지 않았습니다.");
-    if (control.freeze) throw new Error("승격 중에는 production을 활성화할 수 없습니다.");
-    if (control.mode === "production") throw new Error("production이 이미 활성화되어 있습니다.");
-    control.mode = "production";
-    await writeFile(".github/release/control.json", `${JSON.stringify(control, null, 2)}\n`);
-    return;
-  }
-  throw new Error(`지원하지 않는 activation 작업입니다: ${operation}`);
+  const result = applyActivation(operation, control, config, new Date().toISOString());
+  const [path, state] =
+    result.changed === "config"
+      ? [".github/release/lanes.json", result.config]
+      : [".github/release/control.json", result.control];
+  await writeFile(path, `${JSON.stringify(state, null, 2)}\n`);
 }
 
 async function main(): Promise<void> {

--- a/scripts/release/workflow-security.test.ts
+++ b/scripts/release/workflow-security.test.ts
@@ -106,4 +106,13 @@ describe("릴리즈 workflow 권한 경계", () => {
     );
     expect(contract).not.toContain("pull_request_target");
   });
+
+  test("Rootage 계약 준비 상태는 activation workflow가 PR로 변경한다", async () => {
+    const activation = await readFile(".github/workflows/release-activation.yml", "utf8");
+    expect(activation).toContain(
+      "options: [enable-rootage-contract, enable-sync, enable-production]",
+    );
+    expect(activation).toContain("bun scripts/release/cli.ts activation");
+    expect(activation).toContain("git add .github/release/lanes.json .github/release/control.json");
+  });
 });


### PR DESCRIPTION
## 변경 사항

- `Release automation activation` 워크플로에 `enable-rootage-contract` 작업을 추가합니다.
- 활성화 상태 전환 판단을 순수 함수로 분리하고 중복 실행을 거부합니다.
- Rootage 계약 준비, sync, production 활성화 선행 조건을 단위 테스트로 고정합니다.
- 워크플로가 보호된 운영 상태 파일을 자동 PR로 변경하는 경로를 보안 테스트에서 검증합니다.

## 배경

Rootage Worker 배포, stable 백필, `seed-design.io/rootage/*` 라우트 전환과 공개 계약 검증이 완료되었습니다. `.github/release/control.json`은 일반 PR에서 변경할 수 없으므로 GitHub Actions가 신뢰 가능한 상태 변경 PR을 생성해야 합니다.

이 PR 자체는 운영 상태를 변경하지 않습니다. 머지 후 `enable-rootage-contract` 작업을 실행하면 `github-actions[bot]`이 `rootageContractReady`를 활성화하는 별도 PR을 생성합니다.

## 검증

- `bun biome check scripts/release/activation.ts scripts/release/activation.test.ts scripts/release/cli.ts scripts/release/workflow-security.test.ts .github/workflows/release-activation.yml`
- `bun test scripts/release/activation.test.ts scripts/release/release.test.ts scripts/release/workflow-security.test.ts`
- `bun generate:all`
- `bun test:all`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 릴리스 활성화 작업에 Rootage 계약 준비 단계가 추가되었습니다.
  * 동기화 및 production 활성화의 선행 조건과 중복 실행 검증이 강화되었습니다.
  * 활성화 결과에 따라 관련 상태 파일이 자동으로 저장됩니다.

* **버그 수정**
  * 필요한 준비 단계가 완료되기 전 production 활성화가 차단됩니다.

* **테스트**
  * Rootage 계약 준비, 중복 활성화 거부, 단계별 전환 및 워크플로 동작 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->