### PR TITLE
fix(lynx-react): use internal preact in minor lane tests

### DIFF
--- a/packages/lynx-react/vitest.config.ts
+++ b/packages/lynx-react/vitest.config.ts
@@ -1,7 +1,40 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+
 import { createVitestConfig } from "@lynx-js/react/testing-library/vitest-config";
 import { defineConfig, mergeConfig } from "vitest/config";
 
 const defaultConfig = await createVitestConfig();
+const require = createRequire(import.meta.url);
+const aliases = defaultConfig.test?.alias;
+
+if (!Array.isArray(aliases)) {
+  throw new Error("Expected ReactLynx Vitest aliases to be an array.");
+}
+
+const runtimePreactPackageAlias = aliases.find(
+  (alias) =>
+    alias.find instanceof RegExp && alias.find.source === String.raw`^preact\/package.json$`,
+);
+
+if (!runtimePreactPackageAlias) {
+  throw new Error("Expected ReactLynx Vitest config to include a Preact package alias.");
+}
+
+const runtimePreactDirectory = path.dirname(runtimePreactPackageAlias.replacement);
+const internalPreactDirectory = path.dirname(require.resolve("preact/package.json"));
+
+defaultConfig.test = {
+  ...defaultConfig.test,
+  alias: aliases.map((alias) =>
+    alias.find instanceof RegExp && alias.find.source.startsWith("^preact")
+      ? {
+          ...alias,
+          replacement: alias.replacement.replace(runtimePreactDirectory, internalPreactDirectory),
+        }
+      : alias,
+  ),
+};
 
 export default mergeConfig(
   defaultConfig,


### PR DESCRIPTION
## 배경

릴리즈 레인 동기화 PR이 PR #1947보다 오래된 레인 기준점에서 전체 검증을 실행하면서, 이미 수정된 Lynx 테스트 런타임 문제로 FIFO 진행이 막혔습니다.

이 PR은 엄격한 전체 검증을 낮추지 않고 FIFO를 복구하기 위한 일회성 호환성 백포트입니다. PR #1947의 테스트 설정 한 파일만 동일하게 적용하며, 제품 코드·changeset·버전 산출물은 포함하지 않습니다.

## 변경

- ReactLynx Vitest의 Preact alias를 워크스페이스 내부 Preact로 연결
- 변경 파일: `packages/lynx-react/vitest.config.ts`

## 검증

- `bun test:lynx-react` — 63개 통과
- `bun generate:all` — 성공, 추가 추적 변경 없음
- `bun packages:build` — 성공
- `bun test:all` — 성공

## 병합 후

이 PR을 squash merge한 뒤 기존 generated sync PR은 닫고, lane synchronization drain을 다시 실행합니다.
