### PR TITLE
fix(ci): share docs build caches across branches

### DIFF
--- a/.github/actions/nextjs-cache/README.md
+++ b/.github/actions/nextjs-cache/README.md
@@ -1,0 +1,26 @@
+# Next.js 빌드 캐시
+
+문서 프리뷰와 Production 빌드는 이 액션을 통해 `docs/.next/cache`와 `docs/.next/fumadocs-typescript`를 공유한다. 두 경로는 별도 archive와 namespace로 관리한다. 경로 목록 변경으로 Actions 캐시 버전이 달라져 기존 Turbopack 캐시를 못 찾는 상황을 피하기 위해서다.
+
+Turbopack 호환성 namespace는 운영체제, 의존성, Next.js와 빌드 설정의 해시로 구성한다. 일반적인 문서와 패키지 소스는 해시에서 제외한다. 해당 변경은 Turbopack의 의존성 추적에 맡겨 영향받은 작업만 다시 실행한다. Fumadocs namespace는 의존성과 TypeScript 및 타입 테이블 생성 설정을 포함한다. Fumadocs 자체 캐시는 입력 파일 내용과 패키지 버전으로 항목을 무효화한다.
+
+## 복원 순서
+
+GitHub Actions는 현재 브랜치에서 primary key와 restore key를 차례로 찾고, 없으면 기본 브랜치에서 같은 검색을 반복한다.
+
+1. 현재 브랜치의 동일한 primary key
+2. 현재 브랜치의 호환 가능한 최신 v2 캐시
+3. 현재 브랜치의 이전 형식 캐시
+4. 기본 브랜치 `dev`에서 위와 같은 순서
+
+따라서 새 기능 브랜치의 첫 Alpha 빌드는 현재 브랜치 캐시가 없을 때 `dev`의 최신 호환 v2 캐시를 복원한다. v2 캐시가 아직 만들어지지 않은 전환 기간에는 setup의 build suffix까지 같은 이전 형식 캐시를 마지막 후보로 사용한다. 이전 키는 일반 소스도 suffix에 포함했으므로 기능 브랜치 소스가 달라지면 매치되지 않을 수 있다. 새 공통 v2 캐시가 `dev` 빌드에서 한 번 저장되면 이 제약은 사라진다.
+
+## 갱신과 보존량
+
+GitHub Actions 캐시는 같은 key의 내용을 갱신할 수 없다. Production 빌드는 SHA를 세대로 사용해 `dev`의 최신 증분 상태를 계속 발행한다. Alpha 빌드는 `baseline`이라는 고정 세대를 사용해 기능 브랜치마다 호환성 namespace당 하나만 저장한다. 후속 push는 그 캐시를 exact hit로 계속 사용하므로 매 SHA마다 0.7~1GB 캐시를 추가하지 않는다.
+
+이 방식은 Alpha 캐시의 기준점이 첫 성공 빌드 상태로 고정되는 절충이 있다. Turbopack이 이후 소스 차이를 증분 처리하지만, 오래 유지된 기능 브랜치는 최신 빌드 결과를 다시 저장하지 않는다. 의존성이나 빌드 설정이 바뀌면 호환성 해시가 달라져 새 기준 캐시를 만든다. GitHub의 기본 저장 용량과 eviction 정책에 맡기며, 이 액션에서 외부 캐시를 삭제하지 않는다.
+
+## Fumadocs 타입 캐시
+
+현재 `dev`에는 `.next/fumadocs-typescript`를 만드는 구현이 없으므로 경로가 생기기 전까지 저장 단계는 건너뛴다. PR #1984가 반영되면 추가 워크플로 수정 없이 별도 캐시를 복원하고 저장한다.

