### PR TITLE
chore(docs): allow .test dev-proxy hosts in Next and Storybook

### DIFF
--- a/docs/.storybook/main.ts
+++ b/docs/.storybook/main.ts
@@ -10,6 +10,9 @@ export default defineMain({
     options: {},
   },
   staticDirs: ["../public"],
+  core: {
+    allowedHosts: [".test"],
+  },
 });
 
 function getAbsolutePath(value: string): string {

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -15,6 +15,7 @@ const layeredRecipeAliases = Object.fromEntries(
 
 /** @type {import('next').NextConfig} */
 const config = {
+  allowedDevOrigins: ["**.test"],
   output: "export",
   reactStrictMode: true,
   typescript: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 개발 환경에서 `.test` 도메인을 통한 애플리케이션 및 컴포넌트 미리보기 접근이 가능해졌습니다.
  - 로컬 테스트용 도메인 사용 시 호스트 차단으로 발생하던 접근 문제가 줄어듭니다.
  - 별도 설정 없이 허용된 `.test` 도메인 패턴을 활용할 수 있어 개발 및 검증 과정이 더욱 원활해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->