### PR TITLE
fix(docs): update Date/Time Picker Figma node IDs

### DIFF
--- a/docs/content/components/date-picker.mdx
+++ b/docs/content/components/date-picker.mdx
@@ -11,7 +11,7 @@ Date Picker는 캘린더에서 날짜를 직접 골라 입력받는 컴포넌트
 ## Anatomy
 
 <FigmaImage
-  id="2359:9559"
+  id="2391:10211"
   alt="Date Picker의 Anatomy 이미지. Header, Weekday Row, Date Grid로 구성됩니다."
 />
 
@@ -24,11 +24,11 @@ Date Picker는 선택 상태를 관리하는 root 아래에, 선택 UI를 담는
 ### 월·연도 전환
 
 <FigmaImage
-  id="2359:9573"
+  id="2391:10225"
   alt="월·연도 picker가 닫힌 상태와 열린 상태 비교"
 />
 <FigmaImage
-  id="2359:9580"
+  id="2391:10232"
   alt="Visible Range가 Week일 때 월·연도 picker가 monthYearLabel에 anchor된 popover로 떠오르는 닫힘·열림 비교"
 />
 
@@ -47,7 +47,7 @@ prevButton·nextButton은 한 달씩 이동하며, 멀리 떨어진 월·연도�
 날짜를 어떤 방식으로 선택할지 정하는 Property입니다.
 
 <FigmaImage
-  id="2359:9597"
+  id="2391:10249"
   alt="Date Picker의 Selection Property — Single, Range, Multiple 각 선택 예시"
 />
 
@@ -62,11 +62,11 @@ Range는 시작·종료 칸을 채우고 그 사이를 연결된 띠로 잇습�
 캘린더가 한 번에 보여주는 날짜 범위를 정합니다.
 
 <FigmaImage
-  id="2359:9618"
+  id="2391:10270"
   alt="Visible Range 사용 맥락 — Month, Continuous, Week 적용 화면 예시"
 />
 <FigmaImage
-  id="2359:9652"
+  id="2391:10304"
   alt="Visible Range Two Months — 데스크탑 Popover에서 두 달을 나란히 표시하는 예시"
 />
 
@@ -86,7 +86,7 @@ Continuous는 헤더의 prevButton·nextButton·monthYearLabel 대신 스크롤�
 dateGrid의 각 칸(dateCell)이 가지는 상태입니다. 날짜의 성격을 색·배경으로 구분해, 고를 수 있는 날짜와 이미 고른 날짜를 한눈에 알 수 있게 합니다.
 
 <FigmaImage
-  id="2359:9664"
+  id="2391:10316"
   alt="Date Cell의 상태 — Enabled, Pressed, Today, Selected, Range, In Range, Disabled"
 />
 
@@ -109,15 +109,15 @@ dateGrid의 각 칸(dateCell)이 가지는 상태입니다. 날짜의 성격을 
 ### Layout 선택하기
 
 <FigmaImage
-  id="2359:9686"
+  id="2391:10338"
   alt="Layout 선택 — Inline 사용 맥락 예시"
 />
 <FigmaImage
-  id="2359:9721"
+  id="2391:10373"
   alt="Layout 선택 — Sheet 사용 맥락 예시"
 />
 <FigmaImage
-  id="2359:9769"
+  id="2391:10421"
   alt="Layout 선택 — Popover 사용 맥락 예시"
 />
 
