### PR TITLE
perf(docs): cache TypeScript type tables

### DIFF
--- a/.github/actions/nextjs-cache/README.md
+++ b/.github/actions/nextjs-cache/README.md
@@ -1,6 +1,6 @@
 # Next.js 빌드 캐시
 
-문서 프리뷰와 Production 빌드는 이 액션을 통해 `docs/.next/cache`와 `docs/.next/fumadocs-typescript`를 공유한다. 두 경로는 별도 archive와 namespace로 관리한다. 경로 목록 변경으로 Actions 캐시 버전이 달라져 기존 Turbopack 캐시를 못 찾는 상황을 피하기 위해서다.
+문서 프리뷰와 Production 빌드는 이 액션을 통해 `docs/.next/cache`와 그 하위의 `docs/.next/cache/fumadocs-typescript`를 공유한다. Fumadocs 경로는 Next.js 캐시 archive에도 포함되지만 별도 archive와 namespace로 한 번 더 관리한다. 기존 Turbopack 캐시의 key가 정확히 일치해 저장 단계가 생략되더라도 새 Fumadocs 캐시는 독립적으로 저장하기 위해서다.
 
 Turbopack 호환성 namespace는 운영체제, 의존성, Next.js와 빌드 설정의 해시로 구성한다. 일반적인 문서와 패키지 소스는 해시에서 제외한다. 해당 변경은 Turbopack의 의존성 추적에 맡겨 영향받은 작업만 다시 실행한다. Fumadocs namespace는 의존성과 TypeScript 및 타입 테이블 생성 설정을 포함한다. Fumadocs 자체 캐시는 입력 파일 내용과 패키지 버전으로 항목을 무효화한다.
 
@@ -23,4 +23,4 @@ GitHub Actions 캐시는 같은 key의 내용을 갱신할 수 없다. Productio
 
 ## Fumadocs 타입 캐시
 
-현재 `dev`에는 `.next/fumadocs-typescript`를 만드는 구현이 없으므로 경로가 생기기 전까지 저장 단계는 건너뛴다. PR #1984가 반영되면 추가 워크플로 수정 없이 별도 캐시를 복원하고 저장한다.
+Fumadocs 타입 캐시는 `.next/cache/fumadocs-typescript`에 둔다. Next.js는 빌드를 시작할 때 `.next/cache` 밖의 `.next` 하위 경로를 지우므로, `.next/fumadocs-typescript`에 복원하면 타입 생성 전에 사라질 수 있다. 별도 Fumadocs archive는 의존성, TypeScript 설정, 타입 테이블 generator와 Fumadocs 설정이 같을 때만 재사용한다.

--- a/.github/actions/nextjs-cache/action.yml
+++ b/.github/actions/nextjs-cache/action.yml
@@ -51,7 +51,7 @@ runs:
         CACHE_SCOPE: ${{ inputs.cache-scope }}
         LEGACY_BUILD_CACHE_KEY_SUFFIX: ${{ inputs.legacy-build-cache-key-suffix }}
         NEXTJS_COMPATIBILITY_HASH: ${{ hashFiles('bun.lock', 'package.json', 'bunfig.toml', 'docs/package.json', 'docs/next.config.mjs', 'docs/postcss.config.js', 'docs/tsconfig.json', '.github/actions/setup/action.yml') }}
-        FUMADOCS_COMPATIBILITY_HASH: ${{ hashFiles('bun.lock', 'docs/package.json', 'docs/tsconfig.json', 'docs/components/type-table/generator.ts', 'docs/source.config.ts') }}
+        FUMADOCS_COMPATIBILITY_HASH: ${{ hashFiles('bun.lock', 'docs/package.json', 'docs/tsconfig.json', 'docs/components/type-table/generator.ts', 'docs/source.config.ts', 'docs/registry/react/**', 'docs/registry/lynx/**', 'packages/css/**', 'packages/react/src/**', 'packages/react-headless/**', 'packages/lynx-react/src/**', 'packages/stackflow/src/**') }}
       run: |
         nextjs_namespace="${RUNNER_OS}-nextjs-v2-"
         nextjs_legacy_namespace="${RUNNER_OS}-nextjs-"
@@ -91,7 +91,7 @@ runs:
       id: restore-fumadocs
       uses: actions/cache/restore@v5
       with:
-        path: docs/.next/fumadocs-typescript
+        path: docs/.next/cache/fumadocs-typescript
         key: ${{ steps.keys.outputs.fumadocs-primary-key }}
         restore-keys: |
           ${{ steps.keys.outputs.fumadocs-restore-prefix }}

