### PR TITLE
fix(ci): stabilize build cache key

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -32,22 +32,12 @@ runs:
         restore-keys: |
           ${{ runner.os }}-bun-
 
-    - name: Install Dependencies
-      shell: bash
-      run: bun install --frozen-lockfile
-
-    - name: Build Ecosystem Tools and Relink Workspace
-      shell: bash
-      run: |
-        bun ecosystem:build
-        bun install --frozen-lockfile
-
     - name: Generate build cache key
       id: build-cache-key
       if: ${{ inputs.build-packages == 'true' }}
       shell: bash
       env:
-        BUILD_CACHE_KEY_SUFFIX: rootage-${{ inputs.build-rootage }}-${{ hashFiles('packages/**', 'ecosystem/**', 'bun.lock', 'bun.lockb') }}
+        BUILD_CACHE_KEY_SUFFIX: rootage-${{ inputs.build-rootage }}-${{ hashFiles('packages/**', 'ecosystem/**', 'package.json', 'bunfig.toml', 'tsconfig*.json', 'bun.lock', 'bun.lockb', '!packages/**/dist/**', '!packages/**/build/**', '!packages/**/lib/**', '!ecosystem/**/dist/**', '!ecosystem/**/build/**', '!ecosystem/**/lib/**') }}
       run: echo "suffix=$BUILD_CACHE_KEY_SUFFIX" >> "$GITHUB_OUTPUT"
 
     - name: Cache build outputs
@@ -63,6 +53,18 @@ runs:
           ecosystem/**/build
           ecosystem/**/lib
         key: ${{ runner.os }}-build-${{ steps.build-cache-key.outputs.suffix }}
+
+    - name: Install Dependencies
+      if: ${{ inputs.build-packages != 'true' || steps.cache-build.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: bun install --frozen-lockfile
+
+    - name: Build Ecosystem Tools and Relink Workspace
+      if: ${{ inputs.build-packages != 'true' || steps.cache-build.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: |
+        bun ecosystem:build
+        bun install --frozen-lockfile
 
     - name: Relink workspace after cache restore
       if: ${{ inputs.build-packages == 'true' && steps.cache-build.outputs.cache-hit == 'true' }}


### PR DESCRIPTION
## 변경 사항

- 빌드 출력 캐시 키를 생성물 복원과 ecosystem 빌드 전에 계산합니다.
- 출력 디렉터리를 캐시 키 해시 대상에서 제외했습니다.
- 정확한 캐시 적중에서는 불필요한 ecosystem, package, rootage 빌드와 중복 설치를 건너뜁니다.

## 배경

기존 키는 빌드 후 생성된 파일까지 포함해 패키지 소스가 바뀌지 않아도 캐시가 빗나갈 수 있었습니다.

## 검증

- YAML 정적 구문 확인
- `git diff --check`
- 사용자 요청에 따라 테스트는 생략했습니다.