### PR TITLE
fix(docs): layer the search dialog above landing chrome and match the scroll-lock gap

### DIFF
--- a/docs/components/landing/landing-header.tsx
+++ b/docs/components/landing/landing-header.tsx
@@ -87,7 +87,10 @@ export function LandingHeader({ variant, tone }: { variant: HeaderVariant; tone:
     <>
       <header
         className={clsx(
-          "fixed inset-x-0 top-0 z-[1000]",
+          // `right`: same scroll-lock trim the footer compensates for (see section-footer) —
+          // <body> narrows by the removed scrollbar width while this fixed bar does not, which
+          // would slide the right-hand actions out of line with the page under them.
+          "fixed inset-x-0 right-[var(--removed-body-scroll-bar-size,0px)] top-0 z-[1000]",
           LANDING_LIGHT_ONLY_COLOR_BRIDGE,
           `transition-transform ${EASE_DUR} motion-reduce:transition-none`,
           isHidden ? "-translate-y-full pointer-events-none" : "translate-y-0",

--- a/docs/components/landing/sections/section-footer.tsx
+++ b/docs/components/landing/sections/section-footer.tsx
@@ -44,7 +44,13 @@ export function SectionFooter() {
     <footer
       id="footer"
       data-section="footer"
-      className="relative flex w-full flex-col gap-8 overflow-hidden bg-palette-carrot-600 py-8 text-fg-neutral md:fixed md:inset-x-0 md:bottom-0 md:z-0 md:gap-14 md:py-12"
+      // md+ `right`: while a modal (search) locks scroll, react-remove-scroll drops the page
+      // scrollbar and trims <body> by its width, so every in-flow section narrows — but this
+      // footer is viewport-fixed and widens instead. As the bottom-most layer it then bleeds
+      // carrot into the strip the scrollbar vacated, so match the trim. The variable only
+      // exists while locked; mobile is in normal flow, where `right` would shift the box.
+      // `w-auto` goes with it — `w-full` over-constrains the box and `right` gets dropped.
+      className="relative flex w-full flex-col gap-8 overflow-hidden bg-palette-carrot-600 py-8 text-fg-neutral md:fixed md:inset-x-0 md:right-[var(--removed-body-scroll-bar-size,0px)] md:bottom-0 md:z-0 md:w-auto md:gap-14 md:py-12"
     >
       <div className="mx-auto flex w-full max-w-[1760px] flex-col gap-8 px-spacing-x-global-gutter md:flex-row md:justify-between md:gap-12 md:px-12">
         <div className="flex flex-col gap-3">

--- a/docs/components/search/search.tsx
+++ b/docs/components/search/search.tsx
@@ -51,6 +51,15 @@ const searchDatabase = create({
 
 const initSearchDatabase = () => searchDatabase;
 
+/**
+ * fumadocs ships the dialog at `z-50`. The docs header (`z-40`) sits under that, but the
+ * landing chrome does not: its header is `z-[1000]` and the mobile nav panel resolves to
+ * 1200 (`--side-panel-z-index: 1100` + `--layer-index: 100`), so both painted over the
+ * dialog. Search is the site's topmost modal, so it clears the whole ladder — only the
+ * landing custom cursor (`z-[100000]`) stays above it.
+ */
+const DIALOG_LAYER_CLASS_NAME = "z-[1300]";
+
 /** Search input rendered as a standalone pill above the results card (see mockup). */
 export const SEARCH_INPUT_PILL_CLASS_NAME =
   "flex items-center gap-3 rounded-full border border-stroke-neutral-muted bg-bg-layer-floating py-[19.5px] pl-6 pr-4 focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-stroke-focus-ring max-md:py-[14px]";
@@ -121,9 +130,12 @@ export default function DefaultSearchDialog({
 
   return (
     <SearchDialog search={search} onSearchChange={setSearch} isLoading={query.isLoading} {...props}>
-      <SearchDialogOverlay className="!bg-bg-overlay !backdrop-blur-none" />
+      <SearchDialogOverlay
+        className={clsx(DIALOG_LAYER_CLASS_NAME, "!bg-bg-overlay !backdrop-blur-none")}
+      />
       <SearchDialogContent
         className={clsx(
+          DIALOG_LAYER_CLASS_NAME,
           // Strip fumadocs' single-panel chrome so the pill + card render as two separate
           // surfaces; the inner wrapper below keeps them as one child (avoids the
           // between-children border rule) and stacks them with a gap.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 스크롤 잠금 시 랜딩 페이지의 고정 헤더와 데스크톱 푸터 위치가 올바르게 보정됩니다.
  * 검색 다이얼로그와 오버레이가 헤더 및 모바일 패널 위에 정상적으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->