### PR TITLE
fix(drawer): stabilize bottom sheet keyboard focus repositioning

### DIFF
--- a/.changeset/gentle-drawers-settle.md
+++ b/.changeset/gentle-drawers-settle.md
@@ -1,0 +1,8 @@
+---
+"@seed-design/react-drawer": patch
+---
+
+iOS에서 Drawer 내부 Input과 키보드 전환 동작을 개선합니다.
+
+- Input 포커스·해제 중 Drawer 높이와 위치가 일시적으로 흔들리거나 복원되지 않는 문제를 수정합니다.
+- 키보드에 가려진 Input이 Drawer 내부의 가장 가까운 스크롤 영역에서 부드럽게 보이도록 이동합니다.

--- a/docs/components/figma-image/collect-figma-image-ids.ts
+++ b/docs/components/figma-image/collect-figma-image-ids.ts
@@ -28,9 +28,7 @@ export function extractFigmaId({ name, attributes }: MdxJsxFlowElement): string 
 
     if (!idAttr) throw new Error("[remark-figma-image] FigmaImage requires an 'id' prop");
     if (typeof idAttr.value !== "string" || idAttr.value.length === 0) {
-      throw new Error(
-        "[remark-figma-image] FigmaImage requires a static non-empty 'id' prop",
-      );
+      throw new Error("[remark-figma-image] FigmaImage requires a static non-empty 'id' prop");
     }
 
     return idAttr.value;

--- a/docs/content/components/bottom-sheet.mdx
+++ b/docs/content/components/bottom-sheet.mdx
@@ -156,6 +156,8 @@ Bottom Sheet의 콘텐츠가 많거나 해상도 등으로 인해 화면 전체 
 
 Bottom Sheet에서 텍스트 필드 등의 요소를 통해 키보드를 활성화해야 하는 경우, 키보드가 sheet 하단에 나타납니다.
 
+Bottom Sheet 내에 [Input](/components/text-input) 등 키보드를 표시하는 요소가 있는 경우, 키보드 노출 여부에 따라 사용 가능한 화면 높이와 Bottom Sheet의 높이가 함께 달라질 수 있습니다.
+
 ## Specification
 
 ### Bottom Sheet

--- a/examples/stackflow-spa/src/activities/ActivityBottomSheetInputFocus.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityBottomSheetInputFocus.tsx
@@ -1,24 +1,14 @@
-import IconHouseLine from "@karrotmarket/react-monochrome-icon/IconHouseLine";
-import { Box, HStack, Text, VStack } from "@seed-design/react";
+import { Box, HStack, Text, VStack, VisuallyHidden } from "@seed-design/react";
 import { useActivityZIndexBase } from "@seed-design/stackflow";
-import { useFlow, type StaticActivityComponentType } from "@stackflow/react/future";
+import { useActivity, useFlow, type StaticActivityComponentType } from "@stackflow/react/future";
 import { useState } from "react";
-import { ActionButton } from "seed-design/ui/action-button";
-import {
-  AppBar,
-  AppBarBackButton,
-  AppBarIconButton,
-  AppBarLeft,
-  AppBarMain,
-  AppBarRight,
-} from "seed-design/ui/app-bar";
-import { AppScreen, AppScreenContent } from "seed-design/ui/app-screen";
 import {
   BottomSheetBody,
   BottomSheetContent,
   BottomSheetFooter,
   BottomSheetRoot,
 } from "seed-design/ui/bottom-sheet";
+import { Avatar } from "seed-design/ui/avatar";
 import { TextField, TextFieldInput } from "seed-design/ui/text-field";
 
 declare module "@stackflow/config" {
@@ -27,253 +17,135 @@ declare module "@stackflow/config" {
   }
 }
 
-const SCENARIOS = [
+const SNAP_POINTS = [0.5, 0.85] as const;
+
+const CHAT_ROOMS = [
+  { id: "jamsil", name: "잠실엘스", members: "145명", color: "palette.blue100", label: "L" },
+  { id: "fufuf", name: "Fufuf", members: "1명", color: "palette.purple100", label: "F" },
+  { id: "rfwfwfwfaf", name: "Rfwfwfwfaf", members: "1명", color: "palette.purple100", label: "R" },
   {
-    id: "input",
-    title: "Input",
-    description: "시트를 연 뒤 Input을 직접 눌러 포커스합니다.",
-  },
-  {
-    id: "autoFocus",
-    title: "진입 시 Auto focus",
-    description: "시트가 열리면 Input에 자동으로 포커스합니다.",
-  },
-  {
-    id: "autocomplete",
-    title: "포커스 시 새 요소 등장",
-    description: "Input에 포커스하면 아래에 자동완성 목록이 나타납니다.",
-  },
-  {
-    id: "scroll",
-    title: "내부 스크롤",
-    description: "긴 목록을 스크롤한 뒤 Input 포커스와 키보드 닫기를 확인합니다.",
-  },
-  {
-    id: "inputMiddle",
-    title: "중간에 있는 Input",
-    description: "Input 앞뒤에 다른 요소가 있는 상태에서 포커스합니다.",
-  },
-  {
-    id: "inputBottom",
-    title: "하단에 있는 Input",
-    description: "여러 요소 아래, 시트 하단에 가까운 Input을 포커스합니다.",
-  },
-  {
-    id: "footerInput",
-    title: "하단에 고정된 Input",
-    description: "BottomSheet Footer에 배치된 Input을 포커스합니다.",
+    id: "tenants",
+    name: "실거주 인증 채팅방",
+    members: "9명",
+    color: "palette.purple100",
+    label: "채",
   },
 ] as const;
 
-const SHEET_HEIGHTS = ["40vh", "70vh"] as const;
-// Keep QA content within the same minimum top inset that `useDrawer` reserves while the
-// keyboard is open. Android WebView resolves the safe-area custom property to zero, so relying
-// on it alone lets a long sheet reach the very top of the layout viewport.
-const DRAWER_TOP_OFFSET = "26px";
-const SUGGESTIONS = ["당근마켓", "당근알바", "당근비즈니스"] as const;
-const SCROLL_ITEMS = Array.from({ length: 16 }, (_, index) => `스크롤 항목 ${index + 1}`);
-const MIDDLE_BEFORE_ITEMS = ["상단 안내", "최근 검색어", "추천 검색어"] as const;
-const MIDDLE_AFTER_ITEMS = ["인기 검색어", "검색 도움말"] as const;
-const BOTTOM_BEFORE_ITEMS = Array.from({ length: 8 }, (_, index) => `선행 콘텐츠 ${index + 1}`);
-const FOOTER_BODY_ITEMS = Array.from({ length: 6 }, (_, index) => `본문 콘텐츠 ${index + 1}`);
-
-type Scenario = (typeof SCENARIOS)[number];
-type SheetHeight = (typeof SHEET_HEIGHTS)[number];
+type ChatRoom = (typeof CHAT_ROOMS)[number];
+type SnapPoint = (typeof SNAP_POINTS)[number];
 
 const ActivityBottomSheetInputFocus: StaticActivityComponentType<
   "ActivityBottomSheetInputFocus"
 > = () => {
-  const { push } = useFlow();
-  const [open, setOpen] = useState(false);
-  const [scenario, setScenario] = useState<Scenario>(SCENARIOS[0]);
-  const [sheetHeight, setSheetHeight] = useState<SheetHeight>(SHEET_HEIGHTS[0]);
-  const [showSuggestions, setShowSuggestions] = useState(false);
+  const { pop } = useFlow();
+  const { isActive, transitionState } = useActivity();
+  const [selectedRoom, setSelectedRoom] = useState<ChatRoom | null>(null);
+  const [activeSnapPoint, setActiveSnapPoint] = useState<SnapPoint>(SNAP_POINTS[0]);
 
-  const openCase = (nextScenario: Scenario, nextHeight: SheetHeight) => {
-    setScenario(nextScenario);
-    setSheetHeight(nextHeight);
-    setShowSuggestions(false);
-    setOpen(true);
+  const open = transitionState === "enter-active" || transitionState === "enter-done";
+
+  const handleSelectRoom = (room: ChatRoom) => {
+    setSelectedRoom(room);
+    setActiveSnapPoint(SNAP_POINTS[1]);
   };
 
   return (
-    <AppScreen>
-      <AppBar>
-        <AppBarLeft>
-          <AppBarBackButton />
-        </AppBarLeft>
-        <AppBarMain>BottomSheet Input Focus</AppBarMain>
-        <AppBarRight>
-          <AppBarIconButton aria-label="Home" onClick={() => push("ActivityHome", {})}>
-            <IconHouseLine />
-          </AppBarIconButton>
-        </AppBarRight>
-      </AppBar>
+    <BottomSheetRoot
+      open={open}
+      snapPoints={[...SNAP_POINTS]}
+      activeSnapPoint={activeSnapPoint}
+      setActiveSnapPoint={(snapPoint) => {
+        if (snapPoint !== null && SNAP_POINTS.includes(snapPoint as SnapPoint)) {
+          setActiveSnapPoint(snapPoint as SnapPoint);
+        }
+      }}
+      onOpenChange={(nextOpen) => !nextOpen && isActive && pop()}
+    >
+      <BottomSheetContent
+        showHandle
+        showCloseButton
+        title="같이해요 공유"
+        layerIndex={useActivityZIndexBase()}
+        style={{ height: "100%" }}
+      >
+        <BottomSheetBody>
+          <VStack gap="x6">
+            <HStack gap="x3" justify="space-between">
+              {CHAT_ROOMS.map((room) => {
+                const selected = selectedRoom?.id === room.id;
 
-      <AppScreenContent>
-        <VStack gap="x6" p="x4">
-          <Text as="p" textStyle="t4Regular" color="fg.neutralMuted">
-            iOS에서 키보드가 올라올 때 Bottom Sheet와 뷰포트 위치를 확인합니다.
-          </Text>
-
-          {SCENARIOS.map((item) => (
-            <Box as="section" key={item.id}>
-              <VStack gap="x3">
-                <VStack gap="x1">
-                  <Text as="h2" textStyle="t5Bold" color="fg.neutral">
-                    {item.title}
-                  </Text>
-                  <Text as="p" textStyle="t3Regular" color="fg.neutralMuted">
-                    {item.description}
-                  </Text>
-                </VStack>
-                <HStack gap="x2">
-                  {SHEET_HEIGHTS.map((height) => (
-                    <ActionButton
-                      key={height}
-                      flexGrow
-                      variant="neutralSolid"
-                      onClick={() => openCase(item, height)}
+                return (
+                  <Box
+                    as="button"
+                    key={room.id}
+                    alignItems="center"
+                    aria-pressed={selected}
+                    display="flex"
+                    flexDirection="column"
+                    flexGrow
+                    flexShrink={0}
+                    gap="x2"
+                    minWidth="0"
+                    onClick={() => handleSelectRoom(room)}
+                  >
+                    <Box
+                      alignItems="center"
+                      display="flex"
+                      height="64px"
+                      justifyContent="center"
+                      width="64px"
                     >
-                      {height} 열기
-                    </ActionButton>
-                  ))}
-                </HStack>
-              </VStack>
-            </Box>
-          ))}
-        </VStack>
-      </AppScreenContent>
-
-      <BottomSheetRoot open={open} autoFocus={scenario.id !== "autoFocus"} onOpenChange={setOpen}>
-        <BottomSheetContent
-          showHandle
-          showCloseButton={false}
-          title={`${scenario.title} · ${sheetHeight}`}
-          description={scenario.description}
-          layerIndex={useActivityZIndexBase({ activityOffset: 1 })}
-          style={{
-            minHeight: sheetHeight,
-            // `dvh` can grow while Safari's browser controls collapse even though the fixed
-            // positioner has not adopted that larger viewport yet. `svh` is the stable lower
-            // bound, so long QA content cannot extend above the top safe area between those
-            // viewport updates.
-            maxHeight: `calc(100svh - max(${DRAWER_TOP_OFFSET}, var(--seed-safe-area-top)))`,
-          }}
-        >
-          <BottomSheetBody
-            style={{
-              flex: "1 1 auto",
-              minHeight: 0,
-              overflowY: "auto",
-              WebkitOverflowScrolling: "touch",
-            }}
-          >
-            <VStack gap="x3">
-              {scenario.id === "inputMiddle" &&
-                MIDDLE_BEFORE_ITEMS.map((item) => (
-                  <Box key={item} bg="bg.neutralWeak" borderRadius="r2" px="x4" py="x3">
-                    <Text textStyle="t4Regular" color="fg.neutral">
-                      {item}
-                    </Text>
-                  </Box>
-                ))}
-
-              {scenario.id === "inputBottom" &&
-                BOTTOM_BEFORE_ITEMS.map((item) => (
-                  <Box key={item} bg="bg.neutralWeak" borderRadius="r2" px="x4" py="x3">
-                    <Text textStyle="t4Regular" color="fg.neutral">
-                      {item}
-                    </Text>
-                  </Box>
-                ))}
-
-              {scenario.id === "footerInput" &&
-                FOOTER_BODY_ITEMS.map((item) => (
-                  <Box key={item} bg="bg.neutralWeak" borderRadius="r2" px="x4" py="x3">
-                    <Text textStyle="t4Regular" color="fg.neutral">
-                      {item}
-                    </Text>
-                  </Box>
-                ))}
-
-              {scenario.id !== "scroll" && scenario.id !== "footerInput" && (
-                <TextField name={`search-${scenario.id}`} label="검색어">
-                  <TextFieldInput
-                    autoFocus={scenario.id === "autoFocus"}
-                    placeholder="검색어를 입력하세요"
-                    onFocus={() => {
-                      if (scenario.id === "autocomplete") {
-                        setShowSuggestions(true);
-                      }
-                    }}
-                  />
-                </TextField>
-              )}
-
-              {scenario.id === "autocomplete" && showSuggestions && (
-                <Box
-                  bg="bg.layerDefault"
-                  borderColor="stroke.neutralWeak"
-                  borderRadius="r2"
-                  borderWidth={1}
-                  overflowX="hidden"
-                  overflowY="hidden"
-                >
-                  {SUGGESTIONS.map((suggestion) => (
-                    <Box key={suggestion} px="x4" py="x3">
-                      <Text textStyle="t4Regular" color="fg.neutral">
-                        {suggestion}
-                      </Text>
+                      <Avatar
+                        size="56"
+                        fallback={
+                          <Box
+                            alignItems="center"
+                            bg={room.color}
+                            display="flex"
+                            height="full"
+                            justifyContent="center"
+                            width="full"
+                          >
+                            <Text color="fg.neutral" textStyle="t5Bold">
+                              {room.label}
+                            </Text>
+                          </Box>
+                        }
+                      />
                     </Box>
-                  ))}
-                </Box>
-              )}
-
-              {scenario.id === "inputMiddle" &&
-                MIDDLE_AFTER_ITEMS.map((item) => (
-                  <Box key={item} bg="bg.neutralWeak" borderRadius="r2" px="x4" py="x3">
-                    <Text textStyle="t4Regular" color="fg.neutral">
-                      {item}
-                    </Text>
-                  </Box>
-                ))}
-
-              {scenario.id === "scroll" && (
-                <>
-                  <TextField name="search-scroll" label="검색어">
-                    <TextFieldInput placeholder="검색어를 입력하세요" />
-                  </TextField>
-                  {SCROLL_ITEMS.map((item) => (
-                    <Box key={item} bg="bg.neutralWeak" borderRadius="r2" px="x4" py="x3">
-                      <Text textStyle="t4Regular" color="fg.neutral">
-                        {item}
+                    <VStack align="center" gap="x1">
+                      <Text align="center" color="fg.neutral" textStyle="t2Medium">
+                        {room.name}
                       </Text>
-                    </Box>
-                  ))}
-                </>
-              )}
-            </VStack>
-          </BottomSheetBody>
-          <BottomSheetFooter>
-            {scenario.id === "footerInput" ? (
-              <VStack gap="x2">
-                <TextField name="search-footer" label="검색어">
-                  <TextFieldInput placeholder="하단에서 검색어를 입력하세요" />
-                </TextField>
-                <ActionButton variant="neutralSolid" onClick={() => setOpen(false)}>
-                  닫기
-                </ActionButton>
-              </VStack>
-            ) : (
-              <ActionButton variant="neutralSolid" onClick={() => setOpen(false)}>
-                닫기
-              </ActionButton>
+                      <Text align="center" color="fg.neutralMuted" textStyle="t2Regular">
+                        {room.members}
+                      </Text>
+                    </VStack>
+                    {selected && <VisuallyHidden>선택됨</VisuallyHidden>}
+                  </Box>
+                );
+              })}
+            </HStack>
+
+            {selectedRoom && (
+              <TextField
+                hideCharacterCount
+                label={`${selectedRoom.name}에 보낼 메시지`}
+                name="message"
+              >
+                <TextFieldInput autoFocus placeholder="메시지를 입력해 주세요. (선택)" />
+              </TextField>
             )}
-          </BottomSheetFooter>
-        </BottomSheetContent>
-      </BottomSheetRoot>
-    </AppScreen>
+          </VStack>
+        </BottomSheetBody>
+        <BottomSheetFooter>
+          <Text align="center" as="p" color="fg.neutralMuted" textStyle="t2Regular">
+            채팅방을 선택하면 더 큰 snap point로 확장됩니다.
+          </Text>
+        </BottomSheetFooter>
+      </BottomSheetContent>
+    </BottomSheetRoot>
   );
 };
 

--- a/examples/stackflow-spa/src/activities/ActivityBottomSheetInputFocus.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityBottomSheetInputFocus.tsx
@@ -43,10 +43,35 @@ const SCENARIOS = [
     title: "포커스 시 새 요소 등장",
     description: "Input에 포커스하면 아래에 자동완성 목록이 나타납니다.",
   },
+  {
+    id: "scroll",
+    title: "내부 스크롤",
+    description: "긴 목록을 스크롤한 뒤 Input 포커스와 키보드 닫기를 확인합니다.",
+  },
+  {
+    id: "inputMiddle",
+    title: "중간에 있는 Input",
+    description: "Input 앞뒤에 다른 요소가 있는 상태에서 포커스합니다.",
+  },
+  {
+    id: "inputBottom",
+    title: "하단에 있는 Input",
+    description: "여러 요소 아래, 시트 하단에 가까운 Input을 포커스합니다.",
+  },
+  {
+    id: "footerInput",
+    title: "하단에 고정된 Input",
+    description: "BottomSheet Footer에 배치된 Input을 포커스합니다.",
+  },
 ] as const;
 
 const SHEET_HEIGHTS = ["40vh", "70vh"] as const;
 const SUGGESTIONS = ["당근마켓", "당근알바", "당근비즈니스"] as const;
+const SCROLL_ITEMS = Array.from({ length: 16 }, (_, index) => `스크롤 항목 ${index + 1}`);
+const MIDDLE_BEFORE_ITEMS = ["상단 안내", "최근 검색어", "추천 검색어"] as const;
+const MIDDLE_AFTER_ITEMS = ["인기 검색어", "검색 도움말"] as const;
+const BOTTOM_BEFORE_ITEMS = Array.from({ length: 8 }, (_, index) => `선행 콘텐츠 ${index + 1}`);
+const FOOTER_BODY_ITEMS = Array.from({ length: 6 }, (_, index) => `본문 콘텐츠 ${index + 1}`);
 
 type Scenario = (typeof SCENARIOS)[number];
 type SheetHeight = (typeof SHEET_HEIGHTS)[number];
@@ -122,22 +147,53 @@ const ActivityBottomSheetInputFocus: StaticActivityComponentType<
           showCloseButton={false}
           title={`${scenario.title} · ${sheetHeight}`}
           description={scenario.description}
-          layerIndex={useActivityZIndexBase()}
-          style={{ height: sheetHeight }}
+          layerIndex={useActivityZIndexBase({ activityOffset: 1 })}
+          style={{ minHeight: sheetHeight, maxHeight: "calc(100dvh - 48px)" }}
         >
-          <BottomSheetBody>
+          <BottomSheetBody
+            style={{ minHeight: 0, overflowY: "auto", WebkitOverflowScrolling: "touch" }}
+          >
             <VStack gap="x3">
-              <TextField name="search" label="검색어">
-                <TextFieldInput
-                  autoFocus={scenario.id === "autoFocus"}
-                  placeholder="검색어를 입력하세요"
-                  onFocus={() => {
-                    if (scenario.id === "autocomplete") {
-                      setShowSuggestions(true);
-                    }
-                  }}
-                />
-              </TextField>
+              {scenario.id === "inputMiddle" &&
+                MIDDLE_BEFORE_ITEMS.map((item) => (
+                  <Box key={item} bg="bg.neutralWeak" borderRadius="r2" px="x4" py="x3">
+                    <Text textStyle="t4Regular" color="fg.neutral">
+                      {item}
+                    </Text>
+                  </Box>
+                ))}
+
+              {scenario.id === "inputBottom" &&
+                BOTTOM_BEFORE_ITEMS.map((item) => (
+                  <Box key={item} bg="bg.neutralWeak" borderRadius="r2" px="x4" py="x3">
+                    <Text textStyle="t4Regular" color="fg.neutral">
+                      {item}
+                    </Text>
+                  </Box>
+                ))}
+
+              {scenario.id === "footerInput" &&
+                FOOTER_BODY_ITEMS.map((item) => (
+                  <Box key={item} bg="bg.neutralWeak" borderRadius="r2" px="x4" py="x3">
+                    <Text textStyle="t4Regular" color="fg.neutral">
+                      {item}
+                    </Text>
+                  </Box>
+                ))}
+
+              {scenario.id !== "scroll" && scenario.id !== "footerInput" && (
+                <TextField name={`search-${scenario.id}`} label="검색어">
+                  <TextFieldInput
+                    autoFocus={scenario.id === "autoFocus"}
+                    placeholder="검색어를 입력하세요"
+                    onFocus={() => {
+                      if (scenario.id === "autocomplete") {
+                        setShowSuggestions(true);
+                      }
+                    }}
+                  />
+                </TextField>
+              )}
 
               {scenario.id === "autocomplete" && showSuggestions && (
                 <Box
@@ -157,12 +213,47 @@ const ActivityBottomSheetInputFocus: StaticActivityComponentType<
                   ))}
                 </Box>
               )}
+
+              {scenario.id === "inputMiddle" &&
+                MIDDLE_AFTER_ITEMS.map((item) => (
+                  <Box key={item} bg="bg.neutralWeak" borderRadius="r2" px="x4" py="x3">
+                    <Text textStyle="t4Regular" color="fg.neutral">
+                      {item}
+                    </Text>
+                  </Box>
+                ))}
+
+              {scenario.id === "scroll" && (
+                <>
+                  <TextField name="search-scroll" label="검색어">
+                    <TextFieldInput placeholder="검색어를 입력하세요" />
+                  </TextField>
+                  {SCROLL_ITEMS.map((item) => (
+                    <Box key={item} bg="bg.neutralWeak" borderRadius="r2" px="x4" py="x3">
+                      <Text textStyle="t4Regular" color="fg.neutral">
+                        {item}
+                      </Text>
+                    </Box>
+                  ))}
+                </>
+              )}
             </VStack>
           </BottomSheetBody>
           <BottomSheetFooter>
-            <ActionButton variant="neutralSolid" onClick={() => setOpen(false)}>
-              닫기
-            </ActionButton>
+            {scenario.id === "footerInput" ? (
+              <VStack gap="x2">
+                <TextField name="search-footer" label="검색어">
+                  <TextFieldInput placeholder="하단에서 검색어를 입력하세요" />
+                </TextField>
+                <ActionButton variant="neutralSolid" onClick={() => setOpen(false)}>
+                  닫기
+                </ActionButton>
+              </VStack>
+            ) : (
+              <ActionButton variant="neutralSolid" onClick={() => setOpen(false)}>
+                닫기
+              </ActionButton>
+            )}
           </BottomSheetFooter>
         </BottomSheetContent>
       </BottomSheetRoot>

