### PR TITLE
fix(docs): let remarkCodeTab own the icon search tabs

### DIFF
--- a/docs/content/react/migration/migrating-icons.mdx
+++ b/docs/content/react/migration/migrating-icons.mdx
@@ -290,8 +290,6 @@ REP ...을 ...로 변경했지만, 변경된 아이콘이 적절한지 확인이
 - codemod 스크립트를 `--log` flag와 함께 사용 시, 사용된 내역이 `migrate-icons-warnings.log`에 기록돼요.
 - 다음을 활용하여 코드를 직접 검색할 수 있어요.
 
-<Tabs items={["정규 표현식", "git grep"]}>
-
 ```regex tab="정규 표현식"
 (IconBold|IconCobuying|IconDelivery|IconSuggest|IconWriteStory)(Thin|Regular|Fill)|(IconTUppercaseSerif|IconShoppingbag2Stacked|IconTruck|IconLightbulbDot5|IconHorizline2VerticalChatbubbleRight)(Line|Fill)
 ```
@@ -299,8 +297,6 @@ REP ...을 ...로 변경했지만, 변경된 아이콘이 적절한지 확인이
 ```shell tab="git grep"
 git grep -E '(IconBold|IconCobuying|IconDelivery|IconSuggest|IconWriteStory)(Thin|Regular|Fill)|(IconTUppercaseSerif|IconShoppingbag2Stacked|IconTruck|IconLightbulbDot5|IconHorizline2VerticalChatbubbleRight)(Line|Fill)'
 ```
-
-</Tabs>
 
 </Callout>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 아이콘 사용 여부를 검색하는 정규 표현식 및 `git grep` 예시의 표시 형식을 간소화했습니다.
  * 검색 예시와 관련 안내 내용은 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->