### PR TITLE
feat(release): add legacy prerelease normalization

### DIFF
--- a/.github/workflows/release-legacy-normalization.yml
+++ b/.github/workflows/release-legacy-normalization.yml
@@ -1,0 +1,95 @@
+name: Release legacy prerelease normalization
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: release-version-global-operation
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    name: Verify exact one-time legacy state
+    if: github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    outputs:
+      control_sha: ${{ steps.preflight.outputs.control_sha }}
+      operation_id: ${{ steps.preflight.outputs.operation_id }}
+      matrix: ${{ steps.preflight.outputs.matrix }}
+    steps:
+      - name: Checkout trusted current dev control
+        uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+
+      - name: Bind both lanes and disabled release workflows
+        id: preflight
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LEGACY_NORMALIZATION_OPERATION_ID: ${{ github.run_id }}
+        run: bun tools/release-automation/src/setup/legacy-prerelease-normalization-write.ts preflight
+
+  create:
+    name: Create ${{ matrix.lane }} legacy normalization PR
+    needs: preflight
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.preflight.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout immutable trusted dev writer
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.preflight.outputs.control_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+
+      - name: Create exact state-deletion PR without lane code execution
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LEGACY_NORMALIZATION_CONTROL_SHA: ${{ needs.preflight.outputs.control_sha }}
+          LEGACY_NORMALIZATION_LANE: ${{ matrix.lane }}
+          LEGACY_NORMALIZATION_OPERATION_ID: ${{ needs.preflight.outputs.operation_id }}
+        run: bun tools/release-automation/src/setup/legacy-prerelease-normalization-write.ts write
+
+  summarize:
+    name: Require human squash merges
+    if: always() && needs.preflight.result == 'success'
+    needs: [preflight, create]
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Summarize the manual boundary
+        env:
+          CREATE_RESULT: ${{ needs.create.result }}
+        run: |
+          test "$CREATE_RESULT" = "success"
+          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          ## Legacy prerelease normalization PR 생성 완료
+
+          `minor`와 `major` PR의 `Validate release lane` 성공을 확인한 뒤 각각 사람이 **Squash and merge**합니다.
+          두 PR이 모두 merge되기 전에는 다른 release operation을 진행하지 않습니다.
+          이 workflow는 npm, Git tag 또는 Rootage 게시를 수행하지 않습니다.
+          EOF

--- a/tools/release-automation/TECH.md
+++ b/tools/release-automation/TECH.md
@@ -26,8 +26,27 @@
 | `release-publish.yml` | npm, tag, Rootage, durable receipt, 게시 후 코드·baseline 정렬 | OIDC와 Git write를 별도 job으로 분리 |
 | `release-notification.yml` | 완료된 production receipt 알림 | publish 결과와 실패 격리 |
 | `release-e2e.yml` | 로컬과 같은 read-only 검증 | production write 없음 |
+| `release-legacy-normalization.yml` | 기존 `minor`·`major` bootstrap pre state를 dormant로 만드는 1회성 PR 생성 | exact `pre.json` 삭제 PR만 생성 |
 
 파일 수보다 권한을 섞지 않는 것을 우선한다. 특히 publish, notification, validation은 합치면 실패 결과나 credential 경계가 달라지므로 독립 workflow로 유지한다. Sync의 drain, merge, alert는 동일 도메인이고 job 권한으로 안전하게 분리할 수 있어 하나로 통합한다.
+
+## 1회성 legacy prerelease normalization
+
+`release-legacy-normalization.yml`은 기존 Changesets UI의 enter/exit를 호출하지 않는다. Trusted `dev` writer가 `minor@080815d86023ae8c0d3747e1482e634250263e3a`와 `major@44a6c1f3f53a0ad8a558565909c70fcfe499feb1`을 데이터로 읽고, 각 lane의 `.changeset/pre.json`만 삭제하는 별도 generated PR을 만든다. 원본 파일은 SHA-256 `edcbf1bcb9b4e2320be6041629ff423290106bb8c684d56c71fad2eb26a7872e`와 빈 `changesets` 배열로 함께 검증한다.
+
+실행 전과 PR 생성 직전에 `Release publish`, `Release Version PR`, `Release lane synchronization` workflow가 `disabled_manually`인지 재확인한다. Marker는 bot과 same-repository identity, repository 이름, workflow run ID, expected legacy base, generated head, 원본과 patch digest, current trusted `dev` control SHA를 고정한다. 이전 reserved branch나 열린 PR뿐 아니라 closed-unmerged PR도 발견하면 재실행하지 않는다.
+
+두 PR은 `Validate release lane` 성공 뒤 각각 사람이 **Squash and merge**한다. 한 PR만 병합된 동안 release selection과 PR validation은 남은 exact normalization PR 외의 작업을 거부한다. 두 lane의 current head가 human merge, single-parent tree, generated head tree, trusted validation receipt를 모두 증명해야 잠금이 풀린다. 이 경로는 package version, CHANGELOG, Changeset Markdown, 코드, 다른 상태 파일을 변경하지 않으며 npm, Git tag, Rootage 게시도 실행하지 않는다.
+
+두 PR이 모두 병합되어 `minor`와 `major`가 dormant임을 확인한 뒤 일회성 surface를 제거한다. 제거 PR에서는 다음 항목을 한 번에 삭제한다.
+
+1. `.github/workflows/release-legacy-normalization.yml`
+2. `src/setup/legacy-prerelease-normalization-write.ts`
+3. `src/setup/legacy-prerelease-normalization.ts`와 대응 테스트
+4. `legacy-normalization` marker 타입과 marker·provenance·pull policy 분기
+5. release selection과 두 PR validator의 normalization boundary 연결
+
+제거 전에는 active lane을 선택하거나 비활성 release workflow를 다시 활성화하지 않는다. 제거 뒤 `minor`를 active lane으로 선택하는 작업은 별도 운영 변경으로 진행한다.
 
 ## 신뢰 경계
 

--- a/tools/release-automation/bin/control.ts
+++ b/tools/release-automation/bin/control.ts
@@ -12,6 +12,7 @@ import {
   encodeMarker,
   isBaselineMarker,
   isCodePromotionMarker,
+  isLegacyNormalizationMarker,
   isPrereleaseMarker,
   isStablePromotionMarker,
   validateGeneratedPr,
@@ -42,6 +43,10 @@ import { assertDevStablePublishReconciled } from "../src/publish/baseline-reconc
 import { verifyCodePromotionPull } from "../src/promotion/code-promotion-validation";
 import { assertNoCompetingOpenStablePromotion } from "../src/promotion/promotion-state";
 import { assertUniqueOpenReleasePullForHead } from "../src/validation/head-identity";
+import {
+  assertLegacyNormalizationBoundary,
+  verifyLegacyNormalizationPull,
+} from "../src/setup/legacy-prerelease-normalization";
 
 interface PullRequestEvent {
   repository: { full_name: string };
@@ -237,6 +242,19 @@ async function validatePr(values: Map<string, string>): Promise<void> {
   );
   const generated = validateGeneratedPr(identityFromPull(pull));
   const files = await changedFiles(lane, pull.head.sha);
+  await run([
+    "git",
+    "fetch",
+    "--no-tags",
+    "origin",
+    "+refs/heads/minor:refs/remotes/origin/minor",
+    "+refs/heads/major:refs/remotes/origin/major",
+  ]);
+  await assertLegacyNormalizationBoundary({
+    repository: event.repository.full_name,
+    client,
+    marker: generated,
+  });
   const promotionException =
     generated &&
     (isStablePromotionMarker(generated) ||
@@ -329,6 +347,13 @@ async function validatePr(values: Map<string, string>): Promise<void> {
         pull,
         allowDraft: false,
         client,
+      });
+    }
+    if (generated.type === "legacy-normalization" && isLegacyNormalizationMarker(generated)) {
+      await verifyLegacyNormalizationPull({
+        repository: event.repository.full_name,
+        marker: generated,
+        pull,
       });
     }
   }

