### PR TITLE
fix(docs): wrap long tokens in search rows and index container bodies once

### DIFF
--- a/docs/app/source.tsx
+++ b/docs/app/source.tsx
@@ -3,7 +3,6 @@ import { localMd, type SatteriLocalMarkdown } from "@fumadocs/satteri/local-md";
 import { watchWithDevServer } from "@fumadocs/satteri/local-md/dev/ws";
 import { remarkAutoTypeTable } from "@fumadocs/satteri/remark-auto-type-table";
 import { remarkLlms, type LLMsOptions } from "@fumadocs/satteri/remark-llms";
-import type { StructureOptions } from "@fumadocs/satteri/remark-structure";
 import type { SatteriPresetOptions } from "@fumadocs/satteri/preset";
 import { dynamicLoader } from "fumadocs-core/source/dynamic";
 import {
@@ -24,6 +23,11 @@ import { markFeatured } from "@/lib/featured";
 import { COVER_IMAGE_PATH_ERROR_MESSAGE, isValidCoverImagePath } from "@/lib/cover-image";
 import { remarkDocGen } from "@/lib/satteri/remark-doc-gen";
 import { remarkApplyLlmsFilter } from "@/lib/satteri/remark-llms-filter";
+import {
+  filterStructureElement,
+  structureOptions,
+  structureStringify,
+} from "@/lib/satteri/search-structure";
 import { markTabbedFolder, type TabbedFolderNode } from "@/lib/tabbed";
 import { updatesFrontmatterSchema } from "@/lib/updates-frontmatter";
 
@@ -78,75 +82,8 @@ const designSchema = baseDocsSchema.extend({
   ...headingSchema,
 });
 
-const filterStructureElement: NonNullable<LLMsOptions["filterElement"]> = (node) => {
-  if (node.type !== "mdxJsxFlowElement" && node.type !== "mdxJsxTextElement") return true;
-
-  switch (node.name) {
-    case "File":
-    case "Callout":
-    case "Card":
-    case "DoImage":
-    case "DontImage":
-      return true;
-    default:
-      // TypeTable의 거대한 type 속성과 UI 전용 컴포넌트 태그는 검색 본문에서 제외합니다.
-      return "children-only";
-  }
-};
-
 /** 검색 본문과 달리 llms.txt는 룰이 변환할 컴포넌트 태그를 그대로 넘겨받아야 합니다. */
 const filterLlmsElement = preserveRuleElements(filterStructureElement);
-
-/** `mdast-util-mdx-jsx`와 같은 규칙으로 속성값을 이스케이프합니다. */
-const escapeMdxAttributeValue = (value: string) => value.replace(/"/g, "&#x22;");
-
-const structureStringify: NonNullable<StructureOptions["stringify"]> = {
-  filterElement: filterStructureElement,
-  filterMdxAttributes(node, attribute) {
-    if (attribute.type !== "mdxJsxAttribute") return false;
-
-    if (node.name === "DoImage" || node.name === "DontImage") {
-      return attribute.name !== "src";
-    }
-
-    return true;
-  },
-  // stringify는 handlers보다 먼저 불리므로, FigmaImage에서 온 이미지만 원래 컴포넌트
-  // 형태로 갈라지고 나머지 이미지는 아래 image handler로 넘어간다.
-  stringify(node) {
-    // remarkFigmaImage가 remarkStructure보다 먼저 <FigmaImage>를 mdast image로 치환한다.
-    // 다른 커스텀 컴포넌트와 같은 JSX 형태로 되살려야 검색 결과에서 출처를 표시할 수 있다.
-    if (node.type !== "image" || !node.data?.figmaImage || !node.alt) return undefined;
-
-    return `<FigmaImage alt="${escapeMdxAttributeValue(node.alt)}" />`;
-  },
-  handlers: {
-    // Fumadocs 기본 stringifier는 이미지를 빈 문자열로 만들어 alt를 통째로 버린다. 문서의
-    // 이미지 alt는 그 이미지를 설명하는 유일한 텍스트라, 검색 결과에서 출처를 알아볼 수
-    // 있도록 커스텀 컴포넌트와 같은 태그 형태로 남긴다.
-    image: (node) => (node.alt ? `<img alt="${escapeMdxAttributeValue(node.alt)}" />` : ""),
-  },
-};
-
-const structureOptions: StructureOptions = {
-  mdxTypes(node) {
-    // Card는 children이 이미 각자 별도 row로 색인되고, 검색 결과의 URL은 카드가 놓인 페이지라
-    // 카드가 가리키는 문서로 데려가지도 못한다. 검색에서만 제외하며 llms.txt에는 그대로 남는다
-    // (mdxTypes는 remarkStructure 전용, filterElement는 remarkLlms와 공유).
-    if ("name" in node && node.name === "Card") return false;
-    if (!("children" in node) || node.children.length === 0) return true;
-    if (!("name" in node)) return false;
-
-    switch (node.name) {
-      case "TypeTable":
-      case "Callout":
-        return true;
-      default:
-        return false;
-    }
-  },
-  stringify: structureStringify,
-};
 
 const llmsOptions: LLMsOptions = {
   as: "processed",

--- a/docs/components/search/row.tsx
+++ b/docs/components/search/row.tsx
@@ -7,9 +7,14 @@ import { Fragment, type ReactNode } from "react";
  * One row in the results card. The document results and the recent pages that stand in for
  * them take turns filling the same box, so they are measured and coloured the same way rather
  * than each bringing its own idea of what a row is.
+ *
+ * `wrap-anywhere` because a row prints whatever line the page held, and a regex or a shell
+ * command carries no space for the line breaker to work with. Left unbroken, one such row is
+ * wider than the box, and the box — scrollable on one axis — takes a horizontal scrollbar for
+ * it, dragging every other row sideways.
  */
 export const ROW_CLASS_NAME =
-  "relative block w-full select-none rounded-lg px-2.5 py-2 text-start text-sm text-fg-neutral";
+  "relative block w-full select-none rounded-lg px-2.5 py-2 text-start text-sm wrap-anywhere text-fg-neutral";
 
 /** The row's own ground when it is the one the reader is on. */
 export const ROW_ACTIVE_CLASS_NAME = "bg-bg-transparent-selected";

--- a/docs/content/react/components/(foundation)/typography/text.mdx
+++ b/docs/content/react/components/(foundation)/typography/text.mdx
@@ -73,7 +73,7 @@ Figma의 Text Style과 대응되는 `textStyle` 속성을 사용하는 것이 �
 
 `textDecorationLine` 속성을 사용하여 텍스트에 밑줄 또는 취소선을 추가할 수 있습니다.
 
-<Callout type="warning" title={"textDecorationLine=\"underline\"을 사용하기 전 읽어보기"}>
+<Callout type="warning" title='textDecorationLine="underline"을 사용하기 전 읽어보기'>
 
 - 링크가 아닌 텍스트를 강조하기 위해 밑줄을 적용할 때는 사용자 경험을 고려해야 합니다. 밑줄이 있는 텍스트는 링크로 인식될 수 있으므로, 혼동을 피하기 위해 적절한 상황에서만 사용해야 합니다.
 - 본문 밖 영역에서 인라인 텍스트를 링크 용도로 사용하고자 하는 경우 [ActionButton](/react/components/action-button)을 `variant="ghost" bleedX="asPadding" bleedY="asPadding"` 옵션으로 사용하는 것을 고려해보세요.

--- a/docs/lib/satteri/search-structure.test.ts
+++ b/docs/lib/satteri/search-structure.test.ts
@@ -65,6 +65,17 @@ describe("structureOptions", () => {
     ]);
   });
 
+  it("표현식으로 쓴 title도 row로 남긴다", async () => {
+    const contents = await structuredContents(
+      '<Callout type="warn" title={"확인 방법"}>\n\n본문 문단\n\n</Callout>',
+    );
+
+    expect(contents).toEqual([
+      { heading: undefined, content: '<Callout type="warn" title="&#x22;확인 방법&#x22;" />' },
+      { heading: undefined, content: "본문 문단" },
+    ]);
+  });
+
   it("Callout row가 안의 코드블록을 삼키지 않는다", async () => {
     const contents = await structuredContents(
       '<Callout type="info" title="확인 방법">\n\n```\ngit grep -E \'(A|B)\'\n```\n\n</Callout>',

--- a/docs/lib/satteri/search-structure.test.ts
+++ b/docs/lib/satteri/search-structure.test.ts
@@ -31,6 +31,11 @@ describe("structureOptions", () => {
     expect(contents).toEqual([{ heading: undefined, content: "본문 문단" }]);
   });
 
+  it("자식이 없는 Callout도 title이 없으면 row를 만들지 않는다", async () => {
+    expect(await structuredContents('<Callout type="info" />')).toEqual([]);
+    expect(await structuredContents('<Callout type="info"></Callout>')).toEqual([]);
+  });
+
   it("title 있는 Callout은 자식 없는 태그 row와 본문 row로 나뉜다", async () => {
     const contents = await structuredContents(
       '<Callout type="info" title="확인 방법">\n\n본문 문단\n\n</Callout>',

--- a/docs/lib/satteri/search-structure.test.ts
+++ b/docs/lib/satteri/search-structure.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { compileMdx } from "@fumadocs/satteri/compile";
+import { remarkStructure } from "@fumadocs/satteri/remark-structure";
+import { structureOptions } from "./search-structure";
+
+/**
+ * satteri의 remarkStructure는 row가 된 노드의 서브트리를 건너뛰지 않으므로, 컨테이너를 row로
+ * 잡으면 안의 문단이 같은 문장을 한 번 더 색인한다. 부분 일치로는 그 중복이 잡히지 않아
+ * `contents` 전체를 비교한다.
+ */
+async function structuredContents(source: string) {
+  const result = await compileMdx({
+    source,
+    filePath: "/tmp/doc.mdx",
+    options: { mdastPlugins: [remarkStructure(structureOptions)] },
+  });
+
+  return result.data.structuredData?.contents;
+}
+
+describe("structureOptions", () => {
+  it("blockquote를 row로 잡지 않아 안의 문단만 색인한다", async () => {
+    expect(await structuredContents("> 인용된 문장")).toEqual([
+      { heading: undefined, content: "인용된 문장" },
+    ]);
+  });
+
+  it("title 없는 Callout은 row를 만들지 않고 본문만 색인한다", async () => {
+    const contents = await structuredContents('<Callout type="info">\n\n본문 문단\n\n</Callout>');
+
+    expect(contents).toEqual([{ heading: undefined, content: "본문 문단" }]);
+  });
+
+  it("title 있는 Callout은 자식 없는 태그 row와 본문 row로 나뉜다", async () => {
+    const contents = await structuredContents(
+      '<Callout type="info" title="확인 방법">\n\n본문 문단\n\n</Callout>',
+    );
+
+    expect(contents).toEqual([
+      { heading: undefined, content: '<Callout type="info" title="확인 방법" />' },
+      { heading: undefined, content: "본문 문단" },
+    ]);
+  });
+
+  it("Callout 안의 리스트 항목이 각자 row가 되고 Callout row에 다시 실리지 않는다", async () => {
+    const contents = await structuredContents(
+      '<Callout type="warn" title="확인 방법">\n\n* 첫째 항목\n* 둘째 항목\n\n</Callout>',
+    );
+
+    expect(contents).toEqual([
+      { heading: undefined, content: '<Callout type="warn" title="확인 방법" />' },
+      { heading: undefined, content: "첫째 항목" },
+      { heading: undefined, content: "둘째 항목" },
+    ]);
+  });
+
+  it("title 안의 따옴표를 속성값으로 이스케이프한다", async () => {
+    const contents = await structuredContents(
+      "<Callout title='\"underline\"을 쓰기 전에'>\n\n본문 문단\n\n</Callout>",
+    );
+
+    expect(contents).toEqual([
+      { heading: undefined, content: '<Callout title="&#x22;underline&#x22;을 쓰기 전에" />' },
+      { heading: undefined, content: "본문 문단" },
+    ]);
+  });
+
+  it("Callout row가 안의 코드블록을 삼키지 않는다", async () => {
+    const contents = await structuredContents(
+      '<Callout type="info" title="확인 방법">\n\n```\ngit grep -E \'(A|B)\'\n```\n\n</Callout>',
+    );
+
+    expect(contents).toEqual([
+      { heading: undefined, content: '<Callout type="info" title="확인 방법" />' },
+    ]);
+  });
+});

--- a/docs/lib/satteri/search-structure.ts
+++ b/docs/lib/satteri/search-structure.ts
@@ -99,17 +99,12 @@ export const structureOptions: StructureOptions = {
     // 카드가 가리키는 문서로 데려가지도 못한다. 검색에서만 제외하며 llms.txt에는 그대로 남는다
     // (mdxTypes는 remarkStructure 전용, filterElement는 remarkLlms와 공유).
     if ("name" in node && node.name === "Card") return false;
+    // 아래 빈-자식 규칙보다 먼저 물어야 한다. 자기 닫는 `<Callout />`은 그 규칙에 걸려 row가
+    // 되고, 남길 title이 없으니 글자 없는 배지 하나짜리 row로 남는다.
+    if ("name" in node && node.name === "Callout") return stringifyCalloutRow(node) !== undefined;
     if (!("children" in node) || node.children.length === 0) return true;
-    if (!("name" in node)) return false;
 
-    switch (node.name) {
-      case "TypeTable":
-        return true;
-      case "Callout":
-        return stringifyCalloutRow(node) !== undefined;
-      default:
-        return false;
-    }
+    return "name" in node && node.name === "TypeTable";
   },
   stringify: structureStringify,
 };

--- a/docs/lib/satteri/search-structure.ts
+++ b/docs/lib/satteri/search-structure.ts
@@ -1,0 +1,113 @@
+import type { LLMsOptions } from "@fumadocs/satteri/remark-llms";
+import type { StructureOptions } from "@fumadocs/satteri/remark-structure";
+import type { Nodes } from "mdast";
+
+export const filterStructureElement: NonNullable<LLMsOptions["filterElement"]> = (node) => {
+  if (node.type !== "mdxJsxFlowElement" && node.type !== "mdxJsxTextElement") return true;
+
+  switch (node.name) {
+    case "File":
+    case "Callout":
+    case "Card":
+    case "DoImage":
+    case "DontImage":
+      return true;
+    default:
+      // TypeTable의 거대한 type 속성과 UI 전용 컴포넌트 태그는 검색 본문에서 제외합니다.
+      return "children-only";
+  }
+};
+
+/** `mdast-util-mdx-jsx`와 같은 규칙으로 속성값을 이스케이프합니다. */
+const escapeMdxAttributeValue = (value: string) => value.replace(/"/g, "&#x22;");
+
+/** Callout row가 남기는 속성. `type`은 배지를 고르고, `title`은 그 배지 옆에 찍힌다. */
+const CALLOUT_ROW_ATTRIBUTES = ["type", "title"];
+
+/**
+ * `<Callout>`을 자식 없는 태그로 되돌립니다. 안의 문단은 각자 자기 row로 색인되므로 Callout이
+ * 본문까지 안으면 같은 문장이 두 번 나오고, 그 row는 코드블록까지 삼킨 벽이 됩니다. Callout이
+ * 자식에게 물려줄 수 없는 건 속성값뿐이라 그것만 남깁니다.
+ *
+ * title이 없으면 남길 내용이 없다는 뜻이라 `undefined`. `mdxTypes`가 그런 Callout을 row에서
+ * 아예 빼는 판단도 같은 함수로 합니다.
+ */
+function stringifyCalloutRow(node: Nodes) {
+  if (node.type !== "mdxJsxFlowElement" || node.name !== "Callout") return undefined;
+
+  const attributes = node.attributes.flatMap((attribute) =>
+    attribute.type === "mdxJsxAttribute" &&
+    CALLOUT_ROW_ATTRIBUTES.includes(attribute.name) &&
+    typeof attribute.value === "string" &&
+    attribute.value.trim() !== ""
+      ? [{ name: attribute.name, value: attribute.value }]
+      : [],
+  );
+
+  if (!attributes.some(({ name }) => name === "title")) return undefined;
+
+  const stringified = attributes
+    .map(({ name, value }) => `${name}="${escapeMdxAttributeValue(value)}"`)
+    .join(" ");
+
+  return `<Callout ${stringified} />`;
+}
+
+export const structureStringify = {
+  filterElement: filterStructureElement,
+  filterMdxAttributes(node, attribute) {
+    if (attribute.type !== "mdxJsxAttribute") return false;
+
+    if (node.name === "DoImage" || node.name === "DontImage") {
+      return attribute.name !== "src";
+    }
+
+    return true;
+  },
+  // stringify는 handlers보다 먼저 불리므로, FigmaImage에서 온 이미지만 원래 컴포넌트
+  // 형태로 갈라지고 나머지 이미지는 아래 image handler로 넘어간다.
+  stringify(node) {
+    // remarkFigmaImage가 remarkStructure보다 먼저 <FigmaImage>를 mdast image로 치환한다.
+    // 다른 커스텀 컴포넌트와 같은 JSX 형태로 되살려야 검색 결과에서 출처를 표시할 수 있다.
+    if (node.type === "image") {
+      return node.data?.figmaImage && node.alt
+        ? `<FigmaImage alt="${escapeMdxAttributeValue(node.alt)}" />`
+        : undefined;
+    }
+
+    return stringifyCalloutRow(node);
+  },
+  handlers: {
+    // Fumadocs 기본 stringifier는 이미지를 빈 문자열로 만들어 alt를 통째로 버린다. 문서의
+    // 이미지 alt는 그 이미지를 설명하는 유일한 텍스트라, 검색 결과에서 출처를 알아볼 수
+    // 있도록 커스텀 컴포넌트와 같은 태그 형태로 남긴다.
+    image: (node) => (node.alt ? `<img alt="${escapeMdxAttributeValue(node.alt)}" />` : ""),
+  },
+} satisfies NonNullable<StructureOptions["stringify"]>;
+
+export const structureOptions: StructureOptions = {
+  /**
+   * remarkStructure 기본값에서 `blockquote`만 뺐다. satteri의 구현은 upstream과 달리 row가 된
+   * 노드의 서브트리를 건너뛰지 않아, blockquote를 row로 잡으면 안의 문단이 같은 문장을 그대로
+   * 한 번 더 색인한다. 문단 쪽이 `> ` 표식 없이 본문을 다 갖고 있으므로 그쪽을 남긴다.
+   */
+  types: ["heading", "paragraph", "tableCell", "mdxJsxFlowElement"],
+  mdxTypes(node) {
+    // Card는 children이 이미 각자 별도 row로 색인되고, 검색 결과의 URL은 카드가 놓인 페이지라
+    // 카드가 가리키는 문서로 데려가지도 못한다. 검색에서만 제외하며 llms.txt에는 그대로 남는다
+    // (mdxTypes는 remarkStructure 전용, filterElement는 remarkLlms와 공유).
+    if ("name" in node && node.name === "Card") return false;
+    if (!("children" in node) || node.children.length === 0) return true;
+    if (!("name" in node)) return false;
+
+    switch (node.name) {
+      case "TypeTable":
+        return true;
+      case "Callout":
+        return stringifyCalloutRow(node) !== undefined;
+      default:
+        return false;
+    }
+  },
+  stringify: structureStringify,
+};

--- a/docs/lib/satteri/search-structure.ts
+++ b/docs/lib/satteri/search-structure.ts
@@ -35,14 +35,16 @@ const CALLOUT_ROW_ATTRIBUTES = ["type", "title"];
 function stringifyCalloutRow(node: Nodes) {
   if (node.type !== "mdxJsxFlowElement" || node.name !== "Callout") return undefined;
 
-  const attributes = node.attributes.flatMap((attribute) =>
-    attribute.type === "mdxJsxAttribute" &&
-    CALLOUT_ROW_ATTRIBUTES.includes(attribute.name) &&
-    typeof attribute.value === "string" &&
-    attribute.value.trim() !== ""
-      ? [{ name: attribute.name, value: attribute.value }]
-      : [],
-  );
+  const attributes = node.attributes.flatMap((attribute) => {
+    if (attribute.type !== "mdxJsxAttribute") return [];
+    if (!CALLOUT_ROW_ATTRIBUTES.includes(attribute.name)) return [];
+
+    // 표현식으로 쓴 속성값(`title={"…"}`)은 Fumadocs 기본 stringifier와 같이 원본 표현식을
+    // 읽는다. 문자열만 받으면 그렇게 쓴 Callout이 title 없는 것으로 보여 row가 통째로 빠진다.
+    const value = typeof attribute.value === "string" ? attribute.value : attribute.value?.value;
+
+    return value?.trim() ? [{ name: attribute.name, value }] : [];
+  });
 
   if (!attributes.some(({ name }) => name === "title")) return undefined;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 검색 결과 행의 긴 문자열이 자동으로 줄바꿈되어 가로 스크롤을 방지합니다.
  - 인용문, 제목, 콜아웃, 목록, 코드 블록 및 이미지가 검색 결과에 더 일관되게 표시됩니다.
  - 이미지의 불필요한 정보가 검색 본문에 포함되지 않도록 개선했습니다.
  - 경고 콜아웃의 표시 방식이 안정적으로 동작하도록 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->