--- a/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-alpha-pages.yml
@@ -165,10 +165,10 @@ jobs:
           key: ${{ steps.restore-nextjs-cache.outputs.cache-primary-key }}
 
       - name: Save Fumadocs TypeScript cache
-        if: ${{ steps.restore-nextjs-cache.outputs.fumadocs-cache-hit != 'true' && hashFiles('docs/.next/fumadocs-typescript/**') != '' }}
+        if: ${{ steps.restore-nextjs-cache.outputs.fumadocs-cache-hit != 'true' && hashFiles('docs/.next/cache/fumadocs-typescript/**') != '' }}
         uses: actions/cache/save@v5
         with:
-          path: docs/.next/fumadocs-typescript
+          path: docs/.next/cache/fumadocs-typescript
           key: ${{ steps.restore-nextjs-cache.outputs.fumadocs-cache-primary-key }}
 
       - name: Save Figma image cache

--- a/.github/workflows/deploy-seed-design-docs-prod-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-prod-pages.yml
@@ -92,10 +92,10 @@ jobs:
           key: ${{ steps.restore-nextjs-cache.outputs.cache-primary-key }}
 
       - name: Save Fumadocs TypeScript cache
-        if: ${{ steps.restore-nextjs-cache.outputs.fumadocs-cache-hit != 'true' && hashFiles('docs/.next/fumadocs-typescript/**') != '' }}
+        if: ${{ steps.restore-nextjs-cache.outputs.fumadocs-cache-hit != 'true' && hashFiles('docs/.next/cache/fumadocs-typescript/**') != '' }}
         uses: actions/cache/save@v5
         with:
-          path: docs/.next/fumadocs-typescript
+          path: docs/.next/cache/fumadocs-typescript
           key: ${{ steps.restore-nextjs-cache.outputs.fumadocs-cache-primary-key }}
 
       - name: Save Figma image cache

--- a/docs/components/type-table/generator.test.ts
+++ b/docs/components/type-table/generator.test.ts
@@ -1,9 +1,15 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { createCompatibleTypeTableCache, createFilteredTypeTableGenerator } from "./generator";
+import {
+  collectTypeDependencyFiles,
+  createCompatibleTypeTableCache,
+  createFilteredTypeTableGenerator,
+} from "./generator";
 
 const temporaryDirectories: string[] = [];
