### PR TITLE
fix(release): isolate unrelated publish triggers

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,12 +9,33 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: release-publish
+  group: >-
+    ${{
+      (
+        github.event_name != 'pull_request_target' ||
+        (
+          github.event.pull_request.merged == true &&
+          github.event.pull_request.user.login == 'github-actions[bot]' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.event.pull_request.head.ref == format('changeset-release/{0}', github.event.pull_request.base.ref)
+        )
+      )
+      && 'release-publish'
+      || format('release-publish-ignored-{0}', github.run_id)
+    }}
   cancel-in-progress: false
 
 jobs:
   select:
     name: Select oldest approved Version Packages PR
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      (
+        github.event.pull_request.merged == true &&
+        github.event.pull_request.user.login == 'github-actions[bot]' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.head.ref == format('changeset-release/{0}', github.event.pull_request.base.ref)
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/scripts/release/workflow-security.test.ts
+++ b/scripts/release/workflow-security.test.ts
@@ -9,6 +9,10 @@ interface WorkflowJob {
 }
 
 interface Workflow {
+  concurrency?: {
+    group?: string;
+    "cancel-in-progress"?: boolean;
+  };
   permissions?: Record<string, string> | string;
   jobs: Record<string, WorkflowJob>;
 }
@@ -45,6 +49,24 @@ describe("릴리즈 workflow 권한 경계", () => {
       )
       .map(([name]) => name);
     expect(oidcJobs).toEqual(["publish-npm"]);
+  });
+
+  test("publish queue는 신뢰된 Version Packages merge만 PR 이벤트로 처리한다", async () => {
+    const publish = await workflow(".github/workflows/release-publish.yml");
+    const selectCondition = publish.jobs.select.if ?? "";
+    const concurrencyGroup = publish.concurrency?.group ?? "";
+
+    for (const fragment of [
+      "github.event.pull_request.merged == true",
+      "github.event.pull_request.user.login == 'github-actions[bot]'",
+      "github.event.pull_request.head.repo.full_name == github.repository",
+      "format('changeset-release/{0}', github.event.pull_request.base.ref)",
+    ]) {
+      expect(selectCondition).toContain(fragment);
+      expect(concurrencyGroup).toContain(fragment);
+    }
+    expect(concurrencyGroup).toContain("format('release-publish-ignored-{0}', github.run_id)");
+    expect(publish.concurrency?.["cancel-in-progress"]).toBe(false);
   });
 
   test("pull_request_target control workflow는 PR head를 checkout하지 않는다", async () => {


### PR DESCRIPTION
## 변경 사항
- merge된 신뢰 가능한 Version Packages PR만 pull_request_target publish queue를 처리하도록 제한합니다.
- 무관한 PR close run은 run별 concurrency group으로 격리하고 select job을 skip합니다.
- schedule, workflow_dispatch, 정상 Version PR은 기존 전역 publish 직렬화를 유지합니다.
- workflow 보안 회귀 테스트를 추가합니다.

## 검증
- bun generate:all
- bun test:all
- bun test scripts/release/workflow-security.test.ts
- git diff --check

## 배경
- unrelated run: https://github.com/daangn/seed-design/actions/runs/31168473081
- queued release run: https://github.com/daangn/seed-design/actions/runs/31168937927

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 승인된 릴리스 병합 이벤트만 게시 작업을 실행하도록 워크플로를 강화했습니다.
  * 승인되지 않은 풀 리퀘스트 이벤트로 인한 게시 실행을 차단했습니다.
  * 릴리스 작업의 중복 실행과 잘못된 실행 취소를 방지했습니다.

* **테스트**
  * 릴리스 게시 조건과 동시 실행 제어 동작을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->