### PR TITLE
feat(docs): add design tokens to the search dialog

### DIFF
--- a/docs/app/api/token-search/route.ts
+++ b/docs/app/api/token-search/route.ts
@@ -1,0 +1,11 @@
+import { buildTokenSearchIndex } from "@/lib/token-search-index";
+
+// it should be cached forever
+export const revalidate = false;
+
+// `output: "export"` emits this as a static JSON file, like /api/search next to it.
+export const dynamic = "force-static";
+
+export async function GET() {
+  return Response.json(await buildTokenSearchIndex());
+}

--- a/docs/components/rootage.ts
+++ b/docs/components/rootage.ts
@@ -35,6 +35,35 @@ export function stringifyTokenLit(token: AST.TokenLit): AST.TokenRef {
   return `$${[...token.group, token.key].join(".")}`;
 }
 
+/**
+ * A stop/layer colour that is still a token reference after resolution points at the
+ * CSS variable `@seed-design/css` emits for it, so the browser applies the live value.
+ */
+function stringifyColor(color: AST.ColorHexLit | AST.TokenLit): string {
+  if (color.kind === "ColorHexLit") return color.value;
+
+  return `var(--seed-${[...color.group, color.key].join("-")})`;
+}
+
+const stringifyDimension = (dimension: AST.DimensionLit) => `${dimension.value}${dimension.unit}`;
+
+export function gradientToCss(gradient: AST.GradientLit): string {
+  const stops = gradient.stops
+    .map((stop) => `${stringifyColor(stop.color)} ${(stop.position.value * 100).toFixed(1)}%`)
+    .join(", ");
+
+  return `linear-gradient(to right, ${stops})`;
+}
+
+export function shadowToCss(shadow: AST.ShadowLit): string {
+  return shadow.layers
+    .map(
+      (layer) =>
+        `${stringifyDimension(layer.offsetX)} ${stringifyDimension(layer.offsetY)} ${stringifyDimension(layer.blur)} ${stringifyDimension(layer.spread)} ${stringifyColor(layer.color)}`,
+    )
+    .join(", ");
+}
+
 export function stringifyValueLit(lit: AST.ValueLit): string {
   const tokenReference = (token: AST.TokenLit) => stringifyTokenLit(token);
 

--- a/docs/components/search/search.tsx
+++ b/docs/components/search/search.tsx
@@ -14,12 +14,15 @@ import {
 } from "fumadocs-ui/components/dialog/search";
 import type { SharedProps, TagItem } from "fumadocs-ui/contexts/search";
 import { type ReactNode, useMemo, useState } from "react";
+import { TAGS } from "@/app/api/search/constants";
 import { NoResults } from "./no-results";
 import { RecentPages } from "./recent-pages";
 import { SearchResultItem } from "./search-result-item";
 import { SearchResultsState } from "./search-results-state";
 import { SearchTags } from "./tags";
+import { TokenResults } from "./token-results";
 import { koreanTokenizer } from "./tokenizer";
+import { useTokenSearch } from "./use-token-search";
 import { create } from "zbsearch";
 
 export interface DefaultSearchDialogProps extends SharedProps {
@@ -86,6 +89,13 @@ export default function DefaultSearchDialog({
     setTag(v);
   });
 
+  // Tokens live under Foundations, so they only belong in the unfiltered view and in
+  // that section's own filter.
+  const tokens = useTokenSearch({
+    search,
+    enabled: tag === undefined || tag === TAGS.foundations.value,
+  });
+
   // Re-rank fumadocs' results before display. Its advanced search flattens title/heading/
   // body into one field with no field or all-terms weighting, so a partial ("Button"-only)
   // body snippet can outrank the "Action Button" pages. Push closer matches up — exact query
@@ -142,11 +152,17 @@ export default function DefaultSearchDialog({
               isLoading={query.isLoading}
               recent={<RecentPages />}
             >
+              <TokenResults matches={tokens} search={search} />
               <SearchDialogList
                 items={results}
-                Empty={() => <NoResults />}
+                // The token section already answers the query; a "no results" notice
+                // under it would contradict what's on screen.
+                Empty={() => (tokens.length > 0 ? null : <NoResults />)}
                 Item={(itemProps) => <SearchResultItem {...itemProps} />}
-                className="[&>div]:!max-h-[480px]"
+                // Give up most of the 480px budget to the token section when it's
+                // showing, so the card stays close to the height the pinned dialog top
+                // assumes instead of running off short viewports.
+                className={tokens.length > 0 ? "[&>div]:!max-h-[176px]" : "[&>div]:!max-h-[480px]"}
               />
             </SearchResultsState>
             {footer}

--- a/docs/components/search/token-results.tsx
+++ b/docs/components/search/token-results.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useOnChange } from "fumadocs-core/utils/use-on-change";
+import { useSearch } from "fumadocs-ui/components/dialog/search";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { type CSSProperties, type KeyboardEvent, type ReactNode, useMemo, useState } from "react";
+import { TOKEN_KIND_ICON } from "@/components/token-kind-icon";
+import {
+  splitHighlights,
+  splitQueryTerms,
+  type ThemedCss,
+  TOKEN_RESULT_LIMIT,
+  type TokenSearchEntry,
+  tokenReferenceHref,
+} from "@/lib/token-search";
+
+/**
+ * Tall enough for two rows even when a token id wraps onto a second line, so the cut
+ * lands between rows instead of through a description. The grid auto-fills — 2 columns
+ * on a phone, 4 on desktop — and "더 보기" pours the remaining matches into this same
+ * scroll box rather than growing the dialog.
+ */
+const TOKEN_GRID_CLASS_NAME =
+  "grid max-h-[264px] grid-cols-[repeat(auto-fill,minmax(148px,1fr))] gap-2 overflow-y-auto";
+
+/**
+ * Colour roles read differently depending on where the token is meant to land, so each
+ * preview mimics the usage: a background fills the box, a foreground sits on the page
+ * background as a chip, and a stroke draws the 2px line it would draw.
+ */
+const COLOR_ROLE_PREVIEW: Record<string, "chip" | "line" | undefined> = {
+  "$color.fg": "chip",
+  "$color.stroke": "line",
+};
+
+const themed = ({ light, dark }: ThemedCss) =>
+  ({ "--token-preview-light": light, "--token-preview-dark": dark }) as CSSProperties;
+
+/**
+ * fumadocs' result list binds Enter on `window` to open whichever row it considers
+ * active. A focused tile would otherwise navigate to that row instead of itself.
+ */
+function stopEnterPropagation(event: KeyboardEvent) {
+  if (event.key === "Enter") event.stopPropagation();
+}
+
+function Highlighted({ text, terms }: { text: string; terms: string[] }) {
+  return splitHighlights(text, terms).map((chunk, index) =>
+    chunk.match ? (
+      <mark
+        // biome-ignore lint/suspicious/noArrayIndexKey: chunks are positional, and the list is rebuilt whenever the text or terms change
+        key={index}
+        className="bg-[var(--selection-bg)] text-[var(--selection-fg)]"
+      >
+        {chunk.text}
+      </mark>
+    ) : (
+      chunk.text
+    ),
+  );
+}
+
+/**
+ * Stand-in for the page canvas. Foreground, stroke and shadow tokens are all defined
+ * against `$color.bg.layer-default`, so previewing them on the dialog's own surface
+ * would misreport how they land. docs/AGENTS.md steers docs *chrome* away from opaque
+ * SEED greys; this box is content — the point is to show the real backdrop.
+ */
+function PreviewSurface({ children }: { children: ReactNode }) {
+  return (
+    <span
+      aria-hidden
+      className="flex h-11 w-full items-center justify-center overflow-hidden rounded-lg border border-stroke-neutral-muted bg-bg-layer-default"
+    >
+      {children}
+    </span>
+  );
+}
+
+function TokenPreview({ entry }: { entry: TokenSearchEntry }) {
+  const { background, boxShadow, group, kind, label } = entry;
+
+  if (background) {
+    const role = COLOR_ROLE_PREVIEW[group];
+
+    if (role === "chip")
+      return (
+        <PreviewSurface>
+          <span
+            style={themed(background)}
+            className="size-5 rounded-full bg-[var(--token-preview-light)] dark:bg-[var(--token-preview-dark)]"
+          />
+        </PreviewSurface>
+      );
+
+    if (role === "line")
+      return (
+        <PreviewSurface>
+          <span
+            style={themed(background)}
+            className="h-0.5 w-2/3 bg-[var(--token-preview-light)] dark:bg-[var(--token-preview-dark)]"
+          />
+        </PreviewSurface>
+      );
+
+    return (
+      <span
+        aria-hidden
+        style={themed(background)}
+        className="block h-11 w-full rounded-lg border border-stroke-neutral-muted bg-[var(--token-preview-light)] dark:bg-[var(--token-preview-dark)]"
+      />
+    );
+  }
+
+  if (boxShadow)
+    return (
+      <PreviewSurface>
+        <span
+          style={themed(boxShadow)}
+          className="size-6 rounded-md bg-bg-layer-floating shadow-[var(--token-preview-light)] dark:shadow-[var(--token-preview-dark)]"
+        />
+      </PreviewSurface>
+    );
+
+  const Icon = TOKEN_KIND_ICON[kind];
+
+  return (
+    <span
+      aria-hidden
+      className="flex h-11 w-full flex-col items-center justify-center gap-1 rounded-lg bg-bg-transparent-selected px-1 text-fg-neutral-muted"
+    >
+      {Icon ? <Icon className="size-3.5 flex-none" /> : null}
+      <span className="w-full truncate text-center text-[11px] leading-none">{label}</span>
+    </span>
+  );
+}
+
+function TokenTile({ entry, terms }: { entry: TokenSearchEntry; terms: string[] }) {
+  const { onOpenChange } = useSearch();
+  const router = useRouter();
+  const href = tokenReferenceHref(entry.id);
+
+  return (
+    <Link
+      href={href}
+      // The name wraps across lines and splits into two colours, so spell the id out
+      // again for screen readers.
+      aria-label={entry.id}
+      title={`${entry.id}\n${entry.label}`}
+      onClick={(event) => {
+        // Keep cmd/ctrl-click opening a tab; a plain click routes through the client
+        // router and closes the dialog behind it.
+        if (event.metaKey || event.ctrlKey) return;
+
+        event.preventDefault();
+        onOpenChange(false);
+        router.push(href);
+      }}
+      onKeyDown={stopEnterPropagation}
+      className="flex flex-col gap-1.5 rounded-xl p-1.5 transition-colors hover:bg-bg-transparent-selected active:bg-bg-transparent-selected-pressed focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-stroke-focus-ring"
+    >
+      <TokenPreview entry={entry} />
+      <span className="min-w-0 px-0.5">
+        <span className="block wrap-anywhere text-[11px] leading-snug">
+          <span className="text-fg-neutral-subtle">
+            <Highlighted text={`${entry.group}.`} terms={terms} />
+          </span>
+          <span className="font-medium text-fg-neutral">
+            <Highlighted text={entry.key} terms={terms} />
+          </span>
+        </span>
+        {/* No `block` here — line-clamp needs to set `display: -webkit-box` itself, and a
+            display utility alongside it silently wins. Two thirds of the tokens have no
+            description; the reserved line keeps a row of those from collapsing to a
+            different height than its neighbours. */}
+        <span className="mt-0.5 line-clamp-2 min-h-4 text-[11px] leading-snug text-fg-neutral-subtle">
+          {entry.description ? <Highlighted text={entry.description} terms={terms} /> : null}
+        </span>
+      </span>
+    </Link>
+  );
+}
+
+/**
+ * Design tokens matching the query, gathered above the document results so a search for
+ * `bg.neutral` surfaces the tokens themselves rather than only the pages mentioning
+ * them. Each tile links to that token's reference page.
+ */
+export function TokenResults({ matches, search }: { matches: TokenSearchEntry[]; search: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  // A new query is a new list; carrying the expansion over would dump hundreds of tiles
+  // on someone who only added a letter.
+  useOnChange(search, () => {
+    setExpanded(false);
+  });
+
+  const terms = useMemo(() => splitQueryTerms(search), [search]);
+
+  if (matches.length === 0) return null;
+
+  const hidden = matches.length - TOKEN_RESULT_LIMIT;
+
+  return (
+    <section aria-label="토큰 검색 결과" className="border-b border-stroke-neutral-muted p-3 pb-2">
+      <p className="px-0.5 pb-2 text-xs font-medium text-fg-neutral-muted">
+        토큰 <span className="text-fg-neutral-subtle">{matches.length}개</span>
+      </p>
+      <ul className={TOKEN_GRID_CLASS_NAME}>
+        {(expanded ? matches : matches.slice(0, TOKEN_RESULT_LIMIT)).map((entry) => (
+          <li key={entry.id}>
+            <TokenTile entry={entry} terms={terms} />
+          </li>
+        ))}
+      </ul>
+      {hidden > 0 ? (
+        <button
+          type="button"
+          onClick={() => setExpanded((current) => !current)}
+          onKeyDown={stopEnterPropagation}
+          className="mt-1.5 w-full cursor-pointer rounded-lg py-1.5 text-xs text-fg-neutral-subtle transition-colors hover:bg-bg-transparent-selected hover:text-fg-neutral focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-stroke-focus-ring"
+        >
+          {expanded ? "접기" : `${hidden}개 더 보기`}
+        </button>
+      ) : null}
+    </section>
+  );
+}

--- a/docs/components/search/token-results.tsx
+++ b/docs/components/search/token-results.tsx
@@ -26,11 +26,11 @@ const TOKEN_GRID_CLASS_NAME =
 
 /**
  * Colour roles read differently depending on where the token is meant to land, so each
- * preview mimics the usage: a background fills the box, a foreground sits on the page
- * background as a chip, and a stroke draws the 2px line it would draw.
+ * preview mimics the usage: a background fills the box, a foreground paints letterforms
+ * on the page grounds, and a stroke draws the 2px line it would draw.
  */
-const COLOR_ROLE_PREVIEW: Record<string, "chip" | "line" | undefined> = {
-  "$color.fg": "chip",
+const COLOR_ROLE_PREVIEW: Record<string, "text" | "line" | undefined> = {
+  "$color.fg": "text",
   "$color.stroke": "line",
 };
 
@@ -62,18 +62,26 @@ function Highlighted({ text, terms }: { text: string; terms: string[] }) {
 }
 
 /**
- * Stand-in for the page canvas. Foreground, stroke and shadow tokens are all defined
- * against `$color.bg.layer-default`, so previewing them on the dialog's own surface
- * would misreport how they land. docs/AGENTS.md steers docs *chrome* away from opaque
- * SEED greys; this box is content — the point is to show the real backdrop.
+ * Stand-in for the page canvas, showing both grounds a screen is built from:
+ * `layer-default`, the surface most content sits on, and `layer-basement`, the canvas
+ * underneath it. Foreground, stroke and shadow tokens are all defined against those, so
+ * previewing them on the dialog's own surface would misreport how they land — and picking
+ * one of the two would still hide how the token reads on the other. docs/AGENTS.md steers
+ * docs *chrome* away from opaque SEED greys; this box is content — the point is to show
+ * the real backdrop.
+ *
+ * Split down the middle rather than across: the box is 44px tall and the two layers sit
+ * about 1.1 apart in contrast, so as a pair of 22px bands the seam would vanish.
  */
 function PreviewSurface({ children }: { children: ReactNode }) {
   return (
     <span
       aria-hidden
-      className="flex h-11 w-full items-center justify-center overflow-hidden rounded-lg border border-stroke-neutral-muted bg-bg-layer-default"
+      className="relative flex h-11 w-full overflow-hidden rounded-lg border border-stroke-neutral-muted"
     >
-      {children}
+      <span className="flex-1 bg-bg-layer-default" />
+      <span className="flex-1 bg-bg-layer-basement" />
+      <span className="absolute inset-0 flex items-center justify-center">{children}</span>
     </span>
   );
 }
@@ -84,13 +92,18 @@ function TokenPreview({ entry }: { entry: TokenSearchEntry }) {
   if (background) {
     const role = COLOR_ROLE_PREVIEW[group];
 
-    if (role === "chip")
+    // Letterforms can't be cut in half, so each ground gets its own pair rather than one
+    // word straddling the seam. A stroke is a line already, and reads across it.
+    if (role === "text")
       return (
         <PreviewSurface>
           <span
             style={themed(background)}
-            className="size-5 rounded-full bg-[var(--token-preview-light)] dark:bg-[var(--token-preview-dark)]"
-          />
+            className="flex w-full text-[15px] font-semibold leading-none text-[var(--token-preview-light)] dark:text-[var(--token-preview-dark)]"
+          >
+            <span className="flex-1 text-center">Aa</span>
+            <span className="flex-1 text-center">Aa</span>
+          </span>
         </PreviewSurface>
       );
 

--- a/docs/components/search/use-token-search.ts
+++ b/docs/components/search/use-token-search.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { matchTokens, TOKEN_SEARCH_API, type TokenSearchEntry } from "@/lib/token-search";
+
+const NO_MATCHES: TokenSearchEntry[] = [];
+
+/**
+ * Match design tokens against the search query, fetching the static token index the
+ * first time someone actually searches — it is a second blob next to fumadocs' own, and
+ * most page views never open the dialog.
+ *
+ * A failed fetch settles on an empty index: the token section disappears and document
+ * search carries on, which is the right way for an extra to fail.
+ */
+export function useTokenSearch({ search, enabled }: { search: string; enabled: boolean }) {
+  const [entries, setEntries] = useState<TokenSearchEntry[]>();
+
+  const active = enabled && search.trim() !== "";
+
+  useEffect(() => {
+    if (!active || entries) return;
+
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const response = await fetch(TOKEN_SEARCH_API);
+        if (!response.ok) throw new Error(`token index responded ${response.status}`);
+
+        const data: TokenSearchEntry[] = await response.json();
+        if (!cancelled) setEntries(data);
+      } catch {
+        if (!cancelled) setEntries([]);
+      }
+    }
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [active, entries]);
+
+  return useMemo(
+    () => (active && entries ? matchTokens(entries, search) : NO_MATCHES),
+    [active, entries, search],
+  );
+}

--- a/docs/components/token-kind-icon.ts
+++ b/docs/components/token-kind-icon.ts
@@ -1,0 +1,18 @@
+import { IconHashLine, IconTimerLine } from "@karrotmarket/react-monochrome-icon";
+import type { ComponentType, SVGProps } from "react";
+import { IconLayers, IconRuler, IconSpline } from "./icons";
+
+/**
+ * Glyph per rootage `AST.ValueLit` kind. Colours and gradients are absent because they
+ * are always drawn as a swatch instead.
+ *
+ * Keyed by plain string rather than the AST union so the search dialog can use it
+ * without importing `@seed-design/rootage-core` into the page bundle.
+ */
+export const TOKEN_KIND_ICON: Record<string, ComponentType<SVGProps<SVGSVGElement>> | undefined> = {
+  CubicBezierLit: IconSpline,
+  DimensionLit: IconRuler,
+  DurationLit: IconTimerLine,
+  NumberLit: IconHashLine,
+  ShadowLit: IconLayers,
+};

--- a/docs/components/token-link.tsx
+++ b/docs/components/token-link.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { IconSeedArrow } from "@/components/icon-seed-arrow";
+import { tokenReferenceHref } from "@/lib/token-search";
 import Link from "next/link";
 import type { ReactNode } from "react";
 
@@ -20,7 +21,7 @@ export const TokenLink = ({
           target="_blank"
           onClick={(e) => e.stopPropagation()}
           className="inline no-underline hover:underline"
-          href={`/foundations/design-token/reference/${encodeURIComponent(id)}`}
+          href={tokenReferenceHref(id)}
         >
           <span>{id}</span>
           <IconSeedArrow

--- a/docs/components/type-indicator.tsx
+++ b/docs/components/type-indicator.tsx
@@ -1,20 +1,6 @@
-import { IconHashLine, IconTimerLine } from "@karrotmarket/react-monochrome-icon";
-import { AST } from "@seed-design/rootage-core";
-import { IconLayers, IconRuler, IconSpline } from "./icons";
-
-// Gradient를 CSS linear-gradient로 변환하는 유틸리티 함수
-function gradientToCss(gradient: AST.GradientLit): string {
-  const stops = gradient.stops
-    .map((stop) => {
-      const color =
-        stop.color.kind === "ColorHexLit"
-          ? stop.color.value
-          : `var(--seed-${stop.color.identifier.replace(/\$/g, "").replace(/\./g, "-")})`;
-      return `${color} ${(stop.position.value * 100).toFixed(1)}%`;
-    })
-    .join(", ");
-  return `linear-gradient(to right, ${stops})`;
-}
+import type { AST } from "@seed-design/rootage-core";
+import { gradientToCss } from "./rootage";
+import { TOKEN_KIND_ICON } from "./token-kind-icon";
 
 // Gradient 정보를 텍스트로 변환하는 함수
 function gradientToText(gradient: AST.GradientLit): string {
@@ -55,49 +41,16 @@ export function TypeIndicator(props: { value: AST.ValueLit }) {
     );
   }
 
-  if (value.kind === "DimensionLit") {
-    return (
-      <div>
-        <IconRuler className="w-4 h-4 flex-none" />
-      </div>
-    );
-  }
-
-  if (value.kind === "DurationLit") {
-    return (
-      <div>
-        <IconTimerLine className="w-4 h-4 flex-none" />
-      </div>
-    );
-  }
-
-  if (value.kind === "NumberLit") {
-    return (
-      <div>
-        <IconHashLine className="w-4 h-4 flex-none" />
-      </div>
-    );
-  }
-
-  if (value.kind === "ShadowLit") {
-    return (
-      <div>
-        <IconLayers className="w-4 h-4 flex-none" />
-      </div>
-    );
-  }
-
-  if (value.kind === "CubicBezierLit") {
-    return (
-      <div>
-        <IconSpline className="w-4 h-4 flex-none" />
-      </div>
-    );
-  }
-
   if (value.kind === "GradientLit") {
     return <GradientSwatch gradient={value} />;
   }
 
-  return null;
+  const Icon = TOKEN_KIND_ICON[value.kind];
+  if (!Icon) return null;
+
+  return (
+    <div>
+      <Icon className="w-4 h-4 flex-none" />
+    </div>
+  );
 }

--- a/docs/lib/token-search-index.ts
+++ b/docs/lib/token-search-index.ts
@@ -1,0 +1,65 @@
+import "server-only";
+
+import type { AST } from "@seed-design/rootage-core";
+import { resolveToken } from "@seed-design/rootage-core";
+import {
+  getDefaultModes,
+  gradientToCss,
+  shadowToCss,
+  stringifyValueLit,
+} from "@/components/rootage";
+import { getRootage } from "./rootage";
+import type { TokenSearchEntry } from "./token-search";
+
+/** The only mode that makes a token render differently under the docs' dark theme. */
+const DARK_MODE = "theme-dark";
+
+function paint(
+  light: AST.ValueLit,
+  dark: AST.ValueLit,
+): Pick<TokenSearchEntry, "background" | "boxShadow"> {
+  if (light.kind === "ColorHexLit" && dark.kind === "ColorHexLit")
+    return { background: { light: light.value, dark: dark.value } };
+
+  if (light.kind === "GradientLit" && dark.kind === "GradientLit")
+    return { background: { light: gradientToCss(light), dark: gradientToCss(dark) } };
+
+  if (light.kind === "ShadowLit" && dark.kind === "ShadowLit")
+    return { boxShadow: { light: shadowToCss(light), dark: shadowToCss(dark) } };
+
+  return {};
+}
+
+/**
+ * Flatten every token into the shape the search dialog needs. Resolution happens here,
+ * at build time, so the client gets literal values instead of an alias chain to walk.
+ */
+export async function buildTokenSearchIndex(): Promise<TokenSearchEntry[]> {
+  const rootage = await getRootage();
+  const defaultModes = getDefaultModes(rootage);
+
+  return rootage.tokenIds
+    .map((id) => {
+      const { collection, description } = rootage.tokenEntities[id];
+      const modes = rootage.tokenCollectionEntities[collection].modes;
+
+      const resolveIn = (mode: string) =>
+        resolveToken(rootage, id, { ...defaultModes, [collection]: mode }).value;
+
+      const light = resolveIn(modes[0].id);
+      const dark = modes.some((mode) => mode.id === DARK_MODE) ? resolveIn(DARK_MODE) : light;
+
+      const lastDot = id.lastIndexOf(".");
+
+      return {
+        id,
+        group: id.slice(0, lastDot),
+        key: id.slice(lastDot + 1),
+        kind: light.kind,
+        label: stringifyValueLit(light),
+        ...(description && { description }),
+        ...paint(light, dark),
+      } satisfies TokenSearchEntry;
+    })
+    .sort((a, b) => a.id.localeCompare(b.id));
+}

--- a/docs/lib/token-search.test.ts
+++ b/docs/lib/token-search.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "bun:test";
+import {
+  matchTokens,
+  splitHighlights,
+  splitQueryTerms,
+  type TokenSearchEntry,
+  tokenReferenceHref,
+} from "./token-search";
+
+function entry(id: string, overrides: Partial<TokenSearchEntry> = {}): TokenSearchEntry {
+  const lastDot = id.lastIndexOf(".");
+  return {
+    id,
+    group: id.slice(0, lastDot),
+    key: id.slice(lastDot + 1),
+    kind: "ColorHexLit",
+    label: "#ffffff",
+    ...overrides,
+  };
+}
+
+const ENTRIES = [
+  entry("$color.bg.neutral"),
+  entry("$color.bg.neutral-solid", { description: "일반적인 콘텐츠에 사용되는 기본 배경입니다." }),
+  entry("$color.bg.neutral-weak"),
+  entry("$color.fg.neutral"),
+  entry("$color.manner-temp.l1.bg"),
+  entry("$color.palette.static-black-alpha-900"),
+  entry("$dimension.spacing.x4", { kind: "DimensionLit", label: "1rem (16px)" }),
+];
+
+const ids = (search: string) => matchTokens(ENTRIES, search).map(({ id }) => id);
+
+describe("matchTokens", () => {
+  it("returns nothing for a blank query", () => {
+    expect(matchTokens(ENTRIES, "   ")).toEqual([]);
+  });
+
+  it("puts an exact id first, however the separators were typed", () => {
+    expect(ids("$color.bg.neutral-solid")[0]).toBe("$color.bg.neutral-solid");
+    expect(ids("color bg neutral solid")[0]).toBe("$color.bg.neutral-solid");
+  });
+
+  it("ranks a last-segment match above tokens that only contain the query", () => {
+    expect(ids("neutral-weak")[0]).toBe("$color.bg.neutral-weak");
+  });
+
+  it("ranks the family a segment names above tokens ending in that segment", () => {
+    // "bg" is the group of `$color.bg.*` but merely the leaf of `$color.manner-temp.l1.bg`.
+    expect(ids("bg")).toEqual([
+      "$color.bg.neutral",
+      "$color.bg.neutral-weak",
+      "$color.bg.neutral-solid",
+      "$color.manner-temp.l1.bg",
+    ]);
+  });
+
+  it("matches a partial path spanning segments", () => {
+    expect(ids("bg.neutral")).toEqual([
+      "$color.bg.neutral",
+      "$color.bg.neutral-weak",
+      "$color.bg.neutral-solid",
+    ]);
+  });
+
+  it("keeps a group together once one of its tokens ranks, without moving the top hit", () => {
+    // `$color.fg.neutral` alone would rank between the two `$color.bg` tokens; grouping
+    // pulls it out so the tiles don't alternate between swatch and chip.
+    expect(ids("neutral")).toEqual([
+      "$color.bg.neutral",
+      "$color.bg.neutral-weak",
+      "$color.bg.neutral-solid",
+      "$color.fg.neutral",
+    ]);
+  });
+
+  it("matches terms in any order", () => {
+    expect(ids("solid neutral")).toEqual(["$color.bg.neutral-solid"]);
+  });
+
+  it("falls back to the Korean description", () => {
+    expect(ids("배경")).toEqual(["$color.bg.neutral-solid"]);
+  });
+
+  it("prefers the id over the description when both match", () => {
+    expect(ids("neutral")[0]).toBe("$color.bg.neutral");
+  });
+
+  it("returns every match so the section can reveal the rest on demand", () => {
+    expect(ids("color")).toHaveLength(6);
+  });
+
+  it("ignores tokens nothing in the query points at", () => {
+    expect(ids("radius")).toEqual([]);
+  });
+});
+
+describe("splitQueryTerms", () => {
+  it("splits on every separator a token id can contain", () => {
+    expect(splitQueryTerms("$color.bg.neutral-solid")).toEqual(["color", "bg", "neutral", "solid"]);
+  });
+
+  it("returns nothing for separators alone", () => {
+    expect(splitQueryTerms(" .-. ")).toEqual([]);
+  });
+});
+
+describe("splitHighlights", () => {
+  it("marks each term and leaves the separators between them plain", () => {
+    expect(splitHighlights("$color.bg.neutral-solid", ["bg", "neutral"])).toEqual([
+      { text: "$color.", match: false },
+      { text: "bg", match: true },
+      { text: ".", match: false },
+      { text: "neutral", match: true },
+      { text: "-solid", match: false },
+    ]);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(splitHighlights("Action Button", ["button"])).toEqual([
+      { text: "Action ", match: false },
+      { text: "Button", match: true },
+    ]);
+  });
+
+  it("keeps the text whole when there are no terms", () => {
+    expect(splitHighlights("$radius.r3", [])).toEqual([{ text: "$radius.r3", match: false }]);
+  });
+
+  it("treats a term with regex syntax as literal text", () => {
+    expect(splitHighlights("a+b", ["a+"])).toEqual([
+      { text: "a+", match: true },
+      { text: "b", match: false },
+    ]);
+  });
+});
+
+describe("tokenReferenceHref", () => {
+  it("encodes the `$` so the id survives as a single path segment", () => {
+    expect(tokenReferenceHref("$color.bg.neutral-solid")).toBe(
+      "/foundations/design-token/reference/%24color.bg.neutral-solid",
+    );
+  });
+});

--- a/docs/lib/token-search.ts
+++ b/docs/lib/token-search.ts
@@ -1,0 +1,138 @@
+/** Static JSON index built by `app/api/token-search/route.ts`. */
+export const TOKEN_SEARCH_API = "/api/token-search";
+
+const TOKEN_REFERENCE_URL = "/foundations/design-token/reference";
+
+export const tokenReferenceHref = (id: string) =>
+  `${TOKEN_REFERENCE_URL}/${encodeURIComponent(id)}`;
+
+/** How many tiles the token section shows before it offers to reveal the rest. */
+export const TOKEN_RESULT_LIMIT = 12;
+
+/** CSS for the preview box, per theme. Non-color collections repeat one value. */
+export interface ThemedCss {
+  light: string;
+  dark: string;
+}
+
+/**
+ * One design token, flattened at build time so the search dialog never pulls
+ * `@seed-design/rootage-core` (and the alias resolution it does) into the page bundle.
+ */
+export interface TokenSearchEntry {
+  /** Full id, e.g. `$color.bg.neutral-solid`. */
+  id: string;
+  /** Everything before the last segment, e.g. `$color.bg`. */
+  group: string;
+  /** Last segment, e.g. `neutral-solid`. */
+  key: string;
+  /** Resolved value's `AST.ValueLit` kind — picks the glyph when there's no preview. */
+  kind: string;
+  /** Resolved value as text, e.g. `#1a1c20`, `1rem (16px)`, `300ms`. */
+  label: string;
+  description?: string;
+  /** `background` for color and gradient tokens. */
+  background?: ThemedCss;
+  /** `box-shadow` for shadow tokens. */
+  boxShadow?: ThemedCss;
+}
+
+/**
+ * `$color.bg.neutral-solid` → `color bg neutral solid`. Token ids mix `.` and `-` as
+ * separators, so flattening both to spaces lets one query shape match however the user
+ * happened to type it (`bg.neutral`, `bg neutral`, `bg-neutral`).
+ */
+const normalize = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/[$.\-_/\s]+/g, " ")
+    .trim();
+
+export const splitQueryTerms = (search: string) => normalize(search).split(" ").filter(Boolean);
+
+/**
+ * Higher is better; 0 drops the token. The tiers go from "the user typed this exact
+ * token" down to "only the Korean description mentions it", so a paste of a full id
+ * always wins over the hundred tokens that merely share its prefix.
+ */
+function scoreEntry(entry: TokenSearchEntry, query: string, terms: string[]) {
+  const id = normalize(entry.id);
+  if (id === query) return 1000;
+
+  // Normalization leaves the segments space-separated, so padding both sides turns
+  // "lands on a segment boundary" into a plain substring test. Within a tier an earlier
+  // hit wins, because a query that names a segment near the front names a whole family
+  // (`bg` → `$color.bg.*`) rather than one token's leaf (`$color.manner-temp.l1.bg`).
+  const padded = ` ${id} `;
+
+  const wholeSegments = padded.indexOf(` ${query} `);
+  if (wholeSegments >= 0) return 900 - Math.min(wholeSegments, 50);
+
+  const segmentStart = padded.indexOf(` ${query}`);
+  if (segmentStart >= 0) return 700 - Math.min(segmentStart, 50);
+
+  if (id.includes(query)) return 400;
+  if (terms.every((term) => id.includes(term))) return 200;
+
+  const description = entry.description?.toLowerCase();
+  if (description && terms.every((term) => description.includes(term))) return 100;
+
+  return 0;
+}
+
+export function matchTokens(entries: TokenSearchEntry[], search: string) {
+  const query = normalize(search);
+  if (!query) return [];
+
+  const terms = query.split(" ");
+
+  const ranked = entries
+    .map((entry) => ({ entry, score: scoreEntry(entry, query, terms) }))
+    .filter(({ score }) => score > 0)
+    // Within a tier the shorter id is the more general token (`$color.bg.neutral` before
+    // `$color.bg.neutral-solid`), which is the one people usually mean.
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        a.entry.id.length - b.entry.id.length ||
+        a.entry.id.localeCompare(b.entry.id),
+    )
+    .map(({ entry }) => entry);
+
+  // Tokens in a group share a preview shape, so a relevance-interleaved list makes the
+  // grid flicker between swatches, chips and rules. Cluster them, ordering the groups by
+  // where their best match landed — the top result is still whatever ranked first, it
+  // just brings its siblings along.
+  const groups = new Map<string, TokenSearchEntry[]>();
+  for (const entry of ranked) {
+    const group = groups.get(entry.group);
+    if (group) group.push(entry);
+    else groups.set(entry.group, [entry]);
+  }
+
+  return [...groups.values()].flat();
+}
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * Cut `text` into alternating plain and matched chunks so the caller can mark the parts
+ * the query hit — the same treatment fumadocs gives document results, except the terms
+ * are matched here rather than arriving pre-wrapped in `<mark>`.
+ *
+ * Terms come from the normalized query, so they never span a separator; matching them
+ * against the raw text highlights each segment the user typed and leaves the `.`/`-`
+ * between them alone.
+ */
+export function splitHighlights(text: string, terms: string[]) {
+  if (terms.length === 0) return [{ text, match: false }];
+
+  return (
+    text
+      .split(new RegExp(`(${terms.map(escapeRegExp).join("|")})`, "gi"))
+      // `split` with one capture group interleaves plain text and matches, so the odd
+      // slots are the hits.
+      .map((chunk, index) => ({ text: chunk, match: index % 2 === 1 }))
+      .filter((chunk) => chunk.text !== "")
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 검색 대화상자에서 디자인 토큰을 함께 검색할 수 있습니다.
  - 토큰 결과에 미리보기, 검색어 하이라이트, 설명, 참조 페이지 링크를 제공합니다.
  - 검색 결과가 많을 경우 더 보기 및 접기 기능을 지원합니다.
  - 라이트·다크 테마에 맞는 색상, 그라디언트, 그림자 미리보기를 표시합니다.
  - 토큰 종류를 나타내는 아이콘을 제공합니다.

- **개선 사항**
  - 토큰 검색 결과를 일반 검색 결과보다 먼저 표시합니다.
  - 토큰 참조 링크 이동과 새 탭 열기 동작을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->