### PR TITLE
docs(time-picker): remap FigmaImage ids to rebuilt SEED-Docs spec

### DIFF
--- a/docs/content/components/time-picker.mdx
+++ b/docs/content/components/time-picker.mdx
@@ -18,7 +18,7 @@ Time Picker는 선택 상태를 관리하는 root 아래에, 휠 UI를 담는 su
 시·분 휠은 시·분 같은 단위 접미사 없이 숫자만 보여주고, 단위는 오전·오후 칼럼과 선택 위치로 전달됩니다(예: 오전 10 00 = 오전 10시 00분).
 
 <FigmaImage
-  id="2249:6213"
+  id="2369:15634"
   alt="Time Picker의 Anatomy 이미지. Period Column, Hour Column, Minute Column, Selection Indicator로 구성됩니다."
 />
 
@@ -37,7 +37,7 @@ Time Picker는 선택 상태를 관리하는 root 아래에, 휠 UI를 담는 su
 간격이 넓을수록 고를 수 있는 분이 줄어 빠르게 선택할 수 있고, 좁을수록 정밀해집니다. 현재 시각으로 진입할 때는 선택된 분을 Minute Step에 맞춰 가까운 값으로 반올림합니다(예: Minute Step=5에서 9시 13분 → 9시 15분).
 
 <FigmaImage
-  id="2249:6230"
+  id="2369:15651"
   alt="Minute Step을 1, 5, 10, 15, 30으로 설정한 Time Picker 예시"
 />
 
@@ -54,12 +54,12 @@ Time Picker가 화면에서 차지하는 비중과 플랫폼에 따라 Layout을
 Popover와 Sheet는 surface를 여는 trigger가 필요하며, 트리거는 [Input Button](/components/input-button)이나 [Field](/components/field)를 합성해 만듭니다. 시간 선택이 화면의 주된 작업이면 Inline, 모바일 폼에서는 Sheet, 데스크탑 폼에서는 Popover를 기본으로 검토합니다. Inline의 확정은 화면의 액션 영역(다음·완료 등)이, Popover·Sheet의 확정은 confirmButton이 담당합니다.
 
 <FigmaImage
-  id="2249:6255"
+  id="2369:15676"
   alt="모바일 화면에서 Inline과 Sheet Layout으로 Time Picker를 사용한 예시"
 />
 
 <FigmaImage
-  id="2249:6363"
+  id="2369:15784"
   alt="데스크탑 화면에서 Popover Layout으로 Time Picker를 사용한 예시"
 />
 
@@ -68,8 +68,8 @@ Popover와 Sheet는 surface를 여는 trigger가 필요하며, 트리거는 [Inp
 휠을 처음 열면 이미 선택된 시간이 있으면 그 값을, 없으면 `00:00`을 가운데에 두고 엽니다. 현재 시각에서 시작하려면 현재 시각을 Minute Step에 맞춰 반올림한 값을 `defaultValue`로 전달합니다.
 
 <FigmaImage
-  id="2249:6535"
-  alt="선택된 시간과 현재 시각을 기준으로 Time Picker를 처음 연 예시"
+  id="2369:15956"
+  alt="현재 시각 09:56과 11:31을 Minute Step에 맞춰 반올림한 값으로 Time Picker를 처음 연 예시"
 />
 
 ### Date Picker와 함께 쓰기
@@ -81,7 +81,7 @@ Popover와 Sheet는 surface를 여는 trigger가 필요하며, 트리거는 [Inp
 날짜 선택의 동작·가이드는 Date Picker가 담당하고, Time Picker는 시간 선택만 책임집니다.
 
 <FigmaImage
-  id="2249:6554"
+  id="2369:15975"
   alt="Date Picker를 Inline으로 펼치고 Time Picker를 Sheet로 함께 사용한 예시"
 />
 


### PR DESCRIPTION
## 문제

Time Picker 문서 draft 이후 SEED-Docs의 `❖ Time Picker` Spec 프레임이 재구성되면서, 출판된 `time-picker.mdx`가 참조하는 FigmaImage 노드 id 6개(`2249:*`)가 전부 삭제된 상태예요. 다음 docs 빌드에서 Time Picker 페이지의 이미지가 모두 렌더되지 않습니다.

## 변경

- FigmaImage id 6개를 현재 살아 있는 Spec(`2369:15612`)의 노드로 재매핑
  - Anatomy `2369:15634` / Minute Step `2369:15651` / Layout 모바일 `2369:15676`·데스크탑 `2369:15784` / 진입 시 보여줄 시간 `2369:15956` / Date Picker와 함께 쓰기 `2369:15975`
- "진입 시 보여줄 시간" alt 텍스트를 일러스트 실제 내용(현재 시각 09:56·11:31 반올림 예시)에 맞게 갱신

이미지 6개 모두 스크린샷으로 현 문서 섹션과 대응하는지 확인했어요. 새 id는 새 캐시 키라 figma-image 캐시 무효화(skip-figma-cache)는 필요 없습니다. 본문 텍스트는 변경 없음 (docs-only, changeset 불필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * Time Picker 문서의 Figma 이미지 참조를 최신 이미지로 업데이트했습니다.
  * Anatomy, Minute Step, Layout, 시간 입력, Date Picker 연계 예시가 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->