### PR TITLE
feat(ci): add fast-forward merge command

### DIFF
--- a/.github/scripts/ff-merge.js
+++ b/.github/scripts/ff-merge.js
@@ -1,0 +1,406 @@
+// @ts-check
+
+const COMMAND = "/ff-merge";
+const TARGET_BRANCH = "dev";
+const SOURCE_BRANCHES = new Set(["minor", "major"]);
+const ALLOWED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+class FFMergeError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "FFMergeError";
+  }
+}
+
+/**
+ * @param {unknown} value
+ */
+function escapeMarkdown(value) {
+  return String(value).replaceAll("\\", "\\\\").replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+/**
+ * @param {string} sha
+ */
+function shortSha(sha) {
+  return SHA_PATTERN.test(sha) ? `\`${sha.slice(0, 12)}\`` : "-";
+}
+
+/**
+ * @param {unknown} error
+ */
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * @param {{
+ *   repository: string;
+ *   runUrl: string;
+ *   actor: string;
+ *   pullNumber: number;
+ *   pullUrl?: string;
+ *   sourceBranch?: string;
+ *   baseSha?: string;
+ *   headSha?: string;
+ *   status: string;
+ *   detail: string;
+ *   failure?: boolean;
+ * }} report
+ */
+function renderSummary(report) {
+  const pull = report.pullUrl
+    ? `[#${report.pullNumber}](${report.pullUrl})`
+    : `#${report.pullNumber}`;
+  const direction = report.sourceBranch
+    ? `\`${escapeMarkdown(report.sourceBranch)}\` → \`${TARGET_BRANCH}\``
+    : "확인 실패";
+  const lines = [
+    "# `/ff-merge` 실행 결과",
+    "",
+    `- 실행자: @${escapeMarkdown(report.actor)}`,
+    `- Pull Request: ${pull}`,
+    `- 실행 결과: [GitHub Actions](${report.runUrl})`,
+    "",
+    "| 병합 방향 | 이전 `dev` | 이후 `dev` | 결과 | 상세 |",
+    "| --- | --- | --- | --- | --- |",
+    `| ${direction} | ${shortSha(report.baseSha ?? "")} | ${shortSha(report.headSha ?? "")} | ${escapeMarkdown(report.status)} | ${escapeMarkdown(report.detail)} |`,
+  ];
+
+  if (report.failure) {
+    lines.push(
+      "",
+      "<details>",
+      "<summary>실패 확인 방법</summary>",
+      "",
+      "1. 위 상세 사유와 Actions 로그를 확인합니다.",
+      `2. PR이 열린 상태인지, 브랜치 방향이 \`minor|major → ${TARGET_BRANCH}\`인지 확인합니다.`,
+      "3. `dev`와 source 브랜치가 갈라졌다면 source 브랜치를 `dev` 위로 리베이스합니다.",
+      `4. 원격 브랜치가 갱신된 뒤 PR에서 \`${COMMAND}\`를 다시 실행합니다.`,
+      "",
+      "</details>",
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+/**
+ * @param {object} pull
+ * @param {string} repository
+ */
+function validatePullRequest(pull, repository) {
+  if (pull.state !== "open") {
+    throw new FFMergeError("열린 PR에서만 실행할 수 있습니다.");
+  }
+  if (pull.draft === true) {
+    throw new FFMergeError("초안 PR에서는 실행할 수 없습니다.");
+  }
+  if (pull.head?.repo?.full_name !== repository || pull.base?.repo?.full_name !== repository) {
+    throw new FFMergeError("같은 저장소의 브랜치로 만든 PR에서만 실행할 수 있습니다.");
+  }
+  if (!SOURCE_BRANCHES.has(pull.head?.ref) || pull.base?.ref !== TARGET_BRANCH) {
+    throw new FFMergeError("`minor → dev` 또는 `major → dev` PR에서만 실행할 수 있습니다.");
+  }
+  if (!SHA_PATTERN.test(pull.head?.sha ?? "") || !SHA_PATTERN.test(pull.base?.sha ?? "")) {
+    throw new FFMergeError("PR base/head SHA 형식이 올바르지 않습니다.");
+  }
+
+  return {
+    baseSha: pull.base.sha,
+    headSha: pull.head.sha,
+    pullUrl: pull.html_url,
+    sourceBranch: pull.head.ref,
+  };
+}
+
+/**
+ * @param {object} permission
+ */
+function hasWritePermission(permission) {
+  return permission.user?.permissions?.push === true;
+}
+
+/**
+ * @param {object} comparison
+ */
+function validateComparison(comparison) {
+  switch (comparison.status) {
+    case "ahead":
+      if (!(comparison.ahead_by > 0)) {
+        throw new FFMergeError("추가할 커밋을 확인하지 못했습니다.");
+      }
+      return;
+    case "identical":
+      throw new FFMergeError("`dev`가 이미 PR head와 같습니다.");
+    case "behind":
+      throw new FFMergeError("`dev`가 source 브랜치보다 앞서 있어 fast-forward할 수 없습니다.");
+    case "diverged":
+      throw new FFMergeError("`dev`와 source 브랜치가 갈라져 있어 fast-forward할 수 없습니다.");
+    default:
+      throw new FFMergeError(
+        `지원하지 않는 GitHub 비교 상태입니다: ${comparison.status ?? "unknown"}`,
+      );
+  }
+}
+
+/**
+ * @param {{
+ *   github: any;
+ *   context: any;
+ *   expectedBaseSha?: string;
+ *   expectedHeadSha?: string;
+ * }} input
+ */
+async function inspectRequest({ github, context, expectedBaseSha, expectedHeadSha }) {
+  const { owner, repo } = context.repo;
+  const repository = `${owner}/${repo}`;
+  const actor = context.payload.comment?.user?.login ?? context.actor;
+  const association = context.payload.comment?.author_association;
+
+  if (context.payload.comment?.body !== COMMAND) {
+    throw new FFMergeError(`댓글 내용이 정확히 \`${COMMAND}\`여야 합니다.`);
+  }
+  if (!ALLOWED_ASSOCIATIONS.has(association)) {
+    throw new FFMergeError("저장소 협업자만 실행할 수 있습니다.");
+  }
+
+  const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+    owner,
+    repo,
+    username: actor,
+  });
+  if (!hasWritePermission(permission)) {
+    throw new FFMergeError("저장소 쓰기 권한이 있는 사용자만 실행할 수 있습니다.");
+  }
+
+  const { data: pull } = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: context.issue.number,
+  });
+  const pullInfo = validatePullRequest(pull, repository);
+
+  if (expectedBaseSha && pullInfo.baseSha !== expectedBaseSha) {
+    throw new FFMergeError(
+      "사전 검증 이후 `dev`가 변경되었습니다. 최신 상태에서 다시 실행해 주세요.",
+    );
+  }
+  if (expectedHeadSha && pullInfo.headSha !== expectedHeadSha) {
+    throw new FFMergeError(
+      "사전 검증 이후 source 브랜치가 변경되었습니다. 최신 상태에서 다시 실행해 주세요.",
+    );
+  }
+
+  const { data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
+    owner,
+    repo,
+    basehead: `${pullInfo.baseSha}...${pullInfo.headSha}`,
+  });
+  validateComparison(comparison);
+
+  return {
+    ...pullInfo,
+    actor,
+    pullNumber: context.issue.number,
+  };
+}
+
+/**
+ * @param {{
+ *   readGithub: any;
+ *   writeGithub: any;
+ *   context: any;
+ *   expectedBaseSha: string;
+ *   expectedHeadSha: string;
+ * }} input
+ */
+async function performFastForward({
+  readGithub,
+  writeGithub,
+  context,
+  expectedBaseSha,
+  expectedHeadSha,
+}) {
+  const inspected = await inspectRequest({
+    github: readGithub,
+    context,
+    expectedBaseSha,
+    expectedHeadSha,
+  });
+  const { owner, repo } = context.repo;
+
+  await writeGithub.rest.git.updateRef({
+    owner,
+    repo,
+    ref: `heads/${TARGET_BRANCH}`,
+    sha: inspected.headSha,
+    force: false,
+  });
+
+  const { data: updatedRef } = await writeGithub.rest.git.getRef({
+    owner,
+    repo,
+    ref: `heads/${TARGET_BRANCH}`,
+  });
+  if (updatedRef.object?.sha !== inspected.headSha) {
+    throw new FFMergeError("갱신 뒤 `dev`가 예상한 PR head를 가리키지 않습니다.");
+  }
+
+  return inspected;
+}
+
+/**
+ * @param {{ github: any; context: any; core: any; content: string }} input
+ */
+async function addReaction({ github, context, core, content }) {
+  try {
+    await github.rest.reactions.createForIssueComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: context.payload.comment.id,
+      content,
+    });
+  } catch (error) {
+    core.warning(`댓글 반응을 추가하지 못했습니다: ${errorMessage(error)}`);
+  }
+}
+
+/**
+ * @param {{ github: any; context: any; core: any; message: string }} input
+ */
+async function reportFailure({ github, context, core, message }) {
+  await addReaction({ github, context, core, content: "-1" });
+  const runUrl = `${process.env.GITHUB_SERVER_URL ?? "https://github.com"}/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID ?? ""}`;
+  const body = [
+    `\`${COMMAND}\`를 실행하지 못했습니다.`,
+    "",
+    `> ${message}`,
+    "",
+    `[GitHub Actions 실행 결과](${runUrl})에서 자세한 내용을 확인할 수 있습니다.`,
+  ].join("\n");
+
+  try {
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: context.issue.number,
+      body,
+    });
+  } catch (error) {
+    core.warning(`실패 댓글을 남기지 못했습니다: ${errorMessage(error)}`);
+  }
+}
+
+/**
+ * @param {{ core: any; context: any; report: Partial<Parameters<typeof renderSummary>[0]> }} input
+ */
+async function writeSummary({ core, context, report }) {
+  const repository = `${context.repo.owner}/${context.repo.repo}`;
+  const runUrl = `${process.env.GITHUB_SERVER_URL ?? "https://github.com"}/${repository}/actions/runs/${process.env.GITHUB_RUN_ID ?? ""}`;
+  await core.summary
+    .addRaw(
+      renderSummary({
+        repository,
+        runUrl,
+        actor: context.payload.comment?.user?.login ?? context.actor,
+        pullNumber: context.issue.number,
+        status: "실패",
+        detail: "알 수 없는 오류가 발생했습니다.",
+        ...report,
+      }),
+    )
+    .write();
+}
+
+/**
+ * @param {{ github: any; context: any; core: any }} input
+ */
+async function preflight({ github, context, core }) {
+  await addReaction({ github, context, core, content: "eyes" });
+
+  try {
+    const inspected = await inspectRequest({ github, context });
+    core.setOutput("base-sha", inspected.baseSha);
+    core.setOutput("head-sha", inspected.headSha);
+    core.setOutput("source-branch", inspected.sourceBranch);
+    core.setOutput("pull-url", inspected.pullUrl);
+    await writeSummary({
+      core,
+      context,
+      report: {
+        ...inspected,
+        status: "사전 검증 완료",
+        detail: "fast-forward 병합 조건을 확인했습니다.",
+      },
+    });
+  } catch (error) {
+    const message = errorMessage(error);
+    await writeSummary({
+      core,
+      context,
+      report: { status: "실패", detail: message, failure: true },
+    });
+    await reportFailure({ github, context, core, message });
+    core.setFailed(message);
+  }
+}
+
+/**
+ * @param {{ github: any; context: any; core: any; getOctokit: any; appToken: string }} input
+ */
+async function merge({ github, context, core, getOctokit, appToken }) {
+  try {
+    if (!appToken) {
+      throw new FFMergeError("GitHub App 토큰을 발급하지 못했습니다.");
+    }
+    const inspected = await performFastForward({
+      readGithub: github,
+      writeGithub: getOctokit(appToken),
+      context,
+      expectedBaseSha: process.env.FF_MERGE_BASE_SHA ?? "",
+      expectedHeadSha: process.env.FF_MERGE_HEAD_SHA ?? "",
+    });
+    await addReaction({ github, context, core, content: "rocket" });
+    await writeSummary({
+      core,
+      context,
+      report: {
+        ...inspected,
+        status: "성공",
+        detail: "원래 커밋 SHA를 유지한 채 `dev`를 fast-forward했습니다.",
+      },
+    });
+  } catch (error) {
+    const message = errorMessage(error);
+    await writeSummary({
+      core,
+      context,
+      report: {
+        sourceBranch: process.env.FF_MERGE_SOURCE_BRANCH,
+        baseSha: process.env.FF_MERGE_BASE_SHA,
+        headSha: process.env.FF_MERGE_HEAD_SHA,
+        pullUrl: process.env.FF_MERGE_PULL_URL,
+        status: "실패",
+        detail: message,
+        failure: true,
+      },
+    });
+    await reportFailure({ github, context, core, message });
+    core.setFailed(message);
+  }
+}
+
+module.exports = {
+  FFMergeError,
+  escapeMarkdown,
+  hasWritePermission,
+  inspectRequest,
+  merge,
+  performFastForward,
+  preflight,
+  renderSummary,
+  validateComparison,
+  validatePullRequest,
+};

