### PR TITLE
refactor(docs): trim the search dialog's component cards and highlight states

### DIFF
--- a/docs/components/search/component-results.tsx
+++ b/docs/components/search/component-results.tsx
@@ -47,8 +47,8 @@ function ComponentCard({ entry, terms }: { entry: ComponentSearchEntry; terms: s
       }}
       className={(state) =>
         clsx(
-          "relative flex flex-col gap-2 rounded-xl p-1.5 transition-colors active:bg-bg-transparent-selected-pressed",
-          state.highlighted && "bg-bg-transparent-selected",
+          "relative flex flex-col gap-2 rounded-xl p-1.5 transition-colors",
+          state.highlighted && "bg-bg-transparent-pressed",
         )
       }
     >

--- a/docs/components/search/component-results.tsx
+++ b/docs/components/search/component-results.tsx
@@ -7,11 +7,8 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo } from "react";
-import { IconSeedArrow } from "@/components/icon-seed-arrow";
 import { COMPONENT_RESULT_LIMIT, type ComponentSearchEntry } from "@/lib/component-search";
-import { PLATFORM_CONFIG } from "@/lib/platform-status";
 import { splitQueryTerms } from "@/lib/search-text";
-import { isExternalUrl } from "@/lib/url";
 import { Highlighted, PromotedSection, ShowMore, toRows, useExpandable } from "./promoted-section";
 
 /**
@@ -28,59 +25,6 @@ const COMPONENT_COLUMNS = 3;
  * grid narrows to two columns — what the token block escapes only because four divides in two.
  */
 const COMPONENT_GRID_CLASS_NAME = "grid grid-cols-2 gap-2 md:grid-cols-3";
