### PR TITLE
feat(docs): add opt-in sticky table header, enable on Progress Board

### DIFF
--- a/docs/components/progress-board-table.tsx
+++ b/docs/components/progress-board-table.tsx
@@ -85,11 +85,15 @@ export async function ProgressBoardTable() {
   return (
     <div className="not-prose my-6">
       {/* Components Table — SEED design via shared TableRoot (single source in ./table) */}
-      <TableRoot className="[&_thead_th:not(:first-child)]:text-center [&_tbody_tr:hover_td:first-child]:bg-bg-neutral-weak">
+      <TableRoot
+        stickyHeader
+        className="[&_thead_th:not(:first-child)]:text-center [&_tbody_tr:hover_td:first-child]:bg-bg-neutral-weak"
+      >
         <thead>
           <tr>
-            {/* sticky 좌상단 헤더 셀만 TableRoot의 [&_th]:bg-transparent를 이겨 불투명 유지 */}
-            <th className="sticky left-0 bg-bg-layer-default!">Component</th>
+            {/* 가로·세로 양축 고정이라, 가로 스크롤 시 미끄러져 들어오는 나머지 헤더 셀 위에 있어야 한다.
+                배경·z 모두 TableRoot의 `[&_thead_th]:` 규칙보다 명시도가 낮아 !important가 필요하다 */}
+            <th className="sticky left-0 z-20! bg-bg-layer-default!">Component</th>
             {PLATFORM_CONFIG.map(({ key, label }) => (
               <th key={key}>{label}</th>
             ))}

--- a/docs/components/progress-board-table.tsx
+++ b/docs/components/progress-board-table.tsx
@@ -91,9 +91,8 @@ export async function ProgressBoardTable() {
       >
         <thead>
           <tr>
-            {/* 가로·세로 양축 고정이라, 가로 스크롤 시 미끄러져 들어오는 나머지 헤더 셀 위에 있어야 한다.
-                배경·z 모두 TableRoot의 `[&_thead_th]:` 규칙보다 명시도가 낮아 !important가 필요하다 */}
-            <th className="sticky left-0 z-20! bg-bg-layer-default!">Component</th>
+            {/* sticky 좌상단 헤더 셀만 TableRoot의 [&_th]:bg-transparent를 이겨 불투명 유지 */}
+            <th className="sticky left-0 bg-bg-layer-default!">Component</th>
             {PLATFORM_CONFIG.map(({ key, label }) => (
               <th key={key}>{label}</th>
             ))}

--- a/docs/components/table.tsx
+++ b/docs/components/table.tsx
@@ -44,7 +44,13 @@ const seedTableWrapper = "relative w-full overflow-x-auto prose-no-margin my-6";
 const seedStickyHeaderWrapper = "md:overflow-visible";
 
 const seedStickyHeaderChrome = clsx(
-  "md:[&_thead_th]:sticky md:[&_thead_th]:top-(--fd-docs-row-2) md:[&_thead_th]:z-10",
+  /**
+   * 오프셋은 `--fd-docs-row-2`가 아니라 헤더 높이다. row-2는 배너와 헤더가 세로로 쌓인다고
+   * 보고 둘을 더하지만, 이 사이트는 배너·헤더가 모두 `sticky top-0`이라 겹쳐서 헤더가 배너를
+   * 덮는다. 실제로 비워야 할 높이는 헤더 하나뿐이고, row-2를 쓰면 배너 높이만큼 틈이 생겨
+   * 그 사이로 본문 행이 지나간다 (배너가 없는 배포에서는 둘이 같은 값이라 드러나지 않는다).
+   */
+  "md:[&_thead_th]:sticky md:[&_thead_th]:top-[var(--fd-header-height,4rem)] md:[&_thead_th]:z-10",
   // seedTableChrome의 `[&_th]:bg-transparent`를 이겨, 지나가는 본문 행이 헤더 뒤로 비치지 않게 한다
   "md:[&_thead_th]:bg-bg-layer-default",
   // 구분선은 `[&_tr]:border-b`로 tr에 그려지는데 고정되는 건 th뿐이라 선만 떨어져 스크롤된다. 셀로 옮겨야 헤더를 따라 남는다

--- a/docs/components/table.tsx
+++ b/docs/components/table.tsx
@@ -31,15 +31,45 @@ const seedTableChrome = clsx(
 
 const seedTableWrapper = "relative w-full overflow-x-auto prose-no-margin my-6";
 
+/**
+ * 헤더 고정은 래퍼가 세로로 스크롤될 때만 성립한다. `overflow-x-auto`가 나머지 축까지
+ * `auto`로 계산시켜 래퍼를 스크롤 컨테이너로 만들기 때문에, 안쪽 `thead`의 sticky는
+ * 뷰포트가 아니라 이 래퍼를 기준으로 잡힌다. 높이를 제한해야 래퍼가 실제로 스크롤되고,
+ * 그 높이는 뷰포트를 넘으면 안 된다 — 넘으면 고정된 헤더째로 화면 밖으로 밀려난다.
+ */
+const seedStickyHeaderWrapper =
+  "overflow-y-auto max-h-[calc(100dvh_-_var(--fd-docs-row-2,4rem)_-_2rem)]";
+
+const seedStickyHeaderChrome = clsx(
+  "[&_thead_th]:sticky [&_thead_th]:top-0 [&_thead_th]:z-10",
+  // seedTableChrome의 `[&_th]:bg-transparent`를 이겨, 지나가는 본문 행이 헤더 뒤로 비치지 않게 한다
+  "[&_thead_th]:bg-bg-layer-default",
+  // 구분선은 `[&_tr]:border-b`로 tr에 그려지는데 고정되는 건 th뿐이라 선만 떨어져 스크롤된다. 셀로 옮겨야 헤더를 따라 남는다
+  "[&_thead_th]:border-b [&_thead_th]:border-stroke-neutral-muted",
+);
+
 interface TableRootProps extends ComponentPropsWithoutRef<"table"> {
   /** 래퍼 `<div>`에 추가할 클래스 (컨슈머별 레이아웃 확장, 예: 전면 bleed) */
   wrapperClassName?: string;
+  /** 헤더 행을 표 스크롤 박스 상단에 고정한다. 뷰포트를 넘길 만큼 긴 표에만 켠다 */
+  stickyHeader?: boolean;
 }
 
-export function TableRoot({ className, wrapperClassName, children, ...props }: TableRootProps) {
+export function TableRoot({
+  className,
+  wrapperClassName,
+  stickyHeader,
+  children,
+  ...props
+}: TableRootProps) {
   return (
-    <div className={clsx(seedTableWrapper, wrapperClassName)}>
-      <table className={clsx(seedTableChrome, className)} {...props}>
+    <div
+      className={clsx(seedTableWrapper, stickyHeader && seedStickyHeaderWrapper, wrapperClassName)}
+    >
+      <table
+        className={clsx(seedTableChrome, stickyHeader && seedStickyHeaderChrome, className)}
+        {...props}
+      >
         {children}
       </table>
     </div>

--- a/docs/components/table.tsx
+++ b/docs/components/table.tsx
@@ -32,26 +32,32 @@ const seedTableChrome = clsx(
 const seedTableWrapper = "relative w-full overflow-x-auto prose-no-margin my-6";
 
 /**
- * 헤더 고정은 래퍼가 세로로 스크롤될 때만 성립한다. `overflow-x-auto`가 나머지 축까지
- * `auto`로 계산시켜 래퍼를 스크롤 컨테이너로 만들기 때문에, 안쪽 `thead`의 sticky는
- * 뷰포트가 아니라 이 래퍼를 기준으로 잡힌다. 높이를 제한해야 래퍼가 실제로 스크롤되고,
- * 그 높이는 뷰포트를 넘으면 안 된다 — 넘으면 고정된 헤더째로 화면 밖으로 밀려난다.
+ * 스크롤 주체는 페이지(body)로 남고 헤더만 사이트 헤더 아래에 붙는다. 그러려면 래퍼가
+ * 스크롤 컨테이너가 아니어야 한다 — `overflow-x-auto`는 나머지 축까지 `auto`로 계산시켜
+ * 래퍼를 스크롤 컨테이너로 만들고, 그러면 안쪽 `thead`의 sticky가 뷰포트 대신 래퍼를
+ * 기준으로 잡혀 아무 일도 일어나지 않는다.
+ *
+ * 스크롤 컨테이너를 걷어내면 가로 스크롤도 같이 사라지므로, 표가 줄바꿈만으로 들어가는
+ * 폭에서만 전환한다. 상위 문서 레이아웃이 `overflow-x: clip`이라 넘치면 열이 스크롤바
+ * 없이 잘려 접근 자체가 불가능해진다.
  */
-const seedStickyHeaderWrapper =
-  "overflow-y-auto max-h-[calc(100dvh_-_var(--fd-docs-row-2,4rem)_-_2rem)]";
+const seedStickyHeaderWrapper = "md:overflow-visible";
 
 const seedStickyHeaderChrome = clsx(
-  "[&_thead_th]:sticky [&_thead_th]:top-0 [&_thead_th]:z-10",
+  "md:[&_thead_th]:sticky md:[&_thead_th]:top-(--fd-docs-row-2) md:[&_thead_th]:z-10",
   // seedTableChrome의 `[&_th]:bg-transparent`를 이겨, 지나가는 본문 행이 헤더 뒤로 비치지 않게 한다
-  "[&_thead_th]:bg-bg-layer-default",
+  "md:[&_thead_th]:bg-bg-layer-default",
   // 구분선은 `[&_tr]:border-b`로 tr에 그려지는데 고정되는 건 th뿐이라 선만 떨어져 스크롤된다. 셀로 옮겨야 헤더를 따라 남는다
-  "[&_thead_th]:border-b [&_thead_th]:border-stroke-neutral-muted",
+  "md:[&_thead_th]:border-b md:[&_thead_th]:border-stroke-neutral-muted",
 );
 
 interface TableRootProps extends ComponentPropsWithoutRef<"table"> {
   /** 래퍼 `<div>`에 추가할 클래스 (컨슈머별 레이아웃 확장, 예: 전면 bleed) */
   wrapperClassName?: string;
-  /** 헤더 행을 표 스크롤 박스 상단에 고정한다. 뷰포트를 넘길 만큼 긴 표에만 켠다 */
+  /**
+   * 헤더 행을 사이트 헤더 아래에 고정한다(`md` 이상). 가로 스크롤을 포기하는 대신이므로,
+   * `md` 폭에서 줄바꿈만으로 들어가는 표에만 켠다
+   */
   stickyHeader?: boolean;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 표에 고정 헤더 옵션을 추가했습니다.
  * 중간 화면 크기 이상에서 헤더가 사이트 헤더 아래에 고정됩니다.
  * 고정 헤더에 불투명 배경과 셀 기준 하단 구분선을 적용했습니다.
  * 고정 헤더 사용 시 가로 콘텐츠를 더욱 편리하게 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->