--- a/.github/scripts/ff-merge.test.js
+++ b/.github/scripts/ff-merge.test.js
@@ -1,0 +1,209 @@
+const { describe, expect, mock, test } = require("bun:test");
+
+const {
+  escapeMarkdown,
+  hasWritePermission,
+  inspectRequest,
+  performFastForward,
+  renderSummary,
+  validateComparison,
+  validatePullRequest,
+} = require("./ff-merge");
+
+const BASE_SHA = "1".repeat(40);
+const HEAD_SHA = "2".repeat(40);
+
+function createPull(overrides = {}) {
+  return {
+    state: "open",
+    draft: false,
+    html_url: "https://github.com/daangn/seed-design/pull/2000",
+    base: {
+      ref: "dev",
+      sha: BASE_SHA,
+      repo: { full_name: "daangn/seed-design" },
+    },
+    head: {
+      ref: "minor",
+      sha: HEAD_SHA,
+      repo: { full_name: "daangn/seed-design" },
+    },
+    ...overrides,
+  };
+}
+
+function createContext() {
+  return {
+    actor: "seed-maintainer",
+    repo: { owner: "daangn", repo: "seed-design" },
+    issue: { number: 2000 },
+    payload: {
+      comment: {
+        id: 123,
+        body: "/ff-merge",
+        author_association: "MEMBER",
+        user: { login: "seed-maintainer" },
+      },
+    },
+  };
+}
+
+function createReadGithub(pull = createPull()) {
+  return {
+    rest: {
+      repos: {
+        getCollaboratorPermissionLevel: mock(async () => ({
+          data: { user: { permissions: { push: true } } },
+        })),
+        compareCommitsWithBasehead: mock(async () => ({
+          data: { status: "ahead", ahead_by: 2 },
+        })),
+      },
+      pulls: {
+        get: mock(async () => ({ data: pull })),
+      },
+    },
+  };
+}
+
+describe("validatePullRequest", () => {
+  test("minor → dev PR을 허용한다", () => {
+    expect(validatePullRequest(createPull(), "daangn/seed-design")).toEqual({
+      baseSha: BASE_SHA,
+      headSha: HEAD_SHA,
+      pullUrl: "https://github.com/daangn/seed-design/pull/2000",
+      sourceBranch: "minor",
+    });
+  });
+
+  test.each([
+    ["닫힌 PR", { state: "closed" }],
+    ["초안 PR", { draft: true }],
+    ["잘못된 source", { head: { ...createPull().head, ref: "feature/test" } }],
+    ["잘못된 target", { base: { ...createPull().base, ref: "main" } }],
+    ["fork PR", { head: { ...createPull().head, repo: { full_name: "someone/seed-design" } } }],
+  ])("%s을 거부한다", (_, overrides) => {
+    expect(() => validatePullRequest(createPull(overrides), "daangn/seed-design")).toThrow();
+  });
+});
+
+describe("권한과 비교 상태", () => {
+  test("push 권한만 쓰기 권한으로 인정한다", () => {
+    expect(hasWritePermission({ user: { permissions: { push: true } } })).toBe(true);
+    expect(hasWritePermission({ user: { permissions: { push: false } } })).toBe(false);
+    expect(hasWritePermission({ permission: "write" })).toBe(false);
+  });
+
+  test("ahead 상태만 허용한다", () => {
+    expect(() => validateComparison({ status: "ahead", ahead_by: 1 })).not.toThrow();
+    for (const status of ["identical", "behind", "diverged", "unknown"]) {
+      expect(() => validateComparison({ status, ahead_by: 0 })).toThrow();
+    }
+  });
+
+  test("정확한 명령과 실제 push 권한을 모두 요구한다", async () => {
+    const wrongCommand = createContext();
+    wrongCommand.payload.comment.body = "/ff-merge please";
+    await expect(
+      inspectRequest({ github: createReadGithub(), context: wrongCommand }),
+    ).rejects.toThrow("댓글 내용이 정확히 `/ff-merge`여야 합니다");
+
+    const github = createReadGithub();
+    github.rest.repos.getCollaboratorPermissionLevel = mock(async () => ({
+      data: { user: { permissions: { push: false } } },
+    }));
+    await expect(inspectRequest({ github, context: createContext() })).rejects.toThrow(
+      "저장소 쓰기 권한이 있는 사용자만 실행할 수 있습니다",
+    );
+    expect(github.rest.pulls.get).not.toHaveBeenCalled();
+  });
+});
+
+describe("performFastForward", () => {
+  test("dev ref를 force 없이 PR head로 갱신하고 결과를 검증한다", async () => {
+    const readGithub = createReadGithub();
+    const updateRef = mock(async () => ({ data: {} }));
+    const getRef = mock(async () => ({ data: { object: { sha: HEAD_SHA } } }));
+    const writeGithub = { rest: { git: { updateRef, getRef } } };
+
+    await expect(
+      performFastForward({
+        readGithub,
+        writeGithub,
+        context: createContext(),
+        expectedBaseSha: BASE_SHA,
+        expectedHeadSha: HEAD_SHA,
+      }),
+    ).resolves.toMatchObject({ baseSha: BASE_SHA, headSha: HEAD_SHA });
+
+    expect(updateRef).toHaveBeenCalledWith({
+      owner: "daangn",
+      repo: "seed-design",
+      ref: "heads/dev",
+      sha: HEAD_SHA,
+      force: false,
+    });
+    expect(getRef).toHaveBeenCalledWith({
+      owner: "daangn",
+      repo: "seed-design",
+      ref: "heads/dev",
+    });
+  });
+
+  test("사전 검증 이후 base 또는 head가 바뀌면 갱신하지 않는다", async () => {
+    const updateRef = mock(async () => ({ data: {} }));
+    const writeGithub = {
+      rest: { git: { updateRef, getRef: mock(async () => ({ data: {} })) } },
+    };
+
+    await expect(
+      performFastForward({
+        readGithub: createReadGithub(),
+        writeGithub,
+        context: createContext(),
+        expectedBaseSha: "3".repeat(40),
+        expectedHeadSha: HEAD_SHA,
+      }),
+    ).rejects.toThrow("사전 검증 이후 `dev`가 변경되었습니다");
+    expect(updateRef).not.toHaveBeenCalled();
+
+    await expect(
+      performFastForward({
+        readGithub: createReadGithub(),
+        writeGithub,
+        context: createContext(),
+        expectedBaseSha: BASE_SHA,
+        expectedHeadSha: "4".repeat(40),
+      }),
+    ).rejects.toThrow("사전 검증 이후 source 브랜치가 변경되었습니다");
+    expect(updateRef).not.toHaveBeenCalled();
+  });
+});
+
+describe("Summary", () => {
+  test("실행 정보와 실패 안내를 한국어 Markdown으로 만든다", () => {
+    const summary = renderSummary({
+      repository: "daangn/seed-design",
+      runUrl: "https://github.com/daangn/seed-design/actions/runs/1",
+      actor: "maintainer|name",
+      pullNumber: 2000,
+      pullUrl: "https://github.com/daangn/seed-design/pull/2000",
+      sourceBranch: "minor",
+      baseSha: BASE_SHA,
+      headSha: HEAD_SHA,
+      status: "실패",
+      detail: "dev|source가 갈라졌습니다.\n다시 시도하세요.",
+      failure: true,
+    });
+
+    expect(summary).toContain("# `/ff-merge` 실행 결과");
+    expect(summary).toContain("@maintainer\\|name");
+    expect(summary).toContain("`minor` → `dev`");
+    expect(summary).toContain("dev\\|source가 갈라졌습니다. 다시 시도하세요.");
+    expect(summary).toContain("<summary>실패 확인 방법</summary>");
+  });
+
+  test("Markdown 표 구분 문자를 이스케이프한다", () => {
+    expect(escapeMarkdown("a|b\nc")).toBe("a\\|b c");
+  });
+});