-
-const BADGE_CLASS_NAME =
-  "inline-flex items-center gap-0.5 rounded-md bg-bg-neutral-weak-alpha px-1.5 py-0.5 text-[11px] leading-[1.4] text-fg-neutral-muted";
-
-const BADGE_LINK_CLASS_NAME =
-  "transition-colors hover:text-fg-neutral hover:underline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-stroke-focus-ring";
-
-/**
- * One platform the component has shipped on. A badge without a link still reports the
- * rollout — Sanity carries the URL per platform and only some are filled in.
- *
- * A badge sits inside the cell the card occupies, and that cell opens the guideline when it is
- * clicked, so every badge that leads somewhere of its own stops the click from reaching it.
- */
-function PlatformBadge({ label, href }: { label: string; href?: string }) {
-  const { onOpenChange } = useSearch();
-  const router = useRouter();
-
-  if (!href) return <span className={BADGE_CLASS_NAME}>{label}</span>;
-
-  if (isExternalUrl(href)) {
-    return (
-      <a
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={(event) => event.stopPropagation()}
-        className={clsx(BADGE_CLASS_NAME, BADGE_LINK_CLASS_NAME)}
-      >
-        {label}
-        <IconSeedArrow external className="size-2.5" />
-      </a>
-    );
-  }
-
-  return (
-    <Link
-      href={href}
-      onClick={(event) => {
-        event.stopPropagation();
-        if (event.metaKey || event.ctrlKey) return;
-
-        event.preventDefault();
-        onOpenChange(false);
-        router.push(href);
-      }}
-      className={clsx(BADGE_CLASS_NAME, BADGE_LINK_CLASS_NAME)}
-    >
-      {label}
-      <IconSeedArrow className="size-2.5" />
-    </Link>
-  );
-}
 
 function ComponentCard({ entry, terms }: { entry: ComponentSearchEntry; terms: string[] }) {
   const { onOpenChange } = useSearch();
@@ -123,8 +67,8 @@ function ComponentCard({ entry, terms }: { entry: ComponentSearchEntry; terms: s
       </div>
       <div className="flex min-w-0 flex-col px-0.5">
         {/* The `after` overlay hands the whole card the anchor's own behaviour — the address
-            in the status bar, cmd-click, "open in new tab" — while leaving the platform
-            badges as links of their own, since an anchor can't nest inside an anchor. */}
+            in the status bar, cmd-click, "open in new tab" — from an anchor that wraps only
+            the title, so the cover above it is not read out as part of the link's name. */}
         <Link
           href={entry.url}
           className="text-[13px] font-medium leading-snug text-fg-neutral after:absolute after:inset-0 after:rounded-xl focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-stroke-focus-ring"
@@ -139,38 +83,14 @@ function ComponentCard({ entry, terms }: { entry: ComponentSearchEntry; terms: s
           </p>
         ) : null}
       </div>
-      {entry.components.length > 0 ? (
-        // `mt-auto` drops the badges to the card's floor, so a row of cards lines its
-        // platforms up however unevenly the titles and summaries above them ran. `relative`
-        // lifts them over the card-wide overlay, which an earlier sibling paints.
-        <div className="relative mt-auto flex flex-col gap-1 px-0.5">
-          {entry.components.map(({ name, platforms }) => (
-            <div key={name} className="flex flex-wrap items-center gap-1">
-              {/* A page documenting one component is already named by the card's title;
-                  one documenting several names each row, like its own status table. */}
-              {entry.components.length > 1 ? (
-                <span className="w-full text-[11px] font-medium leading-[1.4] text-fg-neutral">
-                  {name}
-                </span>
-              ) : null}
-              {PLATFORM_CONFIG.map(({ key, label }) => {
-                const platform = platforms.find((shipped) => shipped.key === key);
-                return platform ? (
-                  <PlatformBadge key={key} label={label} href={platform.url} />
-                ) : null;
-              })}
-            </div>
-          ))}
-        </div>
-      ) : null}
     </Autocomplete.Item>
   );
 }
 
 /**
  * Component documents matching the query, promoted above the document results so a search
- * for `button` leads with the components themselves — cover, summary and the platforms they
- * ship on — rather than with whichever page happened to mention one.
+ * for `button` leads with the components themselves — cover and summary — rather than with
+ * whichever page happened to mention one.
  */
 export function ComponentResults({
   matches,

--- a/docs/components/search/promoted-section.tsx
+++ b/docs/components/search/promoted-section.tsx
@@ -106,7 +106,7 @@ export function ShowMore({
           clsx(
             "mt-1.5 w-full cursor-pointer rounded-lg py-1.5 text-center text-xs transition-colors",
             state.highlighted
-              ? "bg-bg-transparent-selected text-fg-neutral"
+              ? "bg-bg-transparent-pressed text-fg-neutral"
               : "text-fg-neutral-subtle",
           )
         }

--- a/docs/components/search/row.tsx
+++ b/docs/components/search/row.tsx
@@ -17,7 +17,7 @@ export const ROW_CLASS_NAME =
   "relative block w-full select-none rounded-lg px-2.5 py-2 text-start text-sm wrap-anywhere text-fg-neutral";
 
 /** The row's own ground when it is the one the reader is on. */
-export const ROW_ACTIVE_CLASS_NAME = "bg-bg-transparent-selected";
+export const ROW_ACTIVE_CLASS_NAME = "bg-bg-transparent-pressed";
 
 /**
  * Where a row's page sits, printed over its title — the one line that says which part of the

--- a/docs/components/search/token-results.tsx
+++ b/docs/components/search/token-results.tsx
@@ -157,8 +157,8 @@ function TokenTile({ entry, terms }: { entry: TokenSearchEntry; terms: string[] 
       // neighbour's bottom edge.
       className={(state) =>
         clsx(
-          "relative flex h-full flex-col gap-1.5 rounded-xl p-1.5 transition-colors active:bg-bg-transparent-selected-pressed",
-          state.highlighted && "bg-bg-transparent-selected",
+          "relative flex h-full flex-col gap-1.5 rounded-xl p-1.5 transition-colors",
+          state.highlighted && "bg-bg-transparent-pressed",
         )
       }
     >

--- a/docs/lib/component-search-index.ts
+++ b/docs/lib/component-search-index.ts
@@ -1,36 +1,11 @@
 import "server-only";
 
 import { getComponentsSource } from "@/app/source";
-import { client } from "@/sanity-studio/lib/client";
-import { ALL_COMPONENTS_QUERY } from "@/sanity-studio/lib/queries";
-import type { ComponentData } from "@/sanity-studio/lib/types";
 import type { ComponentSearchEntry } from "./component-search";
-import { PLATFORM_CONFIG } from "./platform-status";
 import { resolveCoverImage } from "./seo";
 
 /** A rollout dashboard rather than a component, and left out of `/components` too. */
 const PROGRESS_BOARD_URL = "/components/progress-board";
-
-/**
- * Platform rollout per component id. A build without network access still has to produce an
- * index, so a failed query settles on an empty map and the cards render without badges —
- * the same way `app/_llms/rules/platform-status-rule.ts` treats it.
- */
-async function fetchComponentData() {
-  try {
-    const components = await client.fetch<ComponentData[]>(ALL_COMPONENTS_QUERY);
-    return new Map(components.map((component) => [component.id, component]));
-  } catch {
-    return new Map<string, ComponentData>();
-  }
-}
-
-/** The component's Done(`ready`) platforms, as `components/platform-status-table.tsx` picks them. */
-const donePlatforms = (component: ComponentData) =>
-  PLATFORM_CONFIG.filter(({ key }) => component[`${key}Status`] === "ready").map(({ key }) => {
-    const url = component[`${key}Url`];
-    return { key, ...(url && { url }) };
-  });
 
 /**
  * Flatten every component document into the shape the search dialog needs. Deprecated
@@ -38,7 +13,7 @@ const donePlatforms = (component: ComponentData) =>
  * description — their pages still answer document search like any other.
  */
 export async function buildComponentSearchIndex(): Promise<ComponentSearchEntry[]> {
-  const [source, componentData] = await Promise.all([getComponentsSource(), fetchComponentData()]);
+  const source = await getComponentsSource();
 
   return source
     .getPages()
@@ -51,21 +26,15 @@ export async function buildComponentSearchIndex(): Promise<ComponentSearchEntry[
         !page.data.frontmatter.deprecated,
     )
     .map((page) => {
-      const slug = page.slugs[0];
-      const { componentIds = [slug], coverImage, keywords } = page.data.frontmatter;
+      const { coverImage, keywords } = page.data.frontmatter;
 
       return {
-        slug,
+        slug: page.slugs[0],
         title: page.data.title,
         url: page.url,
         ...(page.data.description && { description: page.data.description }),
         ...(keywords?.length && { keywords }),
         ...(coverImage && { thumbnail: resolveCoverImage(coverImage).thumbnail }),
-        components: componentIds
-          .map((id) => componentData.get(id))
-          .filter((component): component is ComponentData => Boolean(component))
-          .map((component) => ({ name: component.name, platforms: donePlatforms(component) }))
-          .filter(({ platforms }) => platforms.length > 0),
       } satisfies ComponentSearchEntry;
     })
     .sort((a, b) => a.title.localeCompare(b.title));

--- a/docs/lib/component-search.test.ts
+++ b/docs/lib/component-search.test.ts
@@ -8,12 +8,6 @@ function entry(title: string, overrides: Partial<ComponentSearchEntry> = {}): Co
     title,
     url: `/components/${slug}`,
     thumbnail: `/og/components/${slug}.webp`,
-    components: [
-      {
-        name: title,
-        platforms: [{ key: "figma" }, { key: "react", url: `/react/components/${slug}` }],
-      },
-    ],
     ...overrides,
   };
 }

--- a/docs/lib/component-search.ts
+++ b/docs/lib/component-search.ts
@@ -1,4 +1,3 @@
-import type { PlatformKey } from "./platform-status";
 import { normalizeSearchText } from "./search-text";
 
 /** Static JSON index built by `app/api/component-search/route.ts`. */
@@ -13,9 +12,8 @@ export const COMPONENT_SEARCH_API = "/api/component-search";
 export const COMPONENT_RESULT_LIMIT = 6;
 
 /**
- * One component document, flattened at build time so the search dialog gets the platform
- * rollout — which lives in Sanity and is only reachable from a server component — without
- * a query of its own.
+ * One component document, flattened at build time so the search dialog gets what a card
+ * shows — the page tree it comes from is only reachable from a server component.
  */
 export interface ComponentSearchEntry {
   /** Page slug, e.g. `action-button`. */
@@ -32,13 +30,6 @@ export interface ComponentSearchEntry {
   url: string;
   /** Cover image in its on-page form, from `resolveCoverImage()`. */
   thumbnail?: string;
-  /**
-   * Shipped platforms per component the page documents, in `componentIds` order — a page can
-   * cover more than one (`manner-temp` → Manner Temp + Manner Temp Badge), and each keeps its
-   * own rollout and its own links, the way the page's status table shows them. Components
-   * with nothing shipped are left out.
-   */
-  components: { name: string; platforms: { key: PlatformKey; url?: string }[] }[];
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **변경 사항**
  - 컴포넌트 검색 카드에서 플랫폼 배지와 외부 링크 정보가 제거되었습니다.
  - 검색 결과에는 컴포넌트 제목, 썸네일, 설명 및 키워드가 표시됩니다.
  - 검색 인덱스에서 플랫폼 메타데이터가 제외되고 문서 정보를 기반으로 생성됩니다.

- **스타일**
  - 검색 결과의 활성 및 강조 상태 배경 스타일이 개선되었습니다.
  - 토큰 타일과 더보기 항목의 선택 상태 표시가 일관되게 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->