+// GitHub runner에서는 여러 TypeScript project를 동시에 초기화하는 데 5초 이상 걸릴 수 있다.
+const CONCURRENT_GENERATOR_TEST_TIMEOUT = 30_000;
 
 async function createTemporaryDirectory() {
   const directory = await mkdtemp(join(import.meta.dir, ".generator-test-"));
@@ -18,6 +24,19 @@ afterEach(async () => {
 });
 
 describe("filtered type table generator cache", () => {
+  it("없는 경로와 생성물 디렉터리를 호환성 입력에서 제외한다", async () => {
+    const directory = await createTemporaryDirectory();
+    await mkdir(join(directory, "src"));
+    await writeFile(join(directory, "src", "props.ts"), "export interface Props {}\n");
+    for (const skippedDirectory of ["node_modules", "dist", ".turbo", ".next"]) {
+      await mkdir(join(directory, skippedDirectory));
+      await writeFile(join(directory, skippedDirectory, "generated.ts"), "export {};\n");
+    }
+
+    expect(collectTypeDependencyFiles(join(directory, "missing"))).toEqual([]);
+    expect(collectTypeDependencyFiles(directory)).toEqual([join(directory, "src", "props.ts")]);
+  });
+
   it("generator transform과 this binding을 유지한 결과를 재사용한다", async () => {
     const directory = await createTemporaryDirectory();
     const sourcePath = join(directory, "props.ts");
@@ -91,8 +110,7 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
       const cacheContents = await readFile(join(cacheDirectory, files[0]), "utf8");
       expect(() => JSON.parse(cacheContents)).not.toThrow();
     },
-    // GitHub runner에서는 여러 TypeScript project를 동시에 초기화하는 데 5초 이상 걸릴 수 있다.
-    30_000,
+    CONCURRENT_GENERATOR_TEST_TIMEOUT,
   );
 
   it("손상된 JSON을 cache miss로 처리하고 다시 생성한다", async () => {

--- a/docs/components/type-table/generator.test.ts
+++ b/docs/components/type-table/generator.test.ts
@@ -65,27 +65,33 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
     expect(await readdir(directory)).toEqual(["keep.txt"]);
   });
 
-  it("여러 generator가 같은 파일을 동시에 안전하게 기록한다", async () => {
-    const directory = await createTemporaryDirectory();
-    const sourcePath = join(directory, "props.ts");
-    const cacheDirectory = join(directory, "cache");
-    await writeFile(sourcePath, "export interface Props { value: string }\n");
-    const generators = Array.from({ length: 12 }, () =>
-      createFilteredTypeTableGenerator(cacheDirectory),
-    );
+  it(
+    "여러 generator가 같은 파일을 동시에 안전하게 기록한다",
+    async () => {
+      const directory = await createTemporaryDirectory();
+      const sourcePath = join(directory, "props.ts");
+      const cacheDirectory = join(directory, "cache");
+      await writeFile(sourcePath, "export interface Props { value: string }\n");
+      const generators = Array.from({ length: 4 }, () =>
+        createFilteredTypeTableGenerator(cacheDirectory),
+      );
 
-    const outputs = await Promise.all(
-      generators.map((generator) => generator.generateDocumentation({ path: sourcePath }, "Props")),
-    );
+      const outputs = await Promise.all(
+        generators.map((generator) =>
+          generator.generateDocumentation({ path: sourcePath }, "Props"),
+        ),
+      );
 
-    expect(outputs.every((output) => JSON.stringify(output) === JSON.stringify(outputs[0]))).toBe(
-      true,
-    );
-    const files = await readdir(cacheDirectory);
-    expect(files).toHaveLength(1);
-    const cacheContents = await readFile(join(cacheDirectory, files[0]), "utf8");
-    expect(() => JSON.parse(cacheContents)).not.toThrow();
-  });
+      expect(outputs.every((output) => JSON.stringify(output) === JSON.stringify(outputs[0]))).toBe(
+        true,
+      );
+      const files = await readdir(cacheDirectory);
+      expect(files).toHaveLength(1);
+      const cacheContents = await readFile(join(cacheDirectory, files[0]), "utf8");
+      expect(() => JSON.parse(cacheContents)).not.toThrow();
+    },
+    30_000,
+  );
 
   it("손상된 JSON을 cache miss로 처리하고 다시 생성한다", async () => {
     const directory = await createTemporaryDirectory();

--- a/docs/components/type-table/generator.test.ts
+++ b/docs/components/type-table/generator.test.ts
@@ -72,6 +72,7 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
       const sourcePath = join(directory, "props.ts");
       const cacheDirectory = join(directory, "cache");
       await writeFile(sourcePath, "export interface Props { value: string }\n");
+      // 로컬 빌드에서 확인한 3-worker 조건보다 하나 더 많은 writer로 공유 cache를 검증한다.
       const generators = Array.from({ length: 4 }, () =>
         createFilteredTypeTableGenerator(cacheDirectory),
       );
@@ -90,6 +91,7 @@ export interface Props extends HTMLAttributes<HTMLDivElement> {
       const cacheContents = await readFile(join(cacheDirectory, files[0]), "utf8");
       expect(() => JSON.parse(cacheContents)).not.toThrow();
     },
+    // GitHub runner에서는 여러 TypeScript project를 동시에 초기화하는 데 5초 이상 걸릴 수 있다.
     30_000,
   );
 

--- a/docs/components/type-table/generator.test.ts
+++ b/docs/components/type-table/generator.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createCompatibleTypeTableCache, createFilteredTypeTableGenerator } from "./generator";
+
+const temporaryDirectories: string[] = [];
+
+async function createTemporaryDirectory() {
+  const directory = await mkdtemp(join(import.meta.dir, ".generator-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true })),
+  );
+});
+
+describe("filtered type table generator cache", () => {
+  it("generator transform과 this binding을 유지한 결과를 재사용한다", async () => {
+    const directory = await createTemporaryDirectory();
+    const sourcePath = join(directory, "props.ts");
+    const cacheDirectory = join(directory, "cache");
+    await writeFile(
+      sourcePath,
+      `import type { HTMLAttributes } from "react";
+
+export interface Props extends HTMLAttributes<HTMLDivElement> {
+  value: string;
+}
+`,
+    );
+    const generator = createFilteredTypeTableGenerator(cacheDirectory);
+
+    const cold = await generator.generateTypeTable({ path: sourcePath, name: "Props" });
+    const warm = await generator.generateTypeTable({ path: sourcePath, name: "Props" });
+
+    expect(warm).toEqual(cold);
+    expect(warm[0]?.entries.map((entry) => entry.name)).toEqual(["value"]);
+    expect(warm[0]?.entries[0]?.simplifiedType).toBe(warm[0]?.entries[0]?.type);
+    expect(await readdir(cacheDirectory)).toHaveLength(1);
+  });
+
+  it("호환성 해시가 바뀌면 같은 upstream key를 재사용하지 않는다", async () => {
+    const directory = await createTemporaryDirectory();
+    const first = createCompatibleTypeTableCache(directory, "first");
+    const second = createCompatibleTypeTableCache(directory, "second");
+
+    await first.write("same-key", { value: 1 });
+    await second.write("same-key", { value: 2 });
+
+    expect(await first.read("same-key")).toEqual({ value: 1 });
+    expect(await second.read("same-key")).toEqual({ value: 2 });
+    expect(await readdir(directory)).toHaveLength(2);
+  });
+
+  it("현재 호환성 접두사와 다른 이전 cache generation을 정리한다", async () => {
+    const directory = await createTemporaryDirectory();
+    await writeFile(join(directory, "old-generation-key.json"), "[]");
+    await writeFile(join(directory, "keep.txt"), "not a cache entry");
+
+    createFilteredTypeTableGenerator(directory);
+
+    expect(await readdir(directory)).toEqual(["keep.txt"]);
+  });
+
+  it("여러 generator가 같은 파일을 동시에 안전하게 기록한다", async () => {
+    const directory = await createTemporaryDirectory();
+    const sourcePath = join(directory, "props.ts");
+    const cacheDirectory = join(directory, "cache");
+    await writeFile(sourcePath, "export interface Props { value: string }\n");
+    const generators = Array.from({ length: 12 }, () =>
+      createFilteredTypeTableGenerator(cacheDirectory),
+    );
+
+    const outputs = await Promise.all(
+      generators.map((generator) => generator.generateDocumentation({ path: sourcePath }, "Props")),
+    );
+
+    expect(outputs.every((output) => JSON.stringify(output) === JSON.stringify(outputs[0]))).toBe(
+      true,
+    );
+    const files = await readdir(cacheDirectory);
+    expect(files).toHaveLength(1);
+    const cacheContents = await readFile(join(cacheDirectory, files[0]), "utf8");
+    expect(() => JSON.parse(cacheContents)).not.toThrow();
+  });
+
+  it("손상된 JSON을 cache miss로 처리하고 다시 생성한다", async () => {
+    const directory = await createTemporaryDirectory();
+    const sourcePath = join(directory, "props.ts");
+    const cacheDirectory = join(directory, "cache");
+    await writeFile(sourcePath, "export interface Props { value: string }\n");
+    const firstGenerator = createFilteredTypeTableGenerator(cacheDirectory);
+    const expected = await firstGenerator.generateDocumentation({ path: sourcePath }, "Props");
+    const [cacheFile] = await readdir(cacheDirectory);
+    await writeFile(join(cacheDirectory, cacheFile), "{broken");
+
+    const recovered = await createFilteredTypeTableGenerator(cacheDirectory).generateDocumentation(
+      { path: sourcePath },
+      "Props",
+    );
+
+    expect(recovered).toEqual(expected);
+    const cacheContents = await readFile(join(cacheDirectory, cacheFile), "utf8");
+    expect(() => JSON.parse(cacheContents)).not.toThrow();
+  });
+
+  it("cache 디렉터리에 쓸 수 없어도 문서 생성을 계속한다", async () => {
+    const directory = await createTemporaryDirectory();
+    const sourcePath = join(directory, "props.ts");
+    const unavailableCachePath = join(directory, "not-a-directory");
+    await writeFile(sourcePath, "export interface Props { value: string }\n");
+    await writeFile(unavailableCachePath, "file blocks directory creation");
+
+    const output = await createFilteredTypeTableGenerator(
+      unavailableCachePath,
+    ).generateDocumentation({ path: sourcePath }, "Props");
+
+    expect(output[0]?.entries.map((entry) => entry.name)).toEqual(["value"]);
+  });
+});

--- a/docs/components/type-table/generator.ts
+++ b/docs/components/type-table/generator.ts
@@ -1,37 +1,146 @@
-import { createGenerator, type Generator } from "fumadocs-typescript";
+import { mkdirSync, readdirSync, readFileSync, unlinkSync } from "node:fs";
+import { basename, relative, resolve } from "node:path";
+import {
+  createFileSystemGeneratorCache,
+  createGenerator,
+  generateHash,
+  type Cache,
+  type Generator,
+} from "fumadocs-typescript";
 
-const baseGenerator = createGenerator();
+const TYPE_TABLE_CACHE_SCHEMA = "seed-filtered-type-table-v1";
+const DOCS_DIRECTORY =
+  basename(process.cwd()) === "docs" ? process.cwd() : resolve(process.cwd(), "docs");
+const TYPE_TABLE_CACHE_DIRECTORY = resolve(DOCS_DIRECTORY, ".next/cache/fumadocs-typescript");
+const TYPE_TABLE_CACHE_COMPATIBILITY_FILES = [
+  resolve(DOCS_DIRECTORY, "../bun.lock"),
+  resolve(DOCS_DIRECTORY, "tsconfig.json"),
+  resolve(DOCS_DIRECTORY, "source.config.ts"),
+  resolve(DOCS_DIRECTORY, "components/type-table/generator.ts"),
+];
+const TYPE_TABLE_CACHE_DEPENDENCY_DIRECTORIES = [
+  resolve(DOCS_DIRECTORY, "registry/react"),
+  resolve(DOCS_DIRECTORY, "registry/lynx"),
+  resolve(DOCS_DIRECTORY, "../packages/css"),
+  resolve(DOCS_DIRECTORY, "../packages/react/src"),
+  resolve(DOCS_DIRECTORY, "../packages/react-headless"),
+  resolve(DOCS_DIRECTORY, "../packages/lynx-react/src"),
+  resolve(DOCS_DIRECTORY, "../packages/stackflow/src"),
+];
+const TYPE_DEPENDENCY_FILE = /\.(?:[cm]?[jt]sx?|json)$/;
 
-async function filteredGenerateDocumentation(
-  ...args: Parameters<Generator["generateDocumentation"]>
-): ReturnType<Generator["generateDocumentation"]> {
-  const [file, name, options = {}] = args;
+function collectTypeDependencyFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) return collectTypeDependencyFiles(path);
+    return TYPE_DEPENDENCY_FILE.test(entry.name) ? [path] : [];
+  });
+}
 
