### PR TITLE
chore(docs): add warm build benchmark metrics

### DIFF
--- a/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: string
         default: ""
+      benchmark-cache-key:
+        description: "Optional identifier for a reproducible cold/warm Turbopack benchmark"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -68,12 +73,16 @@ jobs:
         with:
           path: docs/.next/cache
           # Reuse the build inputs already hashed by setup, then add docs inputs only.
-          key: ${{ runner.os }}-nextjs-${{ steps.setup.outputs.build-cache-key-suffix }}-${{ hashFiles('docs/**/*.js', 'docs/**/*.jsx', 'docs/**/*.mjs', 'docs/**/*.ts', 'docs/**/*.tsx', 'docs/**/*.mdx', 'docs/**/*.css', 'docs/**/*.json') }}
-          # Rebuild from the nearest cache when build or docs inputs changed.
+          # A benchmark key creates an isolated namespace. A new value starts cold;
+          # repeating it with the same sources must restore the exact cache entry.
+          key: ${{ runner.os }}-nextjs-${{ inputs.benchmark-cache-key && format('benchmark-{0}-', inputs.benchmark-cache-key) || '' }}${{ steps.setup.outputs.build-cache-key-suffix }}-${{ hashFiles('docs/**/*.js', 'docs/**/*.jsx', 'docs/**/*.mjs', 'docs/**/*.ts', 'docs/**/*.tsx', 'docs/**/*.mdx', 'docs/**/*.css', 'docs/**/*.json') }}
+          # Normal deployments may reuse a nearby cache. Benchmarks only search their
+          # isolated namespace so the first run remains cold.
           restore-keys: |
-            ${{ runner.os }}-nextjs-
+            ${{ inputs.benchmark-cache-key && format('{0}-nextjs-benchmark-{1}-', runner.os, inputs.benchmark-cache-key) || format('{0}-nextjs-', runner.os) }}
 
       - name: Build Docs
+        id: build-docs
         working-directory: ./docs
         env:
           # docs uses Next static export, so NEXT_PUBLIC_* values must be present at build time.
@@ -84,7 +93,69 @@ jobs:
           # Figma image processing + Next webpack export exceed Node's default ~2GB heap on CI.
           NODE_OPTIONS: --max-old-space-size=6144
         run: |
