### PR TITLE
feat(rootage): publish PR snapshots to CDN

### DIFF
--- a/.github/workflows/continuous-releases.yml
+++ b/.github/workflows/continuous-releases.yml
@@ -4,90 +4,232 @@ on:
   issue_comment:
     types: [created]
 
+concurrency:
+  group: snapshot-release-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
-  release:
-    name: Release Seed Design Packages
+  resolve:
+    name: Resolve exact snapshot source
     if: |
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/snapshot') &&
       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
-
+      contents: read
+      issues: write
+      pull-requests: read
+    outputs:
+      base-sha: ${{ steps.pull.outputs.base-sha }}
+      control-sha: ${{ steps.pull.outputs.control-sha }}
+      source-sha: ${{ steps.pull.outputs.source-sha }}
     steps:
-      - name: Add reaction
+      - name: Add acknowledgement reaction and resolve PR identity
+        id: pull
         uses: actions/github-script@v9
         with:
           script: |
-            github.rest.reactions.createForIssueComment({
+            await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               comment_id: context.payload.comment.id,
               content: 'eyes'
             });
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const shaPattern = /^[0-9a-f]{40}$/;
+            if (!shaPattern.test(pull.head.sha) || !shaPattern.test(pull.base.sha)) {
+              throw new Error('PR base/head SHA 형식이 올바르지 않습니다.');
+            }
+            if (!shaPattern.test(context.sha)) {
+              throw new Error('신뢰된 workflow control SHA 형식이 올바르지 않습니다.');
+            }
+            core.setOutput('base-sha', pull.base.sha);
+            core.setOutput('control-sha', context.sha);
+            core.setOutput('source-sha', pull.head.sha);
 
-      - name: Checkout PR branch
+  release:
+    name: Release Seed Design package snapshots
+    needs: resolve
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      rootage-changed: ${{ steps.rootage-change.outputs.changed }}
+      rootage-package-shasum: ${{ steps.rootage-package.outputs.shasum }}
+      rootage-package-url: ${{ steps.rootage-package.outputs.url }}
+      rootage-version: ${{ steps.rootage-prepare.outputs.version }}
+    steps:
+      - name: Checkout exact PR head without credentials
         uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Bind checkout to resolved PR head
+        env:
+          SNAPSHOT_SOURCE_SHA: ${{ needs.resolve.outputs.source-sha }}
+        run: test "$(git rev-parse HEAD)" = "$SNAPSHOT_SOURCE_SHA"
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.13"
 
-      - name: Install Dependencies
+      - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Build
+      - name: Detect Rootage changes in the exact PR diff
+        id: rootage-change
+        env:
+          ROOTAGE_BASE_SHA: ${{ needs.resolve.outputs.base-sha }}
+          ROOTAGE_SOURCE_SHA: ${{ needs.resolve.outputs.source-sha }}
+        run: bun tools/rootage-cdn/src/snapshot-input.ts detect
+
+      - name: Prepare exact Rootage snapshot version
+        id: rootage-prepare
+        if: steps.rootage-change.outputs.changed == 'true'
+        env:
+          ROOTAGE_PR_NUMBER: ${{ github.event.issue.number }}
+          ROOTAGE_SOURCE_SHA: ${{ needs.resolve.outputs.source-sha }}
+        run: |
+          bun tools/rootage-cdn/src/snapshot-input.ts prepare
+          bun install --no-immutable
+          bun rootage:build
+          bun install --no-immutable
+          bun --filter @seed-design/rootage-artifacts rootage:generate
+
+      - name: Build packages
         run: bun packages:build
 
-      - name: Publish
-        run: bunx pkg-pr-new publish './packages/*' './packages/react-headless/*' './packages/utils/*' --compact --comment=off --json output.json
+      - name: Publish package snapshots
+        run: >-
+          bun run pkg-pr-new publish
+          './packages/*'
+          './packages/react-headless/*'
+          './packages/utils/*'
+          --compact
+          --comment=off
+          --json output.json
+
+      - name: Select the exact Rootage snapshot package
+        id: rootage-package
+        if: steps.rootage-change.outputs.changed == 'true'
+        run: |
+          ROOTAGE_PACKAGE="$(jq -ce '[.packages[] | select(.name == "@seed-design/rootage-artifacts")] | if length == 1 then .[0] else error("expected one Rootage package") end' output.json)"
+          echo "url=$(jq -r '.url' <<< "$ROOTAGE_PACKAGE")" >> "$GITHUB_OUTPUT"
+          echo "shasum=$(jq -r '.shasum' <<< "$ROOTAGE_PACKAGE")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload snapshot publish result
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshot-release-output-${{ github.run_id }}
+          path: output.json
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-rootage:
+    name: Publish Rootage snapshot to CDN
+    needs: [resolve, release]
+    if: needs.release.outputs.rootage-changed == 'true'
+    uses: ./.github/workflows/rootage-snapshot-contract.yml
+    permissions:
+      contents: read
+    with:
+      version: ${{ needs.release.outputs.rootage-version }}
+      package-url: ${{ needs.release.outputs.rootage-package-url }}
+      package-shasum: ${{ needs.release.outputs.rootage-package-shasum }}
+      source-sha: ${{ needs.resolve.outputs.source-sha }}
+      control-sha: ${{ needs.resolve.outputs.control-sha }}
+
+  notify:
+    name: Comment snapshot result
+    needs: [resolve, release, publish-rootage]
+    if: always() && needs.release.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      issues: write
+    steps:
+      - name: Download snapshot publish result
+        uses: actions/download-artifact@v5
+        with:
+          name: snapshot-release-output-${{ github.run_id }}
 
       - name: Comment on PR
         uses: actions/github-script@v9
+        env:
+          ROOTAGE_CHANGED: ${{ needs.release.outputs.rootage-changed }}
+          ROOTAGE_PUBLISH_RESULT: ${{ needs.publish-rootage.result }}
+          ROOTAGE_VERSION: ${{ needs.release.outputs.rootage-version }}
+          SNAPSHOT_SOURCE_SHA: ${{ needs.resolve.outputs.source-sha }}
         with:
           script: |
             const fs = require('fs');
             const output = JSON.parse(fs.readFileSync('output.json', 'utf8'));
-
             const packages = output.packages
-              .map(p => `\`${p.name}\`: \`${p.url}\``)
+              .map((item) => `\`${item.name}\`: \`${item.url}\``)
               .join('\n');
-
+            let rootage = 'Rootage 변경이 없어 CDN snapshot은 생략했어요.';
+            if (process.env.ROOTAGE_CHANGED === 'true') {
+              rootage = process.env.ROOTAGE_PUBLISH_RESULT === 'success'
+                ? `Rootage CDN: https://seed-design.io/rootage/v${process.env.ROOTAGE_VERSION}/index.json`
+                : 'Rootage CDN 게시에 실패했어요. 같은 SHA에서 `/snapshot`을 다시 실행할 수 있어요.';
+            }
             const body = `## 📦 Snapshot Release
 
             ${packages}
 
+            ${rootage}
+
+            > Source: \`${process.env.SNAPSHOT_SOURCE_SHA}\`
             > Triggered by @${{ github.event.comment.user.login }} via \`/snapshot\`
             `.replace(/^ +/gm, '');
-
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{ github.event.issue.number }},
-              body
+              issue_number: context.issue.number,
+              body,
             });
 
-      - name: Add success reaction
-        if: success()
-        uses: actions/github-script@v9
+  success-reaction:
+    name: Mark snapshot success
+    needs: [release, publish-rootage, notify]
+    if: >-
+      always() &&
+      needs.release.result == 'success' &&
+      (needs.publish-rootage.result == 'success' || needs.publish-rootage.result == 'skipped') &&
+      needs.notify.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v9
         with:
           script: |
-            github.rest.reactions.createForIssueComment({
+            await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               comment_id: context.payload.comment.id,
               content: 'rocket'
             });
 
-      - name: Add failure reaction
-        if: failure()
-        uses: actions/github-script@v9
+  failure-reaction:
+    name: Mark snapshot failure
+    needs: [resolve, release, publish-rootage, notify]
+    if: always() && contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v9
         with:
           script: |