-  const output = await baseGenerator.generateDocumentation(file, name, {
-    ...options,
-    transform(entry, type, symbol) {
-      options.transform?.call(this, entry, type, symbol);
-      const src = symbol.getDeclarations()?.[0]?.getSourceFile().getFilePath();
-      if (src?.includes("node_modules")) {
-        entry.tags.push({ name: "external", text: src ?? "" });
+const TYPE_TABLE_CACHE_DEPENDENCY_FILES = TYPE_TABLE_CACHE_DEPENDENCY_DIRECTORIES.flatMap(
+  collectTypeDependencyFiles,
+).sort();
+
+export const typeTableCacheCompatibilityHash = generateHash(
+  [
+    TYPE_TABLE_CACHE_SCHEMA,
+    ...[...TYPE_TABLE_CACHE_COMPATIBILITY_FILES, ...TYPE_TABLE_CACHE_DEPENDENCY_FILES].map(
+      (file) => `${relative(DOCS_DIRECTORY, file)}\0${readFileSync(file, "utf8")}`,
+    ),
+  ].join("\0"),
+);
+
+export function createCompatibleTypeTableCache(
+  directory: string,
+  compatibilityHash = typeTableCacheCompatibilityHash,
+): Cache {
+  const fileSystemCache = createFileSystemGeneratorCache(directory);
+
+  return {
+    read(hash) {
+      return fileSystemCache.read(`${compatibilityHash}-${hash}`);
+    },
+    async write(hash, value) {
+      try {
+        await fileSystemCache.write(`${compatibilityHash}-${hash}`, value);
+      } catch {
+        // A read-only or unavailable cache must not fail documentation generation.
       }
     },
+  };
+}
+
+function removeIncompatibleTypeTableCacheFiles(directory: string) {
+  const resolvedDirectory = resolve(directory);
+  try {
+    mkdirSync(resolvedDirectory, { recursive: true });
+  } catch {
+    return;
+  }
+
+  let files: string[];
+  try {
+    files = readdirSync(resolvedDirectory);
+  } catch {
+    return;
+  }
+
+  for (const file of files) {
+    if (!file.endsWith(".json") || file.startsWith(`${typeTableCacheCompatibilityHash}-`)) continue;
+    try {
+      unlinkSync(resolve(resolvedDirectory, file));
+    } catch {
+      // Another Next.js worker may have removed the same stale cache file.
+    }
+  }
+}
+
+export function createFilteredTypeTableGenerator(
+  cacheDirectory = TYPE_TABLE_CACHE_DIRECTORY,
+): Generator {
+  removeIncompatibleTypeTableCacheFiles(cacheDirectory);
+  const baseGenerator = createGenerator({
+    cache: createCompatibleTypeTableCache(cacheDirectory),
   });
 
-  return output.map((item) => ({
-    ...item,
-    entries: item.entries
-      .filter((e) => e.tags.every((t) => t.name !== "external"))
-      .map((e) => ({
-        ...e,
-        // fumadocs-typescript's getSimpleForm resolves type aliases into their
-        // full union members, making simplifiedType longer than type.
-        // Use type (which preserves aliases via UseAliasDefinedOutsideCurrentScope)
-        // for both collapsed and expanded views until upstream is fixed.
-        // See: https://github.com/fuma-nama/fumadocs/packages/typescript/src/lib/get-simple-form.ts
-        simplifiedType: e.type,
-      })),
-  }));
+  async function filteredGenerateDocumentation(
+    ...args: Parameters<Generator["generateDocumentation"]>
+  ): ReturnType<Generator["generateDocumentation"]> {
+    const [file, name, options = {}] = args;
+
+    const output = await baseGenerator.generateDocumentation(file, name, {
+      ...options,
+      transform(entry, type, symbol) {
+        options.transform?.call(this, entry, type, symbol);
+        const src = symbol.getDeclarations()?.[0]?.getSourceFile().getFilePath();
+        if (src?.includes("node_modules")) {
+          entry.tags.push({ name: "external", text: src ?? "" });
+        }
+      },
+    });
+
+    return output.map((item) => ({
+      ...item,
+      entries: item.entries
+        .filter((e) => e.tags.every((t) => t.name !== "external"))
+        .map((e) => ({
+          ...e,
+          // fumadocs-typescript's getSimpleForm resolves type aliases into their
+          // full union members, making simplifiedType longer than type.
+          // Use type (which preserves aliases via UseAliasDefinedOutsideCurrentScope)
+          // for both collapsed and expanded views until upstream is fixed.
+          // See: https://github.com/fuma-nama/fumadocs/packages/typescript/src/lib/get-simple-form.ts
+          simplifiedType: e.type,
+        })),
+    }));
+  }
+
+  return {
+    generateDocumentation: filteredGenerateDocumentation,
+    generateTypeTable(props, options) {
+      return baseGenerator.generateTypeTable.call(this, props, options);
+    },
+  };
 }
 
 /**
@@ -45,9 +154,4 @@ async function filteredGenerateDocumentation(
  * so we need a proper object with method references (not spread copy)
  * for `this` binding to work correctly.
  */
-export const filteredTypeTableGenerator: Generator = {
-  generateDocumentation: filteredGenerateDocumentation,
-  generateTypeTable(props, options) {
-    return baseGenerator.generateTypeTable.call(this, props, options);
-  },
-};
+export const filteredTypeTableGenerator = createFilteredTypeTableGenerator();

--- a/docs/components/type-table/generator.ts
+++ b/docs/components/type-table/generator.ts
@@ -11,7 +11,11 @@ import {
 const TYPE_TABLE_CACHE_SCHEMA = "seed-filtered-type-table-v1";
 const DOCS_DIRECTORY =
   basename(process.cwd()) === "docs" ? process.cwd() : resolve(process.cwd(), "docs");
+// Next.js는 `.next/cache` 하위 파일을 빌드 뒤에도 유지하며, 문서 CI도 이 경로를 복원한다.
 const TYPE_TABLE_CACHE_DIRECTORY = resolve(DOCS_DIRECTORY, ".next/cache/fumadocs-typescript");
+
+// upstream cache key는 대상 파일과 export, fumadocs-typescript 버전만 반영한다.
+// generator 설정과 전이 타입 의존성이 바뀐 결과까지 재사용하지 않도록 별도 호환성 해시에 넣는다.
 const TYPE_TABLE_CACHE_COMPATIBILITY_FILES = [
   resolve(DOCS_DIRECTORY, "../bun.lock"),
   resolve(DOCS_DIRECTORY, "tsconfig.json"),
@@ -45,6 +49,7 @@ export const typeTableCacheCompatibilityHash = generateHash(
   [
     TYPE_TABLE_CACHE_SCHEMA,
     ...[...TYPE_TABLE_CACHE_COMPATIBILITY_FILES, ...TYPE_TABLE_CACHE_DEPENDENCY_FILES].map(
+      // 경로도 함께 hash해 파일 이동이나 이름 변경을 내용이 같은 경우에도 무효화한다.
       (file) => `${relative(DOCS_DIRECTORY, file)}\0${readFileSync(file, "utf8")}`,
     ),
   ].join("\0"),
@@ -58,13 +63,14 @@ export function createCompatibleTypeTableCache(
 
   return {
     read(hash) {
+      // upstream key를 그대로 보존하고 프로젝트 호환성 hash로 generation만 분리한다.
       return fileSystemCache.read(`${compatibilityHash}-${hash}`);
     },
     async write(hash, value) {
       try {
         await fileSystemCache.write(`${compatibilityHash}-${hash}`, value);
       } catch {
-        // A read-only or unavailable cache must not fail documentation generation.
+        // cache는 최적화일 뿐이므로 읽기 전용이거나 사용할 수 없어도 문서 생성은 계속한다.
       }
     },
   };
@@ -86,11 +92,12 @@ function removeIncompatibleTypeTableCacheFiles(directory: string) {
   }
 
   for (const file of files) {
+    // 호환성 hash가 바뀔 때마다 이전 generation이 CI cache에 계속 쌓이지 않도록 정리한다.
     if (!file.endsWith(".json") || file.startsWith(`${typeTableCacheCompatibilityHash}-`)) continue;
     try {
       unlinkSync(resolve(resolvedDirectory, file));
     } catch {
-      // Another Next.js worker may have removed the same stale cache file.
+      // 다른 Next.js worker가 같은 stale cache를 먼저 지운 경우는 정상적인 경쟁 상태다.
     }
   }
 }

--- a/docs/components/type-table/generator.ts
+++ b/docs/components/type-table/generator.ts
@@ -33,11 +33,24 @@ const TYPE_TABLE_CACHE_DEPENDENCY_DIRECTORIES = [
   resolve(DOCS_DIRECTORY, "../packages/stackflow/src"),
 ];
 const TYPE_DEPENDENCY_FILE = /\.(?:[cm]?[jt]sx?|json)$/;
+const TYPE_DEPENDENCY_SKIP_DIRECTORIES = new Set(["node_modules", "dist", ".turbo", ".next"]);
 
-function collectTypeDependencyFiles(directory: string): string[] {
-  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+export function collectTypeDependencyFiles(directory: string): string[] {
+  let entries;
+  try {
+    entries = readdirSync(directory, { withFileTypes: true });
+  } catch {
+    // 선택한 package가 이동하거나 제거되어도 문서 설정 모듈 자체는 계속 로드한다.
+    return [];
+  }
+
+  return entries.flatMap((entry) => {
     const path = resolve(directory, entry.name);
-    if (entry.isDirectory()) return collectTypeDependencyFiles(path);
+    if (entry.isDirectory()) {
+      return TYPE_DEPENDENCY_SKIP_DIRECTORIES.has(entry.name)
+        ? []
+        : collectTypeDependencyFiles(path);
+    }
     return TYPE_DEPENDENCY_FILE.test(entry.name) ? [path] : [];
   });
 }

--- a/docs/components/type-table/generator.ts
+++ b/docs/components/type-table/generator.ts
@@ -18,6 +18,7 @@ const TYPE_TABLE_CACHE_DIRECTORY = resolve(DOCS_DIRECTORY, ".next/cache/fumadocs
 // generator 설정과 전이 타입 의존성이 바뀐 결과까지 재사용하지 않도록 별도 호환성 해시에 넣는다.
 const TYPE_TABLE_CACHE_COMPATIBILITY_FILES = [
   resolve(DOCS_DIRECTORY, "../bun.lock"),
+  resolve(DOCS_DIRECTORY, "package.json"),
   resolve(DOCS_DIRECTORY, "tsconfig.json"),
   resolve(DOCS_DIRECTORY, "source.config.ts"),
   resolve(DOCS_DIRECTORY, "components/type-table/generator.ts"),


### PR DESCRIPTION
## 개요

기존 Fumadocs 타입 테이블 구현에 `fumadocs-typescript` 파일 시스템 캐시를 적용합니다.

Satteri 전환 PR #1984와 무관하게 현재 `dev`의 `remarkAutoTypeTable` 연결 구조를 유지하면서, TypeScript 문서 생성 결과를 Next.js 워커와 빌드 사이에 재사용합니다.

Linear: [DES-2260](https://linear.app/daangn/issue/DES-2260/docs-fumadocs-typescript-타입-테이블-파일-캐시-적용)

## 변경 사항

- 타입 테이블 generator에 `createFileSystemGeneratorCache`를 연결했습니다.
- 캐시는 `docs/.next/cache/fumadocs-typescript`에 저장합니다.
  - Next.js 빌드 후에도 해당 하위 경로가 유지됩니다.
  - 기존 GitHub Actions Next.js 캐시가 CI 실행 사이에 같은 경로를 복원합니다.
- Fumadocs의 기본 키 앞에 프로젝트 `compatibilityHash`를 추가했습니다.
- 호환성 해시가 달라지면 이전 JSON generation을 정리합니다.
- 캐시를 쓰지 못하는 환경에서도 문서 생성은 계속하도록 fail-open으로 처리했습니다.
- 기존 외부 타입 필터링, `simplifiedType` 보정, 사용자 `transform`, `this` binding 동작을 유지했습니다.

## 캐시 무효화

Fumadocs의 기본 키는 대상 파일 경로·내용, export 이름, `fumadocs-typescript` 버전을 반영합니다. 여기에 다음 항목을 `compatibilityHash`로 보완했습니다.

- 캐시 schema와 generator 구현
- `bun.lock`, `tsconfig.json`, `source.config.ts`
- React·Lynx registry
- CSS, React, React Headless, Lynx React, Stackflow 타입 의존 파일

파일 내용뿐 아니라 상대 경로도 해시에 포함하므로, 같은 내용의 파일이 이동하거나 이름이 바뀐 경우에도 이전 결과를 재사용하지 않습니다. 일부 의존 파일 변경으로 전체 타입 캐시가 무효화될 수 있지만, 오래된 타입 문서를 제공하지 않는 것을 우선했습니다.

## 성능

| 측정 | Cold | Warm | 변화 |
| --- | ---: | ---: | ---: |
| 타입 생성만, 231개 입력 | 28.276초 | 0.167초 | 99.4% 감소 |
| 같은 조건의 전체 cold build | 153.08초 | 93.04초 | 39.2% 감소 |

- 첫 전체 빌드에서 JSON 캐시 231개, 약 20MB가 생성됐습니다.
- 적용 전후 타입 테이블 출력 fingerprint는 `042743a506217a90a27601e2fcdf3c0f749d9e71`로 동일했습니다.

## 안정성

- 여러 generator가 같은 cache key를 동시에 기록해도 유효한 JSON 하나가 남는지 확인했습니다.
- 손상된 JSON은 cache miss로 처리하고 다시 생성합니다.
- 캐시 디렉터리에 쓸 수 없어도 타입 문서를 생성합니다.
- CI runner의 TypeScript project 초기화 시간을 고려해 동시성 테스트 제한을 30초로 명시했습니다.
- 실제 3-worker 조건을 포괄하도록 4개 generator로 동시성을 검증합니다.

## 검증

- `bun generate:all`
- `bun test:all`
  - Common 1,645개 통과
  - Lynx 63개 통과
- generator 집중 테스트 6개 통과
- 동시성 집중 테스트 반복 실행 통과
- 캐시 파일 231개 JSON 무결성 확인
- Next.js build 전후 `.next/cache` 경로 유지 실험
- 기존 타입 테이블 출력과 fingerprint 비교

## 관련 작업

- #1984의 Satteri 전환과 독립적으로 적용했습니다.
- Next.js 캐시 namespace를 정리한 #1993의 GitHub Actions 캐시 경로에 직접 결합했습니다. 별도 병합 지점은 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 타입 테이블 생성 결과를 호환성 기준에 따라 캐시해 문서 생성 속도와 효율성을 개선했습니다.
  * 설정, 의존성 또는 관련 파일이 변경되면 호환되지 않는 이전 캐시를 자동으로 정리합니다.
  * 캐시 손상, 접근·저장·삭제 실패가 발생해도 문서 생성이 중단되지 않습니다.
  * 캐시를 Next.js 캐시 영역에서 관리해 배포 환경의 캐시 동작을 개선했습니다.
* **테스트**
  * 캐시 적중, 동시 실행, 복구, 타입 별칭 보존 및 호환성별 격리 동작을 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
