### PR TITLE
fix(dismissible-layer): avoid Array.prototype.at for top-layer check

### DIFF
--- a/.changeset/plenty-badgers-relate.md
+++ b/.changeset/plenty-badgers-relate.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react-dismissible-layer": patch
+---
+
+Chrome 92 / iOS Safari 15.4 이전 버전에서 시트나 다이얼로그를 열 때 `Array.prototype.at` 부재로 `TypeError: layers.at is not a function` 크래시가 나던 문제를 수정합니다.

--- a/packages/react-headless/dismissible-layer/src/layer-stack.ts
+++ b/packages/react-headless/dismissible-layer/src/layer-stack.ts
@@ -43,7 +43,9 @@ export function useLayerStackContext() {
 }
 
 export function isTopMost(ctx: LayerStackContextValue, node: HTMLElement): boolean {
-  return ctx.layers.at(-1)?.node === node;
+  // Not `.at(-1)`: Array.prototype.at is ES2022, so it throws below Chrome 92 /
+  // iOS Safari 15.4.
+  return ctx.layers[ctx.layers.length - 1]?.node === node;
 }
 
 function contains(parent: HTMLElement | null, child: EventTarget | null): boolean {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * Chrome 92 및 iOS Safari 15.4 이전 버전의 웹뷰에서 시트나 다이얼로그를 열 때 발생하던 오류를 수정했습니다.
  * 여러 레이어 사용 시 최상단 레이어가 안정적으로 판정되도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->