--- a/examples/stackflow-spa/src/activities/ActivityBottomSheetInputFocus.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityBottomSheetInputFocus.tsx
@@ -1,0 +1,173 @@
+import IconHouseLine from "@karrotmarket/react-monochrome-icon/IconHouseLine";
+import { Box, HStack, Text, VStack } from "@seed-design/react";
+import { useActivityZIndexBase } from "@seed-design/stackflow";
+import { useFlow, type StaticActivityComponentType } from "@stackflow/react/future";
+import { useState } from "react";
+import { ActionButton } from "seed-design/ui/action-button";
+import {
+  AppBar,
+  AppBarBackButton,
+  AppBarIconButton,
+  AppBarLeft,
+  AppBarMain,
+  AppBarRight,
+} from "seed-design/ui/app-bar";
+import { AppScreen, AppScreenContent } from "seed-design/ui/app-screen";
+import {
+  BottomSheetBody,
+  BottomSheetContent,
+  BottomSheetFooter,
+  BottomSheetRoot,
+} from "seed-design/ui/bottom-sheet";
+import { TextField, TextFieldInput } from "seed-design/ui/text-field";
+
+declare module "@stackflow/config" {
+  interface Register {
+    ActivityBottomSheetInputFocus: {};
+  }
+}
+
+const SCENARIOS = [
+  {
+    id: "input",
+    title: "Input",
+    description: "시트를 연 뒤 Input을 직접 눌러 포커스합니다.",
+  },
+  {
+    id: "autoFocus",
+    title: "진입 시 Auto focus",
+    description: "시트가 열리면 Input에 자동으로 포커스합니다.",
+  },
+  {
+    id: "autocomplete",
+    title: "포커스 시 새 요소 등장",
+    description: "Input에 포커스하면 아래에 자동완성 목록이 나타납니다.",
+  },
+] as const;
+
+const SHEET_HEIGHTS = ["40vh", "70vh"] as const;
+const SUGGESTIONS = ["당근마켓", "당근알바", "당근비즈니스"] as const;
+
+type Scenario = (typeof SCENARIOS)[number];
+type SheetHeight = (typeof SHEET_HEIGHTS)[number];
+
+const ActivityBottomSheetInputFocus: StaticActivityComponentType<
+  "ActivityBottomSheetInputFocus"
+> = () => {
+  const { push } = useFlow();
+  const [open, setOpen] = useState(false);
+  const [scenario, setScenario] = useState<Scenario>(SCENARIOS[0]);
+  const [sheetHeight, setSheetHeight] = useState<SheetHeight>(SHEET_HEIGHTS[0]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+
+  const openCase = (nextScenario: Scenario, nextHeight: SheetHeight) => {
+    setScenario(nextScenario);
+    setSheetHeight(nextHeight);
+    setShowSuggestions(false);
+    setOpen(true);
+  };
+
+  return (
+    <AppScreen>
+      <AppBar>
+        <AppBarLeft>
+          <AppBarBackButton />
+        </AppBarLeft>
+        <AppBarMain>BottomSheet Input Focus</AppBarMain>
+        <AppBarRight>
+          <AppBarIconButton aria-label="Home" onClick={() => push("ActivityHome", {})}>
+            <IconHouseLine />
+          </AppBarIconButton>
+        </AppBarRight>
+      </AppBar>
+
+      <AppScreenContent>
+        <VStack gap="x6" p="x4">
+          <Text as="p" textStyle="t4Regular" color="fg.neutralMuted">
+            iOS에서 키보드가 올라올 때 Bottom Sheet와 뷰포트 위치를 확인합니다.
+          </Text>
+
+          {SCENARIOS.map((item) => (
+            <Box as="section" key={item.id}>
+              <VStack gap="x3">
+                <VStack gap="x1">
+                  <Text as="h2" textStyle="t5Bold" color="fg.neutral">
+                    {item.title}
+                  </Text>
+                  <Text as="p" textStyle="t3Regular" color="fg.neutralMuted">
+                    {item.description}
+                  </Text>
+                </VStack>
+                <HStack gap="x2">
+                  {SHEET_HEIGHTS.map((height) => (
+                    <ActionButton
+                      key={height}
+                      flexGrow
+                      variant="neutralSolid"
+                      onClick={() => openCase(item, height)}
+                    >
+                      {height} 열기
+                    </ActionButton>
+                  ))}
+                </HStack>
+              </VStack>
+            </Box>
+          ))}
+        </VStack>
+      </AppScreenContent>
+
+      <BottomSheetRoot open={open} autoFocus={scenario.id !== "autoFocus"} onOpenChange={setOpen}>
+        <BottomSheetContent
+          showHandle
+          showCloseButton={false}
+          title={`${scenario.title} · ${sheetHeight}`}
+          description={scenario.description}
+          layerIndex={useActivityZIndexBase()}
+          style={{ height: sheetHeight }}
+        >
+          <BottomSheetBody>
+            <VStack gap="x3">
+              <TextField name="search" label="검색어">
+                <TextFieldInput
+                  autoFocus={scenario.id === "autoFocus"}
+                  placeholder="검색어를 입력하세요"
+                  onFocus={() => {
+                    if (scenario.id === "autocomplete") {
+                      setShowSuggestions(true);
+                    }
+                  }}
+                />
+              </TextField>
+
+              {scenario.id === "autocomplete" && showSuggestions && (
+                <Box
+                  bg="bg.layerDefault"
+                  borderColor="stroke.neutralWeak"
+                  borderRadius="r2"
+                  borderWidth={1}
+                  overflowX="hidden"
+                  overflowY="hidden"
+                >
+                  {SUGGESTIONS.map((suggestion) => (
+                    <Box key={suggestion} px="x4" py="x3">
+                      <Text textStyle="t4Regular" color="fg.neutral">
+                        {suggestion}
+                      </Text>
+                    </Box>
+                  ))}
+                </Box>
+              )}
+            </VStack>
+          </BottomSheetBody>
+          <BottomSheetFooter>
+            <ActionButton variant="neutralSolid" onClick={() => setOpen(false)}>
+              닫기
+            </ActionButton>
+          </BottomSheetFooter>
+        </BottomSheetContent>
+      </BottomSheetRoot>
+    </AppScreen>
+  );
+};
+
+export default ActivityBottomSheetInputFocus;

--- a/examples/stackflow-spa/src/activities/ActivityBottomSheetInputFocus.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityBottomSheetInputFocus.tsx
@@ -66,6 +66,10 @@ const SCENARIOS = [
 ] as const;
 
 const SHEET_HEIGHTS = ["40vh", "70vh"] as const;
+// Keep QA content within the same minimum top inset that `useDrawer` reserves while the
+// keyboard is open. Android WebView resolves the safe-area custom property to zero, so relying
+// on it alone lets a long sheet reach the very top of the layout viewport.
+const DRAWER_TOP_OFFSET = "26px";
 const SUGGESTIONS = ["당근마켓", "당근알바", "당근비즈니스"] as const;
 const SCROLL_ITEMS = Array.from({ length: 16 }, (_, index) => `스크롤 항목 ${index + 1}`);
 const MIDDLE_BEFORE_ITEMS = ["상단 안내", "최근 검색어", "추천 검색어"] as const;
@@ -148,10 +152,22 @@ const ActivityBottomSheetInputFocus: StaticActivityComponentType<
           title={`${scenario.title} · ${sheetHeight}`}
           description={scenario.description}
           layerIndex={useActivityZIndexBase({ activityOffset: 1 })}
-          style={{ minHeight: sheetHeight, maxHeight: "calc(100dvh - 48px)" }}
+          style={{
+            minHeight: sheetHeight,
+            // `dvh` can grow while Safari's browser controls collapse even though the fixed
+            // positioner has not adopted that larger viewport yet. `svh` is the stable lower
+            // bound, so long QA content cannot extend above the top safe area between those
+            // viewport updates.
+            maxHeight: `calc(100svh - max(${DRAWER_TOP_OFFSET}, var(--seed-safe-area-top)))`,
+          }}
         >
           <BottomSheetBody
-            style={{ minHeight: 0, overflowY: "auto", WebkitOverflowScrolling: "touch" }}
+            style={{
+              flex: "1 1 auto",
+              minHeight: 0,
+              overflowY: "auto",
+              WebkitOverflowScrolling: "touch",
+            }}
           >
             <VStack gap="x3">
               {scenario.id === "inputMiddle" &&

--- a/examples/stackflow-spa/src/activities/ActivityBottomSheetKeyboardPlayground.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityBottomSheetKeyboardPlayground.tsx
@@ -288,6 +288,10 @@ const ActivityBottomSheetKeyboardPlayground: StaticActivityComponentType<
         showCloseButton={false}
         title="Keyboard playground"
         layerIndex={useActivityZIndexBase()}
+        // The playground deliberately has a `tall` mode. Cap the sheet itself to the visible
+        // viewport so that mode exercises the body's scroll behavior instead of escaping above
+        // the status-bar safe area.
+        style={{ maxHeight: "calc(100dvh - var(--seed-safe-area-top))" }}
       >
         <BottomSheetBody
           // A snap point can leave less vertical space than the playground controls themselves.
@@ -341,7 +345,7 @@ const ActivityBottomSheetKeyboardPlayground: StaticActivityComponentType<
             </div>
           </VStack>
         </BottomSheetBody>
-        <BottomSheetFooter>
+        <BottomSheetFooter style={{ flexShrink: 0 }}>
           <ActionButton variant="neutralSolid" onClick={() => pop()}>
             Close
           </ActionButton>

--- a/examples/stackflow-spa/src/activities/ActivityBottomSheetKeyboardPlayground.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityBottomSheetKeyboardPlayground.tsx
@@ -289,7 +289,12 @@ const ActivityBottomSheetKeyboardPlayground: StaticActivityComponentType<
         title="Keyboard playground"
         layerIndex={useActivityZIndexBase()}
       >
-        <BottomSheetBody>
+        <BottomSheetBody
+          // A snap point can leave less vertical space than the playground controls themselves.
+          // Keep its intrinsic height for Drawer’s initial snap-point measurement, then allow it
+          // to shrink into a scrolling region once the visible viewport becomes smaller.
+          style={{ flex: "1 1 auto", minHeight: 0, overflowY: "auto", overscrollBehavior: "contain" }}
+        >
           <VStack gap="x4">
             <Readout metrics={metrics} />
 

--- a/examples/stackflow-spa/src/activities/ActivityBottomSheetKeyboardPlayground.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityBottomSheetKeyboardPlayground.tsx
@@ -297,7 +297,12 @@ const ActivityBottomSheetKeyboardPlayground: StaticActivityComponentType<
           // A snap point can leave less vertical space than the playground controls themselves.
           // Keep its intrinsic height for Drawer’s initial snap-point measurement, then allow it
           // to shrink into a scrolling region once the visible viewport becomes smaller.
-          style={{ flex: "1 1 auto", minHeight: 0, overflowY: "auto", overscrollBehavior: "contain" }}
+          style={{
+            flex: "1 1 auto",
+            minHeight: 0,
+            overflowY: "auto",
+            overscrollBehavior: "contain",
+          }}
         >
           <VStack gap="x4">
             <Readout metrics={metrics} />

--- a/examples/stackflow-spa/src/activities/ActivityHome.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityHome.tsx
@@ -212,6 +212,10 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
           onClick: () => push("ActivityBottomSheetTextField", {}),
         },
         {
+          title: "BottomSheet Input Focus",
+          onClick: () => push("ActivityBottomSheetInputFocus", {}),
+        },
+        {
           title: "BottomSheet Keyboard Playground",
           onClick: () => push("ActivityBottomSheetKeyboardPlayground", {}),
         },

--- a/examples/stackflow-spa/src/activities/ActivityHome.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityHome.tsx
@@ -212,7 +212,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
           onClick: () => push("ActivityBottomSheetTextField", {}),
         },
         {
-          title: "BottomSheet Input Focus",
+          title: "BottomSheet Share (snapPoints)",
           onClick: () => push("ActivityBottomSheetInputFocus", {}),
         },
         {

--- a/examples/stackflow-spa/src/stackflow/Stack.tsx
+++ b/examples/stackflow-spa/src/stackflow/Stack.tsx
@@ -49,6 +49,9 @@ export const { Stack, actions, stepActions } = stackflow({
     ActivityBadge: lazy(() => import("../activities/ActivityBadge")),
     ActivityBottomSheet: lazy(() => import("../activities/ActivityBottomSheet")),
     ActivityBottomSheetActivity: lazy(() => import("../activities/ActivityBottomSheetActivity")),
+    ActivityBottomSheetInputFocus: lazy(
+      () => import("../activities/ActivityBottomSheetInputFocus"),
+    ),
     ActivityBottomSheetModalTest: lazy(() => import("../activities/ActivityBottomSheetModalTest")),
     ActivityBottomSheetStep: lazy(() => import("../activities/ActivityBottomSheetStep")),
     ActivityBottomSheetKeyboardPlayground: lazy(

--- a/examples/stackflow-spa/src/stackflow/stackflow.config.ts
+++ b/examples/stackflow-spa/src/stackflow/stackflow.config.ts
@@ -19,6 +19,7 @@ export const config = defineConfig({
     { route: "/avatar", name: "ActivityAvatar" },
     { route: "/badge", name: "ActivityBadge" },
     { route: "/bottom-sheet-activity", name: "ActivityBottomSheetActivity" },
+    { route: "/bottom-sheet-input-focus", name: "ActivityBottomSheetInputFocus" },
     { route: "/bottom-sheet-step", name: "ActivityBottomSheetStep" },
     { route: "/bottom-sheet", name: "ActivityBottomSheet" },
     { route: "/bottom-sheet-modal-test", name: "ActivityBottomSheetModalTest" },

--- a/packages/react-headless/drawer/src/constants.ts
+++ b/packages/react-headless/drawer/src/constants.ts
@@ -10,6 +10,16 @@ export const TRANSITIONS = {
   CONTENT_EXIT_TIMING_FUNCTION: "cubic-bezier(0.35, 0, 1, 1)", // $timing-function.exit
 };
 
+/**
+ * Transition that carries the drawer between keyboard-open and keyboard-closed positions. The value
+ * itself belongs to the stylesheet layer (the bottom sheet recipe defines the custom property), but
+ * every inline `transition` write on the content element has to append this — inline styles win
+ * over the recipe, so dragging or snapping the drawer once would otherwise drop the transition.
+ * The keyboard reposition logic also reads this value to configure its synchronized WAAPI timing.
+ *
+ * The fallback keeps the declaration valid for consumers that don't define the property.
+ */
+export const KEYBOARD_TRANSITION = "var(--drawer-keyboard-transition, bottom 0s)";
 export const VELOCITY_THRESHOLD = 0.4;
 
 export const CLOSE_THRESHOLD = 0.25;

--- a/packages/react-headless/drawer/src/constants.ts
+++ b/packages/react-headless/drawer/src/constants.ts
@@ -11,15 +11,16 @@ export const TRANSITIONS = {
 };
 
 /**
- * Transition that carries the drawer between keyboard-open and keyboard-closed positions. The value
- * itself belongs to the stylesheet layer (the bottom sheet recipe defines the custom property), but
- * every inline `transition` write on the content element has to append this — inline styles win
- * over the recipe, so dragging or snapping the drawer once would otherwise drop the transition.
- * The keyboard reposition logic also reads this value to configure its synchronized WAAPI timing.
+ * Transition that carries the drawer between keyboard-open and keyboard-closed positions.
+ * Consumers can override the default through the custom property, but every inline `transition`
+ * write on the content element has to append this — inline styles win over stylesheet rules, so
+ * dragging or snapping the drawer once would otherwise drop the transition. The keyboard
+ * reposition logic also reads this value to configure its synchronized WAAPI timing.
  *
  * The fallback keeps the declaration valid for consumers that don't define the property.
  */
-export const KEYBOARD_TRANSITION = "var(--drawer-keyboard-transition, bottom 0s)";
+export const DEFAULT_KEYBOARD_TRANSITION = `bottom ${TRANSITIONS.ENTER_DURATION}s ${TRANSITIONS.CONTENT_ENTER_TIMING_FUNCTION}`;
+export const KEYBOARD_TRANSITION = `var(--drawer-keyboard-transition, ${DEFAULT_KEYBOARD_TRANSITION})`;
 export const VELOCITY_THRESHOLD = 0.4;
 
 export const CLOSE_THRESHOLD = 0.25;

--- a/packages/react-headless/drawer/src/useDrawer.test.tsx
+++ b/packages/react-headless/drawer/src/useDrawer.test.tsx
@@ -474,6 +474,39 @@ describe("키보드 리포지션", () => {
     rectSpy.mockRestore();
   });
 
+  it("iOS가 visual viewport를 패닝해도 시트 헤더가 화면 위로 밀려나지 않는다", () => {
+    const { getByTestId } = render(<KeyboardHarness defaultOpen />);
+    const drawer = getByTestId("drawer");
+    const input = getByTestId("input-a");
+    const rectSpy = mockRect(drawer, 560);
+
+    drawer.style.minHeight = "70vh";
+    input.focus();
+
+    visualViewport.height = window.innerHeight - 400;
+    visualViewport.dispatchEvent(new Event("resize"));
+
+    expect(drawer.style.height).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.minHeight).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.bottom).toBe("400px");
+
+    visualViewport.offsetTop = 120;
+    visualViewport.dispatchEvent(new Event("scroll"));
+
+    expect(drawer.style.height).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.minHeight).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.bottom).toBe("280px");
+
+    input.blur();
+    act(() => flushFrames());
+
+    expect(drawer.style.height).toBe("");
+    expect(drawer.style.minHeight).toBe("70vh");
+    expect(drawer.style.bottom).toBe("0px");
+
+    rectSpy.mockRestore();
+  });
+
   it("focusout 한 번이면 스냅 변경의 cleanup이 예약된 프레임을 취소한다", () => {
     const { getByTestId } = render(<KeyboardHarness defaultOpen snapPoints={["200px", "400px"]} />);
     const drawer = getByTestId("drawer");

--- a/packages/react-headless/drawer/src/useDrawer.test.tsx
+++ b/packages/react-headless/drawer/src/useDrawer.test.tsx
@@ -409,6 +409,8 @@ describe("키보드 리포지션", () => {
   const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport");
   const originalPlatform = Object.getOwnPropertyDescriptor(window.navigator, "platform");
   const originalInnerHeight = Object.getOwnPropertyDescriptor(window, "innerHeight");
+  const originalSafeAreaTop =
+    document.documentElement.style.getPropertyValue("--seed-safe-area-top");
 
   class MockVisualViewport extends EventTarget {
     height = window.innerHeight;
@@ -448,6 +450,12 @@ describe("키보드 리포지션", () => {
     } else {
       Reflect.deleteProperty(window, "innerHeight");
     }
+
+    if (originalSafeAreaTop) {
+      document.documentElement.style.setProperty("--seed-safe-area-top", originalSafeAreaTop);
+    } else {
+      document.documentElement.style.removeProperty("--seed-safe-area-top");
+    }
   });
 
   it("열림 커밋에서 autoFocus된 input이 이미 축소된 viewport를 즉시 반영한다", () => {
@@ -469,6 +477,44 @@ describe("키보드 리포지션", () => {
   it("autoFocus 중 layout viewport도 함께 축소되어도 닫힌 상태의 높이를 기준으로 계산한다", () => {
     const { getByTestId, rerender } = render(<AutoFocusKeyboardHarness open={false} />);
     const drawer = getByTestId("drawer");
+    let measuredDrawerHeight = 560;
+    const rectSpy = spyOn(drawer, "getBoundingClientRect").mockImplementation(() => ({
+      x: 0,
+      y: 0,
+      width: measuredDrawerHeight,
+      height: measuredDrawerHeight,
+      top: 0,
+      left: 0,
+      right: measuredDrawerHeight,
+      bottom: measuredDrawerHeight,
+      toJSON: () => {},
+    }));
+    const layoutViewportHeight = window.innerHeight;
+
+    visualViewport.height = layoutViewportHeight - 400;
+    measuredDrawerHeight = visualViewport.height * 0.7;
+    Object.defineProperty(window, "innerHeight", {
+      value: visualViewport.height,
+      configurable: true,
+    });
+    rerender(<AutoFocusKeyboardHarness open />);
+
+    expect(getByTestId("auto-focus-input")).toHaveFocus();
+    expect(drawer.style.height).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.minHeight).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.bottom).toBe("400px");
+
+    rectSpy.mockRestore();
+  });
+
+  it("Android adjustResize가 layout viewport를 축소하면 시트를 다시 들어 올리지 않는다", () => {
+    Object.defineProperty(window.navigator, "platform", {
+      value: "Linux armv8l",
+      configurable: true,
+    });
+
+    const { getByTestId, rerender } = render(<AutoFocusKeyboardHarness open={false} />);
+    const drawer = getByTestId("drawer");
     const rectSpy = mockRect(drawer, 560);
     const layoutViewportHeight = window.innerHeight;
 
@@ -482,7 +528,277 @@ describe("키보드 리포지션", () => {
     expect(getByTestId("auto-focus-input")).toHaveFocus();
     expect(drawer.style.height).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
     expect(drawer.style.minHeight).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
-    expect(drawer.style.bottom).toBe("400px");
+    expect(drawer.style.bottom).toBe("0px");
+
+    rectSpy.mockRestore();
+  });
+
+  it("Android에서 열린 시트의 input을 포커스해도 축소된 layout viewport 안에 유지한다", () => {
+    Object.defineProperty(window.navigator, "platform", {
+      value: "Linux armv8l",
+      configurable: true,
+    });
+
+    const { getByTestId } = render(<KeyboardHarness defaultOpen />);
+    const drawer = getByTestId("drawer");
+    const input = getByTestId("input-a");
+    const rectSpy = mockRect(drawer, 560);
+    const layoutViewportHeight = window.innerHeight;
+
+    act(() => {
+      input.focus();
+      visualViewport.height = layoutViewportHeight - 400;
+      Object.defineProperty(window, "innerHeight", {
+        value: visualViewport.height,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event("resize"));
+      visualViewport.dispatchEvent(new Event("resize"));
+    });
+
+    expect(drawer.style.height).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.minHeight).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.bottom).toBe("0px");
+
+    rectSpy.mockRestore();
+  });
+
+  it("Android가 focusin 전에 viewport 단위 높이를 줄여도 열린 시트의 기준 높이를 보존한다", () => {
+    Object.defineProperty(window.navigator, "platform", {
+      value: "Linux armv8l",
+      configurable: true,
+    });
+
+    let measuredDrawerHeight = 560;
+    const rectSpy = spyOn(window.HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function () {
+        const size = this.dataset.testid === "drawer" ? measuredDrawerHeight : 0;
+
+        return {
+          x: 0,
+          y: 0,
+          width: size,
+          height: size,
+          top: 0,
+          left: 0,
+          right: size,
+          bottom: size,
+          toJSON: () => {},
+        };
+      },
+    );
+
+    const { getByTestId } = render(<KeyboardHarness defaultOpen />);
+    const drawer = getByTestId("drawer");
+    const input = getByTestId("input-a");
+    const layoutViewportHeight = window.innerHeight;
+
+    act(() => {
+      measuredDrawerHeight = 220;
+      visualViewport.height = layoutViewportHeight - 400;
+      Object.defineProperty(window, "innerHeight", {
+        value: visualViewport.height,
+        configurable: true,
+      });
+      input.focus();
+      window.dispatchEvent(new Event("resize"));
+      visualViewport.dispatchEvent(new Event("resize"));
+    });
+
+    expect(drawer.style.height).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.minHeight).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.bottom).toBe("0px");
+
+    rectSpy.mockRestore();
+  });
+
+  it("Android blur 후 첫 window resize에서 키보드가 열린 시트 위치부터 복원 애니메이션한다", async () => {
+    Object.defineProperty(window.navigator, "platform", {
+      value: "Linux armv8l",
+      configurable: true,
+    });
+
+    const { getByTestId } = render(<KeyboardHarness defaultOpen />);
+    const drawer = getByTestId("drawer");
+    const input = getByTestId("input-a");
+    const layoutViewportHeight = window.innerHeight;
+    const naturalHeight = 560;
+    const animation = {
+      cancel: mock(() => {}),
+      pause: mock(() => {}),
+      play: mock(() => {}),
+      currentTime: null,
+      finished: new Promise<void>(() => {}),
+    } as unknown as Animation;
+    const animate = mock(() => animation);
+
+    Object.defineProperty(drawer, "animate", {
+      value: animate,
+      configurable: true,
+    });
+    drawer.style.minHeight = "70vh";
+    drawer.style.bottom = "0px";
+    drawer.style.setProperty(
+      "--drawer-keyboard-transition",
+      "bottom 250ms cubic-bezier(0.32, 0.72, 0, 1)",
+    );
+    const rectSpy = spyOn(drawer, "getBoundingClientRect").mockImplementation(() => {
+      const height = Number.parseFloat(drawer.style.height) || naturalHeight;
+      const bottomOffset = Number.parseFloat(drawer.style.bottom) || 0;
+      const bottom = window.innerHeight - bottomOffset;
+
+      return {
+        x: 0,
+        y: bottom - height,
+        width: 100,
+        height,
+        top: bottom - height,
+        left: 0,
+        right: 100,
+        bottom,
+        toJSON: () => {},
+      };
+    });
+
+    act(() => {
+      input.focus();
+      visualViewport.height = layoutViewportHeight - 400;
+      Object.defineProperty(window, "innerHeight", {
+        value: visualViewport.height,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    const keyboardOpenHeight = visualViewport.height - WINDOW_TOP_OFFSET;
+    expect(drawer.style.height).toBe(`${keyboardOpenHeight}px`);
+
+    await act(async () => {
+      input.blur();
+      await Promise.resolve();
+    });
+
+    animate.mockClear();
+    act(() => {
+      visualViewport.height = layoutViewportHeight;
+      Object.defineProperty(window, "innerHeight", {
+        value: layoutViewportHeight,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(animate).toHaveBeenCalledWith(
+      [
+        {
+          height: `${keyboardOpenHeight}px`,
+          minHeight: `${keyboardOpenHeight}px`,
+          bottom: "400px",
+        },
+        {
+          height: `${naturalHeight}px`,
+          minHeight: `${naturalHeight}px`,
+          bottom: "0px",
+        },
+      ],
+      {
+        duration: 250,
+        easing: "cubic-bezier(0.32, 0.72, 0, 1)",
+        fill: "both",
+      },
+    );
+    expect(drawer.style.height).toBe("");
+    expect(drawer.style.minHeight).toBe("70vh");
+    expect(drawer.style.bottom).toBe("0px");
+
+    rectSpy.mockRestore();
+  });
+
+  it("Android 40vh 시트는 input 포커스가 남아도 확장된 viewport 아래로 즉시 떨어지지 않는다", () => {
+    Object.defineProperty(window.navigator, "platform", {
+      value: "Linux armv8l",
+      configurable: true,
+    });
+
+    const { getByTestId } = render(<KeyboardHarness defaultOpen />);
+    const drawer = getByTestId("drawer");
+    const input = getByTestId("input-a");
+    const layoutViewportHeight = window.innerHeight;
+    const naturalHeight = Number((layoutViewportHeight * 0.4).toFixed(3));
+    const animation = {
+      cancel: mock(() => {}),
+      pause: mock(() => {}),
+      play: mock(() => {}),
+      currentTime: null,
+      finished: new Promise<void>(() => {}),
+    } as unknown as Animation;
+    const animate = mock(() => animation);
+
+    Object.defineProperty(drawer, "animate", {
+      value: animate,
+      configurable: true,
+    });
+    drawer.style.minHeight = "40vh";
+    drawer.style.bottom = "0px";
+    drawer.style.setProperty("--drawer-keyboard-transition", "bottom 250ms ease");
+    const rectSpy = spyOn(drawer, "getBoundingClientRect").mockImplementation(() => {
+      const height = Number.parseFloat(drawer.style.height) || naturalHeight;
+      const bottomOffset = Number.parseFloat(drawer.style.bottom) || 0;
+      const bottom = window.innerHeight - bottomOffset;
+
+      return {
+        x: 0,
+        y: bottom - height,
+        width: 100,
+        height,
+        top: bottom - height,
+        left: 0,
+        right: 100,
+        bottom,
+        toJSON: () => {},
+      };
+    });
+
+    act(() => {
+      input.focus();
+      visualViewport.height = layoutViewportHeight - 400;
+      Object.defineProperty(window, "innerHeight", {
+        value: visualViewport.height,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event("resize"));
+    });
+    expect(drawer.style.height).toBe(`${naturalHeight}px`);
+
+    animate.mockClear();
+    act(() => {
+      visualViewport.height = layoutViewportHeight;
+      Object.defineProperty(window, "innerHeight", {
+        value: layoutViewportHeight,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(animate).toHaveBeenCalledWith(
+      [
+        {
+          height: `${naturalHeight}px`,
+          minHeight: `${naturalHeight}px`,
+          bottom: "400px",
+        },
+        {
+          height: `${naturalHeight}px`,
+          minHeight: `${naturalHeight}px`,
+          bottom: "0px",
+        },
+      ],
+      {
+        duration: 250,
+        easing: "ease",
+        fill: "both",
+      },
+    );
 
     rectSpy.mockRestore();
   });
@@ -630,6 +946,34 @@ describe("키보드 리포지션", () => {
     expect(drawer.style.height).toBe("");
     expect(drawer.style.minHeight).toBe("70vh");
     expect(drawer.style.bottom).toBe("0px");
+
+    rectSpy.mockRestore();
+  });
+
+  it("iOS의 상단 safe area보다 아래에 시트 헤더를 유지한다", () => {
+    document.documentElement.style.setProperty("--seed-safe-area-top", "59px");
+
+    const { getByTestId } = render(<KeyboardHarness defaultOpen />);
+    const drawer = getByTestId("drawer");
+    const input = getByTestId("input-a");
+    const rectSpy = mockRect(drawer, 560);
+
+    drawer.style.minHeight = "70vh";
+    input.focus();
+
+    visualViewport.height = window.innerHeight - 400;
+    visualViewport.dispatchEvent(new Event("resize"));
+
+    expect(drawer.style.height).toBe(`${visualViewport.height - 59}px`);
+    expect(drawer.style.minHeight).toBe(`${visualViewport.height - 59}px`);
+    expect(drawer.style.bottom).toBe("400px");
+
+    visualViewport.offsetTop = 120;
+    visualViewport.dispatchEvent(new Event("scroll"));
+
+    expect(drawer.style.height).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.minHeight).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.bottom).toBe("280px");
 
     rectSpy.mockRestore();
   });

--- a/packages/react-headless/drawer/src/useDrawer.test.tsx
+++ b/packages/react-headless/drawer/src/useDrawer.test.tsx
@@ -1136,9 +1136,7 @@ describe("키보드 리포지션", () => {
   });
 
   it("첫 번째 snap point에서도 키보드 오프셋을 반영한다", () => {
-    const { getByTestId } = render(
-      <KeyboardHarness defaultOpen snapPoints={["100px", "300px"]} />,
-    );
+    const { getByTestId } = render(<KeyboardHarness defaultOpen snapPoints={["100px", "300px"]} />);
     const drawer = getByTestId("drawer");
     const input = getByTestId("input-a");
     const rectSpy = mockRect(drawer, 560);

--- a/packages/react-headless/drawer/src/useDrawer.test.tsx
+++ b/packages/react-headless/drawer/src/useDrawer.test.tsx
@@ -1,7 +1,18 @@
 import { act, fireEvent, render } from "@testing-library/react";
-import { afterAll, afterEach, beforeAll, describe, expect, it, jest, mock, spyOn } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+  mock,
+  spyOn,
+} from "bun:test";
 import * as React from "react";
-import { DRAG_CLASS, TRANSITIONS } from "./constants";
+import { DRAG_CLASS, TRANSITIONS, WINDOW_TOP_OFFSET } from "./constants";
 import { DrawerContent, DrawerRoot } from "./Drawer";
 import { useDrawer, type UseDrawerProps } from "./useDrawer";
 
@@ -351,5 +362,181 @@ describe("스크롤 락", () => {
       </DrawerRoot>,
     );
     expect(isScrollLocked()).toBe(false);
+  });
+});
+
+describe("키보드 리포지션", () => {
+  function KeyboardHarness(props: UseDrawerProps) {
+    const api = useDrawer(props);
+
+    return (
+      <div>
+        <button
+          type="button"
+          data-testid="next-snap"
+          onClick={() => api.setActiveSnapPoint(api.snapPoints?.[1] ?? null)}
+        />
+        <div data-testid="drawer" role="dialog" ref={api.drawerRef} />
+        <input data-testid="input-a" />
+        <input data-testid="input-b" />
+      </div>
+    );
+  }
+
+  const originalRaf = window.requestAnimationFrame;
+  const originalCaf = window.cancelAnimationFrame;
+  const originalPlatform = Object.getOwnPropertyDescriptor(window.navigator, "platform");
+  const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport");
+
+  class MockVisualViewport extends EventTarget {
+    height = window.innerHeight;
+    offsetTop = 0;
+    scale = 1;
+  }
+
+  let pending: Map<number, () => void>;
+  let nextHandle: number;
+  let visualViewport: MockVisualViewport;
+
+  function flushFrames() {
+    const callbacks = [...pending.values()];
+    pending.clear();
+    for (const callback of callbacks) callback();
+  }
+
+  function setPlatform(value: string) {
+    Object.defineProperty(window.navigator, "platform", { value, configurable: true });
+  }
+
+  beforeEach(() => {
+    pending = new Map();
+    nextHandle = 1;
+
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      const handle = nextHandle++;
+      pending.set(handle, () => callback(0));
+      return handle;
+    }) as typeof window.requestAnimationFrame;
+
+    window.cancelAnimationFrame = ((handle: number) => {
+      pending.delete(handle);
+    }) as typeof window.cancelAnimationFrame;
+
+    visualViewport = new MockVisualViewport();
+    Object.defineProperty(window, "visualViewport", {
+      value: visualViewport,
+      configurable: true,
+    });
+    setPlatform("iPhone");
+  });
+
+  afterEach(() => {
+    window.requestAnimationFrame = originalRaf;
+    window.cancelAnimationFrame = originalCaf;
+    if (originalPlatform) {
+      Object.defineProperty(window.navigator, "platform", originalPlatform);
+    }
+    if (originalVisualViewport) {
+      Object.defineProperty(window, "visualViewport", originalVisualViewport);
+    } else {
+      Reflect.deleteProperty(window, "visualViewport");
+    }
+  });
+
+  it("키보드 resize가 여러 번 발생해도 닫히면 원래 CSS 높이를 복원한다", () => {
+    const { getByTestId } = render(<KeyboardHarness defaultOpen />);
+    const drawer = getByTestId("drawer");
+    const input = getByTestId("input-a");
+    const rectSpy = mockRect(drawer, 560);
+
+    drawer.style.height = "70vh";
+    input.focus();
+
+    visualViewport.height = window.innerHeight - 200;
+    visualViewport.dispatchEvent(new Event("resize"));
+    visualViewport.height = window.innerHeight - 400;
+    visualViewport.dispatchEvent(new Event("resize"));
+
+    expect(drawer.style.height).toBe(`${window.innerHeight - 400 - WINDOW_TOP_OFFSET}px`);
+
+    input.blur();
+    act(() => flushFrames());
+
+    expect(drawer.style.height).toBe("70vh");
+    expect(drawer.style.bottom).toBe("0px");
+
+    visualViewport.height = window.innerHeight;
+    visualViewport.dispatchEvent(new Event("resize"));
+
+    expect(drawer.style.height).toBe("70vh");
+    expect(drawer.style.bottom).toBe("0px");
+
+    rectSpy.mockRestore();
+  });
+
+  it("focusout 한 번이면 스냅 변경의 cleanup이 예약된 프레임을 취소한다", () => {
+    const { getByTestId } = render(<KeyboardHarness defaultOpen snapPoints={["200px", "400px"]} />);
+    const drawer = getByTestId("drawer");
+
+    // 키보드가 올라와 시트가 들려 있는 상태
+    drawer.style.bottom = "300px";
+
+    fireEvent.focusOut(getByTestId("input-a"));
+    expect(pending.size).toBe(1);
+
+    act(() => {
+      getByTestId("next-snap").click();
+    });
+    expect(pending.size).toBe(0);
+
+    // 새 스냅이 자기 위치로 재배치한 뒤, 남은 프레임이 그 위를 덮지 않아야 한다
+    drawer.style.bottom = "300px";
+    act(() => flushFrames());
+
+    expect(drawer.style.bottom).toBe("300px");
+  });
+
+  it("focusout이 같은 프레임에 두 번이어도 스냅 변경의 cleanup이 모든 프레임을 취소한다", () => {
+    const { getByTestId } = render(<KeyboardHarness defaultOpen snapPoints={["200px", "400px"]} />);
+    const drawer = getByTestId("drawer");
+
+    drawer.style.bottom = "300px";
+
+    fireEvent.focusOut(getByTestId("input-a"));
+    fireEvent.focusOut(getByTestId("input-b"));
+    // 프레임 핸들을 담는 슬롯이 하나뿐이라, 새로 예약하기 전에 직전 프레임을 취소해야
+    // cleanup이 취소할 수 없는 고아 프레임이 남지 않는다
+    expect(pending.size).toBe(1);
+
+    act(() => {
+      getByTestId("next-snap").click();
+    });
+    expect(pending.size).toBe(0);
+
+    drawer.style.bottom = "300px";
+    act(() => flushFrames());
+
+    expect(drawer.style.bottom).toBe("300px");
+  });
+
+  it("iOS가 아니면 focusout 리스너를 등록하지 않는다", () => {
+    setPlatform("Linux armv8l");
+
+    const { getByTestId } = render(<KeyboardHarness defaultOpen snapPoints={["200px", "400px"]} />);
+    const drawer = getByTestId("drawer");
+
+    drawer.style.bottom = "300px";
+
+    fireEvent.focusOut(getByTestId("input-a"));
+    fireEvent.focusOut(getByTestId("input-b"));
+    expect(pending.size).toBe(0);
+
+    act(() => {
+      getByTestId("next-snap").click();
+    });
+    drawer.style.bottom = "300px";
+    act(() => flushFrames());
+
+    expect(drawer.style.bottom).toBe("300px");
   });
 });

--- a/packages/react-headless/drawer/src/useDrawer.test.tsx
+++ b/packages/react-headless/drawer/src/useDrawer.test.tsx
@@ -371,22 +371,44 @@ describe("키보드 리포지션", () => {
 
     return (
       <div>
-        <button
-          type="button"
-          data-testid="next-snap"
-          onClick={() => api.setActiveSnapPoint(api.snapPoints?.[1] ?? null)}
-        />
-        <div data-testid="drawer" role="dialog" ref={api.drawerRef} />
-        <input data-testid="input-a" />
-        <input data-testid="input-b" />
+        <div data-testid="drawer" role="dialog" ref={api.drawerRef}>
+          <input data-testid="input-a" />
+          <input data-testid="input-b" />
+        </div>
       </div>
     );
   }
 
-  const originalRaf = window.requestAnimationFrame;
-  const originalCaf = window.cancelAnimationFrame;
-  const originalPlatform = Object.getOwnPropertyDescriptor(window.navigator, "platform");
+  function ScrollKeyboardHarness(props: UseDrawerProps) {
+    const api = useDrawer(props);
+
+    return (
+      <div data-testid="drawer" role="dialog" ref={api.drawerRef}>
+        <div data-testid="scrollable" style={{ overflowY: "auto" }}>
+          <input data-testid="scroll-input" />
+        </div>
+      </div>
+    );
+  }
+
+  function AutoFocusKeyboardHarness({ open }: { open: boolean }) {
+    const api = useDrawer({ open });
+
+    return (
+      <div
+        data-testid="drawer"
+        role="dialog"
+        ref={api.drawerRef}
+        style={{ minHeight: "70vh", bottom: 0 }}
+      >
+        {open && <input data-testid="auto-focus-input" autoFocus />}
+      </div>
+    );
+  }
+
   const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport");
+  const originalPlatform = Object.getOwnPropertyDescriptor(window.navigator, "platform");
+  const originalInnerHeight = Object.getOwnPropertyDescriptor(window, "innerHeight");
 
   class MockVisualViewport extends EventTarget {
     height = window.innerHeight;
@@ -394,56 +416,143 @@ describe("키보드 리포지션", () => {
     scale = 1;
   }
 
-  let pending: Map<number, () => void>;
-  let nextHandle: number;
   let visualViewport: MockVisualViewport;
 
-  function flushFrames() {
-    const callbacks = [...pending.values()];
-    pending.clear();
-    for (const callback of callbacks) callback();
-  }
-
-  function setPlatform(value: string) {
-    Object.defineProperty(window.navigator, "platform", { value, configurable: true });
-  }
-
   beforeEach(() => {
-    pending = new Map();
-    nextHandle = 1;
-
-    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
-      const handle = nextHandle++;
-      pending.set(handle, () => callback(0));
-      return handle;
-    }) as typeof window.requestAnimationFrame;
-
-    window.cancelAnimationFrame = ((handle: number) => {
-      pending.delete(handle);
-    }) as typeof window.cancelAnimationFrame;
-
     visualViewport = new MockVisualViewport();
     Object.defineProperty(window, "visualViewport", {
       value: visualViewport,
       configurable: true,
     });
-    setPlatform("iPhone");
+    Object.defineProperty(window.navigator, "platform", {
+      value: "iPhone",
+      configurable: true,
+    });
   });
 
   afterEach(() => {
-    window.requestAnimationFrame = originalRaf;
-    window.cancelAnimationFrame = originalCaf;
-    if (originalPlatform) {
-      Object.defineProperty(window.navigator, "platform", originalPlatform);
-    }
     if (originalVisualViewport) {
       Object.defineProperty(window, "visualViewport", originalVisualViewport);
     } else {
       Reflect.deleteProperty(window, "visualViewport");
     }
+
+    if (originalPlatform) {
+      Object.defineProperty(window.navigator, "platform", originalPlatform);
+    } else {
+      Reflect.deleteProperty(window.navigator, "platform");
+    }
+
+    if (originalInnerHeight) {
+      Object.defineProperty(window, "innerHeight", originalInnerHeight);
+    } else {
+      Reflect.deleteProperty(window, "innerHeight");
+    }
   });
 
-  it("키보드 resize가 여러 번 발생해도 닫히면 원래 CSS 높이를 복원한다", () => {
+  it("열림 커밋에서 autoFocus된 input이 이미 축소된 viewport를 즉시 반영한다", () => {
+    const { getByTestId, rerender } = render(<AutoFocusKeyboardHarness open={false} />);
+    const drawer = getByTestId("drawer");
+    const rectSpy = mockRect(drawer, 560);
+
+    visualViewport.height = window.innerHeight - 400;
+    rerender(<AutoFocusKeyboardHarness open />);
+
+    expect(getByTestId("auto-focus-input")).toHaveFocus();
+    expect(drawer.style.height).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.minHeight).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.bottom).toBe("400px");
+
+    rectSpy.mockRestore();
+  });
+
+  it("autoFocus 중 layout viewport도 함께 축소되어도 닫힌 상태의 높이를 기준으로 계산한다", () => {
+    const { getByTestId, rerender } = render(<AutoFocusKeyboardHarness open={false} />);
+    const drawer = getByTestId("drawer");
+    const rectSpy = mockRect(drawer, 560);
+    const layoutViewportHeight = window.innerHeight;
+
+    visualViewport.height = layoutViewportHeight - 400;
+    Object.defineProperty(window, "innerHeight", {
+      value: visualViewport.height,
+      configurable: true,
+    });
+    rerender(<AutoFocusKeyboardHarness open />);
+
+    expect(getByTestId("auto-focus-input")).toHaveFocus();
+    expect(drawer.style.height).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.minHeight).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.bottom).toBe("400px");
+
+    rectSpy.mockRestore();
+  });
+
+  it("직전 키보드 해제 이벤트를 기다리는 중 다시 autoFocus되어도 축소된 viewport를 반영한다", () => {
+    // Native autoFocus can run while the effect is being replaced, leaving the document-level
+    // focusin listener without that event. Block focusin here so only the post-commit
+    // reconciliation path can clear the previous dismissal guard.
+    const blockFocusIn = (event: FocusEvent) => event.stopImmediatePropagation();
+    document.addEventListener("focusin", blockFocusIn, true);
+
+    const { getByTestId, rerender } = render(<AutoFocusKeyboardHarness open={false} />);
+    const drawer = getByTestId("drawer");
+    const rectSpy = mockRect(drawer, 560);
+
+    visualViewport.height = window.innerHeight - 400;
+    rerender(<AutoFocusKeyboardHarness open />);
+
+    // Close directly while the input and visual viewport are still in their keyboard-open state,
+    // then reopen before visualViewport reports that the previous keyboard is gone.
+    rerender(<AutoFocusKeyboardHarness open={false} />);
+    rerender(<AutoFocusKeyboardHarness open />);
+
+    document.removeEventListener("focusin", blockFocusIn, true);
+
+    expect(getByTestId("auto-focus-input")).toHaveFocus();
+    expect(drawer.style.height).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.minHeight).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.bottom).toBe("400px");
+
+    rectSpy.mockRestore();
+  });
+
+  it("닫힐 때 layout viewport가 아직 축소돼 있어도 다음 autoFocus의 기준 높이를 보존한다", () => {
+    const { getByTestId, rerender } = render(<AutoFocusKeyboardHarness open={false} />);
+    const drawer = getByTestId("drawer");
+    const rectSpy = mockRect(drawer, 560);
+    const layoutViewportHeight = window.innerHeight;
+
+    visualViewport.height = layoutViewportHeight - 400;
+    Object.defineProperty(window, "innerHeight", {
+      value: visualViewport.height,
+      configurable: true,
+    });
+
+    rerender(<AutoFocusKeyboardHarness open />);
+    rerender(<AutoFocusKeyboardHarness open={false} />);
+    rerender(<AutoFocusKeyboardHarness open />);
+
+    expect(getByTestId("auto-focus-input")).toHaveFocus();
+    expect(drawer.style.height).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.minHeight).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.bottom).toBe("400px");
+
+    rectSpy.mockRestore();
+  });
+
+  it("snap point가 없으면 keyboard window resize 중에도 viewport listener를 유지한다", () => {
+    const removeEventListener = spyOn(visualViewport, "removeEventListener");
+    render(<KeyboardHarness defaultOpen />);
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(removeEventListener).not.toHaveBeenCalled();
+    removeEventListener.mockRestore();
+  });
+
+  it("focusout에서 viewport 닫힘을 기다리지 않고 원래 CSS 높이를 복원한다", async () => {
     const { getByTestId } = render(<KeyboardHarness defaultOpen />);
     const drawer = getByTestId("drawer");
     const input = getByTestId("input-a");
@@ -459,9 +568,17 @@ describe("키보드 리포지션", () => {
 
     expect(drawer.style.height).toBe(`${window.innerHeight - 400 - WINDOW_TOP_OFFSET}px`);
 
-    input.blur();
-    act(() => flushFrames());
+    await act(async () => {
+      input.blur();
+      await Promise.resolve();
+    });
 
+    expect(drawer.style.height).toBe("70vh");
+    expect(drawer.style.bottom).toBe("0px");
+
+    // iOS가 키보드 닫힘 애니메이션 중 보내는 keyboard-open viewport 이벤트가 복원을
+    // 취소하고 시트를 다시 들어 올리지 않아야 한다.
+    visualViewport.dispatchEvent(new Event("resize"));
     expect(drawer.style.height).toBe("70vh");
     expect(drawer.style.bottom).toBe("0px");
 
@@ -474,7 +591,7 @@ describe("키보드 리포지션", () => {
     rectSpy.mockRestore();
   });
 
-  it("iOS가 visual viewport를 패닝해도 시트 헤더가 화면 위로 밀려나지 않는다", () => {
+  it("iOS가 visual viewport를 패닝해도 시트 헤더가 화면 위로 밀려나지 않는다", async () => {
     const { getByTestId } = render(<KeyboardHarness defaultOpen />);
     const drawer = getByTestId("drawer");
     const input = getByTestId("input-a");
@@ -497,8 +614,18 @@ describe("키보드 리포지션", () => {
     expect(drawer.style.minHeight).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
     expect(drawer.style.bottom).toBe("280px");
 
-    input.blur();
-    act(() => flushFrames());
+    await act(async () => {
+      input.blur();
+      await Promise.resolve();
+    });
+
+    expect(drawer.style.height).toBe("");
+    expect(drawer.style.minHeight).toBe("70vh");
+    expect(drawer.style.bottom).toBe("0px");
+
+    visualViewport.height = window.innerHeight;
+    visualViewport.offsetTop = 0;
+    visualViewport.dispatchEvent(new Event("resize"));
 
     expect(drawer.style.height).toBe("");
     expect(drawer.style.minHeight).toBe("70vh");
@@ -507,69 +634,215 @@ describe("키보드 리포지션", () => {
     rectSpy.mockRestore();
   });
 
-  it("focusout 한 번이면 스냅 변경의 cleanup이 예약된 프레임을 취소한다", () => {
-    const { getByTestId } = render(<KeyboardHarness defaultOpen snapPoints={["200px", "400px"]} />);
+  it("Drawer 내부의 다른 input으로 포커스가 이동하면 열린 키보드 위치를 유지한다", async () => {
+    const { getByTestId } = render(<KeyboardHarness defaultOpen />);
     const drawer = getByTestId("drawer");
+    const inputA = getByTestId("input-a");
+    const inputB = getByTestId("input-b");
+    const rectSpy = mockRect(drawer, 560);
 
-    // 키보드가 올라와 시트가 들려 있는 상태
-    drawer.style.bottom = "300px";
+    drawer.style.minHeight = "70vh";
+    inputA.focus();
+    visualViewport.height = window.innerHeight - 400;
+    visualViewport.dispatchEvent(new Event("resize"));
 
-    fireEvent.focusOut(getByTestId("input-a"));
-    expect(pending.size).toBe(1);
-
-    act(() => {
-      getByTestId("next-snap").click();
+    await act(async () => {
+      inputB.focus();
+      await Promise.resolve();
     });
-    expect(pending.size).toBe(0);
 
-    // 새 스냅이 자기 위치로 재배치한 뒤, 남은 프레임이 그 위를 덮지 않아야 한다
-    drawer.style.bottom = "300px";
-    act(() => flushFrames());
+    expect(drawer.style.height).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.minHeight).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.bottom).toBe("400px");
 
-    expect(drawer.style.bottom).toBe("300px");
+    rectSpy.mockRestore();
   });
 
-  it("focusout이 같은 프레임에 두 번이어도 스냅 변경의 cleanup이 모든 프레임을 취소한다", () => {
-    const { getByTestId } = render(<KeyboardHarness defaultOpen snapPoints={["200px", "400px"]} />);
+  it("키보드가 가린 input은 Drawer 내부의 가장 가까운 스크롤 영역만 이동한다", () => {
+    const { getByTestId } = render(<ScrollKeyboardHarness defaultOpen />);
     const drawer = getByTestId("drawer");
+    const scrollable = getByTestId("scrollable");
+    const input = getByTestId("scroll-input");
+    const drawerRectSpy = mockRect(drawer, 560);
 
-    drawer.style.bottom = "300px";
-
-    fireEvent.focusOut(getByTestId("input-a"));
-    fireEvent.focusOut(getByTestId("input-b"));
-    // 프레임 핸들을 담는 슬롯이 하나뿐이라, 새로 예약하기 전에 직전 프레임을 취소해야
-    // cleanup이 취소할 수 없는 고아 프레임이 남지 않는다
-    expect(pending.size).toBe(1);
-
-    act(() => {
-      getByTestId("next-snap").click();
+    Object.defineProperties(scrollable, {
+      clientHeight: { value: 300, configurable: true },
+      scrollHeight: { value: 1000, configurable: true },
     });
-    expect(pending.size).toBe(0);
+    const scrollTo = mock(() => {});
+    Object.defineProperty(scrollable, "scrollTo", { value: scrollTo, configurable: true });
 
-    drawer.style.bottom = "300px";
-    act(() => flushFrames());
+    const scrollableRectSpy = spyOn(scrollable, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      width: 320,
+      height: window.innerHeight,
+      top: 0,
+      left: 0,
+      right: 320,
+      bottom: window.innerHeight,
+      toJSON: () => {},
+    });
 
-    expect(drawer.style.bottom).toBe("300px");
+    visualViewport.height = window.innerHeight - 400;
+    const inputRectSpy = spyOn(input, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: visualViewport.height + 72,
+      width: 280,
+      height: 48,
+      top: visualViewport.height + 72,
+      left: 0,
+      right: 280,
+      bottom: visualViewport.height + 120,
+      toJSON: () => {},
+    });
+
+    input.focus();
+    visualViewport.dispatchEvent(new Event("resize"));
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 120, behavior: "smooth" });
+    expect(document.scrollingElement?.scrollTop ?? 0).toBe(0);
+
+    inputRectSpy.mockRestore();
+    scrollableRectSpy.mockRestore();
+    drawerRectSpy.mockRestore();
   });
 
-  it("iOS가 아니면 focusout 리스너를 등록하지 않는다", () => {
-    setPlatform("Linux armv8l");
-
-    const { getByTestId } = render(<KeyboardHarness defaultOpen snapPoints={["200px", "400px"]} />);
+  it("키보드 전환 양방향에서 높이와 위치를 하나의 WAAPI 타임라인으로 보간한다", async () => {
+    const { getByTestId } = render(<KeyboardHarness defaultOpen />);
     const drawer = getByTestId("drawer");
+    const input = getByTestId("input-a");
+    const layouts: Array<{
+      height: string;
+      minHeight: string;
+      bottom: string;
+      keyboardTransition: string;
+    }> = [];
+    const animation = {
+      cancel: mock(() => {}),
+      pause: mock(() => {}),
+      play: mock(() => {}),
+      currentTime: null,
+      finished: new Promise<void>(() => {}),
+    } as unknown as Animation;
+    const animate = mock(() => animation);
 
-    drawer.style.bottom = "300px";
-
-    fireEvent.focusOut(getByTestId("input-a"));
-    fireEvent.focusOut(getByTestId("input-b"));
-    expect(pending.size).toBe(0);
-
-    act(() => {
-      getByTestId("next-snap").click();
+    Object.defineProperty(drawer, "animate", {
+      value: animate,
+      configurable: true,
     });
-    drawer.style.bottom = "300px";
-    act(() => flushFrames());
 
-    expect(drawer.style.bottom).toBe("300px");
+    drawer.style.minHeight = "70vh";
+    drawer.style.bottom = "0px";
+    drawer.style.setProperty(
+      "--drawer-keyboard-transition",
+      "bottom 250ms cubic-bezier(0.32, 0.72, 0, 1)",
+    );
+    const rectSpy = spyOn(drawer, "getBoundingClientRect").mockImplementation(() => {
+      const height = Number.parseFloat(drawer.style.height) || 560;
+      const bottom = Number.parseFloat(drawer.style.bottom) || 0;
+
+      layouts.push({
+        height: drawer.style.height,
+        minHeight: drawer.style.minHeight,
+        bottom: drawer.style.bottom,
+        keyboardTransition: drawer.style.getPropertyValue("--drawer-keyboard-transition"),
+      });
+
+      return {
+        x: 0,
+        y: window.innerHeight - bottom - height,
+        width: 100,
+        height,
+        top: window.innerHeight - bottom - height,
+        left: 0,
+        right: 100,
+        bottom: window.innerHeight - bottom,
+        toJSON: () => {},
+      };
+    });
+
+    input.focus();
+    layouts.length = 0;
+    visualViewport.height = window.innerHeight - 400;
+    visualViewport.dispatchEvent(new Event("resize"));
+
+    expect(layouts).toContainEqual({
+      height: `${visualViewport.height - WINDOW_TOP_OFFSET}px`,
+      minHeight: `${visualViewport.height - WINDOW_TOP_OFFSET}px`,
+      bottom: "400px",
+      keyboardTransition: "bottom 0s",
+    });
+    expect(animate).toHaveBeenNthCalledWith(
+      1,
+      [
+        {
+          height: "560px",
+          minHeight: "560px",
+          bottom: "0px",
+        },
+        {
+          height: `${visualViewport.height - WINDOW_TOP_OFFSET}px`,
+          minHeight: `${visualViewport.height - WINDOW_TOP_OFFSET}px`,
+          bottom: "400px",
+        },
+      ],
+      {
+        duration: 250,
+        easing: "cubic-bezier(0.32, 0.72, 0, 1)",
+        fill: "both",
+      },
+    );
+    expect(animation.pause).toHaveBeenCalledTimes(1);
+    expect(animation.play).toHaveBeenCalledTimes(1);
+    expect(animation.currentTime).toBe(0);
+    expect(drawer.style.getPropertyValue("--drawer-keyboard-transition")).toBe(
+      "bottom 250ms cubic-bezier(0.32, 0.72, 0, 1)",
+    );
+
+    layouts.length = 0;
+    await act(async () => {
+      input.blur();
+      await Promise.resolve();
+    });
+
+    expect(layouts).toContainEqual({
+      height: "",
+      minHeight: "70vh",
+      bottom: "0px",
+      keyboardTransition: "bottom 0s",
+    });
+    expect(animation.cancel).toHaveBeenCalledTimes(1);
+    expect(animate).toHaveBeenNthCalledWith(
+      2,
+      [
+        {
+          height: `${window.innerHeight - 400 - WINDOW_TOP_OFFSET}px`,
+          minHeight: `${window.innerHeight - 400 - WINDOW_TOP_OFFSET}px`,
+          bottom: "400px",
+        },
+        {
+          height: "560px",
+          minHeight: "560px",
+          bottom: "0px",
+        },
+      ],
+      {
+        duration: 250,
+        easing: "cubic-bezier(0.32, 0.72, 0, 1)",
+        fill: "both",
+      },
+    );
+    expect(animation.pause).toHaveBeenCalledTimes(2);
+    expect(animation.play).toHaveBeenCalledTimes(2);
+    expect(drawer.style.getPropertyValue("--drawer-keyboard-transition")).toBe(
+      "bottom 250ms cubic-bezier(0.32, 0.72, 0, 1)",
+    );
+
+    visualViewport.height = window.innerHeight;
+    visualViewport.dispatchEvent(new Event("resize"));
+    expect(animate).toHaveBeenCalledTimes(2);
+
+    rectSpy.mockRestore();
   });
 });

--- a/packages/react-headless/drawer/src/useDrawer.test.tsx
+++ b/packages/react-headless/drawer/src/useDrawer.test.tsx
@@ -1135,6 +1135,25 @@ describe("키보드 리포지션", () => {
     removeEventListener.mockRestore();
   });
 
+  it("첫 번째 snap point에서도 키보드 오프셋을 반영한다", () => {
+    const { getByTestId } = render(
+      <KeyboardHarness defaultOpen snapPoints={["100px", "300px"]} />,
+    );
+    const drawer = getByTestId("drawer");
+    const input = getByTestId("input-a");
+    const rectSpy = mockRect(drawer, 560);
+    const keyboardInset = 400;
+    const firstSnapPointOffset = window.innerHeight - 100;
+
+    input.focus();
+    visualViewport.height = window.innerHeight - keyboardInset;
+    visualViewport.dispatchEvent(new Event("resize"));
+
+    expect(drawer.style.bottom).toBe(`${keyboardInset + firstSnapPointOffset}px`);
+
+    rectSpy.mockRestore();
+  });
+
   it("focusout에서 viewport 닫힘을 기다리지 않고 원래 CSS 높이를 복원한다", async () => {
     const { getByTestId } = render(<KeyboardHarness defaultOpen />);
     const drawer = getByTestId("drawer");

--- a/packages/react-headless/drawer/src/useDrawer.test.tsx
+++ b/packages/react-headless/drawer/src/useDrawer.test.tsx
@@ -409,6 +409,8 @@ describe("키보드 리포지션", () => {
   const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport");
   const originalPlatform = Object.getOwnPropertyDescriptor(window.navigator, "platform");
   const originalInnerHeight = Object.getOwnPropertyDescriptor(window, "innerHeight");
+  const originalCssSupports = Object.getOwnPropertyDescriptor(CSS, "supports");
+  const originalMatchMedia = Object.getOwnPropertyDescriptor(window, "matchMedia");
   const originalSafeAreaTop =
     document.documentElement.style.getPropertyValue("--seed-safe-area-top");
 
@@ -430,6 +432,23 @@ describe("키보드 리포지션", () => {
       value: "iPhone",
       configurable: true,
     });
+    Object.defineProperty(CSS, "supports", {
+      value: mock(() => true),
+      configurable: true,
+    });
+    Object.defineProperty(window, "matchMedia", {
+      value: mock(() => ({
+        matches: false,
+        media: "",
+        onchange: null,
+        addListener: mock(() => {}),
+        removeListener: mock(() => {}),
+        addEventListener: mock(() => {}),
+        removeEventListener: mock(() => {}),
+        dispatchEvent: mock(() => true),
+      })),
+      configurable: true,
+    });
   });
 
   afterEach(() => {
@@ -449,6 +468,18 @@ describe("키보드 리포지션", () => {
       Object.defineProperty(window, "innerHeight", originalInnerHeight);
     } else {
       Reflect.deleteProperty(window, "innerHeight");
+    }
+
+    if (originalCssSupports) {
+      Object.defineProperty(CSS, "supports", originalCssSupports);
+    } else {
+      Reflect.deleteProperty(CSS, "supports");
+    }
+
+    if (originalMatchMedia) {
+      Object.defineProperty(window, "matchMedia", originalMatchMedia);
+    } else {
+      Reflect.deleteProperty(window, "matchMedia");
     }
 
     if (originalSafeAreaTop) {
@@ -507,6 +538,60 @@ describe("키보드 리포지션", () => {
     rectSpy.mockRestore();
   });
 
+  it("autoFocus도 플랫폼 공통 translate FLIP 진입 애니메이션을 사용한다", () => {
+    const { getByTestId, rerender } = render(<AutoFocusKeyboardHarness open={false} />);
+    const drawer = getByTestId("drawer");
+    const animation = {
+      cancel: mock(() => {}),
+      pause: mock(() => {}),
+      play: mock(() => {}),
+      currentTime: null,
+      finished: new Promise<void>(() => {}),
+    } as unknown as Animation;
+    const animate = mock(() => animation);
+
+    Object.defineProperty(drawer, "animate", {
+      value: animate,
+      configurable: true,
+    });
+    const rectSpy = spyOn(drawer, "getBoundingClientRect").mockImplementation(() => {
+      const height = Number.parseFloat(drawer.style.height) || 560;
+      const bottom = Number.parseFloat(drawer.style.bottom) || 0;
+
+      return {
+        x: 0,
+        y: window.innerHeight - bottom - height,
+        width: 100,
+        height,
+        top: window.innerHeight - bottom - height,
+        left: 0,
+        right: 100,
+        bottom: window.innerHeight - bottom,
+        toJSON: () => {},
+      };
+    });
+
+    rerender(<AutoFocusKeyboardHarness open />);
+    expect(getByTestId("auto-focus-input")).toHaveFocus();
+
+    visualViewport.height = window.innerHeight - 400;
+    visualViewport.dispatchEvent(new Event("resize"));
+
+    expect(animate).toHaveBeenCalledWith(
+      [
+        { translate: `0px ${window.innerHeight - 560 - WINDOW_TOP_OFFSET}px` },
+        { translate: "0px 0px" },
+      ],
+      {
+        duration: TRANSITIONS.ENTER_DURATION * 1000,
+        easing: TRANSITIONS.CONTENT_ENTER_TIMING_FUNCTION,
+        fill: "both",
+      },
+    );
+
+    rectSpy.mockRestore();
+  });
+
   it("Android adjustResize가 layout viewport를 축소하면 시트를 다시 들어 올리지 않는다", () => {
     Object.defineProperty(window.navigator, "platform", {
       value: "Linux armv8l",
@@ -547,6 +632,15 @@ describe("키보드 리포지션", () => {
 
     act(() => {
       input.focus();
+    });
+
+    // Keep the keyboard-closed geometry through Android's synchronous adjustResize layout.
+    // The resize event below must animate from this fixed pixel size rather than a newly-shrunken
+    // viewport-unit size.
+    expect(drawer.style.height).toBe("560px");
+    expect(drawer.style.minHeight).toBe("560px");
+
+    act(() => {
       visualViewport.height = layoutViewportHeight - 400;
       Object.defineProperty(window, "innerHeight", {
         value: visualViewport.height,
@@ -559,6 +653,173 @@ describe("키보드 리포지션", () => {
     expect(drawer.style.height).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
     expect(drawer.style.minHeight).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
     expect(drawer.style.bottom).toBe("0px");
+
+    rectSpy.mockRestore();
+  });
+
+  it("Android 포커스 직후 키보드 resize 전에는 viewport 단위 높이를 복원하지 않는다", () => {
+    Object.defineProperty(window.navigator, "platform", {
+      value: "Linux armv8l",
+      configurable: true,
+    });
+
+    const { getByTestId } = render(<KeyboardHarness defaultOpen />);
+    const drawer = getByTestId("drawer");
+    const input = getByTestId("input-a");
+    const rectSpy = mockRect(drawer, 560);
+
+    drawer.style.minHeight = "70vh";
+    input.focus();
+
+    // Android에서는 focusin과 IME의 adjustResize 사이에 한 프레임이 있다. 이 시점의
+    // viewport 이벤트가 authored vh 값을 복원하면, 실제 resize에서 시트가 한 번 더
+    // 점프한다. 키보드가 실제로 viewport를 줄일 때까지 캡처한 px 높이를 유지해야 한다.
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(drawer.style.height).toBe("560px");
+    expect(drawer.style.minHeight).toBe("560px");
+
+    rectSpy.mockRestore();
+  });
+
+  it("Android가 window.resize를 visualViewport보다 먼저 보내도 축소된 높이를 유지한다", () => {
+    Object.defineProperty(window.navigator, "platform", {
+      value: "Linux armv8l",
+      configurable: true,
+    });
+
+    const { getByTestId } = render(<KeyboardHarness defaultOpen />);
+    const drawer = getByTestId("drawer");
+    const input = getByTestId("input-a");
+    const layoutViewportHeight = window.innerHeight;
+    const naturalHeight = 560;
+    const animation = {
+      cancel: mock(() => {}),
+      pause: mock(() => {}),
+      play: mock(() => {}),
+      currentTime: null,
+      finished: new Promise<void>(() => {}),
+    } as unknown as Animation;
+    const animate = mock(() => animation);
+
+    Object.defineProperty(drawer, "animate", {
+      value: animate,
+      configurable: true,
+    });
+    drawer.style.minHeight = "70vh";
+    drawer.style.bottom = "0px";
+    const rectSpy = spyOn(drawer, "getBoundingClientRect").mockImplementation(() => {
+      const height = Number.parseFloat(drawer.style.height) || naturalHeight;
+      const bottom = Number.parseFloat(drawer.style.bottom) || 0;
+
+      return {
+        x: 0,
+        y: window.innerHeight - bottom - height,
+        width: 100,
+        height,
+        top: window.innerHeight - bottom - height,
+        left: 0,
+        right: 100,
+        bottom: window.innerHeight - bottom,
+        toJSON: () => {},
+      };
+    });
+
+    const keyboardViewportHeight = layoutViewportHeight - 400;
+    act(() => {
+      input.focus();
+      Object.defineProperty(window, "innerHeight", {
+        value: keyboardViewportHeight,
+        configurable: true,
+      });
+
+      // `window.resize` arrives while VisualViewport still reports the keyboard-closed height.
+      // It must use the shrunken layout viewport rather than restoring the 70vh authored style.
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(drawer.style.height).toBe(`${keyboardViewportHeight - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.minHeight).toBe(`${keyboardViewportHeight - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.bottom).toBe("0px");
+
+    // Android's first adjustResize event already moved the fixed containing block before this
+    // handler runs. The real geometry is committed synchronously, then a compositor-only
+    // translate animates from the captured keyboard-closed screen position. The matching
+    // VisualViewport event must not introduce a second transition afterwards.
+    act(() => {
+      visualViewport.height = keyboardViewportHeight;
+      visualViewport.dispatchEvent(new Event("resize"));
+    });
+
+    expect(animate).toHaveBeenCalledTimes(1);
+    expect(animate).toHaveBeenCalledWith(
+      [
+        {
+          translate: `0px ${layoutViewportHeight - naturalHeight - WINDOW_TOP_OFFSET}px`,
+        },
+        { translate: "0px 0px" },
+      ],
+      {
+        duration: TRANSITIONS.ENTER_DURATION * 1000,
+        easing: TRANSITIONS.CONTENT_ENTER_TIMING_FUNCTION,
+        fill: "both",
+      },
+    );
+    expect(animation.pause).toHaveBeenCalledTimes(1);
+    expect(animation.play).toHaveBeenCalledTimes(1);
+    expect(animation.cancel).not.toHaveBeenCalled();
+
+    rectSpy.mockRestore();
+  });
+
+  it("Android pointerdown에서 focusin 이전의 시트 높이를 고정한다", () => {
+    Object.defineProperty(window.navigator, "platform", {
+      value: "Linux armv8l",
+      configurable: true,
+    });
+
+    let measuredDrawerHeight = 560;
+    const rectSpy = spyOn(window.HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function () {
+        const size = this.dataset.testid === "drawer" ? measuredDrawerHeight : 0;
+
+        return {
+          x: 0,
+          y: 0,
+          width: size,
+          height: size,
+          top: 0,
+          left: 0,
+          right: size,
+          bottom: size,
+          toJSON: () => {},
+        };
+      },
+    );
+
+    const { getByTestId } = render(<KeyboardHarness defaultOpen />);
+    const drawer = getByTestId("drawer");
+    const input = getByTestId("input-a");
+    const layoutViewportHeight = window.innerHeight;
+
+    fireEvent.pointerDown(input);
+
+    expect(drawer.style.height).toBe("560px");
+    expect(drawer.style.minHeight).toBe("560px");
+
+    // Simulate Android shrinking the layout viewport before its later focusin event.
+    measuredDrawerHeight = 220;
+    visualViewport.height = layoutViewportHeight - 400;
+    Object.defineProperty(window, "innerHeight", {
+      value: visualViewport.height,
+      configurable: true,
+    });
+    input.focus();
+
+    expect(drawer.style.height).toBe("560px");
+    expect(drawer.style.minHeight).toBe("560px");
 
     rectSpy.mockRestore();
   });
@@ -662,6 +923,12 @@ describe("키보드 리포지션", () => {
 
     act(() => {
       input.focus();
+    });
+
+    expect(drawer.style.height).toBe(`${naturalHeight}px`);
+    expect(drawer.style.minHeight).toBe(`${naturalHeight}px`);
+
+    act(() => {
       visualViewport.height = layoutViewportHeight - 400;
       Object.defineProperty(window, "innerHeight", {
         value: visualViewport.height,
@@ -978,6 +1245,122 @@ describe("키보드 리포지션", () => {
     rectSpy.mockRestore();
   });
 
+  it("translate 진입 애니메이션이 safe area를 침범하지 않고 overshoot easing을 제거한다", () => {
+    document.documentElement.style.setProperty("--seed-safe-area-top", "59px");
+
+    const { getByTestId } = render(<KeyboardHarness defaultOpen />);
+    const drawer = getByTestId("drawer");
+    const input = getByTestId("input-a");
+    const animation = {
+      cancel: mock(() => {}),
+      pause: mock(() => {}),
+      play: mock(() => {}),
+      currentTime: null,
+      finished: new Promise<void>(() => {}),
+    } as unknown as Animation;
+    const animate = mock(() => animation);
+
+    Object.defineProperty(drawer, "animate", {
+      value: animate,
+      configurable: true,
+    });
+    drawer.style.minHeight = "70vh";
+    drawer.style.bottom = "0px";
+    drawer.style.setProperty(
+      "--drawer-keyboard-transition",
+      "bottom 250ms cubic-bezier(0.2, 1.4, 0.2, 1)",
+    );
+    const rectSpy = spyOn(drawer, "getBoundingClientRect").mockImplementation(() => {
+      const height = Number.parseFloat(drawer.style.height) || 560;
+      const bottom = Number.parseFloat(drawer.style.bottom) || 0;
+
+      return {
+        x: 0,
+        y: window.innerHeight - bottom - height,
+        width: 100,
+        height,
+        top: window.innerHeight - bottom - height,
+        left: 0,
+        right: 100,
+        bottom: window.innerHeight - bottom,
+        toJSON: () => {},
+      };
+    });
+
+    input.focus();
+    visualViewport.height = window.innerHeight - 400;
+    visualViewport.dispatchEvent(new Event("resize"));
+
+    expect(drawer.getBoundingClientRect().top).toBe(59);
+    expect(animate).toHaveBeenCalledWith(
+      [{ translate: `0px ${window.innerHeight - 560 - 59}px` }, { translate: "0px 0px" }],
+      {
+        duration: 250,
+        easing: TRANSITIONS.CONTENT_ENTER_TIMING_FUNCTION,
+        fill: "both",
+      },
+    );
+
+    rectSpy.mockRestore();
+  });
+
+  it("reduced motion에서는 최종 키보드 geometry만 적용하고 translate를 생략한다", () => {
+    Object.defineProperty(window, "matchMedia", {
+      value: mock(() => ({
+        matches: true,
+        media: "(prefers-reduced-motion: reduce)",
+        onchange: null,
+        addListener: mock(() => {}),
+        removeListener: mock(() => {}),
+        addEventListener: mock(() => {}),
+        removeEventListener: mock(() => {}),
+        dispatchEvent: mock(() => true),
+      })),
+      configurable: true,
+    });
+
+    const { getByTestId } = render(<KeyboardHarness defaultOpen />);
+    const drawer = getByTestId("drawer");
+    const input = getByTestId("input-a");
+    const animate = mock(() => ({
+      cancel: mock(() => {}),
+      finished: Promise.resolve(),
+    }));
+
+    Object.defineProperty(drawer, "animate", {
+      value: animate,
+      configurable: true,
+    });
+    drawer.style.minHeight = "70vh";
+    drawer.style.bottom = "0px";
+    const rectSpy = spyOn(drawer, "getBoundingClientRect").mockImplementation(() => {
+      const height = Number.parseFloat(drawer.style.height) || 560;
+      const bottom = Number.parseFloat(drawer.style.bottom) || 0;
+
+      return {
+        x: 0,
+        y: window.innerHeight - bottom - height,
+        width: 100,
+        height,
+        top: window.innerHeight - bottom - height,
+        left: 0,
+        right: 100,
+        bottom: window.innerHeight - bottom,
+        toJSON: () => {},
+      };
+    });
+
+    input.focus();
+    visualViewport.height = window.innerHeight - 400;
+    visualViewport.dispatchEvent(new Event("resize"));
+
+    expect(drawer.style.height).toBe(`${visualViewport.height - WINDOW_TOP_OFFSET}px`);
+    expect(drawer.style.bottom).toBe("400px");
+    expect(animate).not.toHaveBeenCalled();
+
+    rectSpy.mockRestore();
+  });
+
   it("Drawer 내부의 다른 input으로 포커스가 이동하면 열린 키보드 위치를 유지한다", async () => {
     const { getByTestId } = render(<KeyboardHarness defaultOpen />);
     const drawer = getByTestId("drawer");
@@ -1045,6 +1428,8 @@ describe("키보드 리포지션", () => {
     visualViewport.dispatchEvent(new Event("resize"));
 
     expect(scrollTo).toHaveBeenCalledWith({ top: 120, behavior: "smooth" });
+    visualViewport.dispatchEvent(new Event("resize"));
+    expect(scrollTo).toHaveBeenCalledTimes(1);
     expect(document.scrollingElement?.scrollTop ?? 0).toBe(0);
 
     inputRectSpy.mockRestore();
@@ -1052,7 +1437,7 @@ describe("키보드 리포지션", () => {
     drawerRectSpy.mockRestore();
   });
 
-  it("키보드 전환 양방향에서 높이와 위치를 하나의 WAAPI 타임라인으로 보간한다", async () => {
+  it("키보드 진입은 translate FLIP, 복원은 geometry WAAPI로 보간한다", async () => {
     const { getByTestId } = render(<KeyboardHarness defaultOpen />);
     const drawer = getByTestId("drawer");
     const input = getByTestId("input-a");
@@ -1120,16 +1505,8 @@ describe("키보드 리포지션", () => {
     expect(animate).toHaveBeenNthCalledWith(
       1,
       [
-        {
-          height: "560px",
-          minHeight: "560px",
-          bottom: "0px",
-        },
-        {
-          height: `${visualViewport.height - WINDOW_TOP_OFFSET}px`,
-          minHeight: `${visualViewport.height - WINDOW_TOP_OFFSET}px`,
-          bottom: "400px",
-        },
+        { translate: `0px ${window.innerHeight - 560 - WINDOW_TOP_OFFSET}px` },
+        { translate: "0px 0px" },
       ],
       {
         duration: 250,
@@ -1186,6 +1563,63 @@ describe("키보드 리포지션", () => {
     visualViewport.height = window.innerHeight;
     visualViewport.dispatchEvent(new Event("resize"));
     expect(animate).toHaveBeenCalledTimes(2);
+
+    rectSpy.mockRestore();
+  });
+
+  it("키보드 전환 커스텀 속성이 없으면 기본 WAAPI 타이밍을 사용한다", () => {
+    const { getByTestId } = render(<KeyboardHarness defaultOpen />);
+    const drawer = getByTestId("drawer");
+    const input = getByTestId("input-a");
+    const animation = {
+      cancel: mock(() => {}),
+      pause: mock(() => {}),
+      play: mock(() => {}),
+      currentTime: null,
+      finished: new Promise<void>(() => {}),
+    } as unknown as Animation;
+    const animate = mock(() => animation);
+
+    Object.defineProperty(drawer, "animate", {
+      value: animate,
+      configurable: true,
+    });
+    drawer.style.minHeight = "70vh";
+    drawer.style.bottom = "0px";
+    const rectSpy = spyOn(drawer, "getBoundingClientRect").mockImplementation(() => {
+      const height = Number.parseFloat(drawer.style.height) || 560;
+      const bottom = Number.parseFloat(drawer.style.bottom) || 0;
+
+      return {
+        x: 0,
+        y: window.innerHeight - bottom - height,
+        width: 100,
+        height,
+        top: window.innerHeight - bottom - height,
+        left: 0,
+        right: 100,
+        bottom: window.innerHeight - bottom,
+        toJSON: () => {},
+      };
+    });
+
+    input.focus();
+    visualViewport.height = window.innerHeight - 400;
+    visualViewport.dispatchEvent(new Event("resize"));
+
+    expect(animate).toHaveBeenCalledWith(
+      [
+        { translate: `0px ${window.innerHeight - 560 - WINDOW_TOP_OFFSET}px` },
+        { translate: "0px 0px" },
+      ],
+      {
+        duration: TRANSITIONS.ENTER_DURATION * 1000,
+        easing: TRANSITIONS.CONTENT_ENTER_TIMING_FUNCTION,
+        fill: "both",
+      },
+    );
+    expect(animation.pause).toHaveBeenCalledTimes(1);
+    expect(animation.play).toHaveBeenCalledTimes(1);
 
     rectSpy.mockRestore();
   });

--- a/packages/react-headless/drawer/src/useDrawer.ts
+++ b/packages/react-headless/drawer/src/useDrawer.ts
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useSta
 import { isIOS } from "./browser";
 import {
   CLOSE_THRESHOLD,
+  DEFAULT_KEYBOARD_TRANSITION,
   DRAG_CLASS,
   KEYBOARD_TRANSITION,
   SCROLL_LOCK_TIMEOUT,
@@ -217,8 +218,25 @@ export function useDrawer(props: UseDrawerProps) {
     typeof window === "undefined" ? 0 : window.innerWidth,
   );
   const keyboardAnimation = useRef<Animation | null>(null);
+  const keyboardAnimationTarget = useRef<{
+    height: number;
+    minHeight: number;
+    bottom: number;
+  } | null>(null);
+  const keyboardEntryAnimation = useRef<Animation | null>(null);
+  const keyboardEntrySnapshot = useRef<{
+    top: number;
+    offsetTop: number;
+    target: Element | null;
+  } | null>(null);
+  const keyboardEntryConsumed = useRef(true);
   const keyboardDismissalPending = useRef(false);
   const keyboardDismissalGeometry = useRef<{ height: number; bottom: number } | null>(null);
+  // Android dispatches focusin before its IME has resized the layout viewport. Keep the
+  // keyboard-closed pixel geometry captured for that focus until the first actual keyboard
+  // resize; otherwise the focus RAF restores authored `vh` styles during the native gap.
+  const keyboardFocusPending = useRef(false);
+  const keyboardDebugSequence = useRef(0);
 
   const onSnapPointChange = useCallback(
     (activeSnapPointIndex: number) => {
@@ -256,6 +274,7 @@ export function useDrawer(props: UseDrawerProps) {
   // native autoFocus and the final visualViewport event can be missed.
   const keyboardSnapPointsOffset = snapPoints?.length ? snapPointsOffset : undefined;
   const keyboardActiveSnapPointIndex = snapPoints?.length ? activeSnapPointIndex : null;
+  const hasKeyboardEntryMotion = direction === "bottom" && !snapPoints?.length;
 
   function onPress(event: React.PointerEvent<HTMLDivElement>) {
     if (!dismissible && !snapPoints) return;
@@ -379,6 +398,10 @@ export function useDrawer(props: UseDrawerProps) {
       }
 
       if (!isAllowedToDrag.current && !shouldDrag(event.target, isDraggingInDirection)) return;
+      keyboardEntryAnimation.current?.cancel();
+      keyboardEntryAnimation.current = null;
+      keyboardEntrySnapshot.current = null;
+      keyboardEntryConsumed.current = true;
       drawerRef.current.classList.add(DRAG_CLASS);
 
       isAllowedToDrag.current = true;
@@ -443,6 +466,10 @@ export function useDrawer(props: UseDrawerProps) {
 
   const closeDrawer = useCallback(
     (fromWithin?: boolean, details?: DrawerChangeDetails) => {
+      keyboardEntryAnimation.current?.cancel();
+      keyboardEntryAnimation.current = null;
+      keyboardEntrySnapshot.current = null;
+      keyboardEntryConsumed.current = true;
       cancelDrag();
       onClose?.();
 
@@ -576,11 +603,104 @@ export function useDrawer(props: UseDrawerProps) {
     if (Number.isFinite(drawerHeight) && drawerHeight > 0) {
       drawerHeightRef.current = drawerHeight;
     }
-  }, [isOpen, repositionInputs]);
+
+    // Capture the keyboard-closed screen position during the opening commit as well. Native
+    // autoFocus can run before the passive focus listener below is attached, but the FLIP start
+    // position still has to describe the sheet the user actually saw before the keyboard resize.
+    if (hasKeyboardEntryMotion && !keyboardIsOpen.current) {
+      const activeElement = document.activeElement;
+      const focusedInput =
+        activeElement instanceof Element &&
+        isInput(activeElement) &&
+        drawerRef.current.contains(activeElement)
+          ? activeElement
+          : null;
+      const top = drawerRef.current.getBoundingClientRect().top;
+      if (Number.isFinite(top)) {
+        keyboardEntrySnapshot.current = {
+          top,
+          offsetTop: window.visualViewport?.offsetTop ?? 0,
+          target: focusedInput,
+        };
+        // Keep an unfocused opening snapshot provisional. A later pointer/focus event replaces it;
+        // the passive autofocus reconciliation below activates it only when native autofocus ran
+        // between commit and listener setup.
+        keyboardEntryConsumed.current = focusedInput === null;
+      }
+    }
+  }, [hasKeyboardEntryMotion, isOpen, repositionInputs]);
 
   useEffect(() => {
     let keyboardRepositionFrame: number | null = null;
     let keyboardRepositionTimeout: number | null = null;
+    let focusedInputScrollFrame: number | null = null;
+    let focusedInputScrollTarget: { element: HTMLElement; top: number } | null = null;
+
+    function logKeyboardDebug(phase: string, detail: Record<string, unknown> = {}) {
+      const debugWindow = window as typeof window & { __SEED_DRAWER_DEBUG__?: boolean };
+      const debugEnabled =
+        debugWindow.__SEED_DRAWER_DEBUG__ === true ||
+        new URLSearchParams(window.location.search).has("seedDrawerDebug");
+      if (!debugEnabled) return;
+
+      const visualViewport = window.visualViewport;
+      const drawer = drawerRef.current;
+      const rect = drawer?.getBoundingClientRect();
+      const styles = drawer ? getComputedStyle(drawer) : null;
+
+      // Keep this payload primitive-only so Android WebView's CDP console output is directly
+      // comparable across runs and does not depend on remote object expansion.
+      console.info(
+        "[seed-drawer-keyboard]",
+        JSON.stringify({
+          sequence: ++keyboardDebugSequence.current,
+          phase,
+          timestamp: Math.round(performance.now()),
+          platform: isIOS() ? "ios" : "android",
+          window: {
+            innerHeight: Math.round(window.innerHeight),
+            innerWidth: Math.round(window.innerWidth),
+          },
+          visualViewport: visualViewport
+            ? {
+                height: Math.round(visualViewport.height),
+                width: Math.round(visualViewport.width),
+                offsetTop: Math.round(visualViewport.offsetTop),
+                scale: visualViewport.scale,
+              }
+            : null,
+          baseline: {
+            height: Math.round(layoutViewportHeightBeforeKeyboard.current),
+            width: Math.round(layoutViewportWidthBeforeKeyboard.current),
+          },
+          drawer: rect
+            ? {
+                top: Math.round(rect.top),
+                bottom: Math.round(rect.bottom),
+                height: Math.round(rect.height),
+                inlineHeight: drawer?.style.height || "",
+                inlineMinHeight: drawer?.style.minHeight || "",
+                inlineBottom: drawer?.style.bottom || "",
+                computedBottom: styles?.bottom || "",
+              }
+            : null,
+          keyboard: {
+            isOpen: keyboardIsOpen.current,
+            dismissalPending: keyboardDismissalPending.current,
+            focusPending: keyboardFocusPending.current,
+            initialDrawerHeight: Math.round(initialDrawerHeight.current),
+            animationPlaying: keyboardAnimation.current?.playState === "running",
+            animationTarget: keyboardAnimationTarget.current,
+            entryAnimationPlaying: keyboardEntryAnimation.current?.playState === "running",
+            entrySnapshotTop: keyboardEntrySnapshot.current
+              ? Math.round(keyboardEntrySnapshot.current.top)
+              : null,
+            entryConsumed: keyboardEntryConsumed.current,
+          },
+          ...detail,
+        }),
+      );
+    }
 
     function updateLayoutViewportBaseline() {
       const widthChanged =
@@ -627,6 +747,10 @@ export function useDrawer(props: UseDrawerProps) {
       return Number.isFinite(safeAreaTop) ? Math.max(safeAreaTop, 0) : 0;
     }
 
+    function prefersReducedMotion() {
+      return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
+    }
+
     function getKeyboardClosedViewportMinHeight(drawer: HTMLDivElement) {
       const match = drawer.style.minHeight.trim().match(/^(-?\d*\.?\d+)(?:d|s|l)?vh$/i);
       if (!match) return 0;
@@ -657,8 +781,13 @@ export function useDrawer(props: UseDrawerProps) {
       const visualViewport = window.visualViewport;
       const scrollableRect = scrollable.getBoundingClientRect();
       const targetRect = focusedElement.getBoundingClientRect();
-      const viewportTop = visualViewport?.offsetTop ?? 0;
-      const viewportBottom = viewportTop + (visualViewport?.height ?? window.innerHeight);
+      // Android `adjustResize` can update the layout viewport one event before VisualViewport.
+      // The smaller layout viewport is the only visible area in that interval.
+      const viewportTop = isIOS() ? (visualViewport?.offsetTop ?? 0) : 0;
+      const viewportHeight = isIOS()
+        ? (visualViewport?.height ?? window.innerHeight)
+        : Math.min(visualViewport?.height ?? window.innerHeight, window.innerHeight);
+      const viewportBottom = viewportTop + viewportHeight;
       const visibleTop = Math.max(scrollableRect.top, viewportTop);
       const visibleBottom = Math.min(scrollableRect.bottom, viewportBottom);
 
@@ -673,22 +802,47 @@ export function useDrawer(props: UseDrawerProps) {
 
       if (Math.abs(adjustment) < 0.5) return;
 
-      scrollable.scrollTo({
-        top: Math.max(
-          0,
-          Math.min(
-            scrollable.scrollHeight - scrollable.clientHeight,
-            scrollable.scrollTop + adjustment,
-          ),
+      const top = Math.max(
+        0,
+        Math.min(
+          scrollable.scrollHeight - scrollable.clientHeight,
+          scrollable.scrollTop + adjustment,
         ),
-        behavior: "smooth",
+      );
+
+      // Keyboard animation emits several viewport events. Reissuing the same smooth scroll on
+      // every event restarts WebKit's scroll animation, which makes the sheet arrive first and
+      // the focused input follow noticeably later. Keep a single in-flight destination instead.
+      if (
+        focusedInputScrollTarget?.element === scrollable &&
+        Math.abs(focusedInputScrollTarget.top - top) < 0.5
+      ) {
+        return;
+      }
+
+      focusedInputScrollTarget = { element: scrollable, top };
+      scrollable.scrollTo({ top, behavior: prefersReducedMotion() ? "auto" : "smooth" });
+    }
+
+    function scheduleFocusedInputScroll() {
+      if (focusedInputScrollFrame !== null) return;
+
+      // A focus event is delivered before React commits focus-driven content such as an
+      // autocomplete list. The first frame handles already-mounted content; the second catches
+      // the React commit without waiting for the drawer animation to finish.
+      focusedInputScrollFrame = window.requestAnimationFrame(() => {
+        scrollFocusedInputIntoView();
+        focusedInputScrollFrame = window.requestAnimationFrame(() => {
+          focusedInputScrollFrame = null;
+          scrollFocusedInputIntoView();
+        });
       });
     }
 
     function getKeyboardAnimationOptions(drawer: HTMLDivElement): KeyframeAnimationOptions | null {
-      const transition = getComputedStyle(drawer)
-        .getPropertyValue("--drawer-keyboard-transition")
-        .trim();
+      const transition =
+        getComputedStyle(drawer).getPropertyValue("--drawer-keyboard-transition").trim() ||
+        DEFAULT_KEYBOARD_TRANSITION;
       const durationMatch = transition.match(/(?:^|\s)(\d*\.?\d+)(ms|s)(?=\s|$)/);
 
       if (!durationMatch) return null;
@@ -709,10 +863,169 @@ export function useDrawer(props: UseDrawerProps) {
       };
     }
 
+    function getNonOvershootingEasing(easing: string | undefined) {
+      if (!easing) return TRANSITIONS.CONTENT_ENTER_TIMING_FUNCTION;
+      if (/^(linear|ease|ease-in|ease-out|ease-in-out|steps\([^)]*\))$/.test(easing)) {
+        return easing;
+      }
+
+      const cubicBezier = easing.match(
+        /^cubic-bezier\(\s*[-+]?\d*\.?\d+\s*,\s*([-+]?\d*\.?\d+)\s*,\s*[-+]?\d*\.?\d+\s*,\s*([-+]?\d*\.?\d+)\s*\)$/,
+      );
+      if (!cubicBezier) return TRANSITIONS.CONTENT_ENTER_TIMING_FUNCTION;
+
+      const firstY = Number.parseFloat(cubicBezier[1]);
+      const secondY = Number.parseFloat(cubicBezier[2]);
+      return firstY >= 0 && firstY <= 1 && secondY >= 0 && secondY <= 1
+        ? easing
+        : TRANSITIONS.CONTENT_ENTER_TIMING_FUNCTION;
+    }
+
+    function cancelKeyboardEntryAnimation() {
+      keyboardEntryAnimation.current?.cancel();
+      keyboardEntryAnimation.current = null;
+    }
+
+    function captureKeyboardEntrySnapshot(target: Element | null) {
+      if (
+        !hasKeyboardEntryMotion ||
+        keyboardIsOpen.current ||
+        keyboardEntryConsumed.current === false
+      ) {
+        return;
+      }
+
+      const drawer = drawerRef.current;
+      if (!drawer) return;
+
+      const top = drawer.getBoundingClientRect().top;
+      if (!Number.isFinite(top)) return;
+
+      cancelKeyboardEntryAnimation();
+      keyboardEntrySnapshot.current = {
+        top,
+        offsetTop: window.visualViewport?.offsetTop ?? 0,
+        target,
+      };
+      keyboardEntryConsumed.current = false;
+      logKeyboardDebug("entry:capture", { top: Math.round(top) });
+    }
+
+    function animateKeyboardEntry(finalTopInset: number) {
+      if (keyboardEntryConsumed.current) return false;
+
+      const drawer = drawerRef.current;
+      const snapshot = keyboardEntrySnapshot.current;
+      keyboardEntryConsumed.current = true;
+      keyboardEntrySnapshot.current = null;
+
+      if (!drawer || !snapshot || !hasKeyboardEntryMotion) {
+        logKeyboardDebug("entry:skip", { reason: "missing-snapshot-or-unsupported-layout" });
+        return false;
+      }
+
+      const animationOptions = getKeyboardAnimationOptions(drawer);
+      const finalRect = drawer.getBoundingClientRect();
+      const currentOffsetTop = window.visualViewport?.offsetTop ?? 0;
+      const deltaY = snapshot.top + snapshot.offsetTop - (finalRect.top + currentOffsetTop);
+      const computedTranslate = getComputedStyle(drawer).translate;
+      const hasAuthoredTranslate =
+        computedTranslate !== undefined &&
+        computedTranslate !== "" &&
+        computedTranslate !== "none" &&
+        computedTranslate !== "0px" &&
+        computedTranslate !== "0px 0px" &&
+        computedTranslate !== "0px 0px 0px";
+      const supportsTranslate =
+        typeof CSS === "undefined" ||
+        typeof CSS.supports !== "function" ||
+        CSS.supports("translate", "0px 1px");
+
+      if (
+        prefersReducedMotion() ||
+        !animationOptions ||
+        typeof drawer.animate !== "function" ||
+        !supportsTranslate ||
+        hasAuthoredTranslate ||
+        !Number.isFinite(deltaY) ||
+        deltaY < 0.5 ||
+        snapshot.top < finalTopInset - 0.5 ||
+        finalRect.top < finalTopInset - 0.5
+      ) {
+        logKeyboardDebug("entry:skip", {
+          reason: prefersReducedMotion()
+            ? "reduced-motion"
+            : hasAuthoredTranslate
+              ? "authored-translate"
+              : !supportsTranslate
+                ? "unsupported-translate"
+                : "invalid-or-unsafe-geometry",
+          startTop: Math.round(snapshot.top),
+          finalTop: Math.round(finalRect.top),
+          finalTopInset: Math.round(finalTopInset),
+          startOffsetTop: Math.round(snapshot.offsetTop),
+          finalOffsetTop: Math.round(currentOffsetTop),
+          deltaY: Math.round(deltaY),
+        });
+        return false;
+      }
+
+      cancelKeyboardEntryAnimation();
+
+      try {
+        const options = {
+          ...animationOptions,
+          easing: getNonOvershootingEasing(animationOptions.easing),
+        };
+        const animation = drawer.animate(
+          [{ translate: `0px ${deltaY}px` }, { translate: "0px 0px" }],
+          options,
+        );
+
+        // The final layout is already committed. Sample the first compositor keyframe in this
+        // task so neither WebKit nor Android WebView can paint the final position before playback.
+        animation.pause();
+        animation.currentTime = 0;
+        drawer.getBoundingClientRect();
+
+        keyboardEntryAnimation.current = animation;
+        logKeyboardDebug("entry:animation-start", {
+          startTop: Math.round(snapshot.top),
+          finalTop: Math.round(finalRect.top),
+          startOffsetTop: Math.round(snapshot.offsetTop),
+          finalOffsetTop: Math.round(currentOffsetTop),
+          deltaY: Math.round(deltaY),
+          duration: options.duration,
+          easing: options.easing,
+        });
+        animation.play();
+        void animation.finished.then(
+          () => {
+            if (keyboardEntryAnimation.current === animation) {
+              logKeyboardDebug("entry:animation-finish", {
+                finalTop: Math.round(finalRect.top),
+              });
+              keyboardEntryAnimation.current = null;
+              animation.cancel();
+              focusedInputScrollTarget = null;
+              scheduleFocusedInputScroll();
+            }
+          },
+          () => {},
+        );
+        return true;
+      } catch {
+        keyboardEntryAnimation.current = null;
+        logKeyboardDebug("entry:skip", { reason: "animation-error" });
+        return false;
+      }
+    }
+
     function updateDrawerGeometry(
       updateSize: (drawer: HTMLDivElement) => void,
       bottom: number,
       previousGeometry?: { height: number; bottom: number } | null,
+      shouldAnimate = true,
     ) {
       const drawer = drawerRef.current;
       if (!drawer) return;
@@ -727,9 +1040,6 @@ export function useDrawer(props: UseDrawerProps) {
           ? computedBottom
           : Math.max(window.innerHeight - previousRect.bottom, 0);
 
-      keyboardAnimation.current?.cancel();
-      keyboardAnimation.current = null;
-
       const previousKeyboardTransition = drawer.style.getPropertyValue(
         "--drawer-keyboard-transition",
       );
@@ -740,17 +1050,72 @@ export function useDrawer(props: UseDrawerProps) {
       drawer.style.setProperty("--drawer-keyboard-transition", "bottom 0s");
       updateSize(drawer);
       drawer.style.bottom = `${bottom}px`;
-      const nextRect = drawer.getBoundingClientRect();
       const nextHeight = drawer.style.height;
       const nextMinHeight = drawer.style.minHeight;
       const nextBottom = drawer.style.bottom;
+      const currentTarget = keyboardAnimationTarget.current;
+
+      logKeyboardDebug("geometry:target-committed", {
+        requestedBottom: Math.round(bottom),
+        previousHeight: Math.round(previousRect.height),
+        previousBottom: Math.round(previousBottom),
+        nextInlineHeight: nextHeight,
+        nextInlineMinHeight: nextMinHeight,
+      });
+      const nextHeightValue = Number.parseFloat(nextHeight);
+      const nextMinHeightValue = Number.parseFloat(nextMinHeight);
+
+      // Native keyboards emit multiple resize events while a single animation is in progress.
+      // The underlying layout is already committed to the final target, so recreating WAAPI here
+      // would restart the animation from an intermediate paint on every event. This is especially
+      // expensive on Android where `window.resize` and `visualViewport.resize` can be staggered.
+      if (
+        keyboardAnimation.current &&
+        currentTarget &&
+        Number.isFinite(nextHeightValue) &&
+        Number.isFinite(nextMinHeightValue) &&
+        Math.abs(currentTarget.height - nextHeightValue) < 0.5 &&
+        Math.abs(currentTarget.minHeight - nextMinHeightValue) < 0.5 &&
+        Math.abs(currentTarget.bottom - bottom) < 0.5
+      ) {
+        logKeyboardDebug("geometry:reuse-animation", { requestedBottom: Math.round(bottom) });
+        if (previousKeyboardTransition) {
+          drawer.style.setProperty("--drawer-keyboard-transition", previousKeyboardTransition);
+        } else {
+          drawer.style.removeProperty("--drawer-keyboard-transition");
+        }
+        return;
+      }
+
+      keyboardAnimation.current?.cancel();
+      keyboardAnimation.current = null;
+      keyboardAnimationTarget.current = null;
+
+      // An active WAAPI animation can still affect getBoundingClientRect() even after the target
+      // styles have been written. Read the final layout only after canceling it; otherwise the
+      // next keyboard event uses an in-between height as its target and Android visibly takes two
+      // or three steps to settle.
+      const nextRect = drawer.getBoundingClientRect();
+      const nextTarget = {
+        height: nextRect.height,
+        minHeight: nextRect.height,
+        bottom,
+      };
 
       if (
+        !shouldAnimate ||
         !animationOptions ||
         typeof drawer.animate !== "function" ||
         (Math.abs(previousRect.height - nextRect.height) < 0.5 &&
           Math.abs(previousBottom - bottom) < 0.5)
       ) {
+        logKeyboardDebug("geometry:commit-without-animation", {
+          requestedBottom: Math.round(bottom),
+          nextHeight: Math.round(nextRect.height),
+          shouldAnimate,
+          hasAnimationOptions: Boolean(animationOptions),
+          supportsAnimate: typeof drawer.animate === "function",
+        });
         if (previousKeyboardTransition) {
           drawer.style.setProperty("--drawer-keyboard-transition", previousKeyboardTransition);
         } else {
@@ -804,13 +1169,26 @@ export function useDrawer(props: UseDrawerProps) {
       }
 
       keyboardAnimation.current = animation;
+      keyboardAnimationTarget.current = nextTarget;
+      logKeyboardDebug("geometry:animation-start", {
+        fromHeight: Math.round(previousRect.height),
+        fromBottom: Math.round(previousBottom),
+        toHeight: Math.round(nextRect.height),
+        toBottom: Math.round(bottom),
+        duration: animationOptions.duration,
+        easing: animationOptions.easing,
+      });
       animation.play();
       void animation.finished.then(
         () => {
           if (keyboardAnimation.current === animation) {
+            logKeyboardDebug("geometry:animation-finish", {
+              targetHeight: Math.round(nextTarget.height),
+              targetBottom: Math.round(nextTarget.bottom),
+            });
             keyboardAnimation.current = null;
+            keyboardAnimationTarget.current = null;
             animation.cancel();
-            scrollFocusedInputIntoView();
           }
         },
         () => {},
@@ -837,6 +1215,17 @@ export function useDrawer(props: UseDrawerProps) {
       drawerHeightBeforeKeyboard.current = drawer.style.height;
       drawerMinHeightBeforeKeyboard.current = drawer.style.minHeight;
       initialDrawerHeight.current = drawerHeight;
+
+      // Android's adjustResize can re-evaluate a `vh` min-height before the first viewport event
+      // reaches JavaScript. Freeze the keyboard-closed geometry while it is still visible so the
+      // subsequent WAAPI animation starts from the sheet the user saw, not from that transient,
+      // shrunken layout.
+      drawer.style.height = `${drawerHeight}px`;
+      drawer.style.minHeight = `${drawerHeight}px`;
+      logKeyboardDebug("geometry:capture-natural-height", {
+        capturedHeight: Math.round(drawerHeight),
+        minHeightFromViewport: Math.round(getKeyboardClosedViewportMinHeight(drawer)),
+      });
       return true;
     }
 
@@ -906,14 +1295,18 @@ export function useDrawer(props: UseDrawerProps) {
       if ((window.visualViewport?.scale ?? 1) > 1) return;
 
       const focusedElement = document.activeElement as HTMLElement;
-      const visualViewportHeight = window.visualViewport?.height || 0;
-      const visualViewportOffsetTop = window.visualViewport?.offsetTop || 0;
+      const reportedVisualViewportHeight = window.visualViewport?.height || window.innerHeight;
+      const visualViewportHeight = isIOS()
+        ? reportedVisualViewportHeight
+        : Math.min(reportedVisualViewportHeight, window.innerHeight);
+      const visualViewportOffsetTop = isIOS() ? window.visualViewport?.offsetTop || 0 : 0;
       // During a quick keyboard close-and-reopen Safari can temporarily shrink window.innerHeight
       // to the visual viewport as well. Comparing those two live values would then report no
       // keyboard even though it is visible. Keep the layout viewport measured while the drawer was
       // closed (or before focus) as the stable baseline for this keyboard session.
       const totalHeight = Math.max(layoutViewportHeightBeforeKeyboard.current, window.innerHeight);
       const viewportHeightReduction = totalHeight - visualViewportHeight;
+      const layoutViewportHeightReduction = totalHeight - window.innerHeight;
       let keyboardInset = viewportHeightReduction - visualViewportOffsetTop;
       // Android WebView's adjustResize has already shortened the fixed positioner's layout viewport
       // to the area above the keyboard. Applying the stable-baseline inset once more would lift the
@@ -929,7 +1322,28 @@ export function useDrawer(props: UseDrawerProps) {
       // produces a second height transition near the end of dismissal.
       const isKeyboardOpen =
         viewportHeightReduction > 60 ||
-        (!isIOS() && wasKeyboardOpen && viewportHeightReduction > 1);
+        (!isIOS() &&
+          (layoutViewportHeightReduction > 60 ||
+            (wasKeyboardOpen &&
+              (viewportHeightReduction > 1 || layoutViewportHeightReduction > 1))));
+
+      const hasFocusedDrawerInput =
+        focusedElement instanceof HTMLElement &&
+        isInput(focusedElement) &&
+        drawerRef.current.contains(focusedElement);
+
+      logKeyboardDebug("viewport:reconcile", {
+        reportedVisualViewportHeight: Math.round(reportedVisualViewportHeight),
+        visualViewportHeight: Math.round(visualViewportHeight),
+        visualViewportOffsetTop: Math.round(visualViewportOffsetTop),
+        totalHeight: Math.round(totalHeight),
+        viewportHeightReduction: Math.round(viewportHeightReduction),
+        layoutViewportHeightReduction: Math.round(layoutViewportHeightReduction),
+        keyboardInset: Math.round(keyboardInset),
+        drawerBottom: Math.round(drawerBottom),
+        wasKeyboardOpen,
+        nextKeyboardOpen: isKeyboardOpen,
+      });
 
       // focusout starts the downward animation before iOS reports the keyboard dismissal through
       // visualViewport. Ignore the stale keyboard-open resize/scroll events in between, otherwise
@@ -945,9 +1359,38 @@ export function useDrawer(props: UseDrawerProps) {
 
       keyboardIsOpen.current = isKeyboardOpen;
 
-      if (!isInput(focusedElement) && !wasKeyboardOpen && !isKeyboardOpen) return;
+      if (isKeyboardOpen) {
+        keyboardFocusPending.current = false;
+      }
+
+      // focusin is delivered before Android starts adjustResize. The focus RAF below therefore
+      // observes a keyboard-closed viewport first. That state must not restore the authored
+      // `vh` size: Android will otherwise shrink it once, then this hook re-applies the old pixel
+      // height after resize, creating a visible three-step jump. Wait for the real resize or blur.
+      if (!isIOS() && keyboardFocusPending.current && hasFocusedDrawerInput && !isKeyboardOpen) {
+        logKeyboardDebug("viewport:awaiting-android-keyboard");
+        return;
+      }
+
+      if (!hasFocusedDrawerInput && !wasKeyboardOpen && !isKeyboardOpen) return;
+
+      // Native autofocus can run before the browser reports the keyboard viewport. Keep the
+      // provisional FLIP snapshot alive through that gap; blur/close still clears it if no
+      // keyboard ever opens (for example when a hardware keyboard is connected).
+      if (
+        hasFocusedDrawerInput &&
+        !isKeyboardOpen &&
+        !keyboardEntryConsumed.current &&
+        keyboardEntrySnapshot.current
+      ) {
+        logKeyboardDebug("entry:awaiting-keyboard");
+        return;
+      }
 
       if (!isKeyboardOpen) {
+        cancelKeyboardEntryAnimation();
+        keyboardEntrySnapshot.current = null;
+        keyboardEntryConsumed.current = true;
         restoreDrawerHeight(keyboardDismissalGeometry.current);
         keyboardDismissalGeometry.current = null;
         return;
@@ -983,6 +1426,14 @@ export function useDrawer(props: UseDrawerProps) {
         ? Math.max(naturalHeight - Math.max(keyboardInset, 0), 0)
         : Math.min(naturalHeight, availableHeight);
 
+      logKeyboardDebug("viewport:target", {
+        naturalHeight: Math.round(naturalHeight),
+        visualViewportTopInset: Math.round(visualViewportTopInset),
+        availableHeight: Math.round(availableHeight),
+        targetHeight: Math.round(targetHeight),
+        targetBottom: Math.round(Math.max(drawerBottom, 0)),
+      });
+
       // iOS can pan the visual viewport to reveal the focused input. That pan already moves the
       // sheet up on screen, so only lift it by the keyboard-covered part that remains below the
       // visual viewport. Ignoring offsetTop applies both movements and hides the sheet header.
@@ -992,7 +1443,24 @@ export function useDrawer(props: UseDrawerProps) {
           drawer.style.minHeight = `${targetHeight}px`;
         },
         Math.max(drawerBottom, 0),
+        undefined,
+        // The first keyboard-open geometry is synchronous on every platform. Its visible motion
+        // is handled below by the same compositor-only FLIP translate, avoiding an Android-only
+        // branch and keeping the real layout inside the safe viewport throughout playback.
+        wasKeyboardOpen,
       );
+      if (!wasKeyboardOpen) {
+        // Measure the focused input against the committed final layout before the temporary
+        // translate starts affecting getBoundingClientRect(). A second pass runs when the FLIP
+        // finishes to catch focus-driven content that React commits during the animation.
+        scrollFocusedInputIntoView();
+        if (!animateKeyboardEntry(visualViewportTopInset)) {
+          scheduleFocusedInputScroll();
+        }
+      } else {
+        scrollFocusedInputIntoView();
+        scheduleFocusedInputScroll();
+      }
       if (!isIOS()) {
         // Android can dismiss the IME while leaving the input focused (for example via the system
         // keyboard-down button), so focusout is not guaranteed. Keep the last keyboard-open screen
@@ -1002,7 +1470,23 @@ export function useDrawer(props: UseDrawerProps) {
           bottom: currentLayoutViewportHeight - Math.max(drawerBottom, 0),
         };
       }
-      scrollFocusedInputIntoView();
+    }
+
+    function onInputPointerDown(event: PointerEvent) {
+      const target = event.target;
+      if (!repositionInputs || !isOpen || !(target instanceof Element) || !isInput(target)) {
+        return;
+      }
+      if (!drawerRef.current?.contains(target)) return;
+
+      // Android can apply `adjustResize` before it dispatches focusin. Capture the visible,
+      // keyboard-closed geometry during pointerdown so a viewport-unit min-height cannot collapse
+      // before the keyboard resize handler receives it.
+      updateLayoutViewportBaseline();
+      logKeyboardDebug("input:pointerdown");
+      captureKeyboardEntrySnapshot(target);
+      keyboardFocusPending.current = !isIOS();
+      captureDrawerHeight();
     }
 
     let focusOutSequence = 0;
@@ -1015,7 +1499,10 @@ export function useDrawer(props: UseDrawerProps) {
       focusOutSequence += 1;
       keyboardDismissalPending.current = false;
       keyboardDismissalGeometry.current = null;
+      keyboardFocusPending.current = !isIOS();
       updateLayoutViewportBaseline();
+      logKeyboardDebug("input:focusin");
+      captureKeyboardEntrySnapshot(target);
       if (!captureDrawerHeight()) scheduleKeyboardReposition();
 
       const visualViewportHeight = window.visualViewport?.height ?? window.innerHeight;
@@ -1023,6 +1510,7 @@ export function useDrawer(props: UseDrawerProps) {
         onVisualViewportChange();
       }
       scheduleKeyboardReposition();
+      scheduleFocusedInputScroll();
     }
 
     function onFocusOut(event: FocusEvent) {
@@ -1044,6 +1532,8 @@ export function useDrawer(props: UseDrawerProps) {
       // current task so input-to-input moves can be detected, but start the restore before the next
       // frame; visually this is immediate and does not wait for the delayed visualViewport resize.
       const sequence = ++focusOutSequence;
+      focusedInputScrollTarget = null;
+      logKeyboardDebug("input:focusout", { focusOutSequence: sequence });
       queueMicrotask(() => {
         if (sequence !== focusOutSequence) return;
 
@@ -1056,8 +1546,13 @@ export function useDrawer(props: UseDrawerProps) {
           return;
         }
 
+        keyboardFocusPending.current = false;
+        const drawerRect = drawerRef.current?.getBoundingClientRect();
+        cancelKeyboardEntryAnimation();
+        keyboardEntrySnapshot.current = null;
+        keyboardEntryConsumed.current = true;
+
         if (!isIOS()) {
-          const drawerRect = drawerRef.current?.getBoundingClientRect();
           if (drawerRect) {
             // Android expands the adjustResize containing block before visualViewport.resize.
             // Preserve the last keyboard-open screen coordinates so the first resize handler can
@@ -1072,7 +1567,9 @@ export function useDrawer(props: UseDrawerProps) {
         }
 
         keyboardDismissalPending.current = true;
-        restoreDrawerHeight();
+        restoreDrawerHeight(
+          drawerRect ? { height: drawerRect.height, bottom: drawerRect.bottom } : null,
+        );
       });
     }
 
@@ -1081,6 +1578,10 @@ export function useDrawer(props: UseDrawerProps) {
 
       keyboardAnimation.current?.cancel();
       keyboardAnimation.current = null;
+      keyboardAnimationTarget.current = null;
+      cancelKeyboardEntryAnimation();
+      keyboardEntrySnapshot.current = null;
+      keyboardEntryConsumed.current = true;
 
       if (drawer && drawerHeightBeforeKeyboard.current !== null) {
         drawer.style.height = drawerHeightBeforeKeyboard.current;
@@ -1096,26 +1597,40 @@ export function useDrawer(props: UseDrawerProps) {
       keyboardDismissalPending.current = false;
       keyboardDismissalGeometry.current = null;
       keyboardIsOpen.current = false;
+      keyboardFocusPending.current = false;
     }
 
     let lastViewportResizeSignature: string | null = null;
-    function onViewportResize() {
+    function onViewportResize(source: "window" | "visualViewport") {
       const visualViewport = window.visualViewport;
       const signature = `${window.innerHeight}:${visualViewport?.height ?? 0}:${visualViewport?.offsetTop ?? 0}`;
-      if (signature === lastViewportResizeSignature) return;
+      if (signature === lastViewportResizeSignature) {
+        logKeyboardDebug("viewport:resize-ignored", { source, signature });
+        return;
+      }
 
       lastViewportResizeSignature = signature;
+      logKeyboardDebug("viewport:resize", { source, signature });
       onVisualViewportChange();
+    }
+
+    function onWindowResize() {
+      onViewportResize("window");
+    }
+
+    function onVisualViewportResize() {
+      onViewportResize("visualViewport");
     }
 
     // Android dispatches window.resize before visualViewport.resize while adjustResize restores
     // the layout viewport. Handling the first event closes the one-frame gap where the sheet would
     // otherwise be laid out against the expanded viewport using its keyboard-open pixel height.
     if (!isIOS()) {
-      window.addEventListener("resize", onViewportResize);
+      window.addEventListener("resize", onWindowResize);
     }
-    window.visualViewport?.addEventListener("resize", onViewportResize);
+    window.visualViewport?.addEventListener("resize", onVisualViewportResize);
     window.visualViewport?.addEventListener("scroll", onVisualViewportChange);
+    document.addEventListener("pointerdown", onInputPointerDown, true);
     document.addEventListener("focusin", onFocusIn, true);
     document.addEventListener("focusout", onFocusOut, true);
 
@@ -1137,6 +1652,18 @@ export function useDrawer(props: UseDrawerProps) {
       // current viewport.
       focusOutSequence += 1;
       keyboardDismissalPending.current = false;
+      keyboardFocusPending.current = !isIOS();
+      if (
+        hasKeyboardEntryMotion &&
+        keyboardEntryConsumed.current &&
+        keyboardEntrySnapshot.current?.target === null
+      ) {
+        keyboardEntrySnapshot.current.target = focusedElement;
+        keyboardEntryConsumed.current = false;
+        logKeyboardDebug("entry:activate-autofocus", {
+          top: Math.round(keyboardEntrySnapshot.current.top),
+        });
+      }
       if (captureDrawerHeight()) onVisualViewportChange();
       else scheduleKeyboardReposition();
       scheduleKeyboardReposition();
@@ -1150,17 +1677,30 @@ export function useDrawer(props: UseDrawerProps) {
       if (keyboardRepositionTimeout !== null) {
         window.clearTimeout(keyboardRepositionTimeout);
       }
+      if (focusedInputScrollFrame !== null) {
+        window.cancelAnimationFrame(focusedInputScrollFrame);
+      }
       keyboardAnimation.current?.cancel();
       keyboardAnimation.current = null;
+      keyboardAnimationTarget.current = null;
+      cancelKeyboardEntryAnimation();
       if (!isIOS()) {
-        window.removeEventListener("resize", onViewportResize);
+        window.removeEventListener("resize", onWindowResize);
       }
-      window.visualViewport?.removeEventListener("resize", onViewportResize);
+      window.visualViewport?.removeEventListener("resize", onVisualViewportResize);
       window.visualViewport?.removeEventListener("scroll", onVisualViewportChange);
+      document.removeEventListener("pointerdown", onInputPointerDown, true);
       document.removeEventListener("focusin", onFocusIn, true);
       document.removeEventListener("focusout", onFocusOut, true);
     };
-  }, [keyboardActiveSnapPointIndex, keyboardSnapPointsOffset, repositionInputs, fixed, isOpen]);
+  }, [
+    keyboardActiveSnapPointIndex,
+    keyboardSnapPointsOffset,
+    repositionInputs,
+    fixed,
+    hasKeyboardEntryMotion,
+    isOpen,
+  ]);
 
   // Effect 1: Track drawer open state
   useEffect(() => {

--- a/packages/react-headless/drawer/src/useDrawer.ts
+++ b/packages/react-headless/drawer/src/useDrawer.ts
@@ -1,7 +1,7 @@
 import { useControllableState } from "@seed-design/react-use-controllable-state";
 import { buttonProps, dataAttr, elementProps } from "@seed-design/dom-utils";
 import type React from "react";
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { isIOS } from "./browser";
 import {
   CLOSE_THRESHOLD,
@@ -14,6 +14,8 @@ import {
 } from "./constants";
 import { dampenValue, getTranslate, isInput, isVertical, reset, set } from "./helpers";
 import { useSnapPoints } from "./use-snap-points";
+
+const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
 interface DrawerReasonToDetailMap {
   // we might add synthetic events later if needed; currently we aim consistency; DismissibleLayer gives us native events
@@ -216,6 +218,7 @@ export function useDrawer(props: UseDrawerProps) {
   );
   const keyboardAnimation = useRef<Animation | null>(null);
   const keyboardDismissalPending = useRef(false);
+  const keyboardDismissalGeometry = useRef<{ height: number; bottom: number } | null>(null);
 
   const onSnapPointChange = useCallback(
     (activeSnapPointIndex: number) => {
@@ -563,6 +566,18 @@ export function useDrawer(props: UseDrawerProps) {
     };
   }, [isOpen]);
 
+  useIsomorphicLayoutEffect(() => {
+    if (!isOpen || !repositionInputs || !drawerRef.current) return;
+
+    // Android WebView can apply adjustResize between native autoFocus and the passive keyboard
+    // effect below. Preserve the keyboard-closed geometry during the layout phase so viewport-unit
+    // minimum heights (for example 70vh) are not re-evaluated against the already-shrunken window.
+    const drawerHeight = drawerRef.current.getBoundingClientRect().height || 0;
+    if (Number.isFinite(drawerHeight) && drawerHeight > 0) {
+      drawerHeightRef.current = drawerHeight;
+    }
+  }, [isOpen, repositionInputs]);
+
   useEffect(() => {
     let keyboardRepositionFrame: number | null = null;
     let keyboardRepositionTimeout: number | null = null;
@@ -602,6 +617,29 @@ export function useDrawer(props: UseDrawerProps) {
       }
 
       return null;
+    }
+
+    function getSafeAreaTop() {
+      const safeAreaTop = Number.parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue("--seed-safe-area-top"),
+      );
+
+      return Number.isFinite(safeAreaTop) ? Math.max(safeAreaTop, 0) : 0;
+    }
+
+    function getKeyboardClosedViewportMinHeight(drawer: HTMLDivElement) {
+      const match = drawer.style.minHeight.trim().match(/^(-?\d*\.?\d+)(?:d|s|l)?vh$/i);
+      if (!match) return 0;
+
+      const percentage = Number.parseFloat(match[1]);
+      if (!Number.isFinite(percentage)) return 0;
+
+      const keyboardClosedViewportHeight = Math.max(
+        layoutViewportHeightBeforeKeyboard.current,
+        window.innerHeight,
+      );
+
+      return Math.max((keyboardClosedViewportHeight * percentage) / 100, 0);
     }
 
     function scrollFocusedInputIntoView() {
@@ -671,16 +709,23 @@ export function useDrawer(props: UseDrawerProps) {
       };
     }
 
-    function updateDrawerGeometry(updateSize: (drawer: HTMLDivElement) => void, bottom: number) {
+    function updateDrawerGeometry(
+      updateSize: (drawer: HTMLDivElement) => void,
+      bottom: number,
+      previousGeometry?: { height: number; bottom: number } | null,
+    ) {
       const drawer = drawerRef.current;
       if (!drawer) return;
 
       const animationOptions = getKeyboardAnimationOptions(drawer);
-      const previousRect = drawer.getBoundingClientRect();
+      const measuredPreviousRect = drawer.getBoundingClientRect();
+      const previousRect = previousGeometry ?? measuredPreviousRect;
       const computedBottom = Number.parseFloat(getComputedStyle(drawer).bottom);
-      const previousBottom = Number.isFinite(computedBottom)
-        ? computedBottom
-        : Math.max(window.innerHeight - previousRect.bottom, 0);
+      const previousBottom = previousGeometry
+        ? Math.max(window.innerHeight - previousGeometry.bottom, 0)
+        : Number.isFinite(computedBottom)
+          ? computedBottom
+          : Math.max(window.innerHeight - previousRect.bottom, 0);
 
       keyboardAnimation.current?.cancel();
       keyboardAnimation.current = null;
@@ -779,7 +824,14 @@ export function useDrawer(props: UseDrawerProps) {
         return initialDrawerHeight.current > 0;
       }
 
-      const drawerHeight = drawer.getBoundingClientRect().height || 0;
+      // Pointer-down and the opening layout effect both run before Android's adjustResize. The
+      // focus event itself may arrive afterwards, when a viewport-unit min-height has already
+      // collapsed, so keep the larger keyboard-closed measurement as the natural height.
+      const drawerHeight = Math.max(
+        drawer.getBoundingClientRect().height || 0,
+        drawerHeightRef.current,
+        getKeyboardClosedViewportMinHeight(drawer),
+      );
       if (!Number.isFinite(drawerHeight) || drawerHeight <= 0) return false;
 
       drawerHeightBeforeKeyboard.current = drawer.style.height;
@@ -788,13 +840,19 @@ export function useDrawer(props: UseDrawerProps) {
       return true;
     }
 
-    function restoreDrawerHeight() {
+    function restoreDrawerHeight(previousGeometry?: { height: number; bottom: number } | null) {
       if (!drawerRef.current || drawerHeightBeforeKeyboard.current === null) return;
 
-      updateDrawerGeometry((drawer) => {
-        drawer.style.height = drawerHeightBeforeKeyboard.current ?? "";
-        drawer.style.minHeight = drawerMinHeightBeforeKeyboard.current ?? "";
-      }, 0);
+      drawerHeightRef.current = initialDrawerHeight.current;
+
+      updateDrawerGeometry(
+        (drawer) => {
+          drawer.style.height = drawerHeightBeforeKeyboard.current ?? "";
+          drawer.style.minHeight = drawerMinHeightBeforeKeyboard.current ?? "";
+        },
+        0,
+        previousGeometry,
+      );
       drawerHeightBeforeKeyboard.current = null;
       drawerMinHeightBeforeKeyboard.current = null;
       initialDrawerHeight.current = 0;
@@ -857,8 +915,21 @@ export function useDrawer(props: UseDrawerProps) {
       const totalHeight = Math.max(layoutViewportHeightBeforeKeyboard.current, window.innerHeight);
       const viewportHeightReduction = totalHeight - visualViewportHeight;
       let keyboardInset = viewportHeightReduction - visualViewportOffsetTop;
+      // Android WebView's adjustResize has already shortened the fixed positioner's layout viewport
+      // to the area above the keyboard. Applying the stable-baseline inset once more would lift the
+      // sheet out of that smaller viewport. iOS can temporarily report the visual viewport through
+      // innerHeight without changing the fixed containing block, so keep its stable layout height.
+      const currentLayoutViewportHeight = isIOS() ? totalHeight : window.innerHeight;
+      let drawerBottom =
+        currentLayoutViewportHeight - (visualViewportOffsetTop + visualViewportHeight);
       const wasKeyboardOpen = keyboardIsOpen.current;
-      const isKeyboardOpen = viewportHeightReduction > 60;
+      // Android adjustResize can report the closing keyboard in several layout viewport steps.
+      // Once a keyboard session has started, keep it active until the viewport is fully restored;
+      // otherwise crossing the 60px opening threshold restores authored vh styles too early and
+      // produces a second height transition near the end of dismissal.
+      const isKeyboardOpen =
+        viewportHeightReduction > 60 ||
+        (!isIOS() && wasKeyboardOpen && viewportHeightReduction > 1);
 
       // focusout starts the downward animation before iOS reports the keyboard dismissal through
       // visualViewport. Ignore the stale keyboard-open resize/scroll events in between, otherwise
@@ -877,7 +948,8 @@ export function useDrawer(props: UseDrawerProps) {
       if (!isInput(focusedElement) && !wasKeyboardOpen && !isKeyboardOpen) return;
 
       if (!isKeyboardOpen) {
-        restoreDrawerHeight();
+        restoreDrawerHeight(keyboardDismissalGeometry.current);
+        keyboardDismissalGeometry.current = null;
         return;
       }
 
@@ -887,9 +959,9 @@ export function useDrawer(props: UseDrawerProps) {
       }
 
       if (keyboardSnapPointsOffset && keyboardActiveSnapPointIndex) {
-        const activeSnapPointHeight =
-          keyboardSnapPointsOffset[keyboardActiveSnapPointIndex] || 0;
+        const activeSnapPointHeight = keyboardSnapPointsOffset[keyboardActiveSnapPointIndex] || 0;
         keyboardInset += activeSnapPointHeight;
+        drawerBottom += activeSnapPointHeight;
       }
 
       // Derive the height from the natural height and the viewport alone. Measuring the drawer
@@ -899,9 +971,14 @@ export function useDrawer(props: UseDrawerProps) {
       // several resizes per keyboard animation, so that compounding inflated the sheet until it
       // filled the screen.
       const naturalHeight = initialDrawerHeight.current;
-      // Once lifted, the drawer's bottom edge rests on top of the keyboard, so this is all the
-      // room it has left.
-      const availableHeight = visualViewportHeight - WINDOW_TOP_OFFSET;
+      // Reserve the larger of the visual viewport margin and the app's top safe area. The latter is
+      // measured in layout-viewport coordinates, so subtract an iOS visual viewport pan that has
+      // already moved the visible top below it.
+      const visualViewportTopInset = Math.max(
+        WINDOW_TOP_OFFSET,
+        getSafeAreaTop() - visualViewportOffsetTop,
+      );
+      const availableHeight = Math.max(visualViewportHeight - visualViewportTopInset, 0);
       const targetHeight = fixed
         ? Math.max(naturalHeight - Math.max(keyboardInset, 0), 0)
         : Math.min(naturalHeight, availableHeight);
@@ -914,8 +991,17 @@ export function useDrawer(props: UseDrawerProps) {
           drawer.style.height = `${targetHeight}px`;
           drawer.style.minHeight = `${targetHeight}px`;
         },
-        Math.max(keyboardInset, 0),
+        Math.max(drawerBottom, 0),
       );
+      if (!isIOS()) {
+        // Android can dismiss the IME while leaving the input focused (for example via the system
+        // keyboard-down button), so focusout is not guaranteed. Keep the last keyboard-open screen
+        // geometry ready for the layout viewport's first expansion event as well.
+        keyboardDismissalGeometry.current = {
+          height: targetHeight,
+          bottom: currentLayoutViewportHeight - Math.max(drawerBottom, 0),
+        };
+      }
       scrollFocusedInputIntoView();
     }
 
@@ -928,6 +1014,7 @@ export function useDrawer(props: UseDrawerProps) {
 
       focusOutSequence += 1;
       keyboardDismissalPending.current = false;
+      keyboardDismissalGeometry.current = null;
       updateLayoutViewportBaseline();
       if (!captureDrawerHeight()) scheduleKeyboardReposition();
 
@@ -969,6 +1056,21 @@ export function useDrawer(props: UseDrawerProps) {
           return;
         }
 
+        if (!isIOS()) {
+          const drawerRect = drawerRef.current?.getBoundingClientRect();
+          if (drawerRect) {
+            // Android expands the adjustResize containing block before visualViewport.resize.
+            // Preserve the last keyboard-open screen coordinates so the first resize handler can
+            // build its WAAPI start keyframe from the visible sheet rather than the already-dropped
+            // layout position.
+            keyboardDismissalGeometry.current = {
+              height: drawerRect.height,
+              bottom: drawerRect.bottom,
+            };
+          }
+          return;
+        }
+
         keyboardDismissalPending.current = true;
         restoreDrawerHeight();
       });
@@ -989,17 +1091,33 @@ export function useDrawer(props: UseDrawerProps) {
       drawerHeightBeforeKeyboard.current = null;
       drawerMinHeightBeforeKeyboard.current = null;
       initialDrawerHeight.current = 0;
+      drawerHeightRef.current = 0;
       updateLayoutViewportBaseline();
       keyboardDismissalPending.current = false;
+      keyboardDismissalGeometry.current = null;
       keyboardIsOpen.current = false;
     }
 
-    window.visualViewport?.addEventListener("resize", onVisualViewportChange);
+    let lastViewportResizeSignature: string | null = null;
+    function onViewportResize() {
+      const visualViewport = window.visualViewport;
+      const signature = `${window.innerHeight}:${visualViewport?.height ?? 0}:${visualViewport?.offsetTop ?? 0}`;
+      if (signature === lastViewportResizeSignature) return;
+
+      lastViewportResizeSignature = signature;
+      onVisualViewportChange();
+    }
+
+    // Android dispatches window.resize before visualViewport.resize while adjustResize restores
+    // the layout viewport. Handling the first event closes the one-frame gap where the sheet would
+    // otherwise be laid out against the expanded viewport using its keyboard-open pixel height.
+    if (!isIOS()) {
+      window.addEventListener("resize", onViewportResize);
+    }
+    window.visualViewport?.addEventListener("resize", onViewportResize);
     window.visualViewport?.addEventListener("scroll", onVisualViewportChange);
     document.addEventListener("focusin", onFocusIn, true);
-    if (isIOS()) {
-      document.addEventListener("focusout", onFocusOut, true);
-    }
+    document.addEventListener("focusout", onFocusOut, true);
 
     // Native `autoFocus` runs during the commit that opens the drawer. The focus and the first
     // visualViewport resize can therefore both happen before this effect is re-attached for the
@@ -1034,12 +1152,13 @@ export function useDrawer(props: UseDrawerProps) {
       }
       keyboardAnimation.current?.cancel();
       keyboardAnimation.current = null;
-      window.visualViewport?.removeEventListener("resize", onVisualViewportChange);
+      if (!isIOS()) {
+        window.removeEventListener("resize", onViewportResize);
+      }
+      window.visualViewport?.removeEventListener("resize", onViewportResize);
       window.visualViewport?.removeEventListener("scroll", onVisualViewportChange);
       document.removeEventListener("focusin", onFocusIn, true);
-      if (isIOS()) {
-        document.removeEventListener("focusout", onFocusOut, true);
-      }
+      document.removeEventListener("focusout", onFocusOut, true);
     };
   }, [keyboardActiveSnapPointIndex, keyboardSnapPointsOffset, repositionInputs, fixed, isOpen]);
 

--- a/packages/react-headless/drawer/src/useDrawer.ts
+++ b/packages/react-headless/drawer/src/useDrawer.ts
@@ -236,7 +236,6 @@ export function useDrawer(props: UseDrawerProps) {
   // keyboard-closed pixel geometry captured for that focus until the first actual keyboard
   // resize; otherwise the focus RAF restores authored `vh` styles during the native gap.
   const keyboardFocusPending = useRef(false);
-  const keyboardDebugSequence = useRef(0);
 
   const onSnapPointChange = useCallback(
     (activeSnapPointIndex: number) => {
@@ -636,72 +635,6 @@ export function useDrawer(props: UseDrawerProps) {
     let focusedInputScrollFrame: number | null = null;
     let focusedInputScrollTarget: { element: HTMLElement; top: number } | null = null;
 
-    function logKeyboardDebug(phase: string, detail: Record<string, unknown> = {}) {
-      const debugWindow = window as typeof window & { __SEED_DRAWER_DEBUG__?: boolean };
-      const debugEnabled =
-        debugWindow.__SEED_DRAWER_DEBUG__ === true ||
-        new URLSearchParams(window.location.search).has("seedDrawerDebug");
-      if (!debugEnabled) return;
-
-      const visualViewport = window.visualViewport;
-      const drawer = drawerRef.current;
-      const rect = drawer?.getBoundingClientRect();
-      const styles = drawer ? getComputedStyle(drawer) : null;
-
-      // Keep this payload primitive-only so Android WebView's CDP console output is directly
-      // comparable across runs and does not depend on remote object expansion.
-      console.info(
-        "[seed-drawer-keyboard]",
-        JSON.stringify({
-          sequence: ++keyboardDebugSequence.current,
-          phase,
-          timestamp: Math.round(performance.now()),
-          platform: isIOS() ? "ios" : "android",
-          window: {
-            innerHeight: Math.round(window.innerHeight),
-            innerWidth: Math.round(window.innerWidth),
-          },
-          visualViewport: visualViewport
-            ? {
-                height: Math.round(visualViewport.height),
-                width: Math.round(visualViewport.width),
-                offsetTop: Math.round(visualViewport.offsetTop),
-                scale: visualViewport.scale,
-              }
-            : null,
-          baseline: {
-            height: Math.round(layoutViewportHeightBeforeKeyboard.current),
-            width: Math.round(layoutViewportWidthBeforeKeyboard.current),
-          },
-          drawer: rect
-            ? {
-                top: Math.round(rect.top),
-                bottom: Math.round(rect.bottom),
-                height: Math.round(rect.height),
-                inlineHeight: drawer?.style.height || "",
-                inlineMinHeight: drawer?.style.minHeight || "",
-                inlineBottom: drawer?.style.bottom || "",
-                computedBottom: styles?.bottom || "",
-              }
-            : null,
-          keyboard: {
-            isOpen: keyboardIsOpen.current,
-            dismissalPending: keyboardDismissalPending.current,
-            focusPending: keyboardFocusPending.current,
-            initialDrawerHeight: Math.round(initialDrawerHeight.current),
-            animationPlaying: keyboardAnimation.current?.playState === "running",
-            animationTarget: keyboardAnimationTarget.current,
-            entryAnimationPlaying: keyboardEntryAnimation.current?.playState === "running",
-            entrySnapshotTop: keyboardEntrySnapshot.current
-              ? Math.round(keyboardEntrySnapshot.current.top)
-              : null,
-            entryConsumed: keyboardEntryConsumed.current,
-          },
-          ...detail,
-        }),
-      );
-    }
-
     function updateLayoutViewportBaseline() {
       const widthChanged =
         Math.abs(layoutViewportWidthBeforeKeyboard.current - window.innerWidth) > 1;
@@ -908,7 +841,6 @@ export function useDrawer(props: UseDrawerProps) {
         target,
       };
       keyboardEntryConsumed.current = false;
-      logKeyboardDebug("entry:capture", { top: Math.round(top) });
     }
 
     function animateKeyboardEntry(finalTopInset: number) {
@@ -920,7 +852,6 @@ export function useDrawer(props: UseDrawerProps) {
       keyboardEntrySnapshot.current = null;
 
       if (!drawer || !snapshot || !hasKeyboardEntryMotion) {
-        logKeyboardDebug("entry:skip", { reason: "missing-snapshot-or-unsupported-layout" });
         return false;
       }
 
@@ -952,21 +883,6 @@ export function useDrawer(props: UseDrawerProps) {
         snapshot.top < finalTopInset - 0.5 ||
         finalRect.top < finalTopInset - 0.5
       ) {
-        logKeyboardDebug("entry:skip", {
-          reason: prefersReducedMotion()
-            ? "reduced-motion"
-            : hasAuthoredTranslate
-              ? "authored-translate"
-              : !supportsTranslate
-                ? "unsupported-translate"
-                : "invalid-or-unsafe-geometry",
-          startTop: Math.round(snapshot.top),
-          finalTop: Math.round(finalRect.top),
-          finalTopInset: Math.round(finalTopInset),
-          startOffsetTop: Math.round(snapshot.offsetTop),
-          finalOffsetTop: Math.round(currentOffsetTop),
-          deltaY: Math.round(deltaY),
-        });
         return false;
       }
 
@@ -989,22 +905,10 @@ export function useDrawer(props: UseDrawerProps) {
         drawer.getBoundingClientRect();
 
         keyboardEntryAnimation.current = animation;
-        logKeyboardDebug("entry:animation-start", {
-          startTop: Math.round(snapshot.top),
-          finalTop: Math.round(finalRect.top),
-          startOffsetTop: Math.round(snapshot.offsetTop),
-          finalOffsetTop: Math.round(currentOffsetTop),
-          deltaY: Math.round(deltaY),
-          duration: options.duration,
-          easing: options.easing,
-        });
         animation.play();
         void animation.finished.then(
           () => {
             if (keyboardEntryAnimation.current === animation) {
-              logKeyboardDebug("entry:animation-finish", {
-                finalTop: Math.round(finalRect.top),
-              });
               keyboardEntryAnimation.current = null;
               animation.cancel();
               focusedInputScrollTarget = null;
@@ -1016,7 +920,6 @@ export function useDrawer(props: UseDrawerProps) {
         return true;
       } catch {
         keyboardEntryAnimation.current = null;
-        logKeyboardDebug("entry:skip", { reason: "animation-error" });
         return false;
       }
     }
@@ -1055,13 +958,6 @@ export function useDrawer(props: UseDrawerProps) {
       const nextBottom = drawer.style.bottom;
       const currentTarget = keyboardAnimationTarget.current;
 
-      logKeyboardDebug("geometry:target-committed", {
-        requestedBottom: Math.round(bottom),
-        previousHeight: Math.round(previousRect.height),
-        previousBottom: Math.round(previousBottom),
-        nextInlineHeight: nextHeight,
-        nextInlineMinHeight: nextMinHeight,
-      });
       const nextHeightValue = Number.parseFloat(nextHeight);
       const nextMinHeightValue = Number.parseFloat(nextMinHeight);
 
@@ -1078,7 +974,6 @@ export function useDrawer(props: UseDrawerProps) {
         Math.abs(currentTarget.minHeight - nextMinHeightValue) < 0.5 &&
         Math.abs(currentTarget.bottom - bottom) < 0.5
       ) {
-        logKeyboardDebug("geometry:reuse-animation", { requestedBottom: Math.round(bottom) });
         if (previousKeyboardTransition) {
           drawer.style.setProperty("--drawer-keyboard-transition", previousKeyboardTransition);
         } else {
@@ -1109,13 +1004,6 @@ export function useDrawer(props: UseDrawerProps) {
         (Math.abs(previousRect.height - nextRect.height) < 0.5 &&
           Math.abs(previousBottom - bottom) < 0.5)
       ) {
-        logKeyboardDebug("geometry:commit-without-animation", {
-          requestedBottom: Math.round(bottom),
-          nextHeight: Math.round(nextRect.height),
-          shouldAnimate,
-          hasAnimationOptions: Boolean(animationOptions),
-          supportsAnimate: typeof drawer.animate === "function",
-        });
         if (previousKeyboardTransition) {
           drawer.style.setProperty("--drawer-keyboard-transition", previousKeyboardTransition);
         } else {
@@ -1170,22 +1058,10 @@ export function useDrawer(props: UseDrawerProps) {
 
       keyboardAnimation.current = animation;
       keyboardAnimationTarget.current = nextTarget;
-      logKeyboardDebug("geometry:animation-start", {
-        fromHeight: Math.round(previousRect.height),
-        fromBottom: Math.round(previousBottom),
-        toHeight: Math.round(nextRect.height),
-        toBottom: Math.round(bottom),
-        duration: animationOptions.duration,
-        easing: animationOptions.easing,
-      });
       animation.play();
       void animation.finished.then(
         () => {
           if (keyboardAnimation.current === animation) {
-            logKeyboardDebug("geometry:animation-finish", {
-              targetHeight: Math.round(nextTarget.height),
-              targetBottom: Math.round(nextTarget.bottom),
-            });
             keyboardAnimation.current = null;
             keyboardAnimationTarget.current = null;
             animation.cancel();
@@ -1222,10 +1098,6 @@ export function useDrawer(props: UseDrawerProps) {
       // shrunken layout.
       drawer.style.height = `${drawerHeight}px`;
       drawer.style.minHeight = `${drawerHeight}px`;
-      logKeyboardDebug("geometry:capture-natural-height", {
-        capturedHeight: Math.round(drawerHeight),
-        minHeightFromViewport: Math.round(getKeyboardClosedViewportMinHeight(drawer)),
-      });
       return true;
     }
 
@@ -1332,19 +1204,6 @@ export function useDrawer(props: UseDrawerProps) {
         isInput(focusedElement) &&
         drawerRef.current.contains(focusedElement);
 
-      logKeyboardDebug("viewport:reconcile", {
-        reportedVisualViewportHeight: Math.round(reportedVisualViewportHeight),
-        visualViewportHeight: Math.round(visualViewportHeight),
-        visualViewportOffsetTop: Math.round(visualViewportOffsetTop),
-        totalHeight: Math.round(totalHeight),
-        viewportHeightReduction: Math.round(viewportHeightReduction),
-        layoutViewportHeightReduction: Math.round(layoutViewportHeightReduction),
-        keyboardInset: Math.round(keyboardInset),
-        drawerBottom: Math.round(drawerBottom),
-        wasKeyboardOpen,
-        nextKeyboardOpen: isKeyboardOpen,
-      });
-
       // focusout starts the downward animation before iOS reports the keyboard dismissal through
       // visualViewport. Ignore the stale keyboard-open resize/scroll events in between, otherwise
       // they cancel that animation and lift the sheet again. A new input focus cancels this guard.
@@ -1368,7 +1227,6 @@ export function useDrawer(props: UseDrawerProps) {
       // `vh` size: Android will otherwise shrink it once, then this hook re-applies the old pixel
       // height after resize, creating a visible three-step jump. Wait for the real resize or blur.
       if (!isIOS() && keyboardFocusPending.current && hasFocusedDrawerInput && !isKeyboardOpen) {
-        logKeyboardDebug("viewport:awaiting-android-keyboard");
         return;
       }
 
@@ -1383,7 +1241,6 @@ export function useDrawer(props: UseDrawerProps) {
         !keyboardEntryConsumed.current &&
         keyboardEntrySnapshot.current
       ) {
-        logKeyboardDebug("entry:awaiting-keyboard");
         return;
       }
 
@@ -1425,14 +1282,6 @@ export function useDrawer(props: UseDrawerProps) {
       const targetHeight = fixed
         ? Math.max(naturalHeight - Math.max(keyboardInset, 0), 0)
         : Math.min(naturalHeight, availableHeight);
-
-      logKeyboardDebug("viewport:target", {
-        naturalHeight: Math.round(naturalHeight),
-        visualViewportTopInset: Math.round(visualViewportTopInset),
-        availableHeight: Math.round(availableHeight),
-        targetHeight: Math.round(targetHeight),
-        targetBottom: Math.round(Math.max(drawerBottom, 0)),
-      });
 
       // iOS can pan the visual viewport to reveal the focused input. That pan already moves the
       // sheet up on screen, so only lift it by the keyboard-covered part that remains below the
@@ -1483,7 +1332,6 @@ export function useDrawer(props: UseDrawerProps) {
       // keyboard-closed geometry during pointerdown so a viewport-unit min-height cannot collapse
       // before the keyboard resize handler receives it.
       updateLayoutViewportBaseline();
-      logKeyboardDebug("input:pointerdown");
       captureKeyboardEntrySnapshot(target);
       keyboardFocusPending.current = !isIOS();
       captureDrawerHeight();
@@ -1501,7 +1349,6 @@ export function useDrawer(props: UseDrawerProps) {
       keyboardDismissalGeometry.current = null;
       keyboardFocusPending.current = !isIOS();
       updateLayoutViewportBaseline();
-      logKeyboardDebug("input:focusin");
       captureKeyboardEntrySnapshot(target);
       if (!captureDrawerHeight()) scheduleKeyboardReposition();
 
@@ -1533,7 +1380,6 @@ export function useDrawer(props: UseDrawerProps) {
       // frame; visually this is immediate and does not wait for the delayed visualViewport resize.
       const sequence = ++focusOutSequence;
       focusedInputScrollTarget = null;
-      logKeyboardDebug("input:focusout", { focusOutSequence: sequence });
       queueMicrotask(() => {
         if (sequence !== focusOutSequence) return;
 
@@ -1601,26 +1447,24 @@ export function useDrawer(props: UseDrawerProps) {
     }
 
     let lastViewportResizeSignature: string | null = null;
-    function onViewportResize(source: "window" | "visualViewport") {
+      function onViewportResize() {
       const visualViewport = window.visualViewport;
       const signature = `${window.innerHeight}:${visualViewport?.height ?? 0}:${visualViewport?.offsetTop ?? 0}`;
       if (signature === lastViewportResizeSignature) {
-        logKeyboardDebug("viewport:resize-ignored", { source, signature });
         return;
       }
 
       lastViewportResizeSignature = signature;
-      logKeyboardDebug("viewport:resize", { source, signature });
       onVisualViewportChange();
     }
 
-    function onWindowResize() {
-      onViewportResize("window");
-    }
+      function onWindowResize() {
+        onViewportResize();
+      }
 
-    function onVisualViewportResize() {
-      onViewportResize("visualViewport");
-    }
+      function onVisualViewportResize() {
+        onViewportResize();
+      }
 
     // Android dispatches window.resize before visualViewport.resize while adjustResize restores
     // the layout viewport. Handling the first event closes the one-frame gap where the sheet would
@@ -1660,9 +1504,6 @@ export function useDrawer(props: UseDrawerProps) {
       ) {
         keyboardEntrySnapshot.current.target = focusedElement;
         keyboardEntryConsumed.current = false;
-        logKeyboardDebug("entry:activate-autofocus", {
-          top: Math.round(keyboardEntrySnapshot.current.top),
-        });
       }
       if (captureDrawerHeight()) onVisualViewportChange();
       else scheduleKeyboardReposition();

--- a/packages/react-headless/drawer/src/useDrawer.ts
+++ b/packages/react-headless/drawer/src/useDrawer.ts
@@ -208,6 +208,14 @@ export function useDrawer(props: UseDrawerProps) {
   const initialDrawerHeight = useRef(0);
   const drawerHeightBeforeKeyboard = useRef<string | null>(null);
   const drawerMinHeightBeforeKeyboard = useRef<string | null>(null);
+  const layoutViewportHeightBeforeKeyboard = useRef(
+    typeof window === "undefined" ? 0 : window.innerHeight,
+  );
+  const layoutViewportWidthBeforeKeyboard = useRef(
+    typeof window === "undefined" ? 0 : window.innerWidth,
+  );
+  const keyboardAnimation = useRef<Animation | null>(null);
+  const keyboardDismissalPending = useRef(false);
 
   const onSnapPointChange = useCallback(
     (activeSnapPointIndex: number) => {
@@ -238,6 +246,13 @@ export function useDrawer(props: UseDrawerProps) {
     direction,
     snapToSequentialPoint,
   });
+
+  // useSnapPoints tracks window dimensions and consequently creates a new empty offsets array on
+  // every keyboard-driven window resize. A drawer without snap points must not restart the
+  // keyboard effect for that irrelevant array change: doing so creates a listener gap where both
+  // native autoFocus and the final visualViewport event can be missed.
+  const keyboardSnapPointsOffset = snapPoints?.length ? snapPointsOffset : undefined;
+  const keyboardActiveSnapPointIndex = snapPoints?.length ? activeSnapPointIndex : null;
 
   function onPress(event: React.PointerEvent<HTMLDivElement>) {
     if (!dismissible && !snapPoints) return;
@@ -549,26 +564,284 @@ export function useDrawer(props: UseDrawerProps) {
   }, [isOpen]);
 
   useEffect(() => {
-    function captureDrawerHeight() {
-      if (!drawerRef.current || drawerHeightBeforeKeyboard.current !== null) return;
+    let keyboardRepositionFrame: number | null = null;
+    let keyboardRepositionTimeout: number | null = null;
 
-      drawerHeightBeforeKeyboard.current = drawerRef.current.style.height;
-      drawerMinHeightBeforeKeyboard.current = drawerRef.current.style.minHeight;
-      initialDrawerHeight.current = drawerRef.current.getBoundingClientRect().height || 0;
+    function updateLayoutViewportBaseline() {
+      const widthChanged =
+        Math.abs(layoutViewportWidthBeforeKeyboard.current - window.innerWidth) > 1;
+
+      if (widthChanged) {
+        // A real viewport-width change (for example device rotation) starts a new baseline. During
+        // ordinary keyboard transitions iOS can shrink innerHeight while width stays unchanged, so
+        // never let that transient height replace the larger keyboard-closed measurement.
+        layoutViewportWidthBeforeKeyboard.current = window.innerWidth;
+        layoutViewportHeightBeforeKeyboard.current = window.innerHeight;
+        return;
+      }
+
+      layoutViewportHeightBeforeKeyboard.current = Math.max(
+        layoutViewportHeightBeforeKeyboard.current,
+        window.innerHeight,
+      );
+    }
+
+    function getScrollableAncestor(target: Element): HTMLElement | null {
+      const drawer = drawerRef.current;
+      let ancestor = target.parentElement;
+
+      while (ancestor && ancestor !== drawer) {
+        const style = getComputedStyle(ancestor);
+        const scrollsVertically = /(auto|scroll)/.test(`${style.overflow} ${style.overflowY}`);
+
+        if (scrollsVertically && ancestor.scrollHeight > ancestor.clientHeight) {
+          return ancestor;
+        }
+
+        ancestor = ancestor.parentElement;
+      }
+
+      return null;
+    }
+
+    function scrollFocusedInputIntoView() {
+      const drawer = drawerRef.current;
+      const focusedElement = document.activeElement;
+      if (!drawer || !(focusedElement instanceof HTMLElement) || !isInput(focusedElement)) return;
+      if (!drawer.contains(focusedElement)) return;
+
+      // `scrollIntoView({ container: "nearest" })` would express this directly, but Safari does
+      // not support the container option yet. Moving only the closest overflowing ancestor keeps
+      // iOS from scrolling the page or the drawer itself while the keyboard changes the viewport.
+      const scrollable = getScrollableAncestor(focusedElement);
+      if (!scrollable) return;
+
+      const visualViewport = window.visualViewport;
+      const scrollableRect = scrollable.getBoundingClientRect();
+      const targetRect = focusedElement.getBoundingClientRect();
+      const viewportTop = visualViewport?.offsetTop ?? 0;
+      const viewportBottom = viewportTop + (visualViewport?.height ?? window.innerHeight);
+      const visibleTop = Math.max(scrollableRect.top, viewportTop);
+      const visibleBottom = Math.min(scrollableRect.bottom, viewportBottom);
+
+      if (visibleBottom <= visibleTop) return;
+
+      let adjustment = 0;
+      if (targetRect.top < visibleTop) {
+        adjustment = targetRect.top - visibleTop;
+      } else if (targetRect.bottom > visibleBottom) {
+        adjustment = targetRect.bottom - visibleBottom;
+      }
+
+      if (Math.abs(adjustment) < 0.5) return;
+
+      scrollable.scrollTo({
+        top: Math.max(
+          0,
+          Math.min(
+            scrollable.scrollHeight - scrollable.clientHeight,
+            scrollable.scrollTop + adjustment,
+          ),
+        ),
+        behavior: "smooth",
+      });
+    }
+
+    function getKeyboardAnimationOptions(drawer: HTMLDivElement): KeyframeAnimationOptions | null {
+      const transition = getComputedStyle(drawer)
+        .getPropertyValue("--drawer-keyboard-transition")
+        .trim();
+      const durationMatch = transition.match(/(?:^|\s)(\d*\.?\d+)(ms|s)(?=\s|$)/);
+
+      if (!durationMatch) return null;
+
+      const durationValue = Number.parseFloat(durationMatch[1]);
+      const duration = durationMatch[2] === "s" ? durationValue * 1000 : durationValue;
+
+      if (!Number.isFinite(duration) || duration <= 0) return null;
+
+      const easing = transition.match(
+        /cubic-bezier\([^)]*\)|steps\([^)]*\)|linear\([^)]*\)|ease-in-out|ease-in|ease-out|ease|linear/,
+      )?.[0];
+
+      return {
+        duration,
+        easing: easing || "ease",
+        fill: "both",
+      };
+    }
+
+    function updateDrawerGeometry(updateSize: (drawer: HTMLDivElement) => void, bottom: number) {
+      const drawer = drawerRef.current;
+      if (!drawer) return;
+
+      const animationOptions = getKeyboardAnimationOptions(drawer);
+      const previousRect = drawer.getBoundingClientRect();
+      const computedBottom = Number.parseFloat(getComputedStyle(drawer).bottom);
+      const previousBottom = Number.isFinite(computedBottom)
+        ? computedBottom
+        : Math.max(window.innerHeight - previousRect.bottom, 0);
+
+      keyboardAnimation.current?.cancel();
+      keyboardAnimation.current = null;
+
+      const previousKeyboardTransition = drawer.style.getPropertyValue(
+        "--drawer-keyboard-transition",
+      );
+
+      // First commit the final size and position without a CSS transition. Safari can otherwise
+      // paint the synchronous height change before it starts the `bottom` transition, exposing a
+      // frame where the sheet briefly shrinks toward the bottom or grows above the viewport.
+      drawer.style.setProperty("--drawer-keyboard-transition", "bottom 0s");
+      updateSize(drawer);
+      drawer.style.bottom = `${bottom}px`;
+      const nextRect = drawer.getBoundingClientRect();
+      const nextHeight = drawer.style.height;
+      const nextMinHeight = drawer.style.minHeight;
+      const nextBottom = drawer.style.bottom;
+
+      if (
+        !animationOptions ||
+        typeof drawer.animate !== "function" ||
+        (Math.abs(previousRect.height - nextRect.height) < 0.5 &&
+          Math.abs(previousBottom - bottom) < 0.5)
+      ) {
+        if (previousKeyboardTransition) {
+          drawer.style.setProperty("--drawer-keyboard-transition", previousKeyboardTransition);
+        } else {
+          drawer.style.removeProperty("--drawer-keyboard-transition");
+        }
+        return;
+      }
+
+      // WAAPI keeps height and bottom on one timeline. The underlying layout is already at its
+      // final geometry before playback, so canceling or finishing the animation cannot expose an
+      // intermediate CSS layout. Animating the individual geometry properties also leaves the
+      // drawer's transform available for its open, drag, and snap-point interactions.
+      //
+      // Safari does not necessarily sample a newly-created animation until the next frame. Keep
+      // the authored layout at the previous geometry, pause at the first keyframe, and force that
+      // keyframe to be sampled before committing the final underlying layout. Otherwise Safari
+      // can paint `final -> first keyframe -> final`, which looks like the sheet bouncing twice.
+      drawer.style.height = `${previousRect.height}px`;
+      drawer.style.minHeight = `${previousRect.height}px`;
+      drawer.style.bottom = `${previousBottom}px`;
+
+      const animation = drawer.animate(
+        [
+          {
+            height: `${previousRect.height}px`,
+            minHeight: `${previousRect.height}px`,
+            bottom: `${previousBottom}px`,
+          },
+          {
+            height: `${nextRect.height}px`,
+            minHeight: `${nextRect.height}px`,
+            bottom: `${bottom}px`,
+          },
+        ],
+        animationOptions,
+      );
+
+      animation.pause();
+      animation.currentTime = 0;
+      drawer.getBoundingClientRect();
+
+      drawer.style.height = nextHeight;
+      drawer.style.minHeight = nextMinHeight;
+      drawer.style.bottom = nextBottom;
+      drawer.getBoundingClientRect();
+
+      if (previousKeyboardTransition) {
+        drawer.style.setProperty("--drawer-keyboard-transition", previousKeyboardTransition);
+      } else {
+        drawer.style.removeProperty("--drawer-keyboard-transition");
+      }
+
+      keyboardAnimation.current = animation;
+      animation.play();
+      void animation.finished.then(
+        () => {
+          if (keyboardAnimation.current === animation) {
+            keyboardAnimation.current = null;
+            animation.cancel();
+            scrollFocusedInputIntoView();
+          }
+        },
+        () => {},
+      );
+    }
+
+    function captureDrawerHeight() {
+      const drawer = drawerRef.current;
+      if (!drawer) return false;
+      if (drawerHeightBeforeKeyboard.current !== null) {
+        return initialDrawerHeight.current > 0;
+      }
+
+      const drawerHeight = drawer.getBoundingClientRect().height || 0;
+      if (!Number.isFinite(drawerHeight) || drawerHeight <= 0) return false;
+
+      drawerHeightBeforeKeyboard.current = drawer.style.height;
+      drawerMinHeightBeforeKeyboard.current = drawer.style.minHeight;
+      initialDrawerHeight.current = drawerHeight;
+      return true;
     }
 
     function restoreDrawerHeight() {
       if (!drawerRef.current || drawerHeightBeforeKeyboard.current === null) return;
 
-      drawerRef.current.style.height = drawerHeightBeforeKeyboard.current;
-      drawerRef.current.style.minHeight = drawerMinHeightBeforeKeyboard.current ?? "";
+      updateDrawerGeometry((drawer) => {
+        drawer.style.height = drawerHeightBeforeKeyboard.current ?? "";
+        drawer.style.minHeight = drawerMinHeightBeforeKeyboard.current ?? "";
+      }, 0);
       drawerHeightBeforeKeyboard.current = null;
       drawerMinHeightBeforeKeyboard.current = null;
       initialDrawerHeight.current = 0;
     }
 
+    function reconcileFocusedInput() {
+      const focusedElement = document.activeElement;
+      if (
+        !(focusedElement instanceof HTMLElement) ||
+        !isInput(focusedElement) ||
+        !drawerRef.current?.contains(focusedElement)
+      ) {
+        return;
+      }
+
+      if (captureDrawerHeight()) onVisualViewportChange();
+    }
+
+    function scheduleKeyboardReposition() {
+      if (keyboardRepositionFrame === null) {
+        keyboardRepositionFrame = window.requestAnimationFrame(() => {
+          keyboardRepositionFrame = null;
+          reconcileFocusedInput();
+        });
+      }
+
+      if (keyboardRepositionTimeout === null) {
+        // A quick close-and-reopen can reverse the native keyboard animation without producing a
+        // final visualViewport event after this effect is attached. Reconcile once more after both
+        // drawer transition durations so the settled viewport always wins.
+        keyboardRepositionTimeout = window.setTimeout(
+          () => {
+            keyboardRepositionTimeout = null;
+            reconcileFocusedInput();
+          },
+          (TRANSITIONS.ENTER_DURATION + TRANSITIONS.EXIT_DURATION) * 1000,
+        );
+      }
+    }
+
     function onVisualViewportChange() {
-      if (!drawerRef.current || !repositionInputs) return;
+      if (!repositionInputs) return;
+      if (!isOpen) {
+        updateLayoutViewportBaseline();
+        return;
+      }
+      if (!drawerRef.current) return;
       // Pinch zoom shrinks the visual viewport for reasons that have nothing to do with the
       // keyboard, so `diffFromInitial` below would read the zoom as keyboard height and resize the
       // drawer to match. Leave it alone until the zoom is released.
@@ -577,11 +850,27 @@ export function useDrawer(props: UseDrawerProps) {
       const focusedElement = document.activeElement as HTMLElement;
       const visualViewportHeight = window.visualViewport?.height || 0;
       const visualViewportOffsetTop = window.visualViewport?.offsetTop || 0;
-      const totalHeight = window.innerHeight;
+      // During a quick keyboard close-and-reopen Safari can temporarily shrink window.innerHeight
+      // to the visual viewport as well. Comparing those two live values would then report no
+      // keyboard even though it is visible. Keep the layout viewport measured while the drawer was
+      // closed (or before focus) as the stable baseline for this keyboard session.
+      const totalHeight = Math.max(layoutViewportHeightBeforeKeyboard.current, window.innerHeight);
       const viewportHeightReduction = totalHeight - visualViewportHeight;
       let keyboardInset = viewportHeightReduction - visualViewportOffsetTop;
       const wasKeyboardOpen = keyboardIsOpen.current;
       const isKeyboardOpen = viewportHeightReduction > 60;
+
+      // focusout starts the downward animation before iOS reports the keyboard dismissal through
+      // visualViewport. Ignore the stale keyboard-open resize/scroll events in between, otherwise
+      // they cancel that animation and lift the sheet again. A new input focus cancels this guard.
+      if (keyboardDismissalPending.current) {
+        if (!isKeyboardOpen) {
+          keyboardDismissalPending.current = false;
+          keyboardIsOpen.current = false;
+          updateLayoutViewportBaseline();
+        }
+        return;
+      }
 
       keyboardIsOpen.current = isKeyboardOpen;
 
@@ -589,14 +878,17 @@ export function useDrawer(props: UseDrawerProps) {
 
       if (!isKeyboardOpen) {
         restoreDrawerHeight();
-        drawerRef.current.style.bottom = "0px";
         return;
       }
 
-      captureDrawerHeight();
+      if (!captureDrawerHeight()) {
+        scheduleKeyboardReposition();
+        return;
+      }
 
-      if (snapPoints && snapPoints.length > 0 && snapPointsOffset && activeSnapPointIndex) {
-        const activeSnapPointHeight = snapPointsOffset[activeSnapPointIndex] || 0;
+      if (keyboardSnapPointsOffset && keyboardActiveSnapPointIndex) {
+        const activeSnapPointHeight =
+          keyboardSnapPointsOffset[keyboardActiveSnapPointIndex] || 0;
         keyboardInset += activeSnapPointHeight;
       }
 
@@ -614,47 +906,92 @@ export function useDrawer(props: UseDrawerProps) {
         ? Math.max(naturalHeight - Math.max(keyboardInset, 0), 0)
         : Math.min(naturalHeight, availableHeight);
 
-      drawerRef.current.style.height = `${targetHeight}px`;
-      drawerRef.current.style.minHeight = `${targetHeight}px`;
-
       // iOS can pan the visual viewport to reveal the focused input. That pan already moves the
       // sheet up on screen, so only lift it by the keyboard-covered part that remains below the
       // visual viewport. Ignoring offsetTop applies both movements and hides the sheet header.
-      drawerRef.current.style.bottom = `${Math.max(keyboardInset, 0)}px`;
+      updateDrawerGeometry(
+        (drawer) => {
+          drawer.style.height = `${targetHeight}px`;
+          drawer.style.minHeight = `${targetHeight}px`;
+        },
+        Math.max(keyboardInset, 0),
+      );
+      scrollFocusedInputIntoView();
     }
+
+    let focusOutSequence = 0;
 
     function onFocusIn(event: FocusEvent) {
       const target = event.target;
       if (!repositionInputs || !(target instanceof Element) || !isInput(target)) return;
       if (!drawerRef.current?.contains(target)) return;
 
-      captureDrawerHeight();
-      if (keyboardIsOpen.current) onVisualViewportChange();
-    }
+      focusOutSequence += 1;
+      keyboardDismissalPending.current = false;
+      updateLayoutViewportBaseline();
+      if (!captureDrawerHeight()) scheduleKeyboardReposition();
 
-    // On iOS the keyboard's dismissal only reaches `visualViewport` once it has fully retracted —
-    // measured ~480ms after blur on iOS 27, against ~90ms in the opposite direction — so waiting
-    // for `resize` drops the drawer back down long after the keyboard is gone. Blur fires as the
-    // dismissal starts, so restore both the authored height and the resting position from there.
-    // Other platforms report the dismissal promptly and stay on the `resize` path alone.
-    let focusOutFrame = 0;
+      const visualViewportHeight = window.visualViewport?.height ?? window.innerHeight;
+      if (keyboardIsOpen.current || window.innerHeight - visualViewportHeight > 60) {
+        onVisualViewportChange();
+      }
+      scheduleKeyboardReposition();
+    }
 
     function onFocusOut(event: FocusEvent) {
       const target = event.target;
       if (!repositionInputs || !(target instanceof Element) || !isInput(target)) return;
+      if (!drawerRef.current?.contains(target)) return;
       if ((window.visualViewport?.scale ?? 1) > 1) return;
 
-      // Moving between inputs keeps the keyboard up. `relatedTarget` is null on iOS, so wait for
-      // the focus to settle and read what actually ended up focused.
-      cancelAnimationFrame(focusOutFrame);
-      focusOutFrame = requestAnimationFrame(() => {
-        const activeElement = document.activeElement;
-        if (activeElement && isInput(activeElement)) return;
-        if (!drawerRef.current) return;
+      const relatedTarget = event.relatedTarget;
+      if (
+        relatedTarget instanceof Element &&
+        isInput(relatedTarget) &&
+        drawerRef.current?.contains(relatedTarget)
+      ) {
+        return;
+      }
 
+      // iOS reports a null relatedTarget for the keyboard Done button. Let focus settle in the
+      // current task so input-to-input moves can be detected, but start the restore before the next
+      // frame; visually this is immediate and does not wait for the delayed visualViewport resize.
+      const sequence = ++focusOutSequence;
+      queueMicrotask(() => {
+        if (sequence !== focusOutSequence) return;
+
+        const activeElement = document.activeElement;
+        if (
+          activeElement instanceof Element &&
+          isInput(activeElement) &&
+          drawerRef.current?.contains(activeElement)
+        ) {
+          return;
+        }
+
+        keyboardDismissalPending.current = true;
         restoreDrawerHeight();
-        drawerRef.current.style.bottom = "0px";
       });
+    }
+
+    if (!isOpen) {
+      const drawer = drawerRef.current;
+
+      keyboardAnimation.current?.cancel();
+      keyboardAnimation.current = null;
+
+      if (drawer && drawerHeightBeforeKeyboard.current !== null) {
+        drawer.style.height = drawerHeightBeforeKeyboard.current;
+        drawer.style.minHeight = drawerMinHeightBeforeKeyboard.current ?? "";
+        drawer.style.bottom = "0px";
+      }
+
+      drawerHeightBeforeKeyboard.current = null;
+      drawerMinHeightBeforeKeyboard.current = null;
+      initialDrawerHeight.current = 0;
+      updateLayoutViewportBaseline();
+      keyboardDismissalPending.current = false;
+      keyboardIsOpen.current = false;
     }
 
     window.visualViewport?.addEventListener("resize", onVisualViewportChange);
@@ -664,11 +1001,39 @@ export function useDrawer(props: UseDrawerProps) {
       document.addEventListener("focusout", onFocusOut, true);
     }
 
+    // Native `autoFocus` runs during the commit that opens the drawer. The focus and the first
+    // visualViewport resize can therefore both happen before this effect is re-attached for the
+    // open state. Reconcile the already-focused input once so that path does not leave the sheet
+    // underneath the keyboard.
+    const focusedElement = document.activeElement;
+    if (
+      isOpen &&
+      focusedElement instanceof HTMLElement &&
+      isInput(focusedElement) &&
+      drawerRef.current?.contains(focusedElement)
+    ) {
+      // The previous drawer can close before iOS reports that its keyboard finished dismissing.
+      // In that case the dismissal guard survives into the next open. Native autoFocus can also
+      // happen between this effect's cleanup and setup, so there may be no focusin event to clear
+      // the guard. Treat the already-focused input as a new focus sequence before reconciling the
+      // current viewport.
+      focusOutSequence += 1;
+      keyboardDismissalPending.current = false;
+      if (captureDrawerHeight()) onVisualViewportChange();
+      else scheduleKeyboardReposition();
+      scheduleKeyboardReposition();
+    }
+
     return () => {
-      // This effect re-runs whenever the active snap point changes. Without cancelling, a blur that
-      // lands in the same frame as a snap change would let the stale closure write `bottom` on top
-      // of the reposition the new snap point just performed.
-      cancelAnimationFrame(focusOutFrame);
+      focusOutSequence += 1;
+      if (keyboardRepositionFrame !== null) {
+        window.cancelAnimationFrame(keyboardRepositionFrame);
+      }
+      if (keyboardRepositionTimeout !== null) {
+        window.clearTimeout(keyboardRepositionTimeout);
+      }
+      keyboardAnimation.current?.cancel();
+      keyboardAnimation.current = null;
       window.visualViewport?.removeEventListener("resize", onVisualViewportChange);
       window.visualViewport?.removeEventListener("scroll", onVisualViewportChange);
       document.removeEventListener("focusin", onFocusIn, true);
@@ -676,7 +1041,7 @@ export function useDrawer(props: UseDrawerProps) {
         document.removeEventListener("focusout", onFocusOut, true);
       }
     };
-  }, [activeSnapPointIndex, snapPoints, snapPointsOffset, repositionInputs, fixed]);
+  }, [keyboardActiveSnapPointIndex, keyboardSnapPointsOffset, repositionInputs, fixed, isOpen]);
 
   // Effect 1: Track drawer open state
   useEffect(() => {

--- a/packages/react-headless/drawer/src/useDrawer.ts
+++ b/packages/react-headless/drawer/src/useDrawer.ts
@@ -2,10 +2,11 @@ import { useControllableState } from "@seed-design/react-use-controllable-state"
 import { buttonProps, dataAttr, elementProps } from "@seed-design/dom-utils";
 import type React from "react";
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
-import { isAndroid, isIOS, isMobileFirefox } from "./browser";
+import { isIOS } from "./browser";
 import {
   CLOSE_THRESHOLD,
   DRAG_CLASS,
+  KEYBOARD_TRANSITION,
   SCROLL_LOCK_TIMEOUT,
   TRANSITIONS,
   VELOCITY_THRESHOLD,
@@ -201,11 +202,11 @@ export function useDrawer(props: UseDrawerProps) {
   const isAllowedToDrag = useRef<boolean>(false);
   const pointerStart = useRef(0);
   const keyboardIsOpen = useRef(false);
-  const previousDiffFromInitial = useRef(0);
   const drawerRef = useRef<HTMLDivElement>(null);
   const drawerHeightRef = useRef(drawerRef.current?.getBoundingClientRect().height || 0);
   const drawerWidthRef = useRef(drawerRef.current?.getBoundingClientRect().width || 0);
   const initialDrawerHeight = useRef(0);
+  const drawerHeightBeforeKeyboard = useRef<string | null>(null);
 
   const onSnapPointChange = useCallback(
     (activeSnapPointIndex: number) => {
@@ -363,7 +364,7 @@ export function useDrawer(props: UseDrawerProps) {
 
       isAllowedToDrag.current = true;
       set(drawerRef.current, {
-        transition: "none",
+        transition: KEYBOARD_TRANSITION,
       });
 
       set(overlayRef.current, {
@@ -458,7 +459,7 @@ export function useDrawer(props: UseDrawerProps) {
 
     set(drawerRef.current, {
       transform: "translate3d(0, 0, 0)",
-      transition: `transform ${TRANSITIONS.EXIT_DURATION}s ${TRANSITIONS.CONTENT_EXIT_TIMING_FUNCTION}`,
+      transition: `transform ${TRANSITIONS.EXIT_DURATION}s ${TRANSITIONS.CONTENT_EXIT_TIMING_FUNCTION}, ${KEYBOARD_TRANSITION}`,
     });
 
     set(overlayRef.current, {
@@ -547,60 +548,122 @@ export function useDrawer(props: UseDrawerProps) {
   }, [isOpen]);
 
   useEffect(() => {
+    function captureDrawerHeight() {
+      if (!drawerRef.current || drawerHeightBeforeKeyboard.current !== null) return;
+
+      drawerHeightBeforeKeyboard.current = drawerRef.current.style.height;
+      initialDrawerHeight.current = drawerRef.current.getBoundingClientRect().height || 0;
+    }
+
+    function restoreDrawerHeight() {
+      if (!drawerRef.current || drawerHeightBeforeKeyboard.current === null) return;
+
+      drawerRef.current.style.height = drawerHeightBeforeKeyboard.current;
+      drawerHeightBeforeKeyboard.current = null;
+      initialDrawerHeight.current = 0;
+    }
+
     function onVisualViewportChange() {
       if (!drawerRef.current || !repositionInputs) return;
+      // Pinch zoom shrinks the visual viewport for reasons that have nothing to do with the
+      // keyboard, so `diffFromInitial` below would read the zoom as keyboard height and resize the
+      // drawer to match. Leave it alone until the zoom is released.
+      if ((window.visualViewport?.scale ?? 1) > 1) return;
 
       const focusedElement = document.activeElement as HTMLElement;
-      if (isInput(focusedElement) || keyboardIsOpen.current) {
-        const visualViewportHeight = window.visualViewport?.height || 0;
-        const totalHeight = window.innerHeight;
-        let diffFromInitial = totalHeight - visualViewportHeight;
-        const drawerHeight = drawerRef.current.getBoundingClientRect().height || 0;
-        const isTallEnough = drawerHeight > totalHeight * 0.8;
+      const visualViewportHeight = window.visualViewport?.height || 0;
+      const totalHeight = window.innerHeight;
+      let diffFromInitial = totalHeight - visualViewportHeight;
+      const wasKeyboardOpen = keyboardIsOpen.current;
+      const isKeyboardOpen = diffFromInitial > 60;
 
-        if (!initialDrawerHeight.current) {
-          initialDrawerHeight.current = drawerHeight;
-        }
-        const offsetFromTop = drawerRef.current.getBoundingClientRect().top;
+      keyboardIsOpen.current = isKeyboardOpen;
 
-        if (Math.abs(previousDiffFromInitial.current - diffFromInitial) > 60) {
-          keyboardIsOpen.current = !keyboardIsOpen.current;
-        }
+      if (!isInput(focusedElement) && !wasKeyboardOpen && !isKeyboardOpen) return;
 
-        if (snapPoints && snapPoints.length > 0 && snapPointsOffset && activeSnapPointIndex) {
-          const activeSnapPointHeight = snapPointsOffset[activeSnapPointIndex] || 0;
-          diffFromInitial += activeSnapPointHeight;
-        }
-        previousDiffFromInitial.current = diffFromInitial;
-
-        if (drawerHeight > visualViewportHeight || keyboardIsOpen.current) {
-          const height = drawerRef.current.getBoundingClientRect().height;
-          let newDrawerHeight = height;
-
-          if (height > visualViewportHeight) {
-            newDrawerHeight =
-              visualViewportHeight - (isTallEnough ? offsetFromTop : WINDOW_TOP_OFFSET);
-          }
-
-          if (fixed) {
-            drawerRef.current.style.height = `${height - Math.max(diffFromInitial, 0)}px`;
-          } else {
-            drawerRef.current.style.height = `${Math.max(newDrawerHeight, visualViewportHeight - offsetFromTop)}px`;
-          }
-        } else if (!isMobileFirefox() && !isAndroid()) {
-          drawerRef.current.style.height = `${initialDrawerHeight.current}px`;
-        }
-
-        if (snapPoints && snapPoints.length > 0 && !keyboardIsOpen.current) {
-          drawerRef.current.style.bottom = "0px";
-        } else {
-          drawerRef.current.style.bottom = `${Math.max(diffFromInitial, 0)}px`;
-        }
+      if (!isKeyboardOpen) {
+        restoreDrawerHeight();
+        drawerRef.current.style.bottom = "0px";
+        return;
       }
+
+      captureDrawerHeight();
+
+      if (snapPoints && snapPoints.length > 0 && snapPointsOffset && activeSnapPointIndex) {
+        const activeSnapPointHeight = snapPointsOffset[activeSnapPointIndex] || 0;
+        diffFromInitial += activeSnapPointHeight;
+      }
+
+      // Derive the height from the natural height and the viewport alone. Measuring the drawer
+      // here would be circular: `bottom` animates toward the keyboard position, so a rect read
+      // mid-flight describes where the drawer was rather than where it is headed, and folding
+      // that back into the height makes every resize compound the last one. Android emits
+      // several resizes per keyboard animation, so that compounding inflated the sheet until it
+      // filled the screen.
+      const naturalHeight = initialDrawerHeight.current;
+      // Once lifted, the drawer's bottom edge rests on top of the keyboard, so this is all the
+      // room it has left.
+      const availableHeight = visualViewportHeight - WINDOW_TOP_OFFSET;
+      const targetHeight = fixed
+        ? Math.max(naturalHeight - Math.max(diffFromInitial, 0), 0)
+        : Math.min(naturalHeight, availableHeight);
+
+      drawerRef.current.style.height = `${targetHeight}px`;
+
+      drawerRef.current.style.bottom = `${Math.max(diffFromInitial, 0)}px`;
+    }
+
+    function onFocusIn(event: FocusEvent) {
+      const target = event.target;
+      if (!repositionInputs || !(target instanceof Element) || !isInput(target)) return;
+      if (!drawerRef.current?.contains(target)) return;
+
+      captureDrawerHeight();
+      if (keyboardIsOpen.current) onVisualViewportChange();
+    }
+
+    // On iOS the keyboard's dismissal only reaches `visualViewport` once it has fully retracted —
+    // measured ~480ms after blur on iOS 27, against ~90ms in the opposite direction — so waiting
+    // for `resize` drops the drawer back down long after the keyboard is gone. Blur fires as the
+    // dismissal starts, so restore both the authored height and the resting position from there.
+    // Other platforms report the dismissal promptly and stay on the `resize` path alone.
+    let focusOutFrame = 0;
+
+    function onFocusOut(event: FocusEvent) {
+      const target = event.target;
+      if (!repositionInputs || !(target instanceof Element) || !isInput(target)) return;
+      if ((window.visualViewport?.scale ?? 1) > 1) return;
+
+      // Moving between inputs keeps the keyboard up. `relatedTarget` is null on iOS, so wait for
+      // the focus to settle and read what actually ended up focused.
+      cancelAnimationFrame(focusOutFrame);
+      focusOutFrame = requestAnimationFrame(() => {
+        const activeElement = document.activeElement;
+        if (activeElement && isInput(activeElement)) return;
+        if (!drawerRef.current) return;
+
+        restoreDrawerHeight();
+        drawerRef.current.style.bottom = "0px";
+      });
     }
 
     window.visualViewport?.addEventListener("resize", onVisualViewportChange);
-    return () => window.visualViewport?.removeEventListener("resize", onVisualViewportChange);
+    document.addEventListener("focusin", onFocusIn, true);
+    if (isIOS()) {
+      document.addEventListener("focusout", onFocusOut, true);
+    }
+
+    return () => {
+      // This effect re-runs whenever the active snap point changes. Without cancelling, a blur that
+      // lands in the same frame as a snap change would let the stale closure write `bottom` on top
+      // of the reposition the new snap point just performed.
+      cancelAnimationFrame(focusOutFrame);
+      window.visualViewport?.removeEventListener("resize", onVisualViewportChange);
+      document.removeEventListener("focusin", onFocusIn, true);
+      if (isIOS()) {
+        document.removeEventListener("focusout", onFocusOut, true);
+      }
+    };
   }, [activeSnapPointIndex, snapPoints, snapPointsOffset, repositionInputs, fixed]);
 
   // Effect 1: Track drawer open state

--- a/packages/react-headless/drawer/src/useDrawer.ts
+++ b/packages/react-headless/drawer/src/useDrawer.ts
@@ -1447,7 +1447,7 @@ export function useDrawer(props: UseDrawerProps) {
     }
 
     let lastViewportResizeSignature: string | null = null;
-      function onViewportResize() {
+    function onViewportResize() {
       const visualViewport = window.visualViewport;
       const signature = `${window.innerHeight}:${visualViewport?.height ?? 0}:${visualViewport?.offsetTop ?? 0}`;
       if (signature === lastViewportResizeSignature) {
@@ -1458,13 +1458,13 @@ export function useDrawer(props: UseDrawerProps) {
       onVisualViewportChange();
     }
 
-      function onWindowResize() {
-        onViewportResize();
-      }
+    function onWindowResize() {
+      onViewportResize();
+    }
 
-      function onVisualViewportResize() {
-        onViewportResize();
-      }
+    function onVisualViewportResize() {
+      onViewportResize();
+    }
 
     // Android dispatches window.resize before visualViewport.resize while adjustResize restores
     // the layout viewport. Handling the first event closes the one-frame gap where the sheet would

--- a/packages/react-headless/drawer/src/useDrawer.ts
+++ b/packages/react-headless/drawer/src/useDrawer.ts
@@ -1401,7 +1401,7 @@ export function useDrawer(props: UseDrawerProps) {
         return;
       }
 
-      if (keyboardSnapPointsOffset && keyboardActiveSnapPointIndex) {
+      if (keyboardSnapPointsOffset && keyboardActiveSnapPointIndex !== null) {
         const activeSnapPointHeight = keyboardSnapPointsOffset[keyboardActiveSnapPointIndex] || 0;
         keyboardInset += activeSnapPointHeight;
         drawerBottom += activeSnapPointHeight;

--- a/packages/react-headless/drawer/src/useDrawer.ts
+++ b/packages/react-headless/drawer/src/useDrawer.ts
@@ -207,6 +207,7 @@ export function useDrawer(props: UseDrawerProps) {
   const drawerWidthRef = useRef(drawerRef.current?.getBoundingClientRect().width || 0);
   const initialDrawerHeight = useRef(0);
   const drawerHeightBeforeKeyboard = useRef<string | null>(null);
+  const drawerMinHeightBeforeKeyboard = useRef<string | null>(null);
 
   const onSnapPointChange = useCallback(
     (activeSnapPointIndex: number) => {
@@ -552,6 +553,7 @@ export function useDrawer(props: UseDrawerProps) {
       if (!drawerRef.current || drawerHeightBeforeKeyboard.current !== null) return;
 
       drawerHeightBeforeKeyboard.current = drawerRef.current.style.height;
+      drawerMinHeightBeforeKeyboard.current = drawerRef.current.style.minHeight;
       initialDrawerHeight.current = drawerRef.current.getBoundingClientRect().height || 0;
     }
 
@@ -559,7 +561,9 @@ export function useDrawer(props: UseDrawerProps) {
       if (!drawerRef.current || drawerHeightBeforeKeyboard.current === null) return;
 
       drawerRef.current.style.height = drawerHeightBeforeKeyboard.current;
+      drawerRef.current.style.minHeight = drawerMinHeightBeforeKeyboard.current ?? "";
       drawerHeightBeforeKeyboard.current = null;
+      drawerMinHeightBeforeKeyboard.current = null;
       initialDrawerHeight.current = 0;
     }
 
@@ -572,10 +576,12 @@ export function useDrawer(props: UseDrawerProps) {
 
       const focusedElement = document.activeElement as HTMLElement;
       const visualViewportHeight = window.visualViewport?.height || 0;
+      const visualViewportOffsetTop = window.visualViewport?.offsetTop || 0;
       const totalHeight = window.innerHeight;
-      let diffFromInitial = totalHeight - visualViewportHeight;
+      const viewportHeightReduction = totalHeight - visualViewportHeight;
+      let keyboardInset = viewportHeightReduction - visualViewportOffsetTop;
       const wasKeyboardOpen = keyboardIsOpen.current;
-      const isKeyboardOpen = diffFromInitial > 60;
+      const isKeyboardOpen = viewportHeightReduction > 60;
 
       keyboardIsOpen.current = isKeyboardOpen;
 
@@ -591,7 +597,7 @@ export function useDrawer(props: UseDrawerProps) {
 
       if (snapPoints && snapPoints.length > 0 && snapPointsOffset && activeSnapPointIndex) {
         const activeSnapPointHeight = snapPointsOffset[activeSnapPointIndex] || 0;
-        diffFromInitial += activeSnapPointHeight;
+        keyboardInset += activeSnapPointHeight;
       }
 
       // Derive the height from the natural height and the viewport alone. Measuring the drawer
@@ -605,12 +611,16 @@ export function useDrawer(props: UseDrawerProps) {
       // room it has left.
       const availableHeight = visualViewportHeight - WINDOW_TOP_OFFSET;
       const targetHeight = fixed
-        ? Math.max(naturalHeight - Math.max(diffFromInitial, 0), 0)
+        ? Math.max(naturalHeight - Math.max(keyboardInset, 0), 0)
         : Math.min(naturalHeight, availableHeight);
 
       drawerRef.current.style.height = `${targetHeight}px`;
+      drawerRef.current.style.minHeight = `${targetHeight}px`;
 
-      drawerRef.current.style.bottom = `${Math.max(diffFromInitial, 0)}px`;
+      // iOS can pan the visual viewport to reveal the focused input. That pan already moves the
+      // sheet up on screen, so only lift it by the keyboard-covered part that remains below the
+      // visual viewport. Ignoring offsetTop applies both movements and hides the sheet header.
+      drawerRef.current.style.bottom = `${Math.max(keyboardInset, 0)}px`;
     }
 
     function onFocusIn(event: FocusEvent) {
@@ -648,6 +658,7 @@ export function useDrawer(props: UseDrawerProps) {
     }
 
     window.visualViewport?.addEventListener("resize", onVisualViewportChange);
+    window.visualViewport?.addEventListener("scroll", onVisualViewportChange);
     document.addEventListener("focusin", onFocusIn, true);
     if (isIOS()) {
       document.addEventListener("focusout", onFocusOut, true);
@@ -659,6 +670,7 @@ export function useDrawer(props: UseDrawerProps) {
       // of the reposition the new snap point just performed.
       cancelAnimationFrame(focusOutFrame);
       window.visualViewport?.removeEventListener("resize", onVisualViewportChange);
+      window.visualViewport?.removeEventListener("scroll", onVisualViewportChange);
       document.removeEventListener("focusin", onFocusIn, true);
       if (isIOS()) {
         document.removeEventListener("focusout", onFocusOut, true);

--- a/tools/rootage-cdn/src/release-input.test.ts
+++ b/tools/rootage-cdn/src/release-input.test.ts
@@ -100,9 +100,7 @@ describe("resolveRootageIntegrity", () => {
       fetchImpl: async () => {
         calls += 1;
         return Response.json(
-          calls === 1
-            ? registryVersion("2.5.0", { gitHead: undefined })
-            : registryVersion("2.5.0"),
+          calls === 1 ? registryVersion("2.5.0", { gitHead: undefined }) : registryVersion("2.5.0"),
         );
       },
       sleep: async () => {},


### PR DESCRIPTION
- **feat(stackflow-spa): add bottom sheet input focus cases**
- **fix(drawer): restore sheet geometry after keyboard dismissal**
- **fix(drawer): preserve sheet header during keyboard resize**
- **fix(drawer): stabilize iOS keyboard repositioning**
- **chore: add drawer keyboard fix changeset**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * BottomSheet에서 입력 포커스, 자동완성, 내부 스크롤 및 다양한 입력 위치를 확인할 수 있는 예제 화면을 추가했습니다.
  * 예제 목록에서 새로운 BottomSheet 입력 포커스 시나리오로 이동할 수 있습니다.

* **버그 수정**
  * iOS에서 키보드 사용 시 Drawer 내부 입력창의 높이와 위치 복원이 개선되었습니다.
  * 키보드에 가려진 입력창이 자동으로 표시되도록 스크롤 동작을 개선했습니다.
  * 키보드 열림·닫힘 전환과 포커스 처리의 안정성을 높였습니다.

* **문서**
  * 키보드 표시 여부에 따라 BottomSheet의 사용 가능한 높이가 변할 수 있다는 안내를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->