### PR TITLE
fix(release): push tags from detached checkout

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -138,7 +138,7 @@ jobs:
         id: rootage
         run: bun scripts/release/rootage-input.ts "${{ steps.plan.outputs.rootageVersion }}"
       - name: Push package tags
-        run: git push --follow-tags
+        run: git push origin --tags
 
   publish-rootage:
     name: Publish immutable Rootage artifacts

--- a/scripts/release/workflow-security.test.ts
+++ b/scripts/release/workflow-security.test.ts
@@ -5,7 +5,12 @@ import { parse } from "yaml";
 interface WorkflowJob {
   if?: string;
   permissions?: Record<string, string> | string;
-  steps?: Array<{ uses?: string; with?: Record<string, string | boolean> }>;
+  steps?: Array<{
+    name?: string;
+    run?: string;
+    uses?: string;
+    with?: Record<string, string | boolean>;
+  }>;
 }
 
 interface Workflow {
@@ -49,6 +54,15 @@ describe("릴리즈 workflow 권한 경계", () => {
       )
       .map(([name]) => name);
     expect(oidcJobs).toEqual(["publish-npm"]);
+  });
+
+  test("detached HEAD에서는 package tag만 원격에 게시한다", async () => {
+    const publish = await workflow(".github/workflows/release-publish.yml");
+    const pushTags = publish.jobs["publish-npm"].steps?.find(
+      (step) => step.name === "Push package tags",
+    );
+
+    expect(pushTags?.run).toBe("git push origin --tags");
   });
 
   test("publish queue는 신뢰된 Version Packages merge만 PR 이벤트로 처리한다", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 패키지 태그가 모든 원격 태그로 올바르게 푸시되도록 릴리스 게시 명령을 수정했습니다.

- **테스트**
  - detached HEAD 상태에서 패키지 태그 게시가 정상적으로 수행되는지 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->