@@ -132,7 +132,7 @@ Popover·Sheet의 트리거는 [Input Button](/components/input-button)이나 [F
 ### 진입 시 보여줄 월
 
 <FigmaImage
-  id="2359:9788"
+  id="2391:10440"
   alt="캘린더를 열면 오늘이 속한 월이 기본으로 표시되는 예시"
 />
 
@@ -141,7 +141,7 @@ Popover·Sheet의 트리거는 [Input Button](/components/input-button)이나 [F
 ### 기간·여러 날짜 선택 안내
 
 <FigmaImage
-  id="2359:9808"
+  id="2391:10460"
   alt="Range와 Multiple의 제약을 Callout으로 안내하는 예시"
 />
 

--- a/docs/content/components/time-picker.mdx
+++ b/docs/content/components/time-picker.mdx
@@ -18,7 +18,7 @@ Time Picker는 선택 상태를 관리하는 root 아래에, 휠 UI를 담는 su
 시·분 휠은 시·분 같은 단위 접미사 없이 숫자만 보여주고, 단위는 오전·오후 칼럼과 선택 위치로 전달됩니다(예: 오전 10 00 = 오전 10시 00분).
 
 <FigmaImage
-  id="2249:6213"
+  id="2391:18134"
   alt="Time Picker의 Anatomy 이미지. Period Column, Hour Column, Minute Column, Selection Indicator로 구성됩니다."
 />
 
@@ -37,7 +37,7 @@ Time Picker는 선택 상태를 관리하는 root 아래에, 휠 UI를 담는 su
 간격이 넓을수록 고를 수 있는 분이 줄어 빠르게 선택할 수 있고, 좁을수록 정밀해집니다. 현재 시각으로 진입할 때는 선택된 분을 Minute Step에 맞춰 가까운 값으로 반올림합니다(예: Minute Step=5에서 9시 13분 → 9시 15분).
 
 <FigmaImage
-  id="2249:6230"
+  id="2391:18151"
   alt="Minute Step을 1, 5, 10, 15, 30으로 설정한 Time Picker 예시"
 />
 
@@ -54,12 +54,12 @@ Time Picker가 화면에서 차지하는 비중과 플랫폼에 따라 Layout을
 Popover와 Sheet는 surface를 여는 trigger가 필요하며, 트리거는 [Input Button](/components/input-button)이나 [Field](/components/field)를 합성해 만듭니다. 시간 선택이 화면의 주된 작업이면 Inline, 모바일 폼에서는 Sheet, 데스크탑 폼에서는 Popover를 기본으로 검토합니다. Inline의 확정은 화면의 액션 영역(다음·완료 등)이, Popover·Sheet의 확정은 confirmButton이 담당합니다.
 
 <FigmaImage
-  id="2249:6255"
+  id="2391:18176"
   alt="모바일 화면에서 Inline과 Sheet Layout으로 Time Picker를 사용한 예시"
 />
 
 <FigmaImage
-  id="2249:6363"
+  id="2391:18284"
   alt="데스크탑 화면에서 Popover Layout으로 Time Picker를 사용한 예시"
 />
 
@@ -68,7 +68,7 @@ Popover와 Sheet는 surface를 여는 trigger가 필요하며, 트리거는 [Inp
 휠을 처음 열면 이미 선택된 시간이 있으면 그 값을, 없으면 `00:00`을 가운데에 두고 엽니다. 현재 시각에서 시작하려면 현재 시각을 Minute Step에 맞춰 반올림한 값을 `defaultValue`로 전달합니다.
 
 <FigmaImage
-  id="2249:6535"
+  id="2391:18456"
   alt="선택된 시간과 현재 시각을 기준으로 Time Picker를 처음 연 예시"
 />
 
@@ -81,7 +81,7 @@ Popover와 Sheet는 surface를 여는 trigger가 필요하며, 트리거는 [Inp
 날짜 선택의 동작·가이드는 Date Picker가 담당하고, Time Picker는 시간 선택만 책임집니다.
 
 <FigmaImage
-  id="2249:6554"
+  id="2391:18494"
   alt="Date Picker를 Inline으로 펼치고 Time Picker를 Sheet로 함께 사용한 예시"
 />
 

--- a/docs/content/components/time-picker.mdx
+++ b/docs/content/components/time-picker.mdx
@@ -81,7 +81,7 @@ Popover와 Sheet는 surface를 여는 trigger가 필요하며, 트리거는 [Inp
 날짜 선택의 동작·가이드는 Date Picker가 담당하고, Time Picker는 시간 선택만 책임집니다.
 
 <FigmaImage
-  id="2391:18494"
+  id="2391:18475"
   alt="Date Picker를 Inline으로 펼치고 Time Picker를 Sheet로 함께 사용한 예시"
 />
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * Date Picker 문서의 Figma 이미지 참조를 최신 이미지로 업데이트했습니다.
  * Time Picker 문서의 구성, 간격, 레이아웃 및 연동 예시 이미지를 최신 버전으로 교체했습니다.
  * 기존 설명과 동작 안내는 변경되지 않았습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->