### PR TITLE
fix(lynx-react): use internal preact in tests

### DIFF
--- a/packages/lynx-react/vitest.config.ts
+++ b/packages/lynx-react/vitest.config.ts
@@ -1,7 +1,40 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+
 import { createVitestConfig } from "@lynx-js/react/testing-library/vitest-config";
 import { defineConfig, mergeConfig } from "vitest/config";
 
 const defaultConfig = await createVitestConfig();
+const require = createRequire(import.meta.url);
+const aliases = defaultConfig.test?.alias;
+
+if (!Array.isArray(aliases)) {
+  throw new Error("Expected ReactLynx Vitest aliases to be an array.");
+}
+
+const runtimePreactPackageAlias = aliases.find(
+  (alias) =>
+    alias.find instanceof RegExp && alias.find.source === String.raw`^preact\/package.json$`,
+);
+
+if (!runtimePreactPackageAlias) {
+  throw new Error("Expected ReactLynx Vitest config to include a Preact package alias.");
+}
+
+const runtimePreactDirectory = path.dirname(runtimePreactPackageAlias.replacement);
+const internalPreactDirectory = path.dirname(require.resolve("preact/package.json"));
+
+defaultConfig.test = {
+  ...defaultConfig.test,
+  alias: aliases.map((alias) =>
+    alias.find instanceof RegExp && alias.find.source.startsWith("^preact")
+      ? {
+          ...alias,
+          replacement: alias.replacement.replace(runtimePreactDirectory, internalPreactDirectory),
+        }
+      : alias,
+  ),
+};
 
 export default mergeConfig(
   defaultConfig,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 테스트 환경에서 Preact 관련 모듈 경로를 안정적으로 처리하도록 검증 로직을 강화했습니다.
  * 필수 설정이 누락되거나 잘못된 형식으로 지정된 경우 즉시 오류를 표시해 문제를 조기에 확인할 수 있습니다.
  * 런타임과 테스트 환경 간 모듈 경로 차이로 인한 테스트 오류를 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->