### PR TITLE
ci(setup): restore ultra incremental state

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -59,10 +59,14 @@ runs:
           packages/**/dist
           packages/**/build
           packages/**/lib
+          packages/**/.ultra.cache.json
           ecosystem/**/dist
           ecosystem/**/build
           ecosystem/**/lib
+          ecosystem/**/.ultra.cache.json
         key: ${{ runner.os }}-build-${{ steps.build-cache-key.outputs.suffix }}
+        restore-keys: |
+          ${{ runner.os }}-build-rootage-${{ inputs.build-rootage }}-
 
     - name: Relink workspace after cache restore
       if: ${{ inputs.build-packages == 'true' && steps.cache-build.outputs.cache-hit == 'true' }}

--- a/.ultraignore
+++ b/.ultraignore
@@ -1,0 +1,1 @@
+**/node_modules/


### PR DESCRIPTION
## 변경 사항

- 패키지와 ecosystem의 `.ultra.cache.json`을 Actions 캐시에 포함했습니다.
- 동일한 Rootage 구성의 최신 캐시를 `restore-keys`로 부분 복원합니다.
- `.ultraignore`에서 `node_modules`를 제외해 설치 시각 변경이 전체 재빌드를 유발하지 않게 했습니다.

## 배경

새 CI 러너에서는 Ultra의 증분 상태가 사라져 매번 모든 패키지를 첫 빌드로 처리하고 있었습니다.

## 영향

캐시 키가 정확히 일치하지 않아도 이전 출력과 Ultra 상태를 재사용해 변경된 패키지와 의존 패키지만 다시 빌드할 수 있습니다.

## 검증

- 설정 및 diff 정적 검토
- 사용자 요청에 따라 테스트는 생략했습니다.