-          bun run build
+          build_started_at="$(date +%s)"
+          turbopack_duration_seconds="not-run"
+          status=0
+
+          # Keep the package build sequence, while measuring only `next build --turbopack`.
+          set +e
+          bun run prepare:figma-images
+          status=$?
+
+          if [ "$status" -eq 0 ]; then
+            bun run typecheck
+            status=$?
+          fi
+
+          if [ "$status" -eq 0 ]; then
+            turbopack_started_at="$(date +%s)"
+            bun run build:turbopack
+            status=$?
+            turbopack_duration_seconds="$(( $(date +%s) - turbopack_started_at ))"
+          fi
+
+          if [ "$status" -eq 0 ]; then
+            bun run generate:changelog-llms
+            status=$?
+          fi
+
+          echo "duration-seconds=$(( $(date +%s) - build_started_at ))" >> "$GITHUB_OUTPUT"
+          echo "turbopack-duration-seconds=$turbopack_duration_seconds" >> "$GITHUB_OUTPUT"
+          echo "exit-code=$status" >> "$GITHUB_OUTPUT"
+          exit "$status"
+
+      - name: Report docs build benchmark
+        if: ${{ always() }}
+        env:
+          BENCHMARK_CACHE_KEY: ${{ inputs.benchmark-cache-key }}
+          NEXTJS_CACHE_HIT: ${{ steps.restore-nextjs-cache.outputs.cache-hit }}
+          NEXTJS_CACHE_MATCHED_KEY: ${{ steps.restore-nextjs-cache.outputs.cache-matched-key }}
+          NEXTJS_CACHE_PRIMARY_KEY: ${{ steps.restore-nextjs-cache.outputs.cache-primary-key }}
+          BUILD_DURATION_SECONDS: ${{ steps.build-docs.outputs.duration-seconds }}
+          TURBOPACK_DURATION_SECONDS: ${{ steps.build-docs.outputs.turbopack-duration-seconds }}
+          BUILD_EXIT_CODE: ${{ steps.build-docs.outputs.exit-code }}
+        run: |
+          cache_result="miss"
+          if [ "$NEXTJS_CACHE_HIT" = "true" ]; then
+            cache_result="exact hit"
+          elif [ -n "$NEXTJS_CACHE_MATCHED_KEY" ]; then
+            cache_result="restore-key hit (not exact)"
+          fi
+
+          {
+            echo "## Docs build benchmark"
+            echo
+            echo "| Metric | Value |"
+            echo "| --- | --- |"
+            echo "| Benchmark cache key | ${BENCHMARK_CACHE_KEY:-default deployment cache} |"
+            echo "| Next.js Actions cache | $cache_result |"
+            echo "| Next.js cache exact hit | ${NEXTJS_CACHE_HIT:-false} |"
+            echo "| Next.js cache matched key | ${NEXTJS_CACHE_MATCHED_KEY:-none} |"
+            echo "| Next.js cache primary key | ${NEXTJS_CACHE_PRIMARY_KEY:-unknown} |"
+            echo "| Turbopack build time (seconds) | ${TURBOPACK_DURATION_SECONDS:-not-recorded} |"
+            echo "| Total docs build time (seconds) | ${BUILD_DURATION_SECONDS:-not-recorded} |"
+            echo "| Build exit code | ${BUILD_EXIT_CODE:-not-recorded} |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Save Next.js cache
         if: ${{ steps.restore-nextjs-cache.outputs.cache-hit != 'true' }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,31 @@
-# Docs
+# 문서 사이트
 
-All-in-one documentation of SEED Design System.
+SEED Design System의 통합 문서 사이트입니다. Fumadocs를 기반으로 만듭니다.
 
-Powered by [Fumadocs](https://github.com/fuma-nama/fumadocs).
-
-## Development
+## 개발
 
 ```bash
-npm run dev
-# or
-pnpm dev
-# or
 bun dev
 ```
 
-Open http://localhost:3000 with your browser to see the result.
+브라우저에서 <http://localhost:3000>을 엽니다.
+
+## Turbopack cold/warm 빌드 측정
+
+`deploy-seed-design-docs-alpha-pages` 워크플로를 같은 커밋에서 연속 두 번 실행하면, Next.js Actions 캐시와 Turbopack 빌드 시간을 비교할 수 있습니다. 실제 배포가 발생하므로 배포가 허용된 테스트 브랜치에서만 실행합니다.
+
+1. Actions에서 `deploy-seed-design-docs-alpha-pages`를 수동 실행합니다.
+2. `benchmark-cache-key`에 이전에 사용하지 않은 짧은 식별자(예: `docs-warm-20260810`)를 입력합니다. 두 실행에서 브랜치, 커밋, 이 값과 Figma 관련 입력값을 모두 같게 유지합니다.
+3. 첫 실행이 끝나 Next.js 캐시 저장 단계까지 성공했는지 확인합니다. 이 실행은 새 키를 사용하므로 `Next.js cache exact hit`이 `false`여야 합니다.
+4. 같은 설정으로 두 번째 실행을 시작합니다. 두 번째 실행에서는 `Next.js cache exact hit`이 `true`이고 `Next.js cache matched key`가 `Next.js cache primary key`와 같아야 합니다.
+
+각 실행의 작업 요약에 있는 `Docs build benchmark` 표에서 아래 값을 기록합니다.
+
+| 지표 | 의미 |
+| --- | --- |
+| `Turbopack build time (seconds)` | `next build --turbopack` 구간만 측정한 시간입니다. |
+| `Total docs build time (seconds)` | Figma 이미지 준비, 타입 검사, Turbopack, 변경 로그 생성까지 포함한 시간입니다. |
+| `Next.js cache exact hit` | 현재 소스의 기본 캐시 키와 정확히 일치한 캐시를 복원했는지 나타냅니다. `true`만 warm 비교의 기준으로 사용합니다. |
+| `Next.js cache matched key` | 실제로 복원한 캐시 키입니다. 첫 실행에서 값이 있으면 새 식별자를 사용하지 않았거나 같은 식별자를 이미 사용한 것입니다. |
+
+첫 번째 실행의 `exact hit=false`와 두 번째 실행의 `exact hit=true`를 확인한 뒤 두 시간 값을 나란히 비교합니다. 두 번째 실행이 정확한 hit가 아니면 복원 키가 다른 상태이므로 cold/warm 결과로 기록하지 않고, 새 `benchmark-cache-key`로 다시 측정합니다.

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "bun run prepare:figma-images && bun run typecheck && NEXT_EXTERNAL_TYPECHECK=1 next build --turbopack && bun run generate:changelog-llms",
+    "build": "bun run prepare:figma-images && bun run typecheck && bun run build:turbopack && bun run generate:changelog-llms",
+    "build:turbopack": "NEXT_EXTERNAL_TYPECHECK=1 next build --turbopack",
     "dev": "concurrently \"bun --filter @seed-design/stackflow-spa dev\" \"next dev --webpack\"",
     "start": "concurrently \"bun --filter @seed-design/stackflow-spa dev\" \"next start\"",
     "sanity:dev": "sanity dev",


### PR DESCRIPTION
## 변경 사항

- 알파 문서 배포에 cold/warm 빌드를 구분하는 벤치마크 캐시 키를 추가했습니다.
- Turbopack 구간과 전체 문서 빌드 시간을 각각 기록합니다.
- Next.js Actions 캐시의 정확 적중과 부분 복원 키를 출력합니다.
- 한국어 측정 절차와 비교할 지표를 문서화했습니다.

## 배경

연속된 두 배포에서 파일 시스템 캐시가 실제로 재사용되는지 일관되게 비교할 수 있는 계측이 필요했습니다.

## 검증

- 워크플로 및 문서 정적 검토
- `bun generate:all`은 기존 `@seed-design/rootage-core` 해석 문제로 중단
- 사용자 요청에 따라 테스트는 생략했습니다.