--- a/.github/actions/nextjs-cache/action.yml
+++ b/.github/actions/nextjs-cache/action.yml
@@ -1,0 +1,143 @@
+name: Restore docs build caches
+description: Restore shared Next.js, Turbopack, and Fumadocs TypeScript caches
+
+inputs:
+  cache-generation:
+    description: Suffix that controls when the current branch publishes a new immutable cache
+    required: true
+  cache-scope:
+    description: Branch name recorded in the cache key for diagnostics
+    required: true
+  default-branch:
+    description: Repository default branch used to report the matched cache scope
+    required: true
+  legacy-build-cache-key-suffix:
+    description: Setup action suffix used to restore only compatible legacy Next.js caches
+    required: true
+  benchmark-cache-key:
+    description: Optional isolated namespace for reproducible cache benchmarks
+    required: false
+    default: ""
+
+outputs:
+  cache-hit:
+    description: Whether the primary key was restored exactly
+    value: ${{ steps.restore-nextjs.outputs.cache-hit }}
+  cache-matched-key:
+    description: Key of the cache that was restored
+    value: ${{ steps.restore-nextjs.outputs.cache-matched-key }}
+  cache-primary-key:
+    description: Primary key to use when saving the updated cache
+    value: ${{ steps.restore-nextjs.outputs.cache-primary-key }}
+  fumadocs-cache-hit:
+    description: Whether the Fumadocs TypeScript primary key was restored exactly
+    value: ${{ steps.restore-fumadocs.outputs.cache-hit }}
+  fumadocs-cache-matched-key:
+    description: Key of the Fumadocs TypeScript cache that was restored
+    value: ${{ steps.restore-fumadocs.outputs.cache-matched-key }}
+  fumadocs-cache-primary-key:
+    description: Primary key to use when saving the Fumadocs TypeScript cache
+    value: ${{ steps.restore-fumadocs.outputs.cache-primary-key }}
+
+runs:
+  using: composite
+  steps:
+    - name: Generate cache keys
+      id: keys
+      shell: bash
+      env:
+        BENCHMARK_CACHE_KEY: ${{ inputs.benchmark-cache-key }}
+        CACHE_GENERATION: ${{ inputs.cache-generation }}
+        CACHE_SCOPE: ${{ inputs.cache-scope }}
+        LEGACY_BUILD_CACHE_KEY_SUFFIX: ${{ inputs.legacy-build-cache-key-suffix }}
+        NEXTJS_COMPATIBILITY_HASH: ${{ hashFiles('bun.lock', 'package.json', 'bunfig.toml', 'docs/package.json', 'docs/next.config.mjs', 'docs/postcss.config.js', 'docs/tsconfig.json', '.github/actions/setup/action.yml') }}
+        FUMADOCS_COMPATIBILITY_HASH: ${{ hashFiles('bun.lock', 'docs/package.json', 'docs/tsconfig.json', 'docs/components/type-table/generator.ts', 'docs/source.config.ts') }}
+      run: |
+        nextjs_namespace="${RUNNER_OS}-nextjs-v2-"
+        nextjs_legacy_namespace="${RUNNER_OS}-nextjs-"
+        fumadocs_namespace="${RUNNER_OS}-fumadocs-typescript-v1-"
+
+        if [ -n "$BENCHMARK_CACHE_KEY" ]; then
+          nextjs_namespace+="benchmark-${BENCHMARK_CACHE_KEY}-"
+          nextjs_legacy_namespace+="benchmark-${BENCHMARK_CACHE_KEY}-${LEGACY_BUILD_CACHE_KEY_SUFFIX}-"
+          fumadocs_namespace+="benchmark-${BENCHMARK_CACHE_KEY}-"
+        else
+          nextjs_legacy_namespace+="${LEGACY_BUILD_CACHE_KEY_SUFFIX}-"
+        fi
+
+        nextjs_namespace+="${NEXTJS_COMPATIBILITY_HASH}-"
+        fumadocs_namespace+="${FUMADOCS_COMPATIBILITY_HASH}-"
+
+        echo "nextjs-primary-key=${nextjs_namespace}scope-${CACHE_SCOPE}-${CACHE_GENERATION}" >> "$GITHUB_OUTPUT"
+        echo "nextjs-restore-prefix=${nextjs_namespace}" >> "$GITHUB_OUTPUT"
+        echo "nextjs-legacy-restore-prefix=${nextjs_legacy_namespace}" >> "$GITHUB_OUTPUT"
+        echo "fumadocs-primary-key=${fumadocs_namespace}scope-${CACHE_SCOPE}-${CACHE_GENERATION}" >> "$GITHUB_OUTPUT"
+        echo "fumadocs-restore-prefix=${fumadocs_namespace}" >> "$GITHUB_OUTPUT"
+
+    - name: Restore Next.js cache
+      id: restore-nextjs
+      uses: actions/cache/restore@v5
+      with:
+        path: docs/.next/cache
+        # Keep ordinary docs and package sources out of this compatibility hash.
+        # Turbopack tracks them in its own dependency graph. Dependencies and build
+        # configuration stay here because their caches are not safely interchangeable.
+        key: ${{ steps.keys.outputs.nextjs-primary-key }}
+        restore-keys: |
+          ${{ steps.keys.outputs.nextjs-restore-prefix }}
+          ${{ steps.keys.outputs.nextjs-legacy-restore-prefix }}
+
+    - name: Restore Fumadocs TypeScript cache
+      id: restore-fumadocs
+      uses: actions/cache/restore@v5
+      with:
+        path: docs/.next/fumadocs-typescript
+        key: ${{ steps.keys.outputs.fumadocs-primary-key }}
+        restore-keys: |
+          ${{ steps.keys.outputs.fumadocs-restore-prefix }}
+
+    - name: Report cache restore
+      shell: bash
+      env:
+        NEXTJS_CACHE_HIT: ${{ steps.restore-nextjs.outputs.cache-hit }}
+        NEXTJS_CACHE_MATCHED_KEY: ${{ steps.restore-nextjs.outputs.cache-matched-key }}
+        NEXTJS_CACHE_PRIMARY_KEY: ${{ steps.restore-nextjs.outputs.cache-primary-key }}
+        FUMADOCS_CACHE_HIT: ${{ steps.restore-fumadocs.outputs.cache-hit }}
+        FUMADOCS_CACHE_MATCHED_KEY: ${{ steps.restore-fumadocs.outputs.cache-matched-key }}
+        FUMADOCS_CACHE_PRIMARY_KEY: ${{ steps.restore-fumadocs.outputs.cache-primary-key }}
+        CACHE_SCOPE: ${{ inputs.cache-scope }}
+        DEFAULT_BRANCH: ${{ inputs.default-branch }}
+      run: |
+        report_cache() {
+          local name="$1"
+          local hit="$2"
+          local matched_key="$3"
+          local primary_key="$4"
+          local result="miss"
+          local matched_scope="none"
+
+          if [ "$hit" = "true" ]; then
+            result="exact hit"
+            matched_scope="current branch ($CACHE_SCOPE)"
+          elif [ -n "$matched_key" ]; then
+            result="restore-key hit (not exact)"
+            case "$matched_key" in
+              *-scope-"$CACHE_SCOPE"-*) matched_scope="current branch ($CACHE_SCOPE)" ;;
+              *-scope-"$DEFAULT_BRANCH"-*) matched_scope="default branch ($DEFAULT_BRANCH)" ;;
+              *) matched_scope="legacy key (branch is not encoded)" ;;
+            esac
+          fi
+
+          echo "| $name | $result | $matched_scope | ${matched_key:-none} | ${primary_key:-unknown} |"
+        }
+
+        {
+          echo "## Docs build cache restore"
+          echo
+          echo "| Cache | Result | Matched scope | Matched key | Primary key |"
+          echo "| --- | --- | --- | --- | --- |"
+          report_cache "Next.js/Turbopack" "$NEXTJS_CACHE_HIT" "$NEXTJS_CACHE_MATCHED_KEY" "$NEXTJS_CACHE_PRIMARY_KEY"
+          report_cache "Fumadocs TypeScript" "$FUMADOCS_CACHE_HIT" "$FUMADOCS_CACHE_MATCHED_KEY" "$FUMADOCS_CACHE_PRIMARY_KEY"
+          echo
+          echo "Lookup order: current branch ($CACHE_SCOPE), then default branch ($DEFAULT_BRANCH)."
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
@@ -12,6 +12,7 @@ on:
       - "packages/stackflow/**"
       - ".github/workflows/deploy-seed-design-docs-alpha-pages.yml"
       - ".github/actions/setup/action.yml"
+      - ".github/actions/nextjs-cache/**"
   workflow_dispatch:
     inputs:
       skip-figma-cache:
@@ -70,20 +71,15 @@ jobs:
 
       - name: Restore Next.js cache
         id: restore-nextjs-cache
-        uses: actions/cache/restore@v5
+        uses: ./.github/actions/nextjs-cache
         with:
-          path: docs/.next/cache
-          # Keep the compatibility namespace stable across ordinary source changes.
-          # Turbopack tracks those inputs inside its cache and rebuilds only affected modules.
-          # The commit suffix makes each successful build publish refreshed incremental state.
-          key: ${{ runner.os }}-nextjs-v2-${{ inputs.benchmark-cache-key && format('benchmark-{0}-', inputs.benchmark-cache-key) || '' }}${{ hashFiles('bun.lock', 'package.json', 'bunfig.toml', 'docs/package.json', 'docs/next.config.mjs', 'docs/tsconfig.json') }}-${{ github.sha }}
-          # Restore the latest cache made with the same dependency and build configuration.
-          # Package sources, Ultra configuration, and generated Figma files intentionally do
-          # not change this prefix; Turbopack invalidates their affected modules incrementally.
-          # The second prefix migrates the latest cache created by the previous key format.
-          restore-keys: |
-            ${{ runner.os }}-nextjs-v2-${{ inputs.benchmark-cache-key && format('benchmark-{0}-', inputs.benchmark-cache-key) || '' }}${{ hashFiles('bun.lock', 'package.json', 'bunfig.toml', 'docs/package.json', 'docs/next.config.mjs', 'docs/tsconfig.json') }}-
-            ${{ inputs.benchmark-cache-key && format('{0}-nextjs-benchmark-{1}-{2}-', runner.os, inputs.benchmark-cache-key, steps.setup.outputs.build-cache-key-suffix) || format('{0}-nextjs-{1}-', runner.os, steps.setup.outputs.build-cache-key-suffix) }}
+          # A branch publishes one immutable baseline per compatibility namespace.
+          # Later pushes restore it exactly instead of creating a 0.7-1GB cache per SHA.
+          cache-generation: baseline
+          cache-scope: ${{ github.ref_name }}
+          default-branch: ${{ github.event.repository.default_branch }}
+          legacy-build-cache-key-suffix: ${{ steps.setup.outputs.build-cache-key-suffix }}
+          benchmark-cache-key: ${{ inputs.benchmark-cache-key }}
 
       - name: Build Docs
         id: build-docs
@@ -167,6 +163,13 @@ jobs:
         with:
           path: docs/.next/cache
           key: ${{ steps.restore-nextjs-cache.outputs.cache-primary-key }}
+
+      - name: Save Fumadocs TypeScript cache
+        if: ${{ steps.restore-nextjs-cache.outputs.fumadocs-cache-hit != 'true' && hashFiles('docs/.next/fumadocs-typescript/**') != '' }}
+        uses: actions/cache/save@v5
+        with:
+          path: docs/.next/fumadocs-typescript
+          key: ${{ steps.restore-nextjs-cache.outputs.fumadocs-cache-primary-key }}
 
       - name: Save Figma image cache
         uses: actions/cache/save@v5

--- a/.github/workflows/deploy-seed-design-docs-prod-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-prod-pages.yml
@@ -10,6 +10,7 @@ on:
       - "packages/stackflow/**"
       - ".github/workflows/deploy-seed-design-docs-prod-pages.yml"
       - ".github/actions/setup/action.yml"
+      - ".github/actions/nextjs-cache/**"
   workflow_dispatch:
     inputs:
       skip-figma-cache:
@@ -62,14 +63,13 @@ jobs:
 
       - name: Restore Next.js cache
         id: restore-nextjs-cache
-        uses: actions/cache/restore@v5
+        uses: ./.github/actions/nextjs-cache
         with:
-          path: docs/.next/cache
-          # Reuse the build inputs already hashed by setup, then add docs inputs only.
-          key: ${{ runner.os }}-nextjs-${{ steps.setup.outputs.build-cache-key-suffix }}-${{ hashFiles('docs/**/*.js', 'docs/**/*.jsx', 'docs/**/*.mjs', 'docs/**/*.ts', 'docs/**/*.tsx', 'docs/**/*.mdx', 'docs/**/*.css', 'docs/**/*.json') }}
-          # Rebuild from the nearest cache when build or docs inputs changed.
-          restore-keys: |
-            ${{ runner.os }}-nextjs-
+          # Production keeps publishing refreshed state for the default-branch fallback.
+          cache-generation: ${{ github.sha }}
+          cache-scope: ${{ github.ref_name }}
+          default-branch: ${{ github.event.repository.default_branch }}
+          legacy-build-cache-key-suffix: ${{ steps.setup.outputs.build-cache-key-suffix }}
 
       - name: Build Docs
         working-directory: ./docs
@@ -90,6 +90,13 @@ jobs:
         with:
           path: docs/.next/cache
           key: ${{ steps.restore-nextjs-cache.outputs.cache-primary-key }}
+
+      - name: Save Fumadocs TypeScript cache
+        if: ${{ steps.restore-nextjs-cache.outputs.fumadocs-cache-hit != 'true' && hashFiles('docs/.next/fumadocs-typescript/**') != '' }}
+        uses: actions/cache/save@v5
+        with:
+          path: docs/.next/fumadocs-typescript
+          key: ${{ steps.restore-nextjs-cache.outputs.fumadocs-cache-primary-key }}
 
       - name: Save Figma image cache
         uses: actions/cache/save@v5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Next.js, Turbopack 및 Fumadocs 빌드 캐시를 통합 관리하는 캐시 작업이 추가되었습니다.
  * 캐시 복원 결과와 매칭 정보가 빌드 요약에 표시됩니다.

* **문서**
  * 캐시 경로, 복원 순서, 갱신 및 보존 정책을 설명하는 문서가 추가되었습니다.

* **개선**
  * Alpha 및 Production 문서 배포 과정에서 캐시를 효율적으로 복원하고 조건에 따라 저장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->