--- a/tools/release-automation/src/core/generated-pr-provenance.test.ts
+++ b/tools/release-automation/src/core/generated-pr-provenance.test.ts
@@ -86,6 +86,7 @@ describe("generated PR validation control-plane provenance", () => {
     await git(repository, "add", "tools/release-automation/src/core/validator.ts");
     await git(repository, "commit", "-m", "advance control");
     await git(repository, "push", "origin", "dev");
+    const currentControlSha = await git(repository, "rev-parse", "HEAD");
     await expect(
       verifyGeneratedPrProvenance({
         marker,
@@ -94,5 +95,29 @@ describe("generated PR validation control-plane provenance", () => {
         repositoryPath: repository,
       }),
     ).rejects.toThrow("현재 trusted dev control plane");
+
+    const legacyMarker: ReleaseMarker = {
+      schemaVersion: 1,
+      type: "legacy-normalization",
+      lane: "minor",
+      expectedHeadSha: headSha,
+      controlSha: currentControlSha,
+    };
+    await expect(
+      verifyGeneratedPrProvenance({
+        marker: legacyMarker,
+        headSha,
+        changedFiles: ["package.txt"],
+        repositoryPath: repository,
+      }),
+    ).resolves.toMatchObject({ controlSha: currentControlSha });
+    await expect(
+      verifyGeneratedPrProvenance({
+        marker: legacyMarker,
+        headSha,
+        changedFiles: ["tools/release-automation/src/core/validator.ts"],
+        repositoryPath: repository,
+      }),
+    ).rejects.toThrow("legacy-normalization generated PR");
   });
 });