--- a/.github/workflows/ff-merge.yml
+++ b/.github/workflows/ff-merge.yml
@@ -1,0 +1,66 @@
+name: Fast-forward merge
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  ff-merge:
+    name: Fast-forward minor or major into dev
+    if: >-
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/ff-merge' &&
+      contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: ff-merge-dev
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+
+    steps:
+      - name: Checkout trusted workflow scripts
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Validate command and fast-forward eligibility
+        id: preflight
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const command = require('./.github/scripts/ff-merge.js');
+            await command.preflight({ github, context, core });
+
+      - name: Create Daangn Bud token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.DAANGN_BUD_CLIENT_ID }}
+          private-key: ${{ secrets.DAANGN_BUD_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Fast-forward dev to the exact PR head
+        if: always() && steps.preflight.outcome == 'success'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          FF_MERGE_APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          FF_MERGE_BASE_SHA: ${{ steps.preflight.outputs.base-sha }}
+          FF_MERGE_HEAD_SHA: ${{ steps.preflight.outputs.head-sha }}
+          FF_MERGE_SOURCE_BRANCH: ${{ steps.preflight.outputs.source-branch }}
+          FF_MERGE_PULL_URL: ${{ steps.preflight.outputs.pull-url }}
+        with:
+          script: |
+            const command = require('./.github/scripts/ff-merge.js');
+            await command.merge({
+              github,
+              context,
+              core,
+              getOctokit,
+              appToken: process.env.FF_MERGE_APP_TOKEN,
+            });

--- a/.github/workflows/ff-merge.yml
+++ b/.github/workflows/ff-merge.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout trusted workflow scripts
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ github.sha }}
           persist-credentials: false

