### PR TITLE
fix(docs): honor Figma Retry-After instead of exponential backoff

### DIFF
--- a/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
@@ -48,6 +48,7 @@ jobs:
   deploy:
     name: deploy-seed-design-docs-alpha-pages
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/deploy-seed-design-docs-prod-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-prod-pages.yml
@@ -40,6 +40,7 @@ jobs:
   deploy:
     name: deploy-seed-design-docs-prod-pages
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v6

--- a/docs/components/figma-image/fetch-figma-image-urls.test.ts
+++ b/docs/components/figma-image/fetch-figma-image-urls.test.ts
@@ -13,11 +13,14 @@ describe("getRetryDelayMs", () => {
     expect(getRetryDelayMs(new Error("FigmaImage requires an 'alt' prop"))).toBeNull();
   });
 
-  it("waits as long as Retry-After asks, plus jitter", () => {
-    const delay = getRetryDelayMs(rateLimitError({ "retry-after": "3" }));
+  it("waits as long as Retry-After asks and never past the jitter window", () => {
+    const delays = Array.from({ length: 10_000 }, () =>
+      getRetryDelayMs(rateLimitError({ "retry-after": "3" })),
+    ).filter((delay) => delay !== null);
 
-    expect(delay).toBeGreaterThanOrEqual(3000);
-    expect(delay).toBeLessThan(4000);
+    expect(delays).toHaveLength(10_000);
+    expect(Math.min(...delays)).toBeGreaterThanOrEqual(3000);
+    expect(Math.max(...delays)).toBeLessThan(4000);
   });
 
   it("falls back to a short delay when the response carries no Retry-After", () => {

--- a/docs/components/figma-image/fetch-figma-image-urls.test.ts
+++ b/docs/components/figma-image/fetch-figma-image-urls.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { getRetryDelayMs } from "./fetch-figma-image-urls";
+
+// Mirrors what figma-api throws: an `ApiError` carrying the axios error on `.error`.
+function rateLimitError(headers: Record<string, string> = {}) {
+  return Object.assign(new Error("Request failed with status code 429"), {
+    error: { response: { headers } },
+  });
+}
+
+describe("getRetryDelayMs", () => {
+  it("returns null for an error that is not worth retrying", () => {
+    expect(getRetryDelayMs(new Error("FigmaImage requires an 'alt' prop"))).toBeNull();
+  });
+
+  it("waits as long as Retry-After asks, plus jitter", () => {
+    const delay = getRetryDelayMs(rateLimitError({ "retry-after": "3" }));
+
+    expect(delay).toBeGreaterThanOrEqual(3000);
+    expect(delay).toBeLessThan(4000);
+  });
+
+  it("falls back to a short delay when the response carries no Retry-After", () => {
+    const delay = getRetryDelayMs(rateLimitError());
+
+    expect(delay).toBeGreaterThanOrEqual(1000);
+    expect(delay).toBeLessThan(2000);
+  });
+
+  it("gives up instead of honoring a Retry-After longer than the build", () => {
+    expect(getRetryDelayMs(rateLimitError({ "retry-after": "396749" }))).toBeNull();
+  });
+
+  it("retries transient network errors that carry no headers at all", () => {
+    const delay = getRetryDelayMs(new Error("socket hang up"));
+
+    expect(delay).toBeGreaterThanOrEqual(1000);
+    expect(delay).toBeLessThan(2000);
+  });
+
+  it("spreads concurrent retries out instead of waking them on the same tick", () => {
+    const delays = new Set(
+      Array.from({ length: 50 }, () => getRetryDelayMs(rateLimitError({ "retry-after": "1" }))),
+    );
+
+    expect(delays.size).toBeGreaterThan(1);
+  });
+});

--- a/docs/components/figma-image/fetch-figma-image-urls.ts
+++ b/docs/components/figma-image/fetch-figma-image-urls.ts
@@ -7,7 +7,9 @@ import { getFigmaImageCacheKey, type FetchFigmaImageUrlsOptions } from "./figma-
 export type { FetchFigmaImageUrlsOptions } from "./figma-image-manifest";
 
 const LOG_PREFIX = "\n[remark-figma-image]";
-const DEFAULT_MAX_RETRIES = 20;
+// Each wait is a few seconds at most, so a high ceiling costs little: a cold cache leaves one
+// unlucky request losing round after round while the rest of the build drains the rate limit.
+const DEFAULT_MAX_RETRIES = 100;
 const MAX_CONCURRENCY = 1;
 const CACHE_TTL_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 const CACHE_ID = "urls";

--- a/docs/components/figma-image/fetch-figma-image-urls.ts
+++ b/docs/components/figma-image/fetch-figma-image-urls.ts
@@ -7,10 +7,19 @@ import { getFigmaImageCacheKey, type FetchFigmaImageUrlsOptions } from "./figma-
 export type { FetchFigmaImageUrlsOptions } from "./figma-image-manifest";
 
 const LOG_PREFIX = "\n[remark-figma-image]";
-const DEFAULT_MAX_RETRIES = 7;
+const DEFAULT_MAX_RETRIES = 20;
 const MAX_CONCURRENCY = 1;
 const CACHE_TTL_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 const CACHE_ID = "urls";
+
+// Figma answers 429 with `Retry-After` in seconds, so that header decides how long to wait. The
+// fallback covers the retryable errors that carry no header.
+const FALLBACK_RETRY_DELAY_MS = 1000;
+const MAX_RETRY_DELAY_MS = 60_000;
+
+// Turbopack transforms MDX in parallel workers that all draw from one rate limit bucket, so honoring
+// an identical Retry-After would wake them on the same tick and re-saturate it. Spread the retries.
+const RETRY_JITTER_MS = 1000;
 
 // Simple semaphore to limit concurrent Figma API requests
 let activeRequests = 0;
@@ -100,8 +109,6 @@ export async function fetchFigmaImageUrls({
 
   await acquireSemaphore();
 
-  let lastError: Error | null = null;
-
   try {
     // Recheck cache after acquiring semaphore — earlier calls may have populated it while we waited
     imageUrlCache.load(CACHE_ID, cacheDir);
@@ -148,27 +155,33 @@ export async function fetchFigmaImageUrls({
 
         return result;
       } catch (error) {
-        lastError = error instanceof Error ? error : new Error(String(error));
+        const waitTime = getRetryDelayMs(error);
 
-        if (!isRetryableError(error) || attempt === maxRetries - 1) throw error;
-
-        const waitTime = 2 ** attempt * 3000; // 3s, 6s, 12s
+        if (waitTime === null || attempt === maxRetries - 1) throw error;
 
         console.log(
-          `${LOG_PREFIX} ${lastError.message}, waiting ${waitTime}ms (attempt ${attempt + 1}/${maxRetries})...`,
+          `${LOG_PREFIX} ${error instanceof Error ? error.message : String(error)}, waiting ${waitTime}ms (attempt ${attempt + 1}/${maxRetries})...`,
         );
 
         await delay(waitTime);
       }
     }
 
-    throw lastError ?? new Error("Failed to fetch Figma images after retries");
+    throw new Error("Failed to fetch Figma images after retries");
   } finally {
     releaseSemaphore();
   }
 }
 
 // Helpers
+
+/**
+ * figma-api hangs the underlying axios error off `ApiError.error` and exports neither type, so the
+ * single field read here is declared locally.
+ */
+interface FigmaApiError {
+  error?: { response?: { headers?: Record<string, string | undefined> } };
+}
 
 function isCacheBypassRequested(nodeId: string): boolean {
   return env.figmaCacheDisabled || env.figmaBypassCacheNodeIds.includes(nodeId);
@@ -183,6 +196,29 @@ function shouldBypassCache(nodeId: string, options: FetchFigmaImageUrlsOptions):
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * How long to wait before retrying, or `null` when the request should not be retried at all.
+ */
+export function getRetryDelayMs(error: unknown): number | null {
+  if (!isRetryableError(error)) return null;
+
+  const retryAfterMs = getRetryAfterMs(error) ?? FALLBACK_RETRY_DELAY_MS;
+
+  // Figma has been observed handing out multi-day Retry-After values when it misclassifies a token's
+  // seat type. Waiting one out would outlast the build itself, so surface the 429 instead.
+  if (retryAfterMs > MAX_RETRY_DELAY_MS) return null;
+
+  return Math.round(retryAfterMs + Math.random() * RETRY_JITTER_MS);
+}
+
+function getRetryAfterMs(error: unknown): number | null {
+  const seconds = Number((error as FigmaApiError).error?.response?.headers?.["retry-after"]);
+
+  if (!Number.isFinite(seconds) || seconds < 0) return null;
+
+  return seconds * 1000;
 }
 
 function isRetryableError(error: unknown): boolean {

--- a/docs/components/figma-image/fetch-figma-image-urls.ts
+++ b/docs/components/figma-image/fetch-figma-image-urls.ts
@@ -7,8 +7,6 @@ import { getFigmaImageCacheKey, type FetchFigmaImageUrlsOptions } from "./figma-
 export type { FetchFigmaImageUrlsOptions } from "./figma-image-manifest";
 
 const LOG_PREFIX = "\n[remark-figma-image]";
-// Each wait is a few seconds at most, so a high ceiling costs little: a cold cache leaves one
-// unlucky request losing round after round while the rest of the build drains the rate limit.
 const DEFAULT_MAX_RETRIES = 100;
 const MAX_CONCURRENCY = 1;
 const CACHE_TTL_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
@@ -18,6 +16,7 @@ const CACHE_ID = "urls";
 // fallback covers the retryable errors that carry no header.
 const FALLBACK_RETRY_DELAY_MS = 1000;
 const MAX_RETRY_DELAY_MS = 60_000;
+const MAX_TOTAL_RETRY_MS = 8 * 60 * 1000;
 
 // Turbopack transforms MDX in parallel workers that all draw from one rate limit bucket, so honoring
 // an identical Retry-After would wake them on the same tick and re-saturate it. Spread the retries.
@@ -133,6 +132,8 @@ export async function fetchFigmaImageUrls({
       `${LOG_PREFIX} Fetching ${pendingIds.length} image(s) from Figma API... (options: ${JSON.stringify(options)})`,
     );
 
+    const retryDeadline = Date.now() + MAX_TOTAL_RETRY_MS;
+
     for (let attempt = 0; attempt < maxRetries; attempt++) {
       try {
         const response = await client.getImages(
@@ -159,7 +160,12 @@ export async function fetchFigmaImageUrls({
       } catch (error) {
         const waitTime = getRetryDelayMs(error);
 
-        if (waitTime === null || attempt === maxRetries - 1) throw error;
+        if (
+          waitTime === null ||
+          attempt === maxRetries - 1 ||
+          Date.now() + waitTime > retryDeadline
+        )
+          throw error;
 
         console.log(
           `${LOG_PREFIX} ${error instanceof Error ? error.message : String(error)}, waiting ${waitTime}ms (attempt ${attempt + 1}/${maxRetries})...`,
@@ -212,7 +218,7 @@ export function getRetryDelayMs(error: unknown): number | null {
   // seat type. Waiting one out would outlast the build itself, so surface the 429 instead.
   if (retryAfterMs > MAX_RETRY_DELAY_MS) return null;
 
-  return Math.round(retryAfterMs + Math.random() * RETRY_JITTER_MS);
+  return retryAfterMs + Math.floor(Math.random() * RETRY_JITTER_MS);
 }
 
 function getRetryAfterMs(error: unknown): number | null {

--- a/docs/components/figma-image/fetch-figma-image-urls.ts
+++ b/docs/components/figma-image/fetch-figma-image-urls.ts
@@ -18,8 +18,6 @@ const FALLBACK_RETRY_DELAY_MS = 1000;
 const MAX_RETRY_DELAY_MS = 60_000;
 const MAX_TOTAL_RETRY_MS = 8 * 60 * 1000;
 
-// Turbopack transforms MDX in parallel workers that all draw from one rate limit bucket, so honoring
-// an identical Retry-After would wake them on the same tick and re-saturate it. Spread the retries.
 const RETRY_JITTER_MS = 1000;
 
 // Simple semaphore to limit concurrent Figma API requests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * Figma 이미지 가져오기 실패 시 재시도 동작을 개선했습니다.
  * 서버가 안내하는 재시도 시간을 반영하고, 동시 요청의 재시도 시점을 분산합니다.
  * 일시적인 네트워크 오류에 대해 더 오래 재시도하여 이미지 로딩 성공률을 높였습니다.
  * 재시도할 수 없거나 대기 시간이 지나치게 긴 경우 즉시 실패합니다.

* **테스트**
  * 다양한 오류 및 재시도 상황에 대한 검증을 추가했습니다.

* **배포**
  * 배포 작업이 30분을 초과하지 않도록 실행 시간 제한을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->