-            github.rest.reactions.createForIssueComment({
+            await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               comment_id: context.payload.comment.id,

--- a/.github/workflows/continuous-releases.yml
+++ b/.github/workflows/continuous-releases.yml
@@ -106,9 +106,15 @@ jobs:
       - name: Build packages
         run: bun packages:build
 
+      - name: Verify trusted pkg-pr-new executable
+        run: |
+          test "$(jq -r '.version' node_modules/pkg-pr-new/package.json)" = "0.0.87"
+          test "$(sha256sum node_modules/pkg-pr-new/bin/cli.js | cut -d ' ' -f 1)" = "72dfe24919e316a388aa6893b840bba6fc2f7b9fc37df67e2b545d0a12c6e3b2"
+          test "$(sha256sum node_modules/pkg-pr-new/dist/index.js | cut -d ' ' -f 1)" = "196586894e117c8d043310df05742ead273f12fb0575a88272e596a8c90a6658"
+
       - name: Publish package snapshots
         run: >-
-          bun run pkg-pr-new publish
+          bun node_modules/pkg-pr-new/bin/cli.js publish
           './packages/*'
           './packages/react-headless/*'
           './packages/utils/*'

--- a/.github/workflows/rootage-snapshot-cleanup.yml
+++ b/.github/workflows/rootage-snapshot-cleanup.yml
@@ -1,0 +1,44 @@
+name: Cleanup Rootage snapshots
+
+on:
+  schedule:
+    - cron: "17 18 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: rootage-cdn-production-mutation
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Delete snapshots closed for 30 days
+    if: github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: rootage-production
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Bind cleanup to trusted dev
+        run: |
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/dev
+      - uses: ./.github/actions/setup
+      - name: Delete completed snapshots whose PR closed at least 30 days ago
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          ROOTAGE_R2_ACCESS_KEY_ID: ${{ secrets.ROOTAGE_R2_ACCESS_KEY_ID }}
+          ROOTAGE_R2_SECRET_ACCESS_KEY: ${{ secrets.ROOTAGE_R2_SECRET_ACCESS_KEY }}
+          ROOTAGE_R2_BUCKET: seed-design-rootage-artifacts
+          ROOTAGE_GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          bun tools/rootage-cdn/src/cli.ts cleanup-snapshots
+          --older-than-days "30"
+          --apply "true"
+          --confirm "DELETE-SNAPSHOTS"

--- a/.github/workflows/rootage-snapshot-contract.yml
+++ b/.github/workflows/rootage-snapshot-contract.yml
@@ -1,0 +1,79 @@
+name: Rootage snapshot contract
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Exact Rootage snapshot SemVer"
+        required: true
+        type: string
+      package-url:
+        description: "Exact pkg.pr.new Rootage tarball URL"
+        required: true
+        type: string
+      package-shasum:
+        description: "SHA-1 reported by pkg.pr.new"
+        required: true
+        type: string
+      source-sha:
+        description: "Exact PR head represented by the snapshot"
+        required: true
+        type: string
+      control-sha:
+        description: "Immutable trusted dev commit that owns the publisher"
+        required: true
+        type: string
+concurrency:
+  group: rootage-cdn-production-mutation
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish and verify immutable Rootage snapshot
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: rootage-production
+    permissions:
+      contents: read
+    steps:
+      - name: Resolve current trusted dev head
+        uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Record trusted dev head
+        id: dev
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Checkout immutable trusted control plane
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.control-sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Verify control commit belongs to trusted dev history
+        env:
+          ROOTAGE_CONTROL_SHA: ${{ inputs.control-sha }}
+          ROOTAGE_DEV_SHA: ${{ steps.dev.outputs.sha }}
+        run: |
+          [[ "$ROOTAGE_CONTROL_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$(git rev-parse HEAD)" = "$ROOTAGE_CONTROL_SHA"
+          git merge-base --is-ancestor "$ROOTAGE_CONTROL_SHA" "$ROOTAGE_DEV_SHA"
+      - uses: ./.github/actions/setup
+      - name: Publish exact pkg.pr.new Rootage archive
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          ROOTAGE_R2_ACCESS_KEY_ID: ${{ secrets.ROOTAGE_R2_ACCESS_KEY_ID }}
+          ROOTAGE_R2_SECRET_ACCESS_KEY: ${{ secrets.ROOTAGE_R2_SECRET_ACCESS_KEY }}
+          ROOTAGE_R2_BUCKET: seed-design-rootage-artifacts
+          ROOTAGE_PUBLIC_BASE_URL: https://seed-design.io
+          ROOTAGE_VERSION: ${{ inputs.version }}
+          ROOTAGE_PACKAGE_URL: ${{ inputs.package-url }}
+          ROOTAGE_PACKAGE_SHASUM: ${{ inputs.package-shasum }}
+          ROOTAGE_SOURCE_SHA: ${{ inputs.source-sha }}
+        run: >-
+          bun tools/rootage-cdn/src/cli.ts publish-snapshot
+          --version "$ROOTAGE_VERSION"
+          --package-url "$ROOTAGE_PACKAGE_URL"
+          --package-shasum "$ROOTAGE_PACKAGE_SHASUM"
+          --source-sha "$ROOTAGE_SOURCE_SHA"

--- a/TECH.md
+++ b/TECH.md
@@ -231,6 +231,7 @@ export const Checkbox = { Root, Control, HiddenInput, ... };
 - `bun changeset` - 변경사항 기록
 - `bun version` - 버전·잠금파일을 업데이트하고 같은 Version Packages commit에 Rootage JSON 생성. Rootage package 범위만 생성하며 각 패키지의 `package.json`·`CHANGELOG.md`, changeset, lockfile, `packages/rootage/__generated__/**` 밖의 변경은 거부
 - `bun release` - 패키지 빌드 및 npm 배포
+- PR에서 `/snapshot` - `pkg.pr.new` 패키지 snapshot을 게시하고 `packages/rootage/**` 변경이 있으면 exact PR head용 Rootage CDN URL도 생성. snapshot은 stable 포인터를 변경하지 않으며 PR 종료 30일 뒤 정리
 
 ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "bunchee": "^6.5.1",
         "figma-api": "2.1.4-beta",
         "knip": "^6.0.0",
+        "pkg-pr-new": "0.0.87",
         "publint": "^0.3.12",
         "typescript": "^6.0.3",
         "ultra-runner": "^3.10.5",
@@ -5296,6 +5297,8 @@
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
 
     "pkg-dir": ["pkg-dir@5.0.0", "", { "dependencies": { "find-up": "^5.0.0" } }, "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA=="],
+
+    "pkg-pr-new": ["pkg-pr-new@0.0.87", "", { "bin": { "pkg-pr-new": "bin/cli.js" } }, "sha512-nm+30Py1csXWfyMH1ueQyTR11IZGHS5oW8Qok/MxMwjPx9g1jX3wMRrJf8TgEvNo0a0M4i14T0zQsEPWdZfAhg=="],
 
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "bunchee": "^6.5.1",
     "figma-api": "2.1.4-beta",
     "knip": "^6.0.0",
+    "pkg-pr-new": "0.0.87",
     "publint": "^0.3.12",
     "typescript": "^6.0.3",
     "ultra-runner": "^3.10.5",

--- a/tools/rootage-cdn/AGENTS.md
+++ b/tools/rootage-cdn/AGENTS.md
@@ -6,7 +6,7 @@ npm에 게시된 Rootage JSON을 검증해 비공개 R2에 불변 저장하고, 
 
 ## 파일 작성 컨벤션
 
-- 실행 진입점은 운영 명령 `src/cli.ts`, 공개 읽기 `src/worker.ts`, npm 게시 결과 변환 `src/release-input.ts`로 분리한다.
+- 실행 진입점은 운영 명령 `src/cli.ts`, 공개 읽기 `src/worker.ts`, npm 게시 결과 변환 `src/release-input.ts`, PR snapshot 입력 변환 `src/snapshot-input.ts`로 분리한다.
 - 저장 JSON 계약은 `schemas/*.schema.json`에 Draft 2020-12로 명시하고 모든 필드에 설명을 작성한다.
 - 테스트는 대응하는 구현 옆에 `*.test.ts`로 둔다.
 
@@ -17,3 +17,5 @@ npm에 게시된 Rootage JSON을 검증해 비공개 R2에 불변 저장하고, 
 - 412는 재시도할 네트워크 오류가 아니라 충돌 또는 stale pointer 도메인 결과로 처리한다.
 - Worker는 R2 읽기만 수행하고 외부 쓰기·삭제 API를 제공하지 않는다.
 - npm 게시 결과 변환은 레지스트리를 읽고 workflow output만 기록하며 R2·Git·npm을 변경하지 않는다.
+- PR 코드를 실행하는 snapshot job에는 R2 자격 증명을 전달하지 않는다. snapshot 게시기는 신뢰된 `dev` 코드에서 `pkg.pr.new` tarball을 다시 검증하고 stable 포인터를 변경하지 않는다.
+- 완료 snapshot 정리는 snapshot 버전 패턴과 PR 종료 시점을 모두 검증하고 완료 manifest를 먼저 삭제한다.

--- a/tools/rootage-cdn/TECH.md
+++ b/tools/rootage-cdn/TECH.md
@@ -2,11 +2,13 @@
 
 ## 저장 구조
 
-- `versions/v{version}/...`: npm tarball의 JSON 원본 바이트
+- `versions/v{version}/...`: npm 또는 npm 호환 snapshot tarball의 JSON 원본 바이트
 - `manifests/v{version}.json`: 공개 가능한 버전의 완료 manifest
 - `pointers/stable.json`: npm `latest`와 검증된 stable 버전 포인터
 
 완료 manifest가 없는 버전은 Worker가 공개하지 않는다. 모든 파일의 SHA-256을 완료 manifest에 기록하고, 완료 manifest 자체의 SHA-256은 stable 포인터에 기록한다.
+
+PR snapshot은 `0.0.0-snapshot.pr-{PR 번호}.sha-{40자리 head SHA}` 버전을 사용한다. 기존 버전 경로와 완료 manifest 계약을 재사용하지만 stable 포인터는 갱신하지 않는다.
 
 ## 명령어
 
@@ -19,9 +21,13 @@
 - `bun tools/rootage-cdn/src/cli.ts cleanup ...`: 완료 manifest가 없는 7일 이상 객체의 보고/확인 삭제
 - `PUBLISHED_PACKAGES=... ROOTAGE_SOURCE_SHA=<gitHead> GITHUB_OUTPUT=<path> bun tools/rootage-cdn/src/release-input.ts`: source의 현재 Rootage 버전을 npm의 exact `gitHead`·integrity와 대조해 재실행 가능한 workflow output으로 변환하며, Changesets 게시 결과가 있으면 일치 여부를 추가 검증
 - `bun tools/rootage-cdn/src/version-change-policy.ts`: Changesets Version command가 각 패키지의 `package.json`·`CHANGELOG.md`, changeset, lockfile, `packages/rootage/__generated__/**` 밖의 파일을 변경하지 않았는지 검증
+- `bun tools/rootage-cdn/src/snapshot-input.ts detect|prepare`: exact PR diff에서 Rootage 변경을 찾고 package·생성 JSON에 사용할 snapshot 버전을 준비
+- `bun tools/rootage-cdn/src/cli.ts publish-snapshot ...`: `pkg.pr.new` tarball의 URL·SHA-1·package identity·SHA-512를 검증하고 불변 snapshot을 게시
+- `bun tools/rootage-cdn/src/cli.ts cleanup-snapshots ...`: PR이 닫힌 지 30일 지난 완료 snapshot을 manifest부터 제거
 
 production 쓰기에는 `ROOTAGE_R2_ACCESS_KEY_ID`, `ROOTAGE_R2_SECRET_ACCESS_KEY`, `CF_ACCOUNT_ID`, `ROOTAGE_R2_BUCKET`이 필요하다.
 배포·route 변경·rollback·삭제는 GitHub의 `rootage-production` environment 승인을 거친 수동 workflow에서 실행한다.
+Snapshot 게시와 정기 정리도 기존 `rootage-production` environment를 재사용한다. 두 workflow 모두 `dev`의 신뢰된 코드만 실행하며 PR 빌드 job에는 R2 자격 증명을 전달하지 않는다.
 production Worker 배포는 기존 단일 100% traffic deployment/version을 먼저 기록하고 `https://seed-design.io/rootage/latest/index.json`의 응답 shape와 exact Worker version header를 확인한다. smoke 실패 시 현재 deployment와 version이 방금 배포한 두 ID와 모두 일치할 때만 기록한 정확한 이전 version으로 자동 rollback한다.
 성공한 배포의 지연 장애는 `Operate Rootage CDN`의 `worker-rollback`으로 복구한다. target은 history의 과거 단일 100% Worker version이어야 하고, 현재 exact version과 target history deployment를 호출 직전에 다시 확인하며, rollback 뒤 새 100% deployment가 current인지 bounded 검증한다.
 

--- a/tools/rootage-cdn/schemas/completion-manifest.schema.json
+++ b/tools/rootage-cdn/schemas/completion-manifest.schema.json
@@ -2,14 +2,14 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://seed-design.io/schemas/rootage-completion-manifest.v1.json",
   "title": "Rootage 완료 manifest",
-  "description": "npm Rootage tarball에서 검증되어 공개 가능한 불변 JSON 파일 목록이다.",
+  "description": "npm 또는 npm 호환 Rootage tarball에서 검증되어 공개 가능한 불변 JSON 파일 목록이다.",
   "type": "object",
   "additionalProperties": false,
   "required": ["schemaVersion", "package", "version", "npmIntegrity", "gitHead", "files"],
   "properties": {
     "schemaVersion": { "description": "완료 manifest 형식 버전이다.", "const": 1 },
     "package": {
-      "description": "원본 npm 패키지 이름이다.",
+      "description": "원본 npm 호환 패키지 이름이다.",
       "const": "@seed-design/rootage-artifacts"
     },
     "version": {
@@ -18,12 +18,12 @@
       "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?$"
     },
     "npmIntegrity": {
-      "description": "npm tarball의 SHA-512 SRI 값이다.",
+      "description": "npm 또는 npm 호환 tarball의 SHA-512 SRI 값이다.",
       "type": "string",
       "pattern": "^sha512-[A-Za-z0-9+/]+={0,2}$"
     },
     "gitHead": {
-      "description": "npm metadata에 기록된 원본 Git commit SHA다.",
+      "description": "원본 tarball이 나타내는 Git commit SHA다.",
       "type": "string",
       "pattern": "^[0-9a-f]{40}$"
     },

--- a/tools/rootage-cdn/src/cli.ts
+++ b/tools/rootage-cdn/src/cli.ts
@@ -1,7 +1,12 @@
 import { appendFile } from "node:fs/promises";
-import { publishRootage, verifyPublic } from "./publisher";
+import { publishRootage, publishRootageSnapshot, verifyPublic } from "./publisher";
 import { R2ObjectStore } from "./r2-object-store";
-import { cleanupIncompleteVersions, setStablePointer, updateWorkerRoute } from "./operations";
+import {
+  cleanupCompletedSnapshots,
+  cleanupIncompleteVersions,
+  setStablePointer,
+  updateWorkerRoute,
+} from "./operations";
 import { manifestKey, parseManifest } from "./contract";
 
 function required(name: string): string {
@@ -39,7 +44,10 @@ if (command === "route") {
   await output({ result });
   process.exit(0);
 }
-if (!command || !["publish", "set-stable", "cleanup"].includes(command)) {
+if (
+  !command ||
+  !["publish", "publish-snapshot", "set-stable", "cleanup", "cleanup-snapshots"].includes(command)
+) {
   throw new Error(`지원하지 않는 명령입니다: ${command ?? ""}`);
 }
 const accountId = required("CF_ACCOUNT_ID");
@@ -73,6 +81,56 @@ if (command === "cleanup") {
     apply,
   });
   await output({ candidates: result.candidates.join(","), deleted: result.deleted });
+  process.exit(0);
+}
+if (command === "cleanup-snapshots") {
+  const apply = argument("apply") === "true";
+  if (apply && argument("confirm") !== "DELETE-SNAPSHOTS") {
+    throw new Error("Snapshot 삭제 확인 문구가 올바르지 않습니다.");
+  }
+  const githubToken = required("ROOTAGE_GITHUB_TOKEN");
+  const result = await cleanupCompletedSnapshots(store, {
+    olderThanDays: Number(argument("older-than-days")),
+    apply,
+    getPullRequest: async (prNumber) => {
+      const response = await fetch(
+        `https://api.github.com/repos/daangn/seed-design/pulls/${prNumber}`,
+        {
+          headers: {
+            accept: "application/vnd.github+json",
+            authorization: `Bearer ${githubToken}`,
+            "x-github-api-version": "2022-11-28",
+          },
+          signal: AbortSignal.timeout(15_000),
+        },
+      );
+      if (!response.ok) throw new Error(`GitHub PR #${prNumber} 조회 실패: ${response.status}`);
+      const pullRequest = (await response.json()) as { state?: unknown; closed_at?: unknown };
+      if (
+        (pullRequest.state !== "open" && pullRequest.state !== "closed") ||
+        (pullRequest.closed_at !== null && typeof pullRequest.closed_at !== "string")
+      ) {
+        throw new Error(`GitHub PR #${prNumber} 응답 형식이 올바르지 않습니다.`);
+      }
+      return { state: pullRequest.state, closedAt: pullRequest.closed_at };
+    },
+  });
+  await output({ candidates: result.candidates.join(","), deleted: result.deleted });
+  process.exit(0);
+}
+if (command === "publish-snapshot") {
+  const result = await publishRootageSnapshot(store, {
+    version: argument("version"),
+    packageUrl: argument("package-url"),
+    packageShasum: argument("package-shasum"),
+    sourceSha: argument("source-sha"),
+    publicBaseUrl: required("ROOTAGE_PUBLIC_BASE_URL"),
+  });
+  await output({
+    "manifest-sha": result.manifestSha,
+    "file-count": result.fileCount,
+    "reused-manifest": result.reusedManifest,
+  });
   process.exit(0);
 }
 const result = await publishRootage(store, {

--- a/tools/rootage-cdn/src/operations.test.ts
+++ b/tools/rootage-cdn/src/operations.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, test } from "bun:test";
 import { jsonBytes, sha256 } from "./contract";
 import { ROOTAGE_WORKER_VERSION_HEADER } from "./deployment-metadata";
 import {
+  cleanupCompletedSnapshots,
   cleanupIncompleteVersions,
   type FetchImplementation,
   setStablePointer,
   updateWorkerRoute,
   verifyWorkerRoutePublic,
 } from "./operations";
+import { createRootageSnapshotVersion } from "./snapshot";
 import type { ObjectStore, StoredObject } from "./types";
 
 class MemoryStore implements ObjectStore {
@@ -122,6 +124,101 @@ describe("Rootage 운영 명령", () => {
     expect(report.candidates).toEqual(["0.9.0"]);
     await cleanupIncompleteVersions(store, { olderThanDays: 7, apply: true });
     expect(store.deleted).toEqual(["versions/v0.9.0/index.json"]);
+  });
+
+  test("닫힌 지 30일 지난 완료 snapshot만 manifest부터 정리한다", async () => {
+    const store = new MemoryStore();
+    const oldSourceSha = "1".repeat(40);
+    const recentSourceSha = "2".repeat(40);
+    const openSourceSha = "3".repeat(40);
+    const oldVersion = createRootageSnapshotVersion("10", oldSourceSha);
+    const recentVersion = createRootageSnapshotVersion("11", recentSourceSha);
+    const openVersion = createRootageSnapshotVersion("12", openSourceSha);
+    const addSnapshot = (version: string, sourceSha: string) => {
+      const key = `manifests/v${version}.json`;
+      store.uploaded.set(key, new Date("2026-01-01T00:00:00Z"));
+      store.objects.set(key, {
+        etag: version,
+        bytes: jsonBytes({
+          schemaVersion: 1,
+          package: "@seed-design/rootage-artifacts",
+          version,
+          npmIntegrity: integrity,
+          gitHead: sourceSha,
+          files: [
+            {
+              path: "/index.json",
+              key: `versions/v${version}/index.json`,
+              bytes: 2,
+              sha256: "a".repeat(64),
+            },
+          ],
+        }),
+      });
+      store.objects.set(`versions/v${version}/index.json`, {
+        etag: version,
+        bytes: jsonBytes({}),
+      });
+    };
+    addSnapshot(oldVersion, oldSourceSha);
+    addSnapshot(recentVersion, recentSourceSha);
+    addSnapshot(openVersion, openSourceSha);
+    store.uploaded.set("manifests/v2.4.0.json", new Date(0));
+
+    const states = new Map([
+      [10, { state: "closed" as const, closedAt: "2026-06-01T00:00:00Z" }],
+      [11, { state: "closed" as const, closedAt: "2026-07-25T00:00:00Z" }],
+      [12, { state: "open" as const, closedAt: "2026-05-01T00:00:00Z" }],
+    ]);
+    const result = await cleanupCompletedSnapshots(store, {
+      olderThanDays: 30,
+      apply: true,
+      now: new Date("2026-08-11T00:00:00Z"),
+      getPullRequest: async (prNumber) => states.get(prNumber)!,
+    });
+
+    expect(result).toEqual({ candidates: [oldVersion], deleted: 2 });
+    expect(store.deleted).toEqual([
+      `manifests/v${oldVersion}.json`,
+      `versions/v${oldVersion}/index.json`,
+    ]);
+    expect(store.objects.has(`manifests/v${recentVersion}.json`)).toBe(true);
+    expect(store.objects.has(`manifests/v${openVersion}.json`)).toBe(true);
+  });
+
+  test("snapshot manifest의 source identity가 버전과 다르면 삭제하지 않는다", async () => {
+    const store = new MemoryStore();
+    const version = createRootageSnapshotVersion("13", "4".repeat(40));
+    const key = `manifests/v${version}.json`;
+    store.uploaded.set(key, new Date(0));
+    store.objects.set(key, {
+      etag: "manifest",
+      bytes: jsonBytes({
+        schemaVersion: 1,
+        package: "@seed-design/rootage-artifacts",
+        version,
+        npmIntegrity: integrity,
+        gitHead: "5".repeat(40),
+        files: [
+          {
+            path: "/index.json",
+            key: `versions/v${version}/index.json`,
+            bytes: 2,
+            sha256: "a".repeat(64),
+          },
+        ],
+      }),
+    });
+
+    await expect(
+      cleanupCompletedSnapshots(store, {
+        olderThanDays: 30,
+        apply: true,
+        now: new Date("2026-08-11T00:00:00Z"),
+        getPullRequest: async () => ({ state: "closed", closedAt: "2026-01-01T00:00:00Z" }),
+      }),
+    ).rejects.toThrow("identity");
+    expect(store.deleted).toEqual([]);
   });
 
   test("route cutover 후 smoke가 성공해야 생성 완료로 보고한다", async () => {

--- a/tools/rootage-cdn/src/operations.ts
+++ b/tools/rootage-cdn/src/operations.ts
@@ -13,6 +13,7 @@ import {
 import type { ObjectStore, StablePointer } from "./types";
 import { mutateStablePointer, verifyLatestWithRollback } from "./stable-pointer-recovery";
 import { ROOTAGE_PRODUCTION_SMOKE_URL, ROOTAGE_WORKER_VERSION_HEADER } from "./deployment-metadata";
+import { parseRootageSnapshotVersion } from "./snapshot";
 
 export async function setStablePointer(
   store: ObjectStore,
@@ -81,6 +82,68 @@ export async function cleanupIncompleteVersions(
       }
   }
   return { candidates: candidates.sort(), deleted };
+}
+
+export interface SnapshotPullRequestState {
+  state: "open" | "closed";
+  closedAt: string | null;
+}
+
+export async function cleanupCompletedSnapshots(
+  store: ObjectStore,
+  options: {
+    olderThanDays: number;
+    apply: boolean;
+    now?: Date;
+    getPullRequest: (prNumber: number) => Promise<SnapshotPullRequestState>;
+  },
+): Promise<{ candidates: string[]; deleted: number }> {
+  if (!Number.isInteger(options.olderThanDays) || options.olderThanDays < 1) {
+    throw new Error("Snapshot 보존 기간은 1일 이상의 정수여야 합니다.");
+  }
+  const now = options.now ?? new Date();
+  const cutoff = now.getTime() - options.olderThanDays * 86_400_000;
+  const manifests = await store.list("manifests/v0.0.0-snapshot.");
+  const pullRequests = new Map<number, SnapshotPullRequestState>();
+  const candidates: string[] = [];
+  let deleted = 0;
+
+  for (const listed of manifests.sort((left, right) => left.key.localeCompare(right.key))) {
+    const match = /^manifests\/v(.+)\.json$/.exec(listed.key);
+    if (!match) continue;
+    const version = match[1]!;
+    const identity = parseRootageSnapshotVersion(version);
+    if (!identity) continue;
+    let pullRequest = pullRequests.get(identity.prNumber);
+    if (!pullRequest) {
+      pullRequest = await options.getPullRequest(identity.prNumber);
+      pullRequests.set(identity.prNumber, pullRequest);
+    }
+    if (pullRequest.state !== "closed" || !pullRequest.closedAt) continue;
+    const closedAt = Date.parse(pullRequest.closedAt);
+    if (!Number.isFinite(closedAt)) {
+      throw new Error(`PR #${identity.prNumber}의 closed_at 형식이 올바르지 않습니다.`);
+    }
+    if (closedAt > cutoff) continue;
+
+    const stored = await store.get(listed.key);
+    if (!stored) continue;
+    const manifest = parseManifest(JSON.parse(new TextDecoder().decode(stored.bytes)));
+    if (manifest.version !== version || manifest.gitHead !== identity.sourceSha) {
+      throw new Error(`Snapshot 완료 manifest identity가 버전과 다릅니다: ${version}`);
+    }
+    candidates.push(version);
+    if (!options.apply) continue;
+
+    await store.delete(listed.key);
+    deleted += 1;
+    for (const file of manifest.files) {
+      await store.delete(file.key);
+      deleted += 1;
+    }
+  }
+
+  return { candidates, deleted };
 }
 
 interface WorkerRoute {

--- a/tools/rootage-cdn/src/publisher.test.ts
+++ b/tools/rootage-cdn/src/publisher.test.ts
@@ -195,7 +195,7 @@ describe("Rootage publisher offline E2E", () => {
     const store = new MemoryStore();
     const baseInput = {
       version,
-      packageUrl: "https://pkg.pr.new/rootage-artifacts@snapshot",
+      packageUrl: `https://pkg.pr.new/@seed-design/rootage-artifacts@${sourceSha}`,
       packageShasum: createHash("sha1").update(bytes).digest("hex"),
       sourceSha,
       publicBaseUrl: "https://offline.test",
@@ -203,6 +203,18 @@ describe("Rootage publisher offline E2E", () => {
 
     await expect(
       publishRootageSnapshot(store, { ...baseInput, packageUrl: "https://attacker.test/a.tgz" }),
+    ).rejects.toThrow("허용된 pkg.pr.new");
+    await expect(
+      publishRootageSnapshot(store, {
+        ...baseInput,
+        packageUrl: `https://pkg.pr.new/@seed-design/other-package@${sourceSha}`,
+      }),
+    ).rejects.toThrow("허용된 pkg.pr.new");
+    await expect(
+      publishRootageSnapshot(store, {
+        ...baseInput,
+        packageUrl: `https://pkg.pr.new/@seed-design/rootage-artifacts@${"6".repeat(40)}`,
+      }),
     ).rejects.toThrow("허용된 pkg.pr.new");
     await expect(
       publishRootageSnapshot(store, { ...baseInput, sourceSha: "6".repeat(40) }),

--- a/tools/rootage-cdn/src/publisher.test.ts
+++ b/tools/rootage-cdn/src/publisher.test.ts
@@ -170,7 +170,6 @@ describe("Rootage publisher offline E2E", () => {
         fetch: async () =>
           new Response(bytes.slice().buffer as ArrayBuffer, {
             headers: {
-              "content-length": String(bytes.byteLength),
               "content-type": "application/tar+gzip",
             },
           }),
@@ -228,6 +227,39 @@ describe("Rootage publisher offline E2E", () => {
         },
       ),
     ).rejects.toThrow("SHA-1");
+  });
+
+  test("Content-Length가 없는 tarball도 읽는 중 크기 제한을 적용한다", async () => {
+    const sourceSha = "7".repeat(40);
+    const version = createRootageSnapshotVersion("125", sourceSha);
+    let reads = 0;
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        reads += 1;
+        controller.enqueue(new Uint8Array(8 * 1024 * 1024));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+
+    await expect(
+      publishRootageSnapshot(
+        new MemoryStore(),
+        {
+          version,
+          packageUrl: `https://pkg.pr.new/@seed-design/rootage-artifacts@${sourceSha}`,
+          packageShasum: "0".repeat(40),
+          sourceSha,
+          publicBaseUrl: "https://offline.test",
+        },
+        { fetch: async () => new Response(body) },
+      ),
+    ).rejects.toThrow("허용 크기");
+    expect(reads).toBeGreaterThanOrEqual(3);
+    expect(reads).toBeLessThanOrEqual(4);
+    expect(cancelled).toBe(true);
   });
 
   test("재시도 중 immutable object 바이트가 다르면 fail-closed다", async () => {

--- a/tools/rootage-cdn/src/publisher.test.ts
+++ b/tools/rootage-cdn/src/publisher.test.ts
@@ -4,7 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import { jsonBytes, sha256 } from "./contract";
-import { publishRootageArchive, type PublicVerifier } from "./publisher";
+import { publishRootageArchive, publishRootageSnapshot, type PublicVerifier } from "./publisher";
+import { createRootageSnapshotVersion } from "./snapshot";
 import type { ObjectStore, StoredObject } from "./types";
 import { handleRequest, type WorkerEnv } from "./worker";
 
@@ -147,6 +148,74 @@ describe("Rootage publisher offline E2E", () => {
     expect(retry.reusedManifest).toBe(true);
     expect(retry.pointerBefore).toBe(version);
     expect(retry.pointerAfter).toBe(version);
+  });
+
+  test("pkg.pr.new의 exact snapshot tarball을 stable 포인터 없이 게시한다", async () => {
+    const sourceSha = "4".repeat(40);
+    const version = createRootageSnapshotVersion("123", sourceSha);
+    const bytes = await tarball(version);
+    const packageShasum = createHash("sha1").update(bytes).digest("hex");
+    const store = new MemoryStore();
+
+    const result = await publishRootageSnapshot(
+      store,
+      {
+        version,
+        packageUrl: `https://pkg.pr.new/@seed-design/rootage-artifacts@${sourceSha}`,
+        packageShasum,
+        sourceSha,
+        publicBaseUrl: "https://offline.test",
+      },
+      {
+        fetch: async () =>
+          new Response(bytes.slice().buffer as ArrayBuffer, {
+            headers: {
+              "content-length": String(bytes.byteLength),
+              "content-type": "application/tar+gzip",
+            },
+          }),
+        publicVerifier: workerVerifier(store),
+      },
+    );
+
+    expect(result).toMatchObject({ fileCount: 2, pointerBefore: "", pointerAfter: "" });
+    expect(store.objects.has(`manifests/v${version}.json`)).toBe(true);
+    expect(store.objects.has("pointers/stable.json")).toBe(false);
+    const manifest = JSON.parse(
+      new TextDecoder().decode(store.objects.get(`manifests/v${version}.json`)!.bytes),
+    );
+    expect(manifest.gitHead).toBe(sourceSha);
+    expect(manifest.npmIntegrity).toBe(integrity(bytes));
+  });
+
+  test("snapshot URL, source 결속과 tarball SHA-1 불일치를 거부한다", async () => {
+    const sourceSha = "5".repeat(40);
+    const version = createRootageSnapshotVersion("124", sourceSha);
+    const bytes = await tarball(version);
+    const store = new MemoryStore();
+    const baseInput = {
+      version,
+      packageUrl: "https://pkg.pr.new/rootage-artifacts@snapshot",
+      packageShasum: createHash("sha1").update(bytes).digest("hex"),
+      sourceSha,
+      publicBaseUrl: "https://offline.test",
+    };
+
+    await expect(
+      publishRootageSnapshot(store, { ...baseInput, packageUrl: "https://attacker.test/a.tgz" }),
+    ).rejects.toThrow("허용된 pkg.pr.new");
+    await expect(
+      publishRootageSnapshot(store, { ...baseInput, sourceSha: "6".repeat(40) }),
+    ).rejects.toThrow("source SHA");
+    await expect(
+      publishRootageSnapshot(
+        store,
+        { ...baseInput, packageShasum: "0".repeat(40) },
+        {
+          fetch: async () => new Response(bytes.slice().buffer as ArrayBuffer),
+        },
+      ),
+    ).rejects.toThrow("SHA-1");
   });
 
   test("재시도 중 immutable object 바이트가 다르면 fail-closed다", async () => {

--- a/tools/rootage-cdn/src/publisher.ts
+++ b/tools/rootage-cdn/src/publisher.ts
@@ -109,7 +109,7 @@ function sha512Integrity(bytes: Uint8Array): string {
   return `sha512-${createHash("sha512").update(bytes).digest("base64")}`;
 }
 
-function validateSnapshotPackageUrl(value: string): URL {
+function validateSnapshotPackageUrl(value: string, sourceSha: string): URL {
   const url = new URL(value);
   if (
     url.protocol !== "https:" ||
@@ -119,7 +119,7 @@ function validateSnapshotPackageUrl(value: string): URL {
     url.password ||
     url.search ||
     url.hash ||
-    url.pathname === "/"
+    url.pathname !== `/@seed-design/rootage-artifacts@${sourceSha}`
   ) {
     throw new Error("허용된 pkg.pr.new snapshot tarball URL이 아닙니다.");
   }
@@ -439,7 +439,7 @@ export async function publishRootageSnapshot(
   if (!/^[0-9a-f]{40}$/.test(input.packageShasum)) {
     throw new Error("pkg.pr.new snapshot shasum은 40자리 소문자 SHA-1이어야 합니다.");
   }
-  const packageUrl = validateSnapshotPackageUrl(input.packageUrl);
+  const packageUrl = validateSnapshotPackageUrl(input.packageUrl, input.sourceSha);
   const response = await (options.fetch ?? fetch)(packageUrl, {
     headers: { accept: "application/tar+gzip, application/octet-stream" },
     redirect: "error",

--- a/tools/rootage-cdn/src/publisher.ts
+++ b/tools/rootage-cdn/src/publisher.ts
@@ -21,6 +21,7 @@ import {
   type StablePointerMutation,
   verifyLatestWithRollback,
 } from "./stable-pointer-recovery";
+import { parseRootageSnapshotVersion } from "./snapshot";
 
 export interface RegistryVersion {
   name?: string;
@@ -49,6 +50,19 @@ export interface PublishArchiveSource {
   metadata: RegistryVersion;
   tarball: Uint8Array;
   npmLatestVersion?: string;
+}
+
+export interface SnapshotPublishInput {
+  version: string;
+  packageUrl: string;
+  packageShasum: string;
+  sourceSha: string;
+  publicBaseUrl: string;
+}
+
+interface SnapshotPublishOptions {
+  fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+  publicVerifier?: PublicVerifier;
 }
 
 export type PublicVerifier = (
@@ -93,6 +107,23 @@ async function latestVersion(): Promise<string> {
 
 function sha512Integrity(bytes: Uint8Array): string {
   return `sha512-${createHash("sha512").update(bytes).digest("base64")}`;
+}
+
+function validateSnapshotPackageUrl(value: string): URL {
+  const url = new URL(value);
+  if (
+    url.protocol !== "https:" ||
+    url.hostname !== "pkg.pr.new" ||
+    url.port ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    url.pathname === "/"
+  ) {
+    throw new Error("허용된 pkg.pr.new snapshot tarball URL이 아닙니다.");
+  }
+  return url;
 }
 
 async function extractTarball(bytes: Uint8Array): Promise<string> {
@@ -394,4 +425,61 @@ export async function publishRootage(
     tarball,
     npmLatestVersion: input.stable ? await latestVersion() : undefined,
   });
+}
+
+export async function publishRootageSnapshot(
+  store: ObjectStore,
+  input: SnapshotPublishInput,
+  options: SnapshotPublishOptions = {},
+): Promise<PublishResult> {
+  const identity = parseRootageSnapshotVersion(input.version);
+  if (!identity || identity.sourceSha !== input.sourceSha) {
+    throw new Error("Rootage snapshot 버전이 승인된 source SHA와 일치하지 않습니다.");
+  }
+  if (!/^[0-9a-f]{40}$/.test(input.packageShasum)) {
+    throw new Error("pkg.pr.new snapshot shasum은 40자리 소문자 SHA-1이어야 합니다.");
+  }
+  const packageUrl = validateSnapshotPackageUrl(input.packageUrl);
+  const response = await (options.fetch ?? fetch)(packageUrl, {
+    headers: { accept: "application/tar+gzip, application/octet-stream" },
+    redirect: "error",
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) {
+    throw new Error(`pkg.pr.new snapshot tarball을 받지 못했습니다: ${response.status}`);
+  }
+  const declaredBytes = Number(response.headers.get("content-length") ?? "0");
+  const maximumArchiveBytes = 20 * 1024 * 1024;
+  if (Number.isFinite(declaredBytes) && declaredBytes > maximumArchiveBytes) {
+    throw new Error("pkg.pr.new snapshot tarball이 허용 크기를 초과했습니다.");
+  }
+  const tarball = new Uint8Array(await response.arrayBuffer());
+  if (tarball.byteLength === 0 || tarball.byteLength > maximumArchiveBytes) {
+    throw new Error("pkg.pr.new snapshot tarball 크기가 올바르지 않습니다.");
+  }
+  const actualShasum = createHash("sha1").update(tarball).digest("hex");
+  if (actualShasum !== input.packageShasum) {
+    throw new Error("pkg.pr.new snapshot tarball SHA-1이 게시 결과와 다릅니다.");
+  }
+  const archiveIntegrity = sha512Integrity(tarball);
+  return publishRootageArchive(
+    store,
+    {
+      version: input.version,
+      npmIntegrity: archiveIntegrity,
+      sourceSha: input.sourceSha,
+      stable: false,
+      publicBaseUrl: input.publicBaseUrl,
+    },
+    {
+      metadata: {
+        name: PACKAGE_NAME,
+        version: input.version,
+        gitHead: input.sourceSha,
+        dist: { integrity: archiveIntegrity, tarball: packageUrl.href },
+      },
+      tarball,
+    },
+    options.publicVerifier,
+  );
 }

--- a/tools/rootage-cdn/src/publisher.ts
+++ b/tools/rootage-cdn/src/publisher.ts
@@ -126,6 +126,42 @@ function validateSnapshotPackageUrl(value: string, sourceSha: string): URL {
   return url;
 }
 
+async function readBoundedResponseBody(
+  response: Response,
+  maximumBytes: number,
+): Promise<Uint8Array> {
+  if (!response.body) {
+    throw new Error("pkg.pr.new snapshot tarball 크기가 올바르지 않습니다.");
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > maximumBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw new Error("pkg.pr.new snapshot tarball이 허용 크기를 초과했습니다.");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  if (totalBytes === 0) {
+    throw new Error("pkg.pr.new snapshot tarball 크기가 올바르지 않습니다.");
+  }
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
 async function extractTarball(bytes: Uint8Array): Promise<string> {
   const directory = await mkdtemp(join(tmpdir(), "rootage-cdn-"));
   const archive = join(directory, "package.tgz");
@@ -451,12 +487,10 @@ export async function publishRootageSnapshot(
   const declaredBytes = Number(response.headers.get("content-length") ?? "0");
   const maximumArchiveBytes = 20 * 1024 * 1024;
   if (Number.isFinite(declaredBytes) && declaredBytes > maximumArchiveBytes) {
+    await response.body?.cancel().catch(() => undefined);
     throw new Error("pkg.pr.new snapshot tarball이 허용 크기를 초과했습니다.");
   }
-  const tarball = new Uint8Array(await response.arrayBuffer());
-  if (tarball.byteLength === 0 || tarball.byteLength > maximumArchiveBytes) {
-    throw new Error("pkg.pr.new snapshot tarball 크기가 올바르지 않습니다.");
-  }
+  const tarball = await readBoundedResponseBody(response, maximumArchiveBytes);
   const actualShasum = createHash("sha1").update(tarball).digest("hex");
   if (actualShasum !== input.packageShasum) {
     throw new Error("pkg.pr.new snapshot tarball SHA-1이 게시 결과와 다릅니다.");

--- a/tools/rootage-cdn/src/snapshot-input.ts
+++ b/tools/rootage-cdn/src/snapshot-input.ts
@@ -15,7 +15,7 @@ async function git(args: string[]): Promise<string> {
   const process = Bun.spawn({ cmd: ["git", ...args], stdout: "pipe", stderr: "inherit" });
   const output = await new Response(process.stdout).text();
   if ((await process.exited) !== 0) throw new Error(`git ${args.join(" ")} 실행에 실패했습니다.`);
-  return output.trim();
+  return output;
 }
 
 async function output(values: Record<string, string>): Promise<void> {
@@ -32,13 +32,13 @@ const sourceSha = required("ROOTAGE_SOURCE_SHA");
 if (command === "detect") {
   const baseSha = required("ROOTAGE_BASE_SHA");
   const changedFiles = (
-    await git(["diff", "--name-only", "--no-renames", `${baseSha}...${sourceSha}`])
+    await git(["diff", "--name-only", "-z", "--no-renames", `${baseSha}...${sourceSha}`])
   )
-    .split("\n")
+    .split("\0")
     .filter(Boolean);
   await output({ changed: String(hasRootageChanges(changedFiles)) });
 } else if (command === "prepare") {
-  if ((await git(["rev-parse", "HEAD"])) !== sourceSha) {
+  if ((await git(["rev-parse", "HEAD"])).trim() !== sourceSha) {
     throw new Error("checkout HEAD가 승인된 Rootage snapshot source SHA와 다릅니다.");
   }
   const version = createRootageSnapshotVersion(required("ROOTAGE_PR_NUMBER"), sourceSha);

--- a/tools/rootage-cdn/src/snapshot-input.ts
+++ b/tools/rootage-cdn/src/snapshot-input.ts
@@ -1,0 +1,49 @@
+import { appendFile } from "node:fs/promises";
+import {
+  createRootageSnapshotVersion,
+  hasRootageChanges,
+  writeRootageSnapshotVersion,
+} from "./snapshot";
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} 환경 변수가 필요합니다.`);
+  return value;
+}
+
+async function git(args: string[]): Promise<string> {
+  const process = Bun.spawn({ cmd: ["git", ...args], stdout: "pipe", stderr: "inherit" });
+  const output = await new Response(process.stdout).text();
+  if ((await process.exited) !== 0) throw new Error(`git ${args.join(" ")} 실행에 실패했습니다.`);
+  return output.trim();
+}
+
+async function output(values: Record<string, string>): Promise<void> {
+  const lines = Object.entries(values)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+  if (process.env.GITHUB_OUTPUT) await appendFile(process.env.GITHUB_OUTPUT, `${lines}\n`);
+  console.log(lines);
+}
+
+const command = Bun.argv[2];
+const sourceSha = required("ROOTAGE_SOURCE_SHA");
+
+if (command === "detect") {
+  const baseSha = required("ROOTAGE_BASE_SHA");
+  const changedFiles = (
+    await git(["diff", "--name-only", "--no-renames", `${baseSha}...${sourceSha}`])
+  )
+    .split("\n")
+    .filter(Boolean);
+  await output({ changed: String(hasRootageChanges(changedFiles)) });
+} else if (command === "prepare") {
+  if ((await git(["rev-parse", "HEAD"])) !== sourceSha) {
+    throw new Error("checkout HEAD가 승인된 Rootage snapshot source SHA와 다릅니다.");
+  }
+  const version = createRootageSnapshotVersion(required("ROOTAGE_PR_NUMBER"), sourceSha);
+  await writeRootageSnapshotVersion("packages/rootage/package.json", version);
+  await output({ version });
+} else {
+  throw new Error(`지원하지 않는 Rootage snapshot 입력 명령입니다: ${command ?? ""}`);
+}

--- a/tools/rootage-cdn/src/snapshot-workflow.test.ts
+++ b/tools/rootage-cdn/src/snapshot-workflow.test.ts
@@ -4,6 +4,16 @@ import { join } from "node:path";
 const repositoryRoot = join(import.meta.dir, "../../..");
 
 describe("Rootage snapshot workflows", () => {
+  test("Rootage 변경 경로는 NUL 구분 Git 출력으로 읽는다", async () => {
+    const input = await Bun.file(
+      join(repositoryRoot, "tools/rootage-cdn/src/snapshot-input.ts"),
+    ).text();
+
+    expect(input).toContain('"diff", "--name-only", "-z"');
+    expect(input).toContain('.split("\\0")');
+    expect(input).not.toContain('.split("\\n")');
+  });
+
   test("PR source 실행과 CDN credential을 서로 다른 job으로 격리한다", async () => {
     const workflow = await Bun.file(
       join(repositoryRoot, ".github/workflows/continuous-releases.yml"),

--- a/tools/rootage-cdn/src/snapshot-workflow.test.ts
+++ b/tools/rootage-cdn/src/snapshot-workflow.test.ts
@@ -16,7 +16,17 @@ describe("Rootage snapshot workflows", () => {
     expect(releaseJob).toContain("persist-credentials: false");
     expect(releaseJob).toContain("snapshot-input.ts detect");
     expect(releaseJob).toContain("snapshot-input.ts prepare");
-    expect(releaseJob).toContain("bun run pkg-pr-new publish");
+    expect(releaseJob).toContain(
+      'test "$(jq -r \'.version\' node_modules/pkg-pr-new/package.json)" = "0.0.87"',
+    );
+    expect(releaseJob).toContain(
+      "72dfe24919e316a388aa6893b840bba6fc2f7b9fc37df67e2b545d0a12c6e3b2",
+    );
+    expect(releaseJob).toContain(
+      "196586894e117c8d043310df05742ead273f12fb0575a88272e596a8c90a6658",
+    );
+    expect(releaseJob).toContain("bun node_modules/pkg-pr-new/bin/cli.js publish");
+    expect(releaseJob).not.toContain("bun run pkg-pr-new publish");
     expect(releaseJob).not.toContain("bunx pkg-pr-new");
     expect(releaseJob).not.toContain("ROOTAGE_R2_ACCESS_KEY_ID");
     expect(releaseJob).not.toContain("ROOTAGE_R2_SECRET_ACCESS_KEY");
@@ -51,7 +61,7 @@ describe("Rootage snapshot workflows", () => {
     expect(workflow).not.toContain("cleanup-incomplete");
   });
 
-  test("pkg-pr-new CLI는 검토된 exact 개발 의존성으로 고정한다", async () => {
+  test("pkg-pr-new CLI는 검토된 exact 개발 의존성과 실행 파일 checksum으로 고정한다", async () => {
     const packageJson = (await Bun.file(join(repositoryRoot, "package.json")).json()) as {
       devDependencies: Record<string, string>;
     };

--- a/tools/rootage-cdn/src/snapshot-workflow.test.ts
+++ b/tools/rootage-cdn/src/snapshot-workflow.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+const repositoryRoot = join(import.meta.dir, "../../..");
+
+describe("Rootage snapshot workflows", () => {
+  test("PR source 실행과 CDN credential을 서로 다른 job으로 격리한다", async () => {
+    const workflow = await Bun.file(
+      join(repositoryRoot, ".github/workflows/continuous-releases.yml"),
+    ).text();
+    const releaseStart = workflow.indexOf("  release:");
+    const publishStart = workflow.indexOf("  publish-rootage:");
+    const releaseJob = workflow.slice(releaseStart, publishStart);
+
+    expect(workflow).toContain("startsWith(github.event.comment.body, '/snapshot')");
+    expect(releaseJob).toContain("persist-credentials: false");
+    expect(releaseJob).toContain("snapshot-input.ts detect");
+    expect(releaseJob).toContain("snapshot-input.ts prepare");
+    expect(releaseJob).toContain("bun run pkg-pr-new publish");
+    expect(releaseJob).not.toContain("bunx pkg-pr-new");
+    expect(releaseJob).not.toContain("ROOTAGE_R2_ACCESS_KEY_ID");
+    expect(releaseJob).not.toContain("ROOTAGE_R2_SECRET_ACCESS_KEY");
+    expect(workflow).toContain("uses: ./.github/workflows/rootage-snapshot-contract.yml");
+    expect(workflow).toContain("if: needs.release.outputs.rootage-changed == 'true'");
+  });
+
+  test("snapshot 게시기는 trusted dev control SHA와 production environment에 결속된다", async () => {
+    const workflow = await Bun.file(
+      join(repositoryRoot, ".github/workflows/rootage-snapshot-contract.yml"),
+    ).text();
+
+    expect(workflow).toContain("environment: rootage-production");
+    expect(workflow).toContain("ref: dev");
+    expect(workflow).toContain("ref: ${{ inputs.control-sha }}");
+    expect(workflow).toContain("git merge-base --is-ancestor");
+    expect(workflow).toContain("cli.ts publish-snapshot");
+    expect(workflow).not.toContain("secrets: inherit");
+    expect(workflow).not.toContain("--stable");
+  });
+
+  test("정기 정리는 dev와 production environment에서 snapshot 명령만 실행한다", async () => {
+    const workflow = await Bun.file(
+      join(repositoryRoot, ".github/workflows/rootage-snapshot-cleanup.yml"),
+    ).text();
+
+    expect(workflow).toContain("github.ref == 'refs/heads/dev'");
+    expect(workflow).toContain("environment: rootage-production");
+    expect(workflow).toContain("cli.ts cleanup-snapshots");
+    expect(workflow).toContain('--older-than-days "30"');
+    expect(workflow).toContain('--confirm "DELETE-SNAPSHOTS"');
+    expect(workflow).not.toContain("cleanup-incomplete");
+  });
+
+  test("pkg-pr-new CLI는 검토된 exact 개발 의존성으로 고정한다", async () => {
+    const packageJson = (await Bun.file(join(repositoryRoot, "package.json")).json()) as {
+      devDependencies: Record<string, string>;
+    };
+    expect(packageJson.devDependencies["pkg-pr-new"]).toBe("0.0.87");
+  });
+});

--- a/tools/rootage-cdn/src/snapshot.test.ts
+++ b/tools/rootage-cdn/src/snapshot.test.ts
@@ -1,0 +1,58 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  createRootageSnapshotVersion,
+  hasRootageChanges,
+  parseRootageSnapshotVersion,
+  writeRootageSnapshotVersion,
+} from "./snapshot";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("Rootage snapshot 입력", () => {
+  test("PR 번호와 exact source SHA로 불변 SemVer를 만든다", () => {
+    const sourceSha = "a".repeat(40);
+    const version = createRootageSnapshotVersion("123", sourceSha);
+    expect(version).toBe(`0.0.0-snapshot.pr-123.sha-${sourceSha}`);
+    expect(parseRootageSnapshotVersion(version)).toEqual({ prNumber: 123, sourceSha });
+  });
+
+  test("잘못된 PR 번호, SHA와 다른 prerelease 버전을 거부한다", () => {
+    expect(() => createRootageSnapshotVersion("0", "a".repeat(40))).toThrow("PR 번호");
+    expect(() => createRootageSnapshotVersion("1", "main")).toThrow("source SHA");
+    expect(parseRootageSnapshotVersion("2.5.0-beta.1")).toBeNull();
+  });
+
+  test("packages/rootage 아래의 정규 Git 경로만 변경으로 판단한다", () => {
+    expect(hasRootageChanges(["packages/react/Button.tsx", "packages/rootage/color.yaml"])).toBe(
+      true,
+    );
+    expect(hasRootageChanges(["ecosystem/rootage/core/index.ts"])).toBe(false);
+    expect(hasRootageChanges(["packages\\rootage\\color.yaml"])).toBe(false);
+  });
+
+  test("Rootage package identity를 보존하며 snapshot 버전만 쓴다", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "rootage-snapshot-test-"));
+    temporaryDirectories.push(directory);
+    const packageJsonPath = join(directory, "package.json");
+    await writeFile(
+      packageJsonPath,
+      `${JSON.stringify({ name: "@seed-design/rootage-artifacts", version: "2.4.0", files: ["a"] }, null, 2)}\n`,
+    );
+    const version = createRootageSnapshotVersion("77", "b".repeat(40));
+    await writeRootageSnapshotVersion(packageJsonPath, version);
+    expect(JSON.parse(await readFile(packageJsonPath, "utf8"))).toEqual({
+      name: "@seed-design/rootage-artifacts",
+      version,
+      files: ["a"],
+    });
+  });
+});

--- a/tools/rootage-cdn/src/snapshot.test.ts
+++ b/tools/rootage-cdn/src/snapshot.test.ts
@@ -31,10 +31,12 @@ describe("Rootage snapshot 입력", () => {
     expect(parseRootageSnapshotVersion("2.5.0-beta.1")).toBeNull();
   });
 
-  test("packages/rootage 아래의 정규 Git 경로만 변경으로 판단한다", () => {
+  test("packages/rootage 아래의 Git 경로를 파일명 문자와 무관하게 변경으로 판단한다", () => {
     expect(hasRootageChanges(["packages/react/Button.tsx", "packages/rootage/color.yaml"])).toBe(
       true,
     );
+    expect(hasRootageChanges(["packages/rootage/a\\b.yaml"])).toBe(true);
+    expect(hasRootageChanges(["packages/rootage/a\nb.yaml"])).toBe(true);
     expect(hasRootageChanges(["ecosystem/rootage/core/index.ts"])).toBe(false);
     expect(hasRootageChanges(["packages\\rootage\\color.yaml"])).toBe(false);
   });

--- a/tools/rootage-cdn/src/snapshot.ts
+++ b/tools/rootage-cdn/src/snapshot.ts
@@ -24,7 +24,7 @@ export function parseRootageSnapshotVersion(
 }
 
 export function hasRootageChanges(paths: Iterable<string>): boolean {
-  return [...paths].some((path) => !path.includes("\\") && path.startsWith("packages/rootage/"));
+  return [...paths].some((path) => path.startsWith("packages/rootage/"));
 }
 
 interface PackageManifest {

--- a/tools/rootage-cdn/src/snapshot.ts
+++ b/tools/rootage-cdn/src/snapshot.ts
@@ -1,0 +1,51 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const PR_NUMBER_PATTERN = /^[1-9]\d*$/;
+
+export const SNAPSHOT_VERSION_PATTERN = /^0\.0\.0-snapshot\.pr-([1-9]\d*)\.sha-([0-9a-f]{40})$/;
+
+export function createRootageSnapshotVersion(prNumber: string, sourceSha: string): string {
+  if (!PR_NUMBER_PATTERN.test(prNumber)) {
+    throw new Error("Rootage snapshot PR 번호는 1 이상의 정수여야 합니다.");
+  }
+  if (!SHA_PATTERN.test(sourceSha)) {
+    throw new Error("Rootage snapshot source SHA는 40자리 소문자 Git SHA여야 합니다.");
+  }
+  return `0.0.0-snapshot.pr-${prNumber}.sha-${sourceSha}`;
+}
+
+export function parseRootageSnapshotVersion(
+  version: string,
+): { prNumber: number; sourceSha: string } | null {
+  const match = SNAPSHOT_VERSION_PATTERN.exec(version);
+  if (!match) return null;
+  return { prNumber: Number(match[1]), sourceSha: match[2]! };
+}
+
+export function hasRootageChanges(paths: Iterable<string>): boolean {
+  return [...paths].some((path) => !path.includes("\\") && path.startsWith("packages/rootage/"));
+}
+
+interface PackageManifest {
+  name?: unknown;
+  version?: unknown;
+  [key: string]: unknown;
+}
+
+export async function writeRootageSnapshotVersion(
+  packageJsonPath: string,
+  version: string,
+): Promise<void> {
+  if (!SNAPSHOT_VERSION_PATTERN.test(version)) {
+    throw new Error("Rootage snapshot 버전 형식이 올바르지 않습니다.");
+  }
+  const manifest = JSON.parse(await readFile(packageJsonPath, "utf8")) as PackageManifest;
+  if (manifest.name !== "@seed-design/rootage-artifacts") {
+    throw new Error("Rootage snapshot package 이름이 올바르지 않습니다.");
+  }
+  if (typeof manifest.version !== "string") {
+    throw new Error("Rootage snapshot package 버전이 문자열이 아닙니다.");
+  }
+  await writeFile(packageJsonPath, `${JSON.stringify({ ...manifest, version }, null, 2)}\n`);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - Pull Request에서 `/snapshot` 명령으로 검증 가능한 패키지 및 Rootage 스냅샷을 생성할 수 있습니다.
  - 스냅샷은 해당 커밋과 연결된 고유 버전으로 게시되며 stable 버전에는 영향을 주지 않습니다.
  - 종료된 Pull Request의 30일 이상 지난 스냅샷을 자동으로 정리합니다.

- **개선 사항**
  - 스냅샷 게시 전 패키지 URL, 무결성, 소스 커밋을 검증해 잘못된 릴리스를 방지합니다.
  - 게시 성공 여부와 소스 커밋 정보가 Pull Request에 표시됩니다.

- **문서**
  - 스냅샷 생성, 게시 및 정리 방식에 대한 안내를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->