--- a/tools/release-automation/src/core/generated-pr-provenance.ts
+++ b/tools/release-automation/src/core/generated-pr-provenance.ts
@@ -62,11 +62,13 @@ export async function verifyGeneratedPrProvenance(
   const [currentControlTree, recordedControlTree, headControlTree] = await Promise.all([
     controlPlaneFingerprint(repositoryPath, "origin/dev"),
     controlPlaneFingerprint(repositoryPath, input.marker.controlSha),
-    controlPlaneFingerprint(repositoryPath, input.headSha),
+    input.marker.type === "legacy-normalization"
+      ? Promise.resolve(null)
+      : controlPlaneFingerprint(repositoryPath, input.headSha),
   ]);
   if (
     recordedControlTree !== currentControlTree ||
-    headControlTree !== currentControlTree ||
+    (headControlTree !== null && headControlTree !== currentControlTree) ||
     (input.marker.controlTreeSha256 !== undefined &&
       input.marker.controlTreeSha256 !== currentControlTree)
   ) {

--- a/tools/release-automation/src/core/marker-prerelease.test.ts
+++ b/tools/release-automation/src/core/marker-prerelease.test.ts
@@ -4,6 +4,7 @@ import {
   hasExpectedGeneratedHeadRef,
   isBaselineMarker,
   isCodePromotionMarker,
+  isLegacyNormalizationMarker,
   isPrereleaseMarker,
   isStablePromotionMarker,
   parseMarker,
@@ -60,6 +61,50 @@ describe("prerelease generated marker", () => {
       { ...marker, lane: "dev" },
       { ...marker, expectedHeadSha: "short" },
       { ...marker, enterPr: 0 },
+      { ...marker, extra: true },
+    ]) {
+      expect(parseMarker(`<!-- seed-release:${JSON.stringify(invalid)} -->`)).toBeNull();
+    }
+  });
+});
+
+describe("one-time legacy normalization marker", () => {
+  const marker: ReleaseMarker = {
+    schemaVersion: 1,
+    type: "legacy-normalization",
+    lane: "minor",
+    operationId: "789",
+    sourceRepository: repository,
+    expectedBaseSha: baseSha,
+    expectedHeadSha: headSha,
+    expectedPreSha256: digest,
+    patchSha256: stablePatchDigest,
+    controlSha,
+  };
+  const identity: PullRequestIdentity = {
+    author: "github-actions[bot]",
+    body: encodeMarker(marker),
+    baseRef: "minor",
+    headRef: "release-legacy-normalization/minor-789",
+    baseRepository: repository,
+    headRepository: repository,
+  };
+
+  test("repository와 bot, reserved branch, exact SHA/digest를 결속한다", () => {
+    const parsed = parseMarker(identity.body);
+    expect(parsed && isLegacyNormalizationMarker(parsed)).toBe(true);
+    expect(validateGeneratedPr(identity)).toEqual(marker);
+    expect(validateGeneratedPr({ ...identity, author: "maintainer" })).toBeNull();
+    expect(validateGeneratedPr({ ...identity, baseRepository: "fork/seed-design" })).toBeNull();
+    expect(validateGeneratedPr({ ...identity, headRef: `${identity.headRef}-retry` })).toBeNull();
+  });
+
+  test("추가 key와 unsafe identity를 fail-closed한다", () => {
+    for (const invalid of [
+      { ...marker, operationId: "0" },
+      { ...marker, lane: "dev" },
+      { ...marker, expectedBaseSha: "short" },
+      { ...marker, expectedPreSha256: "short" },
       { ...marker, extra: true },
     ]) {
       expect(parseMarker(`<!-- seed-release:${JSON.stringify(invalid)} -->`)).toBeNull();

--- a/tools/release-automation/src/core/marker.ts
+++ b/tools/release-automation/src/core/marker.ts
@@ -86,6 +86,18 @@ const codePromotionMarkerKeys = [
   "stableVersionHeadSha",
   "type",
 ] as const;
+const legacyNormalizationMarkerKeys = [
+  "controlSha",
+  "expectedBaseSha",
+  "expectedHeadSha",
+  "expectedPreSha256",
+  "lane",
+  "operationId",
+  "patchSha256",
+  "schemaVersion",
+  "sourceRepository",
+  "type",
+] as const;
 const promotionTargetKeys = [
   "expectedBaseSha",
   "expectedBaselineTreeSha",
@@ -184,6 +196,42 @@ export type BaselineMarker = ReleaseMarker & {
   controlSha: string;
   versionsSha256: string;
 };
+
+export type LegacyNormalizationMarker = ReleaseMarker & {
+  type: "legacy-normalization";
+  lane: "minor" | "major";
+  operationId: string;
+  sourceRepository: string;
+  expectedBaseSha: string;
+  expectedHeadSha: string;
+  expectedPreSha256: string;
+  patchSha256: string;
+  controlSha: string;
+};
+
+export function isLegacyNormalizationMarker(
+  marker: ReleaseMarker,
+): marker is LegacyNormalizationMarker {
+  return (
+    marker.type === "legacy-normalization" &&
+    (marker.lane === "minor" || marker.lane === "major") &&
+    typeof marker.operationId === "string" &&
+    runIdPattern.test(marker.operationId) &&
+    typeof marker.sourceRepository === "string" &&
+    /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(marker.sourceRepository) &&
+    typeof marker.expectedBaseSha === "string" &&
+    gitShaPattern.test(marker.expectedBaseSha) &&
+    typeof marker.expectedHeadSha === "string" &&
+    gitShaPattern.test(marker.expectedHeadSha) &&
+    marker.expectedHeadSha !== marker.expectedBaseSha &&
+    typeof marker.expectedPreSha256 === "string" &&
+    sha256Pattern.test(marker.expectedPreSha256) &&
+    typeof marker.patchSha256 === "string" &&
+    sha256Pattern.test(marker.patchSha256) &&
+    typeof marker.controlSha === "string" &&
+    gitShaPattern.test(marker.controlSha)
+  );
+}
 
 export function isBaselineMarker(marker: ReleaseMarker): marker is BaselineMarker {
   return (
@@ -376,6 +424,13 @@ export function hasExpectedGeneratedHeadRef(headRef: string, marker: ReleaseMark
     );
   }
 
+  if (marker.type === "legacy-normalization") {
+    return (
+      isLegacyNormalizationMarker(marker) &&
+      headRef === `release-legacy-normalization/${marker.lane}-${marker.operationId}`
+    );
+  }
+
   if (marker.type === "sync") {
     if (
       marker.targetLane !== marker.lane ||
@@ -463,6 +518,12 @@ export function parseMarker(body: string): ReleaseMarker | null {
     ) {
       return null;
     }
+    if (
+      parsed.type === "legacy-normalization" &&
+      (!hasExactKeys(parsed, legacyNormalizationMarkerKeys) || !isLegacyNormalizationMarker(parsed))
+    ) {
+      return null;
+    }
     return parsed;
   } catch {
     return null;
@@ -486,6 +547,12 @@ export function validateGeneratedPr(identity: PullRequestIdentity): ReleaseMarke
   }
 
   if (identity.baseRef !== marker.lane) return null;
+  if (
+    marker.type === "legacy-normalization" &&
+    marker.sourceRepository !== identity.baseRepository
+  ) {
+    return null;
+  }
   if (!hasExpectedGeneratedHeadRef(identity.headRef, marker)) return null;
   return marker;
 }

--- a/tools/release-automation/src/core/types.ts
+++ b/tools/release-automation/src/core/types.ts
@@ -8,6 +8,7 @@ export const generatedPrTypes = [
   "prerelease",
   "baseline",
   "code-promotion",
+  "legacy-normalization",
 ] as const;
 export const prereleaseOperations = ["enter", "exit"] as const;
 export const versionReleaseKinds = ["stable-promotion"] as const;
@@ -104,6 +105,7 @@ export interface ReleaseMarker {
   expectedCodeTreeSha?: string;
   expectedBaselineTreeSha?: string;
   codeMergeSha?: string;
+  expectedPreSha256?: string;
 }
 
 export interface PullRequestIdentity {

--- a/tools/release-automation/src/lane/pull-policy.test.ts
+++ b/tools/release-automation/src/lane/pull-policy.test.ts
@@ -67,6 +67,30 @@ describe("steady-state lane pull policy", () => {
     ).toThrow("릴리즈 상태 파일");
   });
 
+  test("legacy normalization은 target lane의 pre.json 하나만 허용한다", () => {
+    const marker: ReleaseMarker = {
+      schemaVersion: 1,
+      type: "legacy-normalization",
+      lane: "minor",
+    };
+    expect(() =>
+      assertLanePullAllowed({
+        lane: "minor",
+        marker,
+        files: [".changeset/pre.json"],
+        control,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertLanePullAllowed({
+        lane: "minor",
+        marker,
+        files: [".changeset/pre.json", "packages/react/package.json"],
+        control,
+      }),
+    ).toThrow("만 변경");
+  });
+
   test("현재 범위 밖 generated marker를 fail closed한다", () => {
     expect(() =>
       assertLanePullAllowed({

--- a/tools/release-automation/src/lane/pull-policy.ts
+++ b/tools/release-automation/src/lane/pull-policy.ts
@@ -113,6 +113,14 @@ export function assertLanePullAllowed(input: {
     return;
   }
 
+  if (marker.type === "legacy-normalization") {
+    if (lane !== "minor" && lane !== "major") {
+      throw new Error("legacy normalization PR target은 minor 또는 major여야 합니다.");
+    }
+    assertExactFiles(files, [".changeset/pre.json"], "legacy normalization");
+    return;
+  }
+
   if (marker.type === "version") {
     assertDoesNotChange(
       files,

--- a/tools/release-automation/src/setup/legacy-prerelease-normalization-write.ts
+++ b/tools/release-automation/src/setup/legacy-prerelease-normalization-write.ts
@@ -1,0 +1,381 @@
+import { createHash } from "node:crypto";
+import { appendFile } from "node:fs/promises";
+import { GitHubClient, type GitHubPullRequest } from "../core/github";
+import { encodeMarker } from "../core/marker";
+import type { ReleaseMarker } from "../core/types";
+import {
+  assertLegacyPreState,
+  assertReleaseWorkflowsDisabled,
+  inspectLegacyNormalization,
+  legacyLaneHeads,
+  legacyNormalizationBranch,
+  legacyNormalizationRepository,
+  legacyPreSha256,
+  type LegacyNormalizationLane,
+} from "./legacy-prerelease-normalization";
+
+const gitShaPattern = /^[0-9a-f]{40}$/;
+const operationIdPattern = /^[1-9][0-9]*$/;
+
+interface GitReference {
+  object: { sha: string };
+}
+
+interface EnvironmentIdentity {
+  repository: string;
+  token: string;
+  operationId: string;
+  controlSha?: string;
+  lane?: LegacyNormalizationLane;
+}
+
+interface GitOptions {
+  allowFailure?: boolean;
+  environment?: Record<string, string | undefined>;
+  trim?: boolean;
+}
+
+interface GitResult {
+  code: number;
+  output: string;
+}
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} 환경 변수가 필요합니다.`);
+  return value;
+}
+
+function environmentIdentity(includeWriter: boolean): EnvironmentIdentity {
+  const repository = required("GITHUB_REPOSITORY");
+  const token = required("GH_TOKEN");
+  const operationId = required("LEGACY_NORMALIZATION_OPERATION_ID");
+  if (repository !== legacyNormalizationRepository || !operationIdPattern.test(operationId)) {
+    throw new Error("legacy normalization repository 또는 operation ID가 exact 계약과 다릅니다.");
+  }
+  if (!includeWriter) return { repository, token, operationId };
+  const lane = required("LEGACY_NORMALIZATION_LANE");
+  const controlSha = required("LEGACY_NORMALIZATION_CONTROL_SHA");
+  if ((lane !== "minor" && lane !== "major") || !gitShaPattern.test(controlSha)) {
+    throw new Error("legacy normalization writer lane/control SHA가 올바르지 않습니다.");
+  }
+  return { repository, token, operationId, lane, controlSha };
+}
+
+function authenticatedEnvironment(token: string): Record<string, string | undefined> {
+  const authorization = Buffer.from(`x-access-token:${token}`).toString("base64");
+  return {
+    ...process.env,
+    GH_TOKEN: undefined,
+    GITHUB_TOKEN: undefined,
+    GIT_CONFIG_COUNT: "1",
+    GIT_CONFIG_KEY_0: "http.https://github.com/.extraheader",
+    GIT_CONFIG_VALUE_0: `AUTHORIZATION: basic ${authorization}`,
+  };
+}
+
+async function git(arguments_: string[], options: GitOptions = {}): Promise<GitResult> {
+  const child = Bun.spawn(["git", ...arguments_], {
+    env: options.environment ?? { ...process.env, GH_TOKEN: undefined, GITHUB_TOKEN: undefined },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (code !== 0 && !options.allowFailure) {
+    throw new Error(`git ${arguments_.join(" ")} 실패:\n${stderr.trim()}`);
+  }
+  return { code, output: options.trim === false ? stdout : stdout.trim() };
+}
+
+async function fetchControlAndLanes(
+  environment: Record<string, string | undefined>,
+): Promise<void> {
+  await git(
+    [
+      "fetch",
+      "--no-tags",
+      "origin",
+      "+refs/heads/dev:refs/remotes/origin/dev",
+      "+refs/heads/minor:refs/remotes/origin/minor",
+      "+refs/heads/major:refs/remotes/origin/major",
+    ],
+    { environment },
+  );
+}
+
+async function assertNoPreviousSurface(
+  repository: string,
+  client: GitHubClient,
+  environment: Record<string, string | undefined>,
+): Promise<void> {
+  const [minorPulls, majorPulls, branches] = await Promise.all([
+    client.paginate<GitHubPullRequest>(
+      `/repos/${repository}/pulls?state=all&base=minor&sort=created&direction=asc`,
+    ),
+    client.paginate<GitHubPullRequest>(
+      `/repos/${repository}/pulls?state=all&base=major&sort=created&direction=asc`,
+    ),
+    git(["ls-remote", "--heads", "origin", "refs/heads/release-legacy-normalization/*"], {
+      environment,
+    }),
+  ]);
+  const previousPulls = [...minorPulls, ...majorPulls].filter((pull) =>
+    pull.head.ref.startsWith("release-legacy-normalization/"),
+  );
+  if (previousPulls.length > 0 || branches.output) {
+    throw new Error(
+      "legacy normalization은 재실행하거나 closed-unmerged reserved branch를 재사용할 수 없습니다.",
+    );
+  }
+}
+
+async function assertRemoteIdentity(
+  identity: EnvironmentIdentity & { controlSha: string },
+  client: GitHubClient,
+): Promise<void> {
+  const [dev, minor, major, checkout] = await Promise.all([
+    client.request<GitReference>(`/repos/${identity.repository}/git/ref/heads/dev`),
+    client.request<GitReference>(`/repos/${identity.repository}/git/ref/heads/minor`),
+    client.request<GitReference>(`/repos/${identity.repository}/git/ref/heads/major`),
+    git(["rev-parse", "HEAD"]),
+  ]);
+  if (
+    checkout.output !== identity.controlSha ||
+    dev.object.sha !== identity.controlSha ||
+    minor.object.sha !== legacyLaneHeads.minor ||
+    major.object.sha !== legacyLaneHeads.major
+  ) {
+    throw new Error("legacy normalization dev/lane exact head가 stale하거나 부분 완료 상태입니다.");
+  }
+}
+
+async function preflight(): Promise<void> {
+  const identity = environmentIdentity(false);
+  const client = new GitHubClient(identity.repository, identity.token);
+  const environment = authenticatedEnvironment(identity.token);
+  await fetchControlAndLanes(environment);
+  const controlSha = (await git(["rev-parse", "HEAD"])).output;
+  if (
+    !gitShaPattern.test(controlSha) ||
+    (await git(["rev-parse", "origin/dev"])).output !== controlSha
+  ) {
+    throw new Error("legacy normalization preflight가 current exact dev control에 있지 않습니다.");
+  }
+  await Promise.all([
+    assertReleaseWorkflowsDisabled(identity.repository, client),
+    assertRemoteIdentity({ ...identity, controlSha }, client),
+    assertNoPreviousSurface(identity.repository, client, environment),
+  ]);
+  const status = await inspectLegacyNormalization({ repository: identity.repository, client });
+  if (status.complete || status.lanes.minor !== "legacy" || status.lanes.major !== "legacy") {
+    throw new Error(
+      "legacy normalization preflight는 두 lane의 exact bootstrap state에서만 시작합니다.",
+    );
+  }
+  if (process.env.GITHUB_OUTPUT) {
+    await appendFile(
+      process.env.GITHUB_OUTPUT,
+      `control_sha=${controlSha}\noperation_id=${identity.operationId}\nmatrix=${JSON.stringify([
+        { lane: "minor" },
+        { lane: "major" },
+      ])}\n`,
+    );
+  }
+  console.log(`legacy normalization preflight가 dev@${controlSha}에서 두 lane을 고정했습니다.`);
+}
+
+async function remoteBranch(
+  branch: string,
+  environment: Record<string, string | undefined>,
+): Promise<string | null> {
+  const result = await git(["ls-remote", "--heads", "origin", `refs/heads/${branch}`], {
+    environment,
+  });
+  const sha = result.output.split(/\s+/)[0];
+  return sha && gitShaPattern.test(sha) ? sha : null;
+}
+
+async function createDeletionCommit(input: {
+  lane: LegacyNormalizationLane;
+  operationId: string;
+  baseSha: string;
+}): Promise<{ headSha: string; patchSha256: string }> {
+  const indexPath = `/tmp/seed-legacy-normalization-index-${input.lane}-${input.operationId}`;
+  const indexEnvironment = {
+    ...process.env,
+    GH_TOKEN: undefined,
+    GITHUB_TOKEN: undefined,
+    GIT_INDEX_FILE: indexPath,
+  };
+  await git(["read-tree", input.baseSha], { environment: indexEnvironment });
+  await git(["update-index", "--force-remove", ".changeset/pre.json"], {
+    environment: indexEnvironment,
+  });
+  const treeSha = (await git(["write-tree"], { environment: indexEnvironment })).output;
+  const patch = (
+    await git(["diff", "--binary", "--full-index", "--no-ext-diff", input.baseSha, treeSha, "--"], {
+      trim: false,
+    })
+  ).output;
+  const commitEnvironment = {
+    ...process.env,
+    GH_TOKEN: undefined,
+    GITHUB_TOKEN: undefined,
+    GIT_AUTHOR_NAME: "github-actions[bot]",
+    GIT_AUTHOR_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com",
+    GIT_AUTHOR_DATE: "2000-01-01T00:00:00Z",
+    GIT_COMMITTER_NAME: "github-actions[bot]",
+    GIT_COMMITTER_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com",
+    GIT_COMMITTER_DATE: "2000-01-01T00:00:00Z",
+  };
+  const headSha = (
+    await git(
+      [
+        "commit-tree",
+        treeSha,
+        "-p",
+        input.baseSha,
+        "-m",
+        `chore(release): normalize legacy ${input.lane} prerelease`,
+      ],
+      { environment: commitEnvironment },
+    )
+  ).output;
+  return { headSha, patchSha256: createHash("sha256").update(patch).digest("hex") };
+}
+
+async function dispatchValidation(input: {
+  repository: string;
+  token: string;
+  branch: string;
+  headSha: string;
+  pullNumber: number;
+}): Promise<void> {
+  const response = await fetch(
+    `https://api.github.com/repos/${input.repository}/actions/workflows/release-pr-validation.yml/dispatches`,
+    {
+      method: "POST",
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${input.token}`,
+        "content-type": "application/json",
+        "x-github-api-version": "2022-11-28",
+      },
+      body: JSON.stringify({
+        ref: "dev",
+        inputs: {
+          head_ref: input.branch,
+          head_sha: input.headSha,
+          pull_number: String(input.pullNumber),
+        },
+      }),
+    },
+  );
+  if (!response.ok)
+    throw new Error(`legacy normalization validation dispatch 실패: ${response.status}`);
+}
+
+async function writePull(): Promise<void> {
+  const identity = environmentIdentity(true);
+  const lane = identity.lane;
+  const controlSha = identity.controlSha;
+  if (!lane || !controlSha) throw new Error("legacy normalization writer identity가 없습니다.");
+  const client = new GitHubClient(identity.repository, identity.token);
+  const environment = authenticatedEnvironment(identity.token);
+  await fetchControlAndLanes(environment);
+  await Promise.all([
+    assertReleaseWorkflowsDisabled(identity.repository, client),
+    assertRemoteIdentity({ ...identity, controlSha }, client),
+    assertLegacyPreState(process.cwd(), legacyLaneHeads[lane], lane),
+  ]);
+  const branch = legacyNormalizationBranch(lane, identity.operationId);
+  const [existingBranch, pulls] = await Promise.all([
+    remoteBranch(branch, environment),
+    client.paginate<GitHubPullRequest>(
+      `/repos/${identity.repository}/pulls?state=all&base=${lane}&sort=created&direction=asc`,
+    ),
+  ]);
+  if (
+    existingBranch ||
+    pulls.some(
+      (pull) =>
+        pull.head.ref === branch || pull.head.ref.startsWith("release-legacy-normalization/"),
+    )
+  ) {
+    throw new Error(
+      `${lane} legacy normalization reserved branch/PR은 새 실행에서 재사용할 수 없습니다.`,
+    );
+  }
+  const baseSha = legacyLaneHeads[lane];
+  const { headSha, patchSha256 } = await createDeletionCommit({
+    lane,
+    operationId: identity.operationId,
+    baseSha,
+  });
+  await git(["push", "origin", `${headSha}:refs/heads/${branch}`], { environment });
+  const [remote, dev, currentLane] = await Promise.all([
+    client.request<GitReference>(
+      `/repos/${identity.repository}/git/ref/heads/${encodeURIComponent(branch)}`,
+    ),
+    client.request<GitReference>(`/repos/${identity.repository}/git/ref/heads/dev`),
+    client.request<GitReference>(`/repos/${identity.repository}/git/ref/heads/${lane}`),
+  ]);
+  if (
+    remote.object.sha !== headSha ||
+    dev.object.sha !== controlSha ||
+    currentLane.object.sha !== baseSha
+  ) {
+    throw new Error(`${lane} normalization PR 생성 직전 remote identity가 stale합니다.`);
+  }
+  const marker: ReleaseMarker = {
+    schemaVersion: 1,
+    type: "legacy-normalization",
+    lane,
+    operationId: identity.operationId,
+    sourceRepository: identity.repository,
+    expectedBaseSha: baseSha,
+    expectedHeadSha: headSha,
+    expectedPreSha256: legacyPreSha256,
+    patchSha256,
+    controlSha,
+  };
+  const title = `chore(release): normalize legacy ${lane} prerelease`;
+  const body = [
+    encodeMarker(marker),
+    "",
+    `## ${lane} legacy prerelease normalization`,
+    "",
+    `Exact base \`${baseSha}\`; trusted dev control \`${controlSha}\`; operation \`${identity.operationId}\`.`,
+    "",
+    "이 PR은 이 lane의 `.changeset/pre.json`만 삭제합니다. package version, CHANGELOG, Changeset, 코드 또는 다른 상태 파일을 바꾸지 않습니다.",
+    "",
+    "두 normalization PR은 각각 사람이 **Squash and merge**해야 합니다. npm, Git tag, Rootage 게시를 수행하지 않습니다.",
+  ].join("\n");
+  const pull = await client.request<GitHubPullRequest>(`/repos/${identity.repository}/pulls`, {
+    method: "POST",
+    body: JSON.stringify({ title, body, head: branch, base: lane }),
+  });
+  await dispatchValidation({
+    repository: identity.repository,
+    token: identity.token,
+    branch,
+    headSha,
+    pullNumber: pull.number,
+  });
+  if (process.env.GITHUB_OUTPUT) {
+    await appendFile(
+      process.env.GITHUB_OUTPUT,
+      `lane=${lane}\nhead_sha=${headSha}\npull=${pull.number}\n`,
+    );
+  }
+  console.log(`${lane} legacy normalization PR #${pull.number}을 생성하고 검증을 요청했습니다.`);
+}
+
+const command = Bun.argv[2];
+if (command === "preflight") await preflight();
+else if (command === "write") await writePull();
+else throw new Error(`지원하지 않는 legacy normalization command입니다: ${command ?? "없음"}`);

--- a/tools/release-automation/src/setup/legacy-prerelease-normalization.test.ts
+++ b/tools/release-automation/src/setup/legacy-prerelease-normalization.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { GitHubPullRequest } from "../core/github";
+import { encodeMarker, type LegacyNormalizationMarker } from "../core/marker";
+import {
+  releaseValidationRunName,
+  releaseValidationStatusDescription,
+  type ReleaseValidationStatus,
+  type ReleaseValidationWorkflowRun,
+} from "../core/validation-status";
+import {
+  assertLegacyNormalizationBoundary,
+  assertLegacyPreState,
+  assertReleaseWorkflowsDisabled,
+  inspectLegacyNormalization,
+  legacyLaneHeads,
+  legacyNormalizationBranch,
+  legacyNormalizationRepository,
+  legacyPreSha256,
+  type LegacyNormalizationClient,
+  type LegacyNormalizationLane,
+  verifyLegacyNormalizationPull,
+} from "./legacy-prerelease-normalization";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+async function git(cwd: string, arguments_: string[], trim = true): Promise<string> {
+  const child = Bun.spawn(["git", ...arguments_], { cwd, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (code !== 0) throw new Error(`git ${arguments_.join(" ")} 실패:\n${stderr}`);
+  return trim ? stdout.trim() : stdout;
+}
+
+interface GeneratedNormalization {
+  marker: LegacyNormalizationMarker;
+  pull: GitHubPullRequest;
+  mergeSha: string;
+  run: ReleaseValidationWorkflowRun;
+  status: ReleaseValidationStatus;
+}
+
+interface Fixture {
+  repository: string;
+  controlSha: string;
+  generated: GeneratedNormalization[];
+}
+
+async function fixture(): Promise<Fixture> {
+  const root = await mkdtemp(join(tmpdir(), "seed-legacy-normalization-test-"));
+  temporaryDirectories.push(root);
+  const origin = join(root, "origin.git");
+  const repository = join(root, "repository");
+  await git(root, ["clone", "--mirror", process.cwd(), origin]);
+  await git(root, ["clone", origin, repository]);
+  await git(repository, ["config", "user.name", "github-actions[bot]"]);
+  await git(repository, [
+    "config",
+    "user.email",
+    "41898282+github-actions[bot]@users.noreply.github.com",
+  ]);
+  await git(repository, ["config", "commit.gpgsign", "false"]);
+  const controlSha = await git(repository, ["rev-parse", "HEAD"]);
+  await git(repository, ["update-ref", "refs/remotes/origin/dev", controlSha]);
+  await git(repository, ["update-ref", "refs/remotes/origin/minor", legacyLaneHeads.minor]);
+  await git(repository, ["update-ref", "refs/remotes/origin/major", legacyLaneHeads.major]);
+  return { repository, controlSha, generated: [] };
+}
+
+async function generate(
+  value: Fixture,
+  lane: LegacyNormalizationLane,
+  number: number,
+): Promise<GeneratedNormalization> {
+  const baseSha = legacyLaneHeads[lane];
+  const operationId = String(700 + number);
+  await git(value.repository, ["switch", "--detach", baseSha]);
+  await git(value.repository, ["rm", ".changeset/pre.json"]);
+  await git(value.repository, [
+    "commit",
+    "-m",
+    `chore(release): normalize legacy ${lane} prerelease`,
+  ]);
+  const headSha = await git(value.repository, ["rev-parse", "HEAD"]);
+  const patch = await git(
+    value.repository,
+    ["diff", "--binary", "--full-index", "--no-ext-diff", baseSha, headSha, "--"],
+    false,
+  );
+  const patchSha256 = createHash("sha256").update(patch).digest("hex");
+  const marker: LegacyNormalizationMarker = {
+    schemaVersion: 1,
+    type: "legacy-normalization",
+    lane,
+    operationId,
+    sourceRepository: legacyNormalizationRepository,
+    expectedBaseSha: baseSha,
+    expectedHeadSha: headSha,
+    expectedPreSha256: legacyPreSha256,
+    patchSha256,
+    controlSha: value.controlSha,
+  };
+  await git(value.repository, ["push", "origin", `${headSha}:refs/pull/${number}/head`]);
+  const treeSha = await git(value.repository, ["rev-parse", `${headSha}^{tree}`]);
+  const mergeSha = await git(value.repository, [
+    "commit-tree",
+    treeSha,
+    "-p",
+    baseSha,
+    "-m",
+    `Squash ${lane} normalization`,
+  ]);
+  const status: ReleaseValidationStatus = {
+    id: number,
+    state: "success",
+    context: "Validate release lane",
+    description: releaseValidationStatusDescription("workflow_dispatch", headSha),
+    target_url: `https://github.com/${legacyNormalizationRepository}/actions/runs/${number}`,
+    updated_at: "2026-08-10T00:00:00.000Z",
+    creator: { login: "github-actions[bot]" },
+  };
+  const run: ReleaseValidationWorkflowRun = {
+    id: number,
+    name: "Release lane PR validation",
+    path: ".github/workflows/release-pr-validation.yml",
+    display_title: releaseValidationRunName(headSha),
+    event: "workflow_dispatch",
+    status: "completed",
+    conclusion: "success",
+    head_branch: "dev",
+    head_sha: value.controlSha,
+    repository: { full_name: legacyNormalizationRepository },
+  };
+  const pull: GitHubPullRequest = {
+    number,
+    body: encodeMarker(marker),
+    draft: false,
+    merged_at: "2026-08-10T00:00:00.000Z",
+    merge_commit_sha: mergeSha,
+    created_at: "2026-08-10T00:00:00.000Z",
+    user: { login: "github-actions[bot]" },
+    merged_by: { login: "maintainer" },
+    base: { ref: lane, sha: baseSha, repo: { full_name: legacyNormalizationRepository } },
+    head: {
+      ref: legacyNormalizationBranch(lane, operationId),
+      sha: headSha,
+      repo: { full_name: legacyNormalizationRepository },
+    },
+  };
+  const generated = { marker, pull, mergeSha, run, status };
+  value.generated.push(generated);
+  return generated;
+}
+
+function client(value: Fixture): LegacyNormalizationClient {
+  return {
+    async paginate<T>(path: string): Promise<T[]> {
+      if (path.includes("pulls?")) {
+        const lane = path.includes("base=minor") ? "minor" : "major";
+        return value.generated
+          .filter((item) => item.marker.lane === lane)
+          .map((item) => item.pull) as T[];
+      }
+      if (path.includes("/statuses")) {
+        const item = value.generated.find((candidate) =>
+          path.includes(candidate.marker.expectedHeadSha),
+        );
+        return (item ? [item.status] : []) as T[];
+      }
+      throw new Error(`unexpected paginate path: ${path}`);
+    },
+    async request<T>(path: string): Promise<T> {
+      const item = value.generated.find((candidate) => path.endsWith(`/${candidate.run.id}`));
+      if (!item) throw new Error(`unexpected request path: ${path}`);
+      return item.run as T;
+    },
+  };
+}
+
+async function merge(value: Fixture, generated: GeneratedNormalization): Promise<void> {
+  await git(value.repository, [
+    "push",
+    "--force",
+    "origin",
+    `${generated.mergeSha}:refs/heads/${generated.marker.lane}`,
+  ]);
+  await git(value.repository, [
+    "update-ref",
+    `refs/remotes/origin/${generated.marker.lane}`,
+    generated.mergeSha,
+  ]);
+}
+
+describe("one-time legacy prerelease normalization", () => {
+  test("publish, Version PR, sync workflow는 disabled_manually 상태를 유지한다", async () => {
+    const disabledClient: LegacyNormalizationClient = {
+      async paginate<T>(): Promise<T[]> {
+        return [];
+      },
+      async request<T>(): Promise<T> {
+        return { state: "disabled_manually" } as T;
+      },
+    };
+    await expect(
+      assertReleaseWorkflowsDisabled(legacyNormalizationRepository, disabledClient),
+    ).resolves.toBeUndefined();
+    await expect(
+      assertReleaseWorkflowsDisabled(legacyNormalizationRepository, {
+        ...disabledClient,
+        async request<T>(): Promise<T> {
+          return { state: "active" } as T;
+        },
+      }),
+    ).rejects.toThrow("disabled_manually");
+  });
+
+  test("고정된 두 legacy head의 exact pre.json과 빈 changesets를 검증한다", async () => {
+    await expect(
+      assertLegacyPreState(process.cwd(), legacyLaneHeads.minor, "minor"),
+    ).resolves.toBeUndefined();
+    await expect(
+      assertLegacyPreState(process.cwd(), legacyLaneHeads.major, "major"),
+    ).resolves.toBeUndefined();
+    await expect(assertLegacyPreState(process.cwd(), "HEAD", "minor")).rejects.toThrow();
+  });
+
+  test("generated PR은 exact base의 단일 자식이며 pre.json 삭제만 허용한다", async () => {
+    const value = await fixture();
+    const generated = await generate(value, "minor", 101);
+    await expect(
+      verifyLegacyNormalizationPull({
+        repositoryPath: value.repository,
+        repository: legacyNormalizationRepository,
+        marker: generated.marker,
+        pull: generated.pull,
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      verifyLegacyNormalizationPull({
+        repositoryPath: value.repository,
+        repository: legacyNormalizationRepository,
+        marker: { ...generated.marker, expectedPreSha256: "f".repeat(64) },
+        pull: generated.pull,
+      }),
+    ).rejects.toThrow("exact one-time 계약");
+  });
+
+  test("한 lane만 human squash merge된 중간 상태에서는 다른 operation을 잠근다", async () => {
+    const value = await fixture();
+    const minor = await generate(value, "minor", 201);
+    await merge(value, minor);
+    const status = await inspectLegacyNormalization({
+      repositoryPath: value.repository,
+      repository: legacyNormalizationRepository,
+      client: client(value),
+    });
+    expect(status).toEqual({
+      complete: false,
+      lanes: { minor: "normalized", major: "legacy" },
+    });
+    await expect(
+      assertLegacyNormalizationBoundary({
+        repositoryPath: value.repository,
+        repository: legacyNormalizationRepository,
+        client: client(value),
+        marker: null,
+      }),
+    ).rejects.toThrow("다른 release operation");
+
+    const major = await generate(value, "major", 202);
+    await merge(value, major);
+    await expect(
+      assertLegacyNormalizationBoundary({
+        repositoryPath: value.repository,
+        repository: legacyNormalizationRepository,
+        client: client(value),
+        marker: null,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tools/release-automation/src/setup/legacy-prerelease-normalization.ts
+++ b/tools/release-automation/src/setup/legacy-prerelease-normalization.ts
@@ -1,0 +1,386 @@
+import { createHash } from "node:crypto";
+import { parseLaneConfig, parseReleaseControl } from "../core/config";
+import type { GitHubPullRequest } from "../core/github";
+import {
+  isLegacyNormalizationMarker,
+  type LegacyNormalizationMarker,
+  validateGeneratedPr,
+} from "../core/marker";
+import type { PullRequestIdentity, ReleaseMarker } from "../core/types";
+import {
+  isValidationStatusBoundToRun,
+  latestValidationStatus,
+  type ReleaseValidationStatus,
+  type ReleaseValidationWorkflowRun,
+  validationRunIdFromStatus,
+} from "../core/validation-status";
+import { parsePrereleaseState } from "../lane/prerelease-state";
+import { isTrustedDevControlCommit } from "../sync/sync-control-plane";
+
+export const legacyNormalizationRepository = "daangn/seed-design";
+export const legacyPreSha256 = "edcbf1bcb9b4e2320be6041629ff423290106bb8c684d56c71fad2eb26a7872e";
+export const legacyLaneHeads = {
+  minor: "080815d86023ae8c0d3747e1482e634250263e3a",
+  major: "44a6c1f3f53a0ad8a558565909c70fcfe499feb1",
+} as const;
+export const releaseWorkflowsThatMustRemainDisabled = [
+  "release-packages.yml",
+  "release-publish.yml",
+  "release-sync.yml",
+] as const;
+
+export type LegacyNormalizationLane = keyof typeof legacyLaneHeads;
+
+export interface LegacyNormalizationClient {
+  request<T>(path: string): Promise<T>;
+  paginate<T>(path: string): Promise<T[]>;
+}
+
+export interface LegacyNormalizationStatus {
+  complete: boolean;
+  lanes: Record<LegacyNormalizationLane, "legacy" | "normalized">;
+}
+
+interface GitResult {
+  code: number;
+  output: string;
+}
+
+async function git(
+  repositoryPath: string,
+  arguments_: string[],
+  options: { allowFailure?: boolean; trim?: boolean } = {},
+): Promise<GitResult> {
+  const child = Bun.spawn(["git", ...arguments_], {
+    cwd: repositoryPath,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (code !== 0 && !options.allowFailure) {
+    throw new Error(`git ${arguments_.join(" ")} 실패:\n${stderr.trim()}`);
+  }
+  return { code, output: options.trim === false ? stdout : stdout.trim() };
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function identityFromPull(pull: GitHubPullRequest): PullRequestIdentity {
+  return {
+    author: pull.user.login,
+    body: pull.body ?? "",
+    baseRef: pull.base.ref,
+    headRef: pull.head.ref,
+    baseRepository: pull.base.repo.full_name,
+    headRepository: pull.head.repo?.full_name ?? "",
+  };
+}
+
+export function legacyNormalizationBranch(
+  lane: LegacyNormalizationLane,
+  operationId: string,
+): string {
+  if (!/^[1-9][0-9]*$/.test(operationId)) {
+    throw new Error("legacy normalization operation ID가 올바르지 않습니다.");
+  }
+  return `release-legacy-normalization/${lane}-${operationId}`;
+}
+
+export function assertLegacyNormalizationMarkerContract(
+  marker: ReleaseMarker,
+): asserts marker is LegacyNormalizationMarker {
+  if (
+    !isLegacyNormalizationMarker(marker) ||
+    marker.sourceRepository !== legacyNormalizationRepository ||
+    marker.expectedBaseSha !== legacyLaneHeads[marker.lane] ||
+    marker.expectedPreSha256 !== legacyPreSha256
+  ) {
+    throw new Error("legacy normalization marker가 exact one-time 계약과 다릅니다.");
+  }
+}
+
+async function assertControlState(repositoryPath: string, ref: string): Promise<void> {
+  const [controlText, lanesText] = await Promise.all([
+    git(repositoryPath, ["show", `${ref}:.github/release/control.json`]),
+    git(repositoryPath, ["show", `${ref}:.github/release/lanes.json`]),
+  ]);
+  const control = parseReleaseControl(JSON.parse(controlText.output) as unknown);
+  const config = parseLaneConfig(JSON.parse(lanesText.output) as unknown);
+  if (
+    control.mode !== "dry-run" ||
+    !control.rootageContractReady ||
+    config.repository !== legacyNormalizationRepository
+  ) {
+    throw new Error(
+      "legacy normalization은 exact repository의 Rootage-ready dry-run control에서만 허용됩니다.",
+    );
+  }
+}
+
+export async function assertLegacyPreState(
+  repositoryPath: string,
+  ref: string,
+  lane: LegacyNormalizationLane,
+): Promise<void> {
+  const result = await git(repositoryPath, ["show", `${ref}:.changeset/pre.json`], {
+    trim: false,
+  });
+  if (sha256(result.output) !== legacyPreSha256) {
+    throw new Error(`${lane} pre.json이 expected legacy bootstrap 내용과 다릅니다.`);
+  }
+  const state = parsePrereleaseState(
+    JSON.parse(result.output) as unknown,
+    `${lane} legacy prerelease state`,
+  );
+  if (state.mode !== "pre" || state.tag !== "beta" || state.changesets.length !== 0) {
+    throw new Error(`${lane} legacy prerelease state는 changesets가 빈 beta pre 상태여야 합니다.`);
+  }
+}
+
+async function assertPreStateAbsent(
+  repositoryPath: string,
+  ref: string,
+  lane: LegacyNormalizationLane,
+): Promise<void> {
+  const result = await git(repositoryPath, ["cat-file", "-e", `${ref}:.changeset/pre.json`], {
+    allowFailure: true,
+  });
+  if (result.code === 0) throw new Error(`${lane} normalized tree에 pre.json이 남아 있습니다.`);
+}
+
+async function assertDeletionCommit(
+  repositoryPath: string,
+  marker: LegacyNormalizationMarker,
+  headSha: string,
+): Promise<void> {
+  const [parents, files, patch, tree] = await Promise.all([
+    git(repositoryPath, ["rev-list", "--parents", "-n", "1", headSha]),
+    git(repositoryPath, ["diff", "--name-status", marker.expectedBaseSha, headSha, "--"]),
+    git(
+      repositoryPath,
+      ["diff", "--binary", "--full-index", "--no-ext-diff", marker.expectedBaseSha, headSha, "--"],
+      { trim: false },
+    ),
+    git(repositoryPath, ["rev-parse", `${headSha}^{tree}`]),
+  ]);
+  const commitParents = parents.output.split(/\s+/);
+  if (
+    commitParents.length !== 2 ||
+    commitParents[0] !== headSha ||
+    commitParents[1] !== marker.expectedBaseSha
+  ) {
+    throw new Error("legacy normalization head는 expected base의 단일 자식이어야 합니다.");
+  }
+  if (files.output !== "D\t.changeset/pre.json") {
+    throw new Error("legacy normalization PR은 자신의 .changeset/pre.json 삭제만 포함해야 합니다.");
+  }
+  if (sha256(patch.output) !== marker.patchSha256) {
+    throw new Error("legacy normalization patch SHA-256이 exact diff와 다릅니다.");
+  }
+  if (!/^[0-9a-f]{40}$/.test(tree.output)) {
+    throw new Error("legacy normalization tree SHA를 읽지 못했습니다.");
+  }
+  await assertPreStateAbsent(repositoryPath, headSha, marker.lane);
+}
+
+export async function verifyLegacyNormalizationPull(input: {
+  repositoryPath?: string;
+  repository: string;
+  marker: ReleaseMarker;
+  pull: GitHubPullRequest;
+}): Promise<void> {
+  const repositoryPath = input.repositoryPath ?? process.cwd();
+  assertLegacyNormalizationMarkerContract(input.marker);
+  const marker = input.marker;
+  const { pull } = input;
+  if (
+    input.repository !== legacyNormalizationRepository ||
+    pull.user.login !== "github-actions[bot]" ||
+    pull.base.repo.full_name !== input.repository ||
+    pull.head.repo?.full_name !== input.repository ||
+    pull.base.ref !== marker.lane ||
+    pull.head.ref !== legacyNormalizationBranch(marker.lane, marker.operationId) ||
+    pull.base.sha !== marker.expectedBaseSha ||
+    pull.head.sha !== marker.expectedHeadSha
+  ) {
+    throw new Error("legacy normalization PR identity가 exact marker/repository와 다릅니다.");
+  }
+  const [currentDev, currentLane] = await Promise.all([
+    git(repositoryPath, ["rev-parse", "origin/dev"]),
+    git(repositoryPath, ["rev-parse", `origin/${marker.lane}`]),
+  ]);
+  if (currentDev.output !== marker.controlSha) {
+    throw new Error("legacy normalization trusted dev control SHA가 stale합니다.");
+  }
+  if (currentLane.output !== marker.expectedBaseSha) {
+    throw new Error("legacy normalization PR base가 current exact legacy lane head가 아닙니다.");
+  }
+  await Promise.all([
+    assertControlState(repositoryPath, "origin/dev"),
+    assertLegacyPreState(repositoryPath, marker.expectedBaseSha, marker.lane),
+    assertDeletionCommit(repositoryPath, marker, marker.expectedHeadSha),
+  ]);
+}
+
+async function exactMergedNormalizationPull(input: {
+  repositoryPath: string;
+  repository: string;
+  lane: LegacyNormalizationLane;
+  laneHead: string;
+  client: LegacyNormalizationClient;
+}): Promise<GitHubPullRequest | null> {
+  const pulls = await input.client.paginate<GitHubPullRequest>(
+    `/repos/${input.repository}/pulls?state=closed&base=${input.lane}&sort=updated&direction=desc`,
+  );
+  const matches = pulls.flatMap((pull) => {
+    const marker = validateGeneratedPr(identityFromPull(pull));
+    if (!marker || !isLegacyNormalizationMarker(marker)) return [];
+    try {
+      assertLegacyNormalizationMarkerContract(marker);
+    } catch {
+      return [];
+    }
+    return marker.lane === input.lane &&
+      pull.merged_at &&
+      pull.merge_commit_sha === input.laneHead &&
+      pull.merged_by?.login &&
+      !pull.merged_by.login.endsWith("[bot]") &&
+      pull.base.sha === marker.expectedBaseSha &&
+      pull.head.sha === marker.expectedHeadSha
+      ? [{ pull, marker }]
+      : [];
+  });
+  if (matches.length === 0) return null;
+  if (matches.length !== 1) {
+    throw new Error(`${input.lane} normalization merge 증명이 유일하지 않습니다.`);
+  }
+  const { marker, pull } = matches[0];
+  await git(input.repositoryPath, [
+    "fetch",
+    "--no-tags",
+    "origin",
+    `+refs/pull/${pull.number}/head:refs/remotes/pull/${pull.number}/head`,
+  ]);
+  if (!(await isTrustedDevControlCommit(input.repositoryPath, marker.controlSha))) {
+    throw new Error(`${input.lane} normalization control SHA가 trusted dev 이력이 아닙니다.`);
+  }
+  const [mergeParents, mergeTree, generatedTree, statuses] = await Promise.all([
+    git(input.repositoryPath, ["rev-list", "--parents", "-n", "1", input.laneHead]),
+    git(input.repositoryPath, ["rev-parse", `${input.laneHead}^{tree}`]),
+    git(input.repositoryPath, ["rev-parse", `${marker.expectedHeadSha}^{tree}`]),
+    input.client.paginate<ReleaseValidationStatus>(
+      `/repos/${input.repository}/commits/${marker.expectedHeadSha}/statuses`,
+    ),
+  ]);
+  const parents = mergeParents.output.split(/\s+/);
+  if (
+    parents.length !== 2 ||
+    parents[1] !== marker.expectedBaseSha ||
+    input.laneHead === marker.expectedHeadSha ||
+    mergeTree.output !== generatedTree.output
+  ) {
+    throw new Error(
+      `${input.lane} normalization은 expected base에 human squash merge되어야 합니다.`,
+    );
+  }
+  const status = latestValidationStatus(
+    statuses,
+    input.repository,
+    marker.expectedHeadSha,
+    "workflow_dispatch",
+  );
+  const runId = status ? validationRunIdFromStatus(status, input.repository) : null;
+  if (!status || !runId) {
+    throw new Error(`${input.lane} normalization trusted validation receipt가 없습니다.`);
+  }
+  const run = await input.client.request<ReleaseValidationWorkflowRun>(
+    `/repos/${input.repository}/actions/runs/${runId}`,
+  );
+  if (
+    run.head_sha !== marker.controlSha ||
+    !isValidationStatusBoundToRun(status, run, input.repository, marker.expectedHeadSha)
+  ) {
+    throw new Error(`${input.lane} normalization validation receipt/run/control 결속이 다릅니다.`);
+  }
+  await Promise.all([
+    assertDeletionCommit(input.repositoryPath, marker, marker.expectedHeadSha),
+    assertPreStateAbsent(input.repositoryPath, input.laneHead, input.lane),
+  ]);
+  return pull;
+}
+
+export async function inspectLegacyNormalization(input: {
+  repositoryPath?: string;
+  repository: string;
+  client: LegacyNormalizationClient;
+}): Promise<LegacyNormalizationStatus> {
+  const repositoryPath = input.repositoryPath ?? process.cwd();
+  if (input.repository !== legacyNormalizationRepository) {
+    throw new Error("legacy normalization repository가 exact 계약과 다릅니다.");
+  }
+  await assertControlState(repositoryPath, "origin/dev");
+  const lanes = {} as LegacyNormalizationStatus["lanes"];
+  for (const lane of ["minor", "major"] as const) {
+    const laneHead = (await git(repositoryPath, ["rev-parse", `origin/${lane}`])).output;
+    if (laneHead === legacyLaneHeads[lane]) {
+      await assertLegacyPreState(repositoryPath, laneHead, lane);
+      lanes[lane] = "legacy";
+      continue;
+    }
+    const pull = await exactMergedNormalizationPull({
+      repositoryPath,
+      repository: input.repository,
+      lane,
+      laneHead,
+      client: input.client,
+    });
+    if (!pull) {
+      throw new Error(`${lane} head가 expected legacy 또는 trusted normalized 상태가 아닙니다.`);
+    }
+    lanes[lane] = "normalized";
+  }
+  return {
+    complete: lanes.minor === "normalized" && lanes.major === "normalized",
+    lanes,
+  };
+}
+
+export async function assertLegacyNormalizationBoundary(input: {
+  repositoryPath?: string;
+  repository: string;
+  client: LegacyNormalizationClient;
+  marker: ReleaseMarker | null;
+}): Promise<void> {
+  const status = await inspectLegacyNormalization(input);
+  if (status.complete) return;
+  if (input.marker?.type === "legacy-normalization") {
+    assertLegacyNormalizationMarkerContract(input.marker);
+    if (status.lanes[input.marker.lane] === "legacy") return;
+  }
+  throw new Error(
+    "minor와 major legacy prerelease normalization이 모두 완료되기 전에는 다른 release operation을 진행할 수 없습니다.",
+  );
+}
+
+export async function assertReleaseWorkflowsDisabled(
+  repository: string,
+  client: LegacyNormalizationClient,
+): Promise<void> {
+  if (repository !== legacyNormalizationRepository) {
+    throw new Error("release workflow 상태를 확인할 repository가 exact 계약과 다릅니다.");
+  }
+  for (const workflow of releaseWorkflowsThatMustRemainDisabled) {
+    const state = await client.request<{ state: string }>(
+      `/repos/${repository}/actions/workflows/${workflow}`,
+    );
+    if (state.state !== "disabled_manually") {
+      throw new Error(`${workflow}는 legacy normalization 동안 disabled_manually여야 합니다.`);
+    }
+  }
+}

--- a/tools/release-automation/src/validation/generated-pr-validation.ts
+++ b/tools/release-automation/src/validation/generated-pr-validation.ts
@@ -6,6 +6,7 @@ import { GitHubClient, type GitHubPullRequest } from "../core/github";
 import {
   isBaselineMarker,
   isCodePromotionMarker,
+  isLegacyNormalizationMarker,
   isPrereleaseMarker,
   isStablePromotionMarker,
   validateGeneratedPr,
@@ -32,6 +33,10 @@ import { assertDevStablePublishReconciled } from "../publish/baseline-reconcilia
 import { verifyCodePromotionPull } from "../promotion/code-promotion-validation";
 import { assertNoCompetingOpenStablePromotion } from "../promotion/promotion-state";
 import { assertUniqueOpenReleasePullForHead } from "./head-identity";
+import {
+  assertLegacyNormalizationBoundary,
+  verifyLegacyNormalizationPull,
+} from "../setup/legacy-prerelease-normalization";
 
 type AssociatedPullRequest = GitHubPullRequest & { state: "open" | "closed" };
 
@@ -152,6 +157,14 @@ if (fetchedHeadSha !== headSha || pull.head.sha !== headSha || pull.head.ref !==
 }
 const filesOutput = await git(["diff", "--name-only", `origin/${marker.lane}...${headSha}`, "--"]);
 const changedFiles = filesOutput ? filesOutput.split("\n") : [];
+await git([
+  "fetch",
+  "--no-tags",
+  "origin",
+  "+refs/heads/minor:refs/remotes/origin/minor",
+  "+refs/heads/major:refs/remotes/origin/major",
+]);
+await assertLegacyNormalizationBoundary({ repository, client, marker });
 const provenance = await verifyGeneratedPrProvenance({ marker, headSha, changedFiles });
 const promotionException =
   isStablePromotionMarker(marker) || marker.type === "code-promotion" || marker.type === "baseline";
@@ -215,6 +228,9 @@ if (marker.type === "code-promotion" && isCodePromotionMarker(marker)) {
     allowDraft: validationKind === "code-promotion-preflight",
     client,
   });
+}
+if (marker.type === "legacy-normalization" && isLegacyNormalizationMarker(marker)) {
+  await verifyLegacyNormalizationPull({ repository, marker, pull });
 }
 if (marker.type === "bootstrap") {
   if (marker.lane !== "minor" && marker.lane !== "major") {

--- a/tools/release-automation/src/validation/generated-pr-workflow.test.ts
+++ b/tools/release-automation/src/validation/generated-pr-workflow.test.ts
@@ -27,6 +27,50 @@ async function readWorkflow(path: string): Promise<Workflow> {
 }
 
 describe("generated release PR workflow dispatch", () => {
+  test("legacy normalization은 별도 one-time workflow에서 두 lane PR만 생성한다", async () => {
+    const [workflow, writer, policy] = await Promise.all([
+      readWorkflow(".github/workflows/release-legacy-normalization.yml"),
+      readFile(
+        "tools/release-automation/src/setup/legacy-prerelease-normalization-write.ts",
+        "utf8",
+      ),
+      readFile("tools/release-automation/src/setup/legacy-prerelease-normalization.ts", "utf8"),
+    ]);
+    const preflight = workflow.jobs.preflight;
+    const create = workflow.jobs.create;
+    const createStep = create.steps?.find(
+      (step) => step.name === "Create exact state-deletion PR without lane code execution",
+    );
+    expect(workflow.concurrency).toEqual({
+      group: "release-version-global-operation",
+      "cancel-in-progress": false,
+    });
+    expect(Object.keys(workflow.jobs)).toEqual(["preflight", "create", "summarize"]);
+    expect(preflight.permissions).toEqual({
+      actions: "read",
+      contents: "read",
+      "pull-requests": "read",
+    });
+    expect(create.permissions).toEqual({
+      actions: "write",
+      contents: "write",
+      "pull-requests": "write",
+    });
+    expect(createStep?.run).toContain("legacy-prerelease-normalization-write.ts write");
+    expect(create.steps?.some((step) => step.uses === "./.github/actions/setup")).toBe(false);
+    expect(writer).toContain("matrix=${JSON.stringify([");
+    expect(writer).toContain('{ lane: "minor" }');
+    expect(writer).toContain('{ lane: "major" }');
+    expect(writer).toContain('"update-index", "--force-remove", ".changeset/pre.json"');
+    expect(writer).toContain("state=all&base=");
+    expect(writer).not.toContain("changeset pre enter");
+    expect(writer).not.toContain("changeset pre exit");
+    expect(policy).toContain("legacyLaneHeads");
+    expect(policy).toContain("legacyPreSha256");
+    expect(policy).toContain("isValidationStatusBoundToRun");
+    expect(policy).toContain("disabled_manually");
+  });
+
   test("Version Packages PR은 tokenless lane plan과 trusted dev writer를 분리한다", async () => {
     const workflow = await readWorkflow(".github/workflows/release-packages.yml");
     const plan = workflow.jobs.plan;
@@ -214,6 +258,8 @@ describe("generated release PR workflow dispatch", () => {
       expect(validator).toContain("exiting lane에는 exact Stable Version Packages PR만 허용됩니다");
       expect(validator).toContain("proposedConfig");
       expect(validator).toContain("verifyTrustedGeneratedSync({");
+      expect(validator).toContain("verifyLegacyNormalizationPull");
+      expect(validator).toContain("assertLegacyNormalizationBoundary");
     }
     expect(cli.indexOf("verifyGeneratedLaneWritePlan(")).toBeLessThan(
       cli.indexOf('generated: "true"'),

--- a/tools/release-automation/src/validation/release-selection.ts
+++ b/tools/release-automation/src/validation/release-selection.ts
@@ -14,6 +14,7 @@ import {
   validationRunIdFromStatus,
 } from "../core/validation-status";
 import { assertNoCompetingOpenStablePromotion } from "../promotion/promotion-state";
+import { assertLegacyNormalizationBoundary } from "../setup/legacy-prerelease-normalization";
 
 const gitShaPattern = /^[0-9a-f]{40}$/;
 const operationIdPattern = /^[1-9][0-9]*$/;
@@ -232,6 +233,22 @@ export async function selectReleaseWork(input: {
   const requestedOperation = parseOperation(input.requestedOperation);
   if (!operationIdPattern.test(input.operationId))
     throw new Error("workflow run ID가 올바르지 않습니다.");
+  if (!input.client || !input.repository) {
+    throw new Error("release selection에는 trusted GitHub client와 repository가 필요합니다.");
+  }
+  await git([
+    "fetch",
+    "--no-tags",
+    "origin",
+    "+refs/heads/dev:refs/remotes/origin/dev",
+    "+refs/heads/minor:refs/remotes/origin/minor",
+    "+refs/heads/major:refs/remotes/origin/major",
+  ]);
+  await assertLegacyNormalizationBoundary({
+    repository: input.repository,
+    client: input.client,
+    marker: null,
+  });
 
   if (input.eventName === "push") {
     const item = await regularVersionItem("dev", input.controlSha, input);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 레거시 `minor`·`major` 프리릴리스 상태를 정리하는 수동 실행 절차를 추가했습니다.
  - 각 대상에 대해 필요한 상태 파일만 정리하는 검증된 PR을 생성합니다.
  - 작업 결과와 진행 상태를 확인할 수 있으며, 모든 정리가 완료될 때까지 관련 릴리스 진행을 차단합니다.

- **문서**
  - 정리 작업의 실행 조건, 검증 절차, 중복 실행 방지 및 후속 정리 방법을 문서화했습니다.

- **안정성 개선**
  - 권한, 브랜치, 변경 범위 및 커밋 상태를 엄격히 검증해 잘못된 변경이나 중복 작업을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->