### PR TITLE
chore(tsconfig): pin browser packages' TS lib to ES2021

### DIFF
--- a/packages/react-headless/attachment-display/src/useAttachmentDisplay.test.tsx
+++ b/packages/react-headless/attachment-display/src/useAttachmentDisplay.test.tsx
@@ -101,6 +101,10 @@ const sampleSuccess = (id: string): DisplayItemEntry => ({
   status: "success",
 });
 
+// Annotated `T | undefined` because `noUncheckedIndexedAccess` is off, so the
+// indexed read alone would hide the empty-array case the callers guard against.
+const lastCall = <T,>(calls: T[]): T | undefined => calls[calls.length - 1];
+
 describe("useAttachmentDisplay", () => {
   describe("basic rendering", () => {
     it("renders trigger and items", () => {
@@ -371,7 +375,7 @@ describe("useAttachmentDisplay", () => {
       expect(queryAllByTestId(/^item-/)).toHaveLength(1);
 
       act(() => api.addEntries([sampleSuccess("b")]));
-      expect(onEntriesChange.mock.calls.at(-1)?.[0]).toEqual([
+      expect(lastCall(onEntriesChange.mock.calls)?.[0]).toEqual([
         sampleSuccess("a"),
         sampleSuccess("b"),
       ]);
@@ -380,7 +384,7 @@ describe("useAttachmentDisplay", () => {
       // Second call must read the now-current [a, b] (committed via the controlled prop),
       // not the [a] captured when the first render's setter was created.
       act(() => api.addEntries([sampleSuccess("c")]));
-      expect(onEntriesChange.mock.calls.at(-1)?.[0]).toEqual([
+      expect(lastCall(onEntriesChange.mock.calls)?.[0]).toEqual([
         sampleSuccess("a"),
         sampleSuccess("b"),
         sampleSuccess("c"),
@@ -527,8 +531,8 @@ describe("useAttachmentDisplay", () => {
 
       // map returns the same entries; useControllableState may or may not fire onChange for identity-equal results,
       // but the post-state must equal the pre-state.
-      const lastCall = onEntriesChange.mock.calls.at(-1);
-      if (lastCall) expect(lastCall[0]).toEqual([sampleSuccess("a")]);
+      const call = lastCall(onEntriesChange.mock.calls);
+      if (call) expect(call[0]).toEqual([sampleSuccess("a")]);
     });
 
     it("works regardless of disabled/readOnly (external push category)", () => {

--- a/packages/react-headless/pull-to-refresh/src/PullToRefresh.test.tsx
+++ b/packages/react-headless/pull-to-refresh/src/PullToRefresh.test.tsx
@@ -153,7 +153,7 @@ describe("PullToRefreshIndicator", () => {
     movePointer(root, 150);
 
     expect(getByTestId("indicator-child")).toHaveTextContent("40");
-    expect(values.at(-1)).toBe(40);
+    expect(values[values.length - 1]).toBe(40);
   });
 
   it("merges caller props onto the indicator element", () => {
@@ -280,6 +280,6 @@ describe("PullToRefresh composition", () => {
 
     await act(async () => settle());
     expect(root).toHaveAttribute("data-ptr-state", "idle");
-    expect(values.at(-1)).toBe(0);
+    expect(values[values.length - 1]).toBe(0);
   });
 });

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.browser.json",
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",

--- a/packages/stackflow/tsconfig.json
+++ b/packages/stackflow/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.browser.json",
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",

--- a/packages/utils/dom-utils/tsconfig.json
+++ b/packages/utils/dom-utils/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../../tsconfig.browser.json",
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -4,8 +4,11 @@
   // fully supports: ES2022 would admit `Array.prototype.at` (Chrome 92 / Safari
   // 15.4) and `Object.hasOwn` (Chrome 93 / Safari 15.4).
   //
-  // This bounds APIs only. Emitted syntax is still governed by `target` and by
-  // each package's bundler target, which are not pinned to the baseline yet.
+  // Only the ES half tracks the baseline. `DOM` carries no version -- it ships
+  // whatever web platform the current TypeScript knows, so `structuredClone`
+  // (Chrome 98), `scrollend` (Chrome 114) and the like still typecheck, and no
+  // `lib` setting can bound them. Emitted syntax is unbounded too, governed by
+  // `target` and each package's bundler target.
   "compilerOptions": {
     "lib": ["ES2021", "DOM", "DOM.Iterable"]
   }

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -1,0 +1,12 @@
+{
+  // Shared by every package that ships code to a browser. The oldest supported
+  // WebView is Chrome 88 / Safari 15, and ES2021 is the newest lib that baseline
+  // fully supports: ES2022 would admit `Array.prototype.at` (Chrome 92 / Safari
+  // 15.4) and `Object.hasOwn` (Chrome 93 / Safari 15.4).
+  //
+  // This bounds APIs only. Emitted syntax is still governed by `target` and by
+  // each package's bundler target, which are not pinned to the baseline yet.
+  "compilerOptions": {
+    "lib": ["ES2021", "DOM", "DOM.Iterable"]
+  }
+}

--- a/tsconfig.headless.json
+++ b/tsconfig.headless.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.browser.json",
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **호환성 개선**
  - 브라우저 환경에 맞는 TypeScript 설정을 정비해 지원 브라우저에서의 안정적인 빌드와 타입 검사를 강화했습니다.
  - 최신 환경에만 의존하지 않도록 브라우저 호환 기준을 명확히 했습니다.

- **테스트**
  - 테스트 실행 환경에 따라 발생할 수 있는 배열 기능 호환성 문제를 개선했습니다.
  - 빈 결과나 호출 기록도 안전하게 검증하도록 테스트 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->