--- a/TECH.md
+++ b/TECH.md
@@ -233,6 +233,13 @@ export const Checkbox = { Root, Control, HiddenInput, ... };
 - `bun release` - 패키지 빌드 및 npm 배포
 - PR에서 `/snapshot` - `pkg.pr.new` 패키지 snapshot을 게시하고 `packages/rootage/**` 변경이 있으면 exact PR head용 Rootage CDN URL도 생성. snapshot은 stable 포인터를 변경하지 않으며 PR 종료 30일 뒤 정리
 
+### 릴리스 브랜치 Fast-forward
+
+- `minor → dev`, `major → dev` PR에서 저장소 쓰기 권한이 있는 사용자가 `/ff-merge` 댓글을 남기면 `dev`를 PR head로 fast-forward한다.
+- GitHub의 rebase merge를 사용하지 않는다. 기존 커밋과 SHA를 유지한 채 `dev` ref만 `force: false`로 갱신한다.
+- PR이 열려 있고 초안이 아니며 두 브랜치가 갈라지지 않은 경우에만 실행한다. 실행 중 SHA가 바뀌면 병합하지 않고 최신 상태에서 다시 실행하도록 안내한다.
+- 실행 결과와 이전·이후 SHA는 GitHub Actions Summary에서 확인한다. 실패한 경우 명령 댓글의 👎 반응과 PR 댓글에서도 원인을 확인할 수 있다.
+
 ---
 
 ## 환경 변수


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 권한 있는 사용자가 PR 댓글의 `/ff-merge` 명령으로 릴리스 브랜치를 `dev`에 fast-forward 병합할 수 있습니다.
  - 병합 전 PR 상태, 브랜치, 커밋 및 권한을 자동으로 검증합니다.
  - 병합 결과와 실패 원인을 Actions 요약 및 PR 댓글에서 확인할 수 있습니다.
  - 실행 중 커밋 변경과 강제 업데이트를 방지해 안전성을 강화했습니다.

- **문서**
  - fast-forward 병합 절차와 사용 방법을 기술 문서에 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->