### PR TITLE
fix(docs): index FigmaImage alt and label search result sources

### DIFF
--- a/docs/app/source.tsx
+++ b/docs/app/source.tsx
@@ -84,7 +84,6 @@ const filterStructureElement: NonNullable<LLMsOptions["filterElement"]> = (node)
     case "File":
     case "Callout":
     case "Card":
-    case "FigmaImage":
     case "DoImage":
     case "DontImage":
       return true;
@@ -94,28 +93,49 @@ const filterStructureElement: NonNullable<LLMsOptions["filterElement"]> = (node)
   }
 };
 
+/** `mdast-util-mdx-jsx`와 같은 규칙으로 속성값을 이스케이프합니다. */
+const escapeMdxAttributeValue = (value: string) => value.replace(/"/g, "&#x22;");
+
 const structureStringify: NonNullable<StructureOptions["stringify"]> = {
   filterElement: filterStructureElement,
   filterMdxAttributes(node, attribute) {
     if (attribute.type !== "mdxJsxAttribute") return false;
 
-    if (node.name === "FigmaImage" || node.name === "DoImage" || node.name === "DontImage") {
+    if (node.name === "DoImage" || node.name === "DontImage") {
       return attribute.name !== "src";
     }
 
     return true;
   },
+  // stringify는 handlers보다 먼저 불리므로, FigmaImage에서 온 이미지만 원래 컴포넌트
+  // 형태로 갈라지고 나머지 이미지는 아래 image handler로 넘어간다.
+  stringify(node) {
+    // remarkFigmaImage가 remarkStructure보다 먼저 <FigmaImage>를 mdast image로 치환한다.
+    // 다른 커스텀 컴포넌트와 같은 JSX 형태로 되살려야 검색 결과에서 출처를 표시할 수 있다.
+    if (node.type !== "image" || !node.data?.figmaImage || !node.alt) return undefined;
+
+    return `<FigmaImage alt="${escapeMdxAttributeValue(node.alt)}" />`;
+  },
+  handlers: {
+    // Fumadocs 기본 stringifier는 이미지를 빈 문자열로 만들어 alt를 통째로 버린다. 문서의
+    // 이미지 alt는 그 이미지를 설명하는 유일한 텍스트라, 검색 결과에서 출처를 알아볼 수
+    // 있도록 커스텀 컴포넌트와 같은 태그 형태로 남긴다.
+    image: (node) => (node.alt ? `<img alt="${escapeMdxAttributeValue(node.alt)}" />` : ""),
+  },
 };
 
 const structureOptions: StructureOptions = {
   mdxTypes(node) {
+    // Card는 children이 이미 각자 별도 row로 색인되고, 검색 결과의 URL은 카드가 놓인 페이지라
+    // 카드가 가리키는 문서로 데려가지도 못한다. 검색에서만 제외하며 llms.txt에는 그대로 남는다
+    // (mdxTypes는 remarkStructure 전용, filterElement는 remarkLlms와 공유).
+    if ("name" in node && node.name === "Card") return false;
     if (!("children" in node) || node.children.length === 0) return true;
     if (!("name" in node)) return false;
 
     switch (node.name) {
       case "TypeTable":
       case "Callout":
-      case "Card":
         return true;
       default:
         return false;

--- a/docs/components/callout.tsx
+++ b/docs/components/callout.tsx
@@ -1,22 +1,26 @@
 import { Callout as SeedSnippetCallout } from "seed-design/ui/callout";
 import clsx from "clsx";
-import type { ReactNode } from "react";
+import type { CalloutType } from "fumadocs-ui/components/callout";
+import type { ComponentProps, ReactNode } from "react";
+import { match } from "ts-pattern";
 
-type FumadocsCalloutType = "info" | "warn" | "warning" | "error" | "success" | "idea";
-type SeedTone = "neutral" | "informative" | "positive" | "warning" | "critical" | "magic";
+type SeedTone = NonNullable<ComponentProps<typeof SeedSnippetCallout>["tone"]>;
 
-/** Map Fumadocs callout `type` to a SEED Callout `tone`. */
-const TONE_BY_TYPE: Record<FumadocsCalloutType, SeedTone> = {
-  info: "informative",
-  warn: "warning",
-  warning: "warning",
-  error: "critical",
-  success: "positive",
-  idea: "magic",
-};
+/**
+ * Map Fumadocs callout `type` to a SEED Callout `tone`. A type added upstream fails the build
+ * here, and an MDX author's typo — MDX isn't type-checked — throws during the static export.
+ */
+const toneOf = (type: CalloutType) =>
+  match<CalloutType, SeedTone>(type)
+    .with("info", () => "informative")
+    .with("warn", "warning", () => "warning")
+    .with("error", () => "critical")
+    .with("success", () => "positive")
+    .with("idea", () => "magic")
+    .exhaustive();
 
 interface CalloutProps {
-  type?: FumadocsCalloutType;
+  type?: CalloutType;
   title?: ReactNode;
   /** Accepted for Fumadocs MDX compat; SEED conveys meaning through `tone`. */
   icon?: ReactNode;
@@ -31,7 +35,7 @@ interface CalloutProps {
 export function Callout({ type = "info", title, className, children }: CalloutProps) {
   return (
     <SeedSnippetCallout
-      tone={TONE_BY_TYPE[type] ?? "neutral"}
+      tone={toneOf(type)}
       title={title}
       description={children}
       className={clsx("my-4", className)}

--- a/docs/components/figma-image/remark-figma-image.ts
+++ b/docs/components/figma-image/remark-figma-image.ts
@@ -9,6 +9,17 @@ import { extractFigmaId, FIGMA_ID_PROP_SUPPORTED_COMPONENTS } from "./collect-fi
 import { type FigmaImageManifest, getFigmaImageUrlsFromManifest } from "./figma-image-manifest";
 import { resolveFigmaImageUrls } from "./resolve-figma-image-urls";
 
+declare module "mdast" {
+  interface ImageData {
+    /**
+     * `<FigmaImage>`를 치환해 만든 이미지라는 표시입니다. 검색 색인(`remarkStructure`)은
+     * 이 플러그인 뒤에 돌면서 image를 빈 문자열로 직렬화하므로, 이 표시를 보고 원래
+     * 컴포넌트 형태를 되살려야 `alt`가 색인에 남습니다 (app/source.tsx).
+     */
+    figmaImage?: true;
+  }
+}
+
 const DEFAULT_IMAGE_SIZE = {
   width: 1080,
   height: 720,
@@ -167,6 +178,7 @@ export function remarkFigmaImage({
           url,
           alt: typeof altAttr.value === "string" ? altAttr.value : "",
           data: {
+            figmaImage: true,
             // 실제 크기는 아니지만 Next.js Image를 통해 레이아웃 이동을 방지합니다.
             hProperties: DEFAULT_IMAGE_SIZE,
           },

--- a/docs/components/search/mdx-tag.test.ts
+++ b/docs/components/search/mdx-tag.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test";
+import { decodeCharacterReferences, parseMdxTag } from "./mdx-tag";
+
+describe("parseMdxTag", () => {
+  it("parses a self-closing tag with attributes", () => {
+    expect(parseMdxTag('<DoImage alt="나란히 배치한 예시" body="나란히 쓸 수 있어요." />')).toEqual(
+      {
+        name: "DoImage",
+        attributes: [
+          { name: "alt", value: "나란히 배치한 예시" },
+          { name: "body", value: "나란히 쓸 수 있어요." },
+        ],
+        children: "",
+      },
+    );
+  });
+
+  it("parses a tag with children across multiple lines", () => {
+    expect(
+      parseMdxTag('<Card title="Foundations" href="/foundations">\n  토큰과 원칙.\n</Card>'),
+    ).toEqual({
+      name: "Card",
+      attributes: [
+        { name: "title", value: "Foundations" },
+        { name: "href", value: "/foundations" },
+      ],
+      children: "토큰과 원칙.",
+    });
+  });
+
+  it("parses a tag with no attributes", () => {
+    expect(parseMdxTag("<Callout>\n  © 2025 Daangn Market.\n</Callout>")).toEqual({
+      name: "Callout",
+      attributes: [],
+      children: "© 2025 Daangn Market.",
+    });
+  });
+
+  it("decodes character references inside attribute values", () => {
+    expect(parseMdxTag('<File name="&#x22;a&#x22;.log" />')?.attributes).toEqual([
+      { name: "name", value: '"a".log' },
+    ]);
+  });
+
+  it("keeps a value-less boolean attribute", () => {
+    expect(parseMdxTag("<Callout inline>본문</Callout>")?.attributes).toEqual([
+      { name: "inline", value: "" },
+    ]);
+  });
+
+  it("returns null for plain prose", () => {
+    expect(parseMdxTag("Elevation은 UI 요소 간의 깊이를 표현합니다.")).toBeNull();
+  });
+
+  it("parses the lowercase `img` tag the index carries for Markdown images", () => {
+    expect(parseMdxTag('<img alt="당근 로고를 UI 형태로 옮긴 디자인 요소" />')).toEqual({
+      name: "img",
+      attributes: [{ name: "alt", value: "당근 로고를 UI 형태로 옮긴 디자인 요소" }],
+      children: "",
+    });
+  });
+
+  it("returns null for other lowercase HTML tags, including highlight wrappers", () => {
+    expect(parseMdxTag("<mark>Button</mark>")).toBeNull();
+    expect(parseMdxTag('<meta name="viewport" />')).toBeNull();
+  });
+
+  // JSX written inside a code block must not be labelled as a component result.
+  it("returns null when the tag is only part of the content", () => {
+    expect(
+      parseMdxTag("```tsx\n<DialogRoot open>\n  <DialogContent />\n</DialogRoot>\n```"),
+    ).toBeNull();
+    expect(parseMdxTag('<File name="a.log" />\n\n뒤따르는 문단.')).toBeNull();
+  });
+
+  it("returns null for a malformed opening tag", () => {
+    expect(parseMdxTag('<File name="unterminated />')).toBeNull();
+  });
+});
+
+describe("decodeCharacterReferences", () => {
+  it("decodes hexadecimal, decimal, and named references", () => {
+    expect(decodeCharacterReferences("&#x2A;*강조**")).toBe("**강조**");
+    expect(decodeCharacterReferences("&#42;")).toBe("*");
+    expect(decodeCharacterReferences("&amp;&lt;&gt;&quot;")).toBe('&<>"');
+  });
+
+  it("leaves unknown and out-of-range references untouched", () => {
+    expect(decodeCharacterReferences("&nbsp;")).toBe("&nbsp;");
+    expect(decodeCharacterReferences("&#x110000;")).toBe("&#x110000;");
+  });
+});

--- a/docs/components/search/mdx-tag.ts
+++ b/docs/components/search/mdx-tag.ts
@@ -1,0 +1,102 @@
+/**
+ * A custom MDX component as it survives into the search index. `remarkStructure` serializes
+ * page content to Markdown and leaves whitelisted components as raw JSX (see
+ * `structureStringify` in app/source.tsx), so naming the source component in a result row
+ * means parsing that JSX back out.
+ */
+export interface MdxTag {
+  name: string;
+  attributes: { name: string; value: string }[];
+  children: string;
+}
+
+const NAMED_CHARACTER_REFERENCES = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  quot: '"',
+} as const satisfies Record<string, string>;
+
+/**
+ * Undo the character references Markdown serialization leaves behind: `mdast-util-to-markdown`
+ * writes a `"` inside an attribute value as `&#x22;`, and a `*` that would otherwise read as
+ * emphasis as `&#x2A;`.
+ */
+export function decodeCharacterReferences(value: string): string {
+  return value.replace(/&(?:#(\d+)|#x([0-9a-f]+)|([a-z]+));/gi, (match, decimal, hex, name) => {
+    if (name) {
+      const key = name.toLowerCase() as keyof typeof NAMED_CHARACTER_REFERENCES;
+      return NAMED_CHARACTER_REFERENCES[key] ?? match;
+    }
+
+    const code = decimal ? Number(decimal) : Number.parseInt(hex, 16);
+    return code <= 0x10ffff ? String.fromCodePoint(code) : match;
+  });
+}
+
+/** Read the opening tag's attributes and return the offset just past it, or `null` if malformed. */
+function readOpeningTag(source: string, start: number) {
+  const attributes: MdxTag["attributes"] = [];
+  let cursor = start;
+
+  while (cursor < source.length) {
+    while (/\s/.test(source[cursor])) cursor++;
+
+    if (source.startsWith("/>", cursor)) return { attributes, end: cursor + 2, selfClosing: true };
+    if (source[cursor] === ">") return { attributes, end: cursor + 1, selfClosing: false };
+
+    const name = /^[A-Za-z_][A-Za-z0-9_.:-]*/.exec(source.slice(cursor))?.[0];
+    if (!name) return null;
+
+    cursor += name.length;
+
+    // Boolean attribute — a bare name with no value.
+    if (source[cursor] !== "=") {
+      attributes.push({ name, value: "" });
+      continue;
+    }
+
+    const quote = source[cursor + 1];
+    if (quote !== '"' && quote !== "'") return null;
+
+    const closing = source.indexOf(quote, cursor + 2);
+    if (closing === -1) return null;
+
+    attributes.push({ name, value: decodeCharacterReferences(source.slice(cursor + 2, closing)) });
+    cursor = closing + 1;
+  }
+
+  return null;
+}
+
+/**
+ * Only parse content that is a single MDX component tag end to end. Anything outside the tag
+ * returns `null`, which keeps JSX written inside a code block from being read as a component.
+ */
+export function parseMdxTag(content: string): MdxTag | null {
+  const source = content.trim();
+  // MDX components are capitalized. `img` is the one lowercase tag the index carries, emitted
+  // for Markdown images by the same `structureStringify`; naming it keeps the highlighter's
+  // own `<mark>` wrappers from reading as a component.
+  const name = /^<(img|[A-Z][A-Za-z0-9]*)(?=[\s/>])/.exec(source)?.[1];
+  if (!name) return null;
+
+  const opening = readOpeningTag(source, name.length + 1);
+  if (!opening) return null;
+
+  if (opening.selfClosing) {
+    if (opening.end !== source.length) return null;
+
+    return { name, attributes: opening.attributes, children: "" };
+  }
+
+  const closingTag = `</${name}>`;
+  if (!source.endsWith(closingTag)) return null;
+
+  return {
+    name,
+    attributes: opening.attributes,
+    children: source.slice(opening.end, source.length - closingTag.length).trim(),
+  };
+}

--- a/docs/components/search/search-result-item.tsx
+++ b/docs/components/search/search-result-item.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import clsx from "clsx";
+import type { CalloutType } from "fumadocs-ui/components/callout";
 import type { SearchItemType } from "fumadocs-ui/components/dialog/search";
 import { useSearchList } from "fumadocs-ui/components/dialog/search";
 import { type ReactNode, type Ref, useEffect, useRef } from "react";
 import { ListButtonItem, ListLinkItem } from "seed-design/ui/list";
 import { sectionLabel } from "@/lib/docs-sections";
+import { decodeCharacterReferences, type MdxTag, parseMdxTag } from "./mdx-tag";
 
 /**
  * fumadocs wraps the matched query terms in `<mark>…</mark>` inside the result content
@@ -18,11 +21,101 @@ function renderContent(content: ReactNode): ReactNode {
   return content.split(/<mark>(.*?)<\/mark>/g).map((chunk, i) =>
     i % 2 === 1 ? (
       <mark key={`${i}-${chunk}`} className="bg-[var(--selection-bg)] text-[var(--selection-fg)]">
-        {chunk}
+        {decodeCharacterReferences(chunk)}
       </mark>
     ) : (
-      chunk
+      decodeCharacterReferences(chunk)
     ),
+  );
+}
+
+/** Props whose value isn't prose. Still indexed, so they keep matching — just not shown. */
+const NON_CONTENT_ATTRIBUTES = ["href", "src", "id", "figmaId", "type"];
+
+/**
+ * SEED Badge's `tone=neutral` pairing. The alpha fill rather than plain `bg-neutral-weak`:
+ * a row lightens under hover/keyboard focus, and an opaque fill stays put — dropping the
+ * badge's contrast against its own row to ~1.04, with no hue left to tell them apart.
+ */
+const NEUTRAL_BADGE = "bg-bg-neutral-weak-alpha text-fg-neutral-muted";
+
+/**
+ * One badge per Fumadocs callout type, mirroring the SEED tone `components/callout.tsx` maps
+ * each one to. Keyed off the upstream union, so a type added there breaks this table.
+ */
+const CALLOUT_BADGE = {
+  info: { label: "안내", className: "bg-bg-informative-weak text-fg-informative-contrast" },
+  warn: { label: "주의", className: "bg-bg-warning-weak text-fg-warning-contrast" },
+  warning: { label: "주의", className: "bg-bg-warning-weak text-fg-warning-contrast" },
+  error: { label: "경고", className: "bg-bg-critical-weak text-fg-critical-contrast" },
+  success: { label: "확인", className: "bg-bg-positive-weak text-fg-positive-contrast" },
+  idea: { label: "팁", className: NEUTRAL_BADGE },
+} as const satisfies Record<CalloutType, { label: string; className: string }>;
+
+const isCalloutType = (value: string): value is CalloutType => value in CALLOUT_BADGE;
+
+function calloutBadge(attributes: MdxTag["attributes"]) {
+  // The index carries plain strings. `components/callout.tsx` already throws on a type Fumadocs
+  // doesn't know, and every indexed page is rendered through it during the static export — so a
+  // value arriving here that isn't one means that guard was bypassed, not that content is wrong.
+  const type = attributes.find(({ name }) => name === "type")?.value ?? "info";
+  if (!isCalloutType(type)) throw new Error(`Unknown Callout type in the search index: ${type}`);
+
+  return CALLOUT_BADGE[type];
+}
+
+/**
+ * Names the block a result came from in the reader's terms rather than the component's, and
+ * borrows that block's own colors — Do/Don't from the guideline images, Callout from the
+ * Callout recipe's tones.
+ */
+function tagBadge({ name, attributes }: MdxTag) {
+  switch (name) {
+    case "DoImage":
+      return { label: "Do", className: "bg-bg-positive-weak text-fg-positive-contrast" };
+    case "DontImage":
+      return { label: "Don’t", className: "bg-bg-critical-weak text-fg-critical-contrast" };
+    case "Callout":
+      return calloutBadge(attributes);
+    case "FigmaImage":
+    case "img":
+      return { label: "이미지", className: NEUTRAL_BADGE };
+    case "File":
+      return { label: "파일", className: NEUTRAL_BADGE };
+    default:
+      // Surfaces a component that got indexed without being given a badge here.
+      return { label: name, className: NEUTRAL_BADGE };
+  }
+}
+
+/**
+ * Title for a result that came from a custom MDX component: a badge for the block it sits in,
+ * then its attribute values and children at normal body size. Follows how fumadocs' own search
+ * dialog (`SearchDialogListItem`'s `custom` renderer) marks up unknown tags.
+ */
+function MdxTagTitle({ tag }: { tag: MdxTag }) {
+  const { label, className } = tagBadge(tag);
+  const body = [
+    ...tag.attributes
+      .filter(({ name }) => !NON_CONTENT_ATTRIBUTES.includes(name))
+      .map(({ value }) => value),
+    tag.children,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <>
+      <span
+        className={clsx(
+          "me-1.5 rounded-md px-1.5 py-0.5 align-[0.1em] text-xs font-medium",
+          className,
+        )}
+      >
+        {label}
+      </span>
+      {renderContent(body)}
+    </>
   );
 }
 
@@ -61,11 +154,14 @@ export function SearchResultItem({ item, onClick }: { item: SearchItemType; onCl
     );
   }
 
+  // Custom MDX components survive into the index as raw JSX (see app/source.tsx).
+  const tag = typeof item.content === "string" ? parseMdxTag(item.content) : null;
+
   return (
     <ListLinkItem
       ref={ref as Ref<HTMLAnchorElement>}
       href={item.url}
-      title={renderContent(item.content)}
+      title={tag ? <MdxTagTitle tag={tag} /> : renderContent(item.content)}
       // The static advanced index has no breadcrumbs, so derive the section from the URL.
       detail={sectionLabel(item.url) || undefined}
       onClick={(e) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 검색 결과에서 MDX 컴포넌트의 유형, 속성, 콘텐츠가 더 명확하게 표시됩니다.
  - 검색 결과의 제목과 본문에서 문자 참조가 올바르게 해석됩니다.
  - Figma 이미지는 전용 이미지 형식으로, 일반 이미지는 대체 텍스트를 유지한 형태로 처리됩니다.
  - Callout 유형별 라벨과 스타일이 검색 결과에 반영됩니다.

- **개선 사항**
  - 다양한 MDX 태그와 이미지 콘텐츠의 검색 및 표시 호환성이 향상되었습니다.
  - 지원되지 않는 Callout 유형은 보다 명확하게 식별됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->