### PR TITLE
test(storybook): Kapture 시각 검토를 연결한다

### DIFF
--- a/.github/workflows/kapture-approve.yml
+++ b/.github/workflows/kapture-approve.yml
@@ -30,11 +30,16 @@ jobs:
         with:
           node-version: "24"
 
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.13"
+
       - name: Approve the exact full-SHA report
-        uses: karrot-emu/kapture-action@685c0527c31470fe36ac733fb853ee6b46940ea9
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        with:
-          mode: approve
-          status-context: SEED Kapture Visual Review
-          comment-language: ko
+          npm_config_registry: https://registry.npmjs.org/
+        run: |
+          bunx @kaptures/cli@0.0.6 github approve \
+            --status-context "SEED Kapture Visual Review" \
+            --comment-language ko

--- a/.github/workflows/kapture-approve.yml
+++ b/.github/workflows/kapture-approve.yml
@@ -1,0 +1,40 @@
+name: Kapture Visual Approval
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  approve:
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/kapture approve ') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    concurrency:
+      group: kapture-review-${{ github.repository }}-pr-${{ github.event.issue.number }}
+      queue: max
+      cancel-in-progress: false
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: read
+      statuses: write
+
+    steps:
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "24"
+
+      - name: Approve the exact full-SHA report
+        uses: karrot-emu/kapture-action@685c0527c31470fe36ac733fb853ee6b46940ea9
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          mode: approve
+          status-context: SEED Kapture Visual Review
+          comment-language: ko

--- a/.github/workflows/kapture-capture.yml
+++ b/.github/workflows/kapture-capture.yml
@@ -20,24 +20,649 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: kapture-capture-${{ github.repository }}-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
+  context:
+    name: Bind exact pull request context
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      integration-mode: ${{ steps.integration.outputs.integration-mode }}
+      artifact-suffix: ${{ steps.context.outputs.artifact-suffix }}
+      base-repository: ${{ steps.context.outputs.base-repository }}
+      base-sha: ${{ steps.context.outputs.base-sha }}
+      head-repository: ${{ steps.context.outputs.head-repository }}
+      head-sha: ${{ steps.context.outputs.head-sha }}
+      context-artifact-id: ${{ steps.context-artifact.outputs.artifact-id }}
+      context-artifact-digest: ${{ steps.context-artifact.outputs.artifact-digest }}
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Set up Node.js 24
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "24"
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.13"
+
+      - name: Bind exact pull request revisions
+        id: context
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          npm_config_registry: https://registry.npmjs.org/
+        run: |
+          set -euo pipefail
+          bunx @kaptures/cli@0.0.6 github context \
+            --base-branch dev \
+            --output "${{ runner.temp }}/kapture-context/context.json" \
+            --changed-files-output "${{ runner.temp }}/kapture-context/changed-files.json"
+
+      - name: Validate the optional bootstrap marker
+        id: marker
+        shell: bash
+        env:
+          KAPTURE_BOOTSTRAP_MARKER: .github/workflows/kapture-capture.yml
+        run: |
+          set -euo pipefail
+          marker="$KAPTURE_BOOTSTRAP_MARKER"
+          if [[ -z "$marker" ]]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$marker" == /* || "$marker" == */ || "$marker" == *\\* ]]; then
+            echo "bootstrap-marker must be a project-relative file path" >&2
+            exit 1
+          fi
+          if [[ ! "$marker" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "bootstrap-marker contains unsupported characters" >&2
+            exit 1
+          fi
+          IFS='/' read -ra segments <<< "$marker"
+          for segment in "${segments[@]}"; do
+            if [[ -z "$segment" || "$segment" == "." || "$segment" == ".." ]]; then
+              echo "bootstrap-marker must not contain empty, dot, or parent segments" >&2
+              exit 1
+            fi
+          done
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
+      - name: Inspect the exact base marker without executing repository code
+        if: steps.marker.outputs.enabled == 'true'
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: ${{ steps.context.outputs.base-repository }}
+          ref: ${{ steps.context.outputs.base-sha }}
+          path: .kapture/bootstrap/base
+          persist-credentials: false
+          sparse-checkout: .github/workflows/kapture-capture.yml
+          sparse-checkout-cone-mode: false
+
+      - name: Inspect the exact head marker without executing repository code
+        if: steps.marker.outputs.enabled == 'true'
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: ${{ steps.context.outputs.head-repository }}
+          ref: ${{ steps.context.outputs.head-sha }}
+          path: .kapture/bootstrap/head
+          persist-credentials: false
+          sparse-checkout: .github/workflows/kapture-capture.yml
+          sparse-checkout-cone-mode: false
+
+      - name: Resolve bootstrap integration mode
+        id: integration
+        shell: bash
+        env:
+          KAPTURE_BOOTSTRAP_MARKER: .github/workflows/kapture-capture.yml
+        run: |
+          set -euo pipefail
+          marker="$KAPTURE_BOOTSTRAP_MARKER"
+          if [[ -z "$marker" ]]; then
+            echo "integration-mode=compare" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base_marker="$GITHUB_WORKSPACE/.kapture/bootstrap/base/$marker"
+          head_marker="$GITHUB_WORKSPACE/.kapture/bootstrap/head/$marker"
+          if [[ ! -f "$head_marker" || -L "$head_marker" ]]; then
+            echo "bootstrap-marker must exist as a regular file at the exact head revision" >&2
+            exit 1
+          fi
+          if [[ -f "$base_marker" && ! -L "$base_marker" ]]; then
+            echo "integration-mode=compare" >> "$GITHUB_OUTPUT"
+          else
+            echo "integration-mode=bootstrap-skip" >> "$GITHUB_OUTPUT"
+            echo "Kapture bootstrap detected; visual comparison is intentionally skipped for this run."
+          fi
+
+      - name: Upload the transient context boundary
+        id: context-artifact
+        if: steps.integration.outputs.integration-mode == 'compare'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: kapture-context-${{ steps.context.outputs.artifact-suffix }}
+          path: |
+            ${{ steps.context.outputs.context-path }}
+            ${{ steps.context.outputs.changed-files-path }}
+          if-no-files-found: error
+          include-hidden-files: true
+          overwrite: true
+          retention-days: 1
+  build-base:
+    name: Build exact base Storybook
+    if: needs.context.outputs.integration-mode == 'compare'
+    needs: context
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    outputs:
+      artifact-id: ${{ steps.storybook-artifact.outputs.artifact-id }}
+      artifact-digest: ${{ steps.storybook-artifact.outputs.artifact-digest }}
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout the exact base revision
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: ${{ needs.context.outputs.base-repository }}
+          ref: ${{ needs.context.outputs.base-sha }}
+          path: .kapture/source
+          persist-credentials: false
+
+      - name: Validate the Storybook output input
+        working-directory: .kapture/source
+        shell: bash
+        env:
+          KAPTURE_STORYBOOK_OUTPUT: docs/.kapture/storybook-static
+        run: |
+          set -euo pipefail
+          output="$KAPTURE_STORYBOOK_OUTPUT"
+          if [[ -z "$output" || "$output" == /* || "$output" == */ || "$output" == *\\* ]]; then
+            echo "storybook-output must be a project-relative directory" >&2
+            exit 1
+          fi
+          if [[ ! "$output" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "storybook-output contains unsupported characters" >&2
+            exit 1
+          fi
+          IFS='/' read -ra segments <<< "$output"
+          for segment in "${segments[@]}"; do
+            if [[ -z "$segment" || "$segment" == "." || "$segment" == ".." ]]; then
+              echo "storybook-output must not contain empty, dot, or parent segments" >&2
+              exit 1
+            fi
+          done
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "24"
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Install dependencies
+        working-directory: .kapture/source
+        shell: bash
+        env:
+          KAPTURE_STORYBOOK_OUTPUT: docs/.kapture/storybook-static
+        run: |
+          bun install --frozen-lockfile
+          bun ecosystem:build
+          bun install --frozen-lockfile
+          bun packages:build
+
+      - name: Build Storybook
+        working-directory: .kapture/source
+        shell: bash
+        env:
+          KAPTURE_STORYBOOK_OUTPUT: docs/.kapture/storybook-static
+        run: |
+          bun storybook:build -- --output-dir "$PWD/$KAPTURE_STORYBOOK_OUTPUT"
+
+      - name: Validate the Storybook output boundary
+        working-directory: .kapture/source
+        shell: bash
+        env:
+          KAPTURE_STORYBOOK_OUTPUT: docs/.kapture/storybook-static
+        run: |
+          set -euo pipefail
+          output="$KAPTURE_STORYBOOK_OUTPUT"
+          if [[ ! -d "$output" || -L "$output" ]]; then
+            echo "storybook-output must exist as a non-symlink directory" >&2
+            exit 1
+          fi
+
+          inventory="$(mktemp "$RUNNER_TEMP/kapture-storybook-inventory.XXXXXX")"
+          find "$output" -xdev -mindepth 1 -print0 > "$inventory"
+
+          file_count=0
+          total_bytes=0
+          while IFS= read -r -d '' entry; do
+            if [[ -L "$entry" ]]; then
+              echo "storybook-output must not contain symbolic links" >&2
+              exit 1
+            fi
+            if [[ -d "$entry" ]]; then
+              continue
+            fi
+            if [[ ! -f "$entry" ]]; then
+              echo "storybook-output must contain only regular files and directories" >&2
+              exit 1
+            fi
+
+            size="$(stat -c '%s' -- "$entry")"
+            file_count=$((file_count + 1))
+            total_bytes=$((total_bytes + size))
+            if (( file_count > 100000 )); then
+              echo "storybook-output exceeds the 100000 file limit" >&2
+              exit 1
+            fi
+            if (( size > 104857600 )); then
+              echo "storybook-output contains a file larger than 100 MiB" >&2
+              exit 1
+            fi
+            if (( total_bytes > 1073741824 )); then
+              echo "storybook-output exceeds the 1 GiB uncompressed limit" >&2
+              exit 1
+            fi
+          done < "$inventory"
+          echo "Validated $file_count Storybook files ($total_bytes bytes)."
+
+      - name: Upload the exact base Storybook
+        id: storybook-artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: kapture-storybook-base-${{ needs.context.outputs.artifact-suffix }}
+          path: .kapture/source/docs/.kapture/storybook-static
+          if-no-files-found: error
+          include-hidden-files: true
+          overwrite: true
+          retention-days: 1
+
+  build-head:
+    name: Build exact head Storybook
+    if: needs.context.outputs.integration-mode == 'compare'
+    needs: context
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    outputs:
+      artifact-id: ${{ steps.storybook-artifact.outputs.artifact-id }}
+      artifact-digest: ${{ steps.storybook-artifact.outputs.artifact-digest }}
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout the exact head revision
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: ${{ needs.context.outputs.head-repository }}
+          ref: ${{ needs.context.outputs.head-sha }}
+          path: .kapture/source
+          persist-credentials: false
+
+      - name: Validate the Storybook output input
+        working-directory: .kapture/source
+        shell: bash
+        env:
+          KAPTURE_STORYBOOK_OUTPUT: docs/.kapture/storybook-static
+        run: |
+          set -euo pipefail
+          output="$KAPTURE_STORYBOOK_OUTPUT"
+          if [[ -z "$output" || "$output" == /* || "$output" == */ || "$output" == *\\* ]]; then
+            echo "storybook-output must be a project-relative directory" >&2
+            exit 1
+          fi
+          if [[ ! "$output" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "storybook-output contains unsupported characters" >&2
+            exit 1
+          fi
+          IFS='/' read -ra segments <<< "$output"
+          for segment in "${segments[@]}"; do
+            if [[ -z "$segment" || "$segment" == "." || "$segment" == ".." ]]; then
+              echo "storybook-output must not contain empty, dot, or parent segments" >&2
+              exit 1
+            fi
+          done
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "24"
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Install dependencies
+        working-directory: .kapture/source
+        shell: bash
+        env:
+          KAPTURE_STORYBOOK_OUTPUT: docs/.kapture/storybook-static
+        run: |
+          bun install --frozen-lockfile
+          bun ecosystem:build
+          bun install --frozen-lockfile
+          bun packages:build
+
+      - name: Build Storybook
+        working-directory: .kapture/source
+        shell: bash
+        env:
+          KAPTURE_STORYBOOK_OUTPUT: docs/.kapture/storybook-static
+        run: |
+          bun storybook:build -- --output-dir "$PWD/$KAPTURE_STORYBOOK_OUTPUT"
+
+      - name: Validate the Storybook output boundary
+        working-directory: .kapture/source
+        shell: bash
+        env:
+          KAPTURE_STORYBOOK_OUTPUT: docs/.kapture/storybook-static
+        run: |
+          set -euo pipefail
+          output="$KAPTURE_STORYBOOK_OUTPUT"
+          if [[ ! -d "$output" || -L "$output" ]]; then
+            echo "storybook-output must exist as a non-symlink directory" >&2
+            exit 1
+          fi
+
+          inventory="$(mktemp "$RUNNER_TEMP/kapture-storybook-inventory.XXXXXX")"
+          find "$output" -xdev -mindepth 1 -print0 > "$inventory"
+
+          file_count=0
+          total_bytes=0
+          while IFS= read -r -d '' entry; do
+            if [[ -L "$entry" ]]; then
+              echo "storybook-output must not contain symbolic links" >&2
+              exit 1
+            fi
+            if [[ -d "$entry" ]]; then
+              continue
+            fi
+            if [[ ! -f "$entry" ]]; then
+              echo "storybook-output must contain only regular files and directories" >&2
+              exit 1
+            fi
+
+            size="$(stat -c '%s' -- "$entry")"
+            file_count=$((file_count + 1))
+            total_bytes=$((total_bytes + size))
+            if (( file_count > 100000 )); then
+              echo "storybook-output exceeds the 100000 file limit" >&2
+              exit 1
+            fi
+            if (( size > 104857600 )); then
+              echo "storybook-output contains a file larger than 100 MiB" >&2
+              exit 1
+            fi
+            if (( total_bytes > 1073741824 )); then
+              echo "storybook-output exceeds the 1 GiB uncompressed limit" >&2
+              exit 1
+            fi
+          done < "$inventory"
+          echo "Validated $file_count Storybook files ($total_bytes bytes)."
+
+      - name: Upload the exact head Storybook
+        id: storybook-artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: kapture-storybook-head-${{ needs.context.outputs.artifact-suffix }}
+          path: .kapture/source/docs/.kapture/storybook-static
+          if-no-files-found: error
+          include-hidden-files: true
+          overwrite: true
+          retention-days: 1
+
   capture:
-    uses: karrot-emu/kapture-action/.github/workflows/capture.yml@685c0527c31470fe36ac733fb853ee6b46940ea9
-    with:
-      base-branch: dev
-      bootstrap-marker: .github/workflows/kapture-capture.yml
-      bun-version: 1.3.13
-      apt-packages: fonts-noto-cjk=1:20230817+repack1-3
-      install-command: |
-        bun install --frozen-lockfile
-        bun ecosystem:build
-        bun install --frozen-lockfile
-        bun packages:build
-      build-command: |
-        bun storybook:build -- --output-dir "$KAPTURE_STORYBOOK_OUTPUT"
-      storybook-output: docs/.kapture/storybook-static
-      workers: 4
-      pixel-threshold: 0.2
-      max-diff-ratio: 0
-      locale: ko-KR
-      timezone: Asia/Seoul
+    name: Capture affected Stories
+    if: needs.context.outputs.integration-mode == 'compare'
+    needs: [context, build-base, build-head]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    outputs:
+      report-artifact-name: ${{ steps.artifact.outputs.name }}
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Set up Node.js 24
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "24"
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.13"
+
+      - name: Validate optional capture runner packages
+        id: apt
+        shell: bash
+        env:
+          KAPTURE_APT_PACKAGES: fonts-noto-cjk=1:20230817+repack1-3
+        run: |
+          set -euo pipefail
+          raw="$KAPTURE_APT_PACKAGES"
+          if [[ -z "$raw" ]]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$raw" == *$'\n'* || "$raw" == *$'\r'* ]]; then
+            echo "apt-packages must be a single whitespace-separated line" >&2
+            exit 1
+          fi
+
+          read -ra packages <<< "$raw"
+          if (( ${#packages[@]} == 0 )); then
+            echo "apt-packages must contain at least one package name" >&2
+            exit 1
+          fi
+          for package in "${packages[@]}"; do
+            if [[ ! "$package" =~ ^[a-z0-9][a-z0-9+.-]*(:[a-z0-9][a-z0-9-]*)?(=[0-9A-Za-z.+:~_-]+)?$ ]]; then
+              echo "apt-packages contains an invalid Debian package token" >&2
+              exit 1
+            fi
+          done
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+          echo "packages=${packages[*]}" >> "$GITHUB_OUTPUT"
+
+      - name: Install capture runner packages
+        if: steps.apt.outputs.enabled == 'true'
+        shell: bash
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          KAPTURE_APT_PACKAGES: ${{ steps.apt.outputs.packages }}
+        run: |
+          set -euo pipefail
+          read -ra packages <<< "$KAPTURE_APT_PACKAGES"
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends "${packages[@]}"
+
+      - name: Download the exact context boundary
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          artifact-ids: ${{ needs.context.outputs.context-artifact-id }}
+          path: ${{ runner.temp }}/kapture-context
+
+      - name: Download the exact base Storybook
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          artifact-ids: ${{ needs.build-base.outputs.artifact-id }}
+          path: ${{ runner.temp }}/kapture-storybook/base
+
+      - name: Download the exact head Storybook
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          artifact-ids: ${{ needs.build-head.outputs.artifact-id }}
+          path: ${{ runner.temp }}/kapture-storybook/head
+
+      - name: Validate the downloaded Storybook boundaries
+        shell: bash
+        env:
+          KAPTURE_BASE_STORYBOOK: ${{ runner.temp }}/kapture-storybook/base
+          KAPTURE_HEAD_STORYBOOK: ${{ runner.temp }}/kapture-storybook/head
+        run: |
+          set -euo pipefail
+          for output in "$KAPTURE_BASE_STORYBOOK" "$KAPTURE_HEAD_STORYBOOK"; do
+            if [[ ! -d "$output" || -L "$output" ]]; then
+              echo "downloaded Storybook must be a non-symlink directory" >&2
+              exit 1
+            fi
+
+            inventory="$(mktemp "$RUNNER_TEMP/kapture-downloaded-inventory.XXXXXX")"
+            find "$output" -xdev -mindepth 1 -print0 > "$inventory"
+            file_count=0
+            total_bytes=0
+            while IFS= read -r -d '' entry; do
+              if [[ -L "$entry" ]]; then
+                echo "downloaded Storybook must not contain symbolic links" >&2
+                exit 1
+              fi
+              if [[ -d "$entry" ]]; then
+                continue
+              fi
+              if [[ ! -f "$entry" ]]; then
+                echo "downloaded Storybook must contain only regular files and directories" >&2
+                exit 1
+              fi
+              size="$(stat -c '%s' -- "$entry")"
+              file_count=$((file_count + 1))
+              total_bytes=$((total_bytes + size))
+              if (( file_count > 100000 || size > 104857600 || total_bytes > 1073741824 )); then
+                echo "downloaded Storybook exceeds its file or size boundary" >&2
+                exit 1
+              fi
+            done < "$inventory"
+          done
+
+      - name: Capture only affected Stories in isolated browsers
+        id: kapture
+        shell: bash
+        env:
+          npm_config_registry: https://registry.npmjs.org/
+        run: |
+          set -uo pipefail
+          bunx @kaptures/cli@0.0.6 test \
+            --base-dir "${{ runner.temp }}/kapture-storybook/base" \
+            --head-dir "${{ runner.temp }}/kapture-storybook/head" \
+            --base-revision "${{ needs.context.outputs.base-sha }}" \
+            --head-revision "${{ needs.context.outputs.head-sha }}" \
+            --changed-files "${{ runner.temp }}/kapture-context/changed-files.json" \
+            --output "${{ runner.temp }}/kapture-result" \
+            --install-browser \
+            --browser-with-deps \
+            --workers 4 \
+            --pixel-threshold 0.2 \
+            --max-diff-ratio 0 \
+            --frozen-time 2026-01-01T00:00:00.000Z \
+            --random-seed 20260101 \
+            --locale ko-KR \
+            --timezone Asia/Seoul
+          exit_code=$?
+          if [[ "$exit_code" -ne 0 && "$exit_code" -ne 2 ]]; then
+            exit "$exit_code"
+          fi
+          report_directory="${{ runner.temp }}/kapture-result/report"
+          {
+            echo "report-directory=$report_directory"
+            echo "report-path=$report_directory/report.json"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Bind the exact downloaded artifact identities
+        shell: bash
+        env:
+          KAPTURE_BOUNDARY_PATH: ${{ steps.kapture.outputs.report-directory }}/capture-boundary.json
+          KAPTURE_ARTIFACT_SUFFIX: ${{ needs.context.outputs.artifact-suffix }}
+          KAPTURE_CONTEXT_ARTIFACT_ID: ${{ needs.context.outputs.context-artifact-id }}
+          KAPTURE_CONTEXT_ARTIFACT_DIGEST: ${{ needs.context.outputs.context-artifact-digest }}
+          KAPTURE_BASE_ARTIFACT_ID: ${{ needs.build-base.outputs.artifact-id }}
+          KAPTURE_BASE_ARTIFACT_DIGEST: ${{ needs.build-base.outputs.artifact-digest }}
+          KAPTURE_HEAD_ARTIFACT_ID: ${{ needs.build-head.outputs.artifact-id }}
+          KAPTURE_HEAD_ARTIFACT_DIGEST: ${{ needs.build-head.outputs.artifact-digest }}
+        run: |
+          set -euo pipefail
+          node --input-type=module -e '
+            import { writeFile } from "node:fs/promises";
+
+            const required = (name) => {
+              const value = process.env[name];
+              if (!value) throw new Error(`${name} is required`);
+              return value;
+            };
+            const artifact = (label, idName, digestName, name) => {
+              const id = required(idName);
+              const digest = required(digestName);
+              if (!/^[1-9][0-9]*$/.test(id) || !Number.isSafeInteger(Number(id))) {
+                throw new Error(`${label} artifact ID is invalid`);
+              }
+              if (!/^[0-9a-f]{64}$/.test(digest)) {
+                throw new Error(`${label} artifact digest is invalid`);
+              }
+              return { id: Number(id), name, digest: `sha256:${digest}` };
+            };
+
+            const suffix = required("KAPTURE_ARTIFACT_SUFFIX");
+            if (!/^pr-[1-9][0-9]*-base-[0-9a-f]{40}-head-[0-9a-f]{40}$/.test(suffix)) {
+              throw new Error("artifact suffix is invalid");
+            }
+            const boundary = {
+              schemaVersion: 1,
+              artifacts: {
+                context: artifact(
+                  "context",
+                  "KAPTURE_CONTEXT_ARTIFACT_ID",
+                  "KAPTURE_CONTEXT_ARTIFACT_DIGEST",
+                  `kapture-context-${suffix}`,
+                ),
+                baseStorybook: artifact(
+                  "base Storybook",
+                  "KAPTURE_BASE_ARTIFACT_ID",
+                  "KAPTURE_BASE_ARTIFACT_DIGEST",
+                  `kapture-storybook-base-${suffix}`,
+                ),
+                headStorybook: artifact(
+                  "head Storybook",
+                  "KAPTURE_HEAD_ARTIFACT_ID",
+                  "KAPTURE_HEAD_ARTIFACT_DIGEST",
+                  `kapture-storybook-head-${suffix}`,
+                ),
+              },
+            };
+            await writeFile(
+              required("KAPTURE_BOUNDARY_PATH"),
+              `${JSON.stringify(boundary)}\n`,
+              { encoding: "utf8", flag: "wx", mode: 0o600 },
+            );
+          '
+
+      - name: Bind the report artifact name
+        id: artifact
+        shell: bash
+        env:
+          KAPTURE_ARTIFACT_SUFFIX: ${{ needs.context.outputs.artifact-suffix }}
+        run: echo "name=kapture-visual-report-$KAPTURE_ARTIFACT_SUFFIX" >> "$GITHUB_OUTPUT"
+
+      - name: Upload transient report JSON and referenced PNGs
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: ${{ steps.artifact.outputs.name }}
+          path: |
+            ${{ steps.kapture.outputs.report-path }}
+            ${{ steps.kapture.outputs.report-directory }}/capture-boundary.json
+            ${{ steps.kapture.outputs.report-directory }}/images/**/*.png
+          if-no-files-found: error
+          include-hidden-files: true
+          overwrite: true
+          compression-level: 0
+          retention-days: 1

--- a/.github/workflows/kapture-capture.yml
+++ b/.github/workflows/kapture-capture.yml
@@ -1,0 +1,43 @@
+name: Kapture Visual Capture
+
+on:
+  pull_request:
+    branches: [dev]
+    types: [opened, synchronize, reopened]
+    paths:
+      - "docs/registry/react/**"
+      - "docs/stories/**"
+      - "docs/.storybook/**"
+      - "docs/package.json"
+      - "packages/react/**"
+      - "packages/css/**"
+      - "packages/qvism-preset/**"
+      - "ecosystem/rootage/**"
+      - "bun.lock"
+      - ".github/workflows/kapture-*.yml"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  capture:
+    uses: karrot-emu/kapture-action/.github/workflows/capture.yml@685c0527c31470fe36ac733fb853ee6b46940ea9
+    with:
+      base-branch: dev
+      bootstrap-marker: .github/workflows/kapture-capture.yml
+      bun-version: 1.3.13
+      apt-packages: fonts-noto-cjk=1:20230817+repack1-3
+      install-command: |
+        bun install --frozen-lockfile
+        bun ecosystem:build
+        bun install --frozen-lockfile
+        bun packages:build
+      build-command: |
+        bun storybook:build -- --output-dir "$KAPTURE_STORYBOOK_OUTPUT"
+      storybook-output: docs/.kapture/storybook-static
+      workers: 4
+      pixel-threshold: 0.2
+      max-diff-ratio: 0
+      locale: ko-KR
+      timezone: Asia/Seoul

--- a/.github/workflows/kapture-report.yml
+++ b/.github/workflows/kapture-report.yml
@@ -1,0 +1,203 @@
+name: Kapture Visual Report
+
+on:
+  workflow_run:
+    workflows: [Kapture Visual Capture]
+    types: [in_progress, completed]
+
+permissions: {}
+
+jobs:
+  in-progress:
+    name: Mark the current revision as pending
+    if: >-
+      github.event.action == 'in_progress' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    concurrency:
+      group: >-
+        kapture-review-${{ github.repository }}-pr-${{
+          github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id
+        }}
+      queue: max
+      cancel-in-progress: false
+    permissions:
+      actions: read
+      pull-requests: read
+      statuses: write
+
+    steps:
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "24"
+
+      - name: Reconcile the current full-SHA status
+        uses: karrot-emu/kapture-action@685c0527c31470fe36ac733fb853ee6b46940ea9
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          mode: reconcile-run
+          capture-workflow-path: .github/workflows/kapture-capture.yml
+          base-branch: dev
+          status-context: SEED Kapture Visual Review
+
+  publish:
+    name: Publish the trusted dashboard and Storybook
+    if: >-
+      github.event.action == 'completed' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    concurrency:
+      group: >-
+        kapture-review-${{ github.repository }}-pr-${{
+          github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id
+        }}
+      queue: max
+      cancel-in-progress: false
+    permissions:
+      actions: write
+      contents: read
+      issues: write
+      pull-requests: read
+      statuses: write
+
+    steps:
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "24"
+
+      - name: Reconcile the completed full-SHA status
+        id: reconcile
+        uses: karrot-emu/kapture-action@685c0527c31470fe36ac733fb853ee6b46940ea9
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          mode: reconcile-run
+          capture-workflow-path: .github/workflows/kapture-capture.yml
+          base-branch: dev
+          status-context: SEED Kapture Visual Review
+
+      - name: Verify artifacts and build the trusted dashboard
+        id: prepare
+        if: >-
+          github.event.workflow_run.conclusion == 'success' &&
+          steps.reconcile.outputs.status == 'pending'
+        uses: karrot-emu/kapture-action@685c0527c31470fe36ac733fb853ee6b46940ea9
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          mode: prepare-run
+          capture-workflow-path: .github/workflows/kapture-capture.yml
+          base-branch: dev
+          output: ${{ runner.temp }}/kapture-trusted/report
+          receipt: ${{ runner.temp }}/kapture-trusted/receipt.json
+          storybook-url: ./storybook/
+          temporary-root: ${{ runner.temp }}/kapture-prepare
+
+      - name: Verify and extract the exact head Storybook
+        id: prepare-storybook
+        if: steps.prepare.outcome == 'success'
+        uses: karrot-emu/kapture-action@685c0527c31470fe36ac733fb853ee6b46940ea9
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          mode: prepare-storybook-run
+          capture-workflow-path: .github/workflows/kapture-capture.yml
+          base-branch: dev
+          receipt: ${{ steps.prepare.outputs.receipt }}
+          output: ${{ steps.prepare.outputs.report-directory }}/storybook
+          temporary-root: ${{ runner.temp }}/kapture-prepare-storybook
+
+      - name: Deploy the dashboard and exact Storybook to the existing Pages project
+        id: deploy
+        if: steps.prepare-storybook.outcome == 'success'
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          wranglerVersion: "4.45.3"
+          command: >-
+            pages deploy ${{ steps.prepare.outputs.report-directory }}
+            --project-name=seed-design-storybook
+            --branch=${{ steps.prepare.outputs.preview-alias }}
+            --commit-hash=${{ steps.prepare.outputs.head-sha }}
+
+      - name: Accept only the immutable deployment URL
+        id: dashboard
+        if: steps.deploy.outcome == 'success'
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
+        with:
+          script: |
+            const url = new URL((process.env.DEPLOYMENT_URL || '').trim());
+            if (
+              url.protocol !== 'https:' ||
+              !/^[0-9a-f]{8}\.seed-design-storybook\.pages\.dev$/.test(url.hostname) ||
+              url.username || url.password || url.pathname !== '/' || url.search || url.hash
+            ) {
+              throw new Error('The deploy step did not return an immutable Storybook Pages URL');
+            }
+            core.setOutput('immutable-url', url.toString());
+
+      - name: Publish the PR comment and commit status
+        id: publish
+        if: steps.dashboard.outcome == 'success'
+        uses: karrot-emu/kapture-action@685c0527c31470fe36ac733fb853ee6b46940ea9
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          mode: publish-run
+          receipt: ${{ steps.prepare.outputs.receipt }}
+          report: ${{ steps.prepare.outputs.report-path }}
+          report-url: ${{ steps.dashboard.outputs.immutable-url }}
+          status-context: SEED Kapture Visual Review
+          comment-language: ko
+
+      - name: Delete the exact transient source artifacts
+        if: steps.publish.outcome == 'success'
+        uses: karrot-emu/kapture-action@685c0527c31470fe36ac733fb853ee6b46940ea9
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          mode: cleanup
+          receipt: ${{ steps.prepare.outputs.receipt }}
+
+  finalize:
+    name: Fail closed when trusted publication did not finish
+    needs: publish
+    if: >-
+      always() &&
+      github.event.action == 'completed' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    concurrency:
+      group: >-
+        kapture-review-${{ github.repository }}-pr-${{
+          github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id
+        }}
+      queue: max
+      cancel-in-progress: false
+    permissions:
+      actions: read
+      issues: read
+      pull-requests: read
+      statuses: write
+
+    steps:
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "24"
+
+      - name: Finalize the exact full-SHA status
+        uses: karrot-emu/kapture-action@685c0527c31470fe36ac733fb853ee6b46940ea9
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          mode: finalize-run
+          capture-workflow-path: .github/workflows/kapture-capture.yml
+          base-branch: dev
+          status-context: SEED Kapture Visual Review

--- a/.github/workflows/kapture-report.yml
+++ b/.github/workflows/kapture-report.yml
@@ -32,15 +32,20 @@ jobs:
         with:
           node-version: "24"
 
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.13"
+
       - name: Reconcile the current full-SHA status
-        uses: karrot-emu/kapture-action@685c0527c31470fe36ac733fb853ee6b46940ea9
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        with:
-          mode: reconcile-run
-          capture-workflow-path: .github/workflows/kapture-capture.yml
-          base-branch: dev
-          status-context: SEED Kapture Visual Review
+          npm_config_registry: https://registry.npmjs.org/
+        run: |
+          bunx @kaptures/cli@0.0.6 github reconcile-run \
+            --capture-workflow-path .github/workflows/kapture-capture.yml \
+            --base-branch dev \
+            --status-context "SEED Kapture Visual Review"
 
   publish:
     name: Publish the trusted dashboard and Storybook
@@ -68,47 +73,54 @@ jobs:
         with:
           node-version: "24"
 
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.13"
+
       - name: Reconcile the completed full-SHA status
         id: reconcile
-        uses: karrot-emu/kapture-action@685c0527c31470fe36ac733fb853ee6b46940ea9
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        with:
-          mode: reconcile-run
-          capture-workflow-path: .github/workflows/kapture-capture.yml
-          base-branch: dev
-          status-context: SEED Kapture Visual Review
+          npm_config_registry: https://registry.npmjs.org/
+        run: |
+          bunx @kaptures/cli@0.0.6 github reconcile-run \
+            --capture-workflow-path .github/workflows/kapture-capture.yml \
+            --base-branch dev \
+            --status-context "SEED Kapture Visual Review"
 
       - name: Verify artifacts and build the trusted dashboard
         id: prepare
         if: >-
           github.event.workflow_run.conclusion == 'success' &&
           steps.reconcile.outputs.status == 'pending'
-        uses: karrot-emu/kapture-action@685c0527c31470fe36ac733fb853ee6b46940ea9
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        with:
-          mode: prepare-run
-          capture-workflow-path: .github/workflows/kapture-capture.yml
-          base-branch: dev
-          output: ${{ runner.temp }}/kapture-trusted/report
-          receipt: ${{ runner.temp }}/kapture-trusted/receipt.json
-          storybook-url: ./storybook/
-          temporary-root: ${{ runner.temp }}/kapture-prepare
+          npm_config_registry: https://registry.npmjs.org/
+        run: |
+          bunx @kaptures/cli@0.0.6 github prepare-run \
+            --capture-workflow-path .github/workflows/kapture-capture.yml \
+            --base-branch dev \
+            --output "${{ runner.temp }}/kapture-trusted/report" \
+            --receipt "${{ runner.temp }}/kapture-trusted/receipt.json" \
+            --storybook-url ./storybook/ \
+            --temporary-root "${{ runner.temp }}/kapture-prepare"
 
       - name: Verify and extract the exact head Storybook
         id: prepare-storybook
         if: steps.prepare.outcome == 'success'
-        uses: karrot-emu/kapture-action@685c0527c31470fe36ac733fb853ee6b46940ea9
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        with:
-          mode: prepare-storybook-run
-          capture-workflow-path: .github/workflows/kapture-capture.yml
-          base-branch: dev
-          receipt: ${{ steps.prepare.outputs.receipt }}
-          output: ${{ steps.prepare.outputs.report-directory }}/storybook
-          temporary-root: ${{ runner.temp }}/kapture-prepare-storybook
+          npm_config_registry: https://registry.npmjs.org/
+        run: |
+          bunx @kaptures/cli@0.0.6 github prepare-storybook-run \
+            --capture-workflow-path .github/workflows/kapture-capture.yml \
+            --base-branch dev \
+            --receipt "${{ steps.prepare.outputs.receipt }}" \
+            --output "${{ steps.prepare.outputs.report-directory }}/storybook" \
+            --temporary-root "${{ runner.temp }}/kapture-prepare-storybook"
 
       - name: Deploy the dashboard and exact Storybook to the existing Pages project
         id: deploy
@@ -145,25 +157,27 @@ jobs:
       - name: Publish the PR comment and commit status
         id: publish
         if: steps.dashboard.outcome == 'success'
-        uses: karrot-emu/kapture-action@685c0527c31470fe36ac733fb853ee6b46940ea9
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        with:
-          mode: publish-run
-          receipt: ${{ steps.prepare.outputs.receipt }}
-          report: ${{ steps.prepare.outputs.report-path }}
-          report-url: ${{ steps.dashboard.outputs.immutable-url }}
-          status-context: SEED Kapture Visual Review
-          comment-language: ko
+          npm_config_registry: https://registry.npmjs.org/
+        run: |
+          bunx @kaptures/cli@0.0.6 github publish-run \
+            --receipt "${{ steps.prepare.outputs.receipt }}" \
+            --report "${{ steps.prepare.outputs.report-path }}" \
+            --report-url "${{ steps.dashboard.outputs.immutable-url }}" \
+            --status-context "SEED Kapture Visual Review" \
+            --comment-language ko
 
       - name: Delete the exact transient source artifacts
         if: steps.publish.outcome == 'success'
-        uses: karrot-emu/kapture-action@685c0527c31470fe36ac733fb853ee6b46940ea9
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        with:
-          mode: cleanup
-          receipt: ${{ steps.prepare.outputs.receipt }}
+          npm_config_registry: https://registry.npmjs.org/
+        run: |
+          bunx @kaptures/cli@0.0.6 github cleanup \
+            --receipt "${{ steps.prepare.outputs.receipt }}"
 
   finalize:
     name: Fail closed when trusted publication did not finish
@@ -192,12 +206,17 @@ jobs:
         with:
           node-version: "24"
 
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.13"
+
       - name: Finalize the exact full-SHA status
-        uses: karrot-emu/kapture-action@685c0527c31470fe36ac733fb853ee6b46940ea9
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        with:
-          mode: finalize-run
-          capture-workflow-path: .github/workflows/kapture-capture.yml
-          base-branch: dev
-          status-context: SEED Kapture Visual Review
+          npm_config_registry: https://registry.npmjs.org/
+        run: |
+          bunx @kaptures/cli@0.0.6 github finalize-run \
+            --capture-workflow-path .github/workflows/kapture-capture.yml \
+            --base-branch dev \
+            --status-context "SEED Kapture Visual Review"

--- a/bun.lock
+++ b/bun.lock
@@ -117,6 +117,7 @@
       "devDependencies": {
         "@chromatic-com/storybook": "^4.1.3",
         "@figma/rest-api-spec": "^0.36.0",
+        "@kaptures/storybook": "0.0.6",
         "@karrotmarket/lynx-multicolor-icon": "1.25.0",
         "@lynx-js/config-rsbuild-plugin": "0.2.2",
         "@lynx-js/react": "0.123.3",
@@ -2410,6 +2411,8 @@
     "@jsonjoy.com/util": ["@jsonjoy.com/util@1.9.0", "", { "dependencies": { "@jsonjoy.com/buffers": "^1.0.0", "@jsonjoy.com/codegen": "^1.0.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ=="],
 
     "@juggle/resize-observer": ["@juggle/resize-observer@3.4.0", "", {}, "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="],
+
+    "@kaptures/storybook": ["@kaptures/storybook@0.0.6", "", { "peerDependencies": { "storybook": "^10.5.6" } }, "sha512-8CeEwE+A8B/AT/E6tUXZOL0yx6ol6YXvIBcbJuZccgpIx/NP+InUwWAMez0R/P31tvTLef8jCNbuiviGVN/61w=="],
 
     "@karrotmarket/assets-monochrome": ["@karrotmarket/assets-monochrome@1.26.0", "", {}, "sha512-Kf1wPy7lX49WpEw1o383gPJUx95abXRTvELhq+1Gi/HXZSWiNoLXUZoiI8VG6wFwFOgr7PFjFHrSQuuj8JLWWw=="],
 

--- a/docs/.storybook/main.ts
+++ b/docs/.storybook/main.ts
@@ -4,7 +4,23 @@ import { dirname } from "node:path";
 
 export default defineMain({
   stories: ["../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
-  addons: [getAbsolutePath("@chromatic-com/storybook")],
+  addons: [
+    getAbsolutePath("@chromatic-com/storybook"),
+    {
+      name: "@kaptures/storybook/preset",
+      options: {
+        projectRoot: "..",
+        globalInputs: [
+          "docs/.storybook/**",
+          "docs/public/**",
+          "packages/css/**",
+          "packages/qvism-preset/**",
+          "ecosystem/rootage/**",
+        ],
+        ignoredInputs: [".changeset/**"],
+      },
+    },
+  ],
   framework: {
     name: getAbsolutePath("@storybook/nextjs-vite"),
     options: {},

--- a/docs/.storybook/preview.ts
+++ b/docs/.storybook/preview.ts
@@ -1,5 +1,6 @@
 // import Seed Design
 import { definePreview } from "@storybook/nextjs-vite";
+import kapture from "@kaptures/storybook";
 
 import "@seed-design/css/all.css";
 
@@ -29,6 +30,9 @@ const viewportMap: ViewportMap = Object.fromEntries(
 
 export default definePreview({
   parameters: {
+    kapture: {
+      requiredFonts: [{ text: "가나다라마바사 ABC 123" }],
+    },
     viewport: {
       options: viewportMap,
     },
@@ -40,5 +44,5 @@ export default definePreview({
     },
   },
 
-  addons: [],
+  addons: [kapture()],
 }).type<{ parameters: StoryParameters }>();

--- a/docs/package.json
+++ b/docs/package.json
@@ -119,6 +119,7 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.3",
     "@figma/rest-api-spec": "^0.36.0",
+    "@kaptures/storybook": "0.0.6",
     "@karrotmarket/lynx-multicolor-icon": "1.25.0",
     "@lynx-js/config-rsbuild-plugin": "0.2.2",
     "@lynx-js/react": "0.123.3",

--- a/docs/stories/Accordion.stories.tsx
+++ b/docs/stories/Accordion.stories.tsx
@@ -11,7 +11,7 @@ import { accordionVariantMap } from "@seed-design/css/recipes/accordion";
 import { IconTruckLine } from "@karrotmarket/react-monochrome-icon";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const AccordionDemo = ({ style, ...props }: React.ComponentProps<typeof Accordion>) => (
   <Accordion {...props} style={{ ...style, width: 360 }}>
@@ -58,5 +58,5 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });

--- a/docs/stories/ActionButton.stories.tsx
+++ b/docs/stories/ActionButton.stories.tsx
@@ -1,7 +1,7 @@
 import preview from "../.storybook/preview";
 import { ActionButton } from "seed-design/ui/action-button";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { IconBellFill, IconChevronRightFill } from "@karrotmarket/react-monochrome-icon";
 import { actionButtonVariantMap } from "@seed-design/css/recipes/action-button";
 import { PrefixIcon, SuffixIcon, Icon } from "@seed-design/react";
@@ -105,44 +105,44 @@ const LargeTemplate = meta.story({
 
 export const XSmallLightTheme = XSmallTemplate.extend({});
 export const XSmallDarkTheme = XSmallTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 export const XSmallFontScalingExtraSmall = XSmallTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 export const XSmallFontScalingExtraExtraExtraLarge = XSmallTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });
 
 export const SmallLightTheme = SmallTemplate.extend({});
 export const SmallDarkTheme = SmallTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 export const SmallFontScalingExtraSmall = SmallTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 export const SmallFontScalingExtraExtraExtraLarge = SmallTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });
 
 export const MediumLightTheme = MediumTemplate.extend({});
 export const MediumDarkTheme = MediumTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 export const MediumFontScalingExtraSmall = MediumTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 export const MediumFontScalingExtraExtraExtraLarge = MediumTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });
 
 export const LargeLightTheme = LargeTemplate.extend({});
 export const LargeDarkTheme = LargeTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 export const LargeFontScalingExtraSmall = LargeTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 export const LargeFontScalingExtraExtraExtraLarge = LargeTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ActionChip.stories.tsx
+++ b/docs/stories/ActionChip.stories.tsx
@@ -5,7 +5,7 @@ import { actionChipVariantMap } from "@seed-design/css/recipes/action-chip";
 import { VariantTable } from "./components/variant-table";
 import { IconBellFill, IconChevronDownFill } from "@karrotmarket/react-monochrome-icon";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { Count, Icon, PrefixIcon, SuffixIcon } from "@seed-design/react";
 
 const meta = preview.meta({
@@ -44,13 +44,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ActionableCallout.stories.tsx
+++ b/docs/stories/ActionableCallout.stories.tsx
@@ -4,7 +4,7 @@ import { ActionableCallout } from "seed-design/ui/callout";
 import { calloutVariantMap } from "@seed-design/css/recipes/callout";
 import { VariantTable } from "./components/variant-table";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: ActionableCallout,
@@ -23,13 +23,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ActionableInlineBanner.stories.tsx
+++ b/docs/stories/ActionableInlineBanner.stories.tsx
@@ -5,7 +5,7 @@ import { inlineBannerVariantMap } from "@seed-design/css/recipes/inline-banner";
 import { VariantTable } from "./components/variant-table";
 import { IconBellFill } from "@karrotmarket/react-monochrome-icon";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: ActionableInlineBanner,
@@ -26,13 +26,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ActionablePageBanner.stories.tsx
+++ b/docs/stories/ActionablePageBanner.stories.tsx
@@ -5,7 +5,7 @@ import { pageBannerVariantMap } from "@seed-design/css/recipes/page-banner";
 import { VariantTable } from "./components/variant-table";
 import { IconBellFill } from "@karrotmarket/react-monochrome-icon";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: ActionablePageBanner,
@@ -26,13 +26,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/AlertDialog.stories.tsx
+++ b/docs/stories/AlertDialog.stories.tsx
@@ -1,5 +1,5 @@
 import preview from "../.storybook/preview";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { dialogVariantMap } from "@seed-design/css/recipes/dialog";
 import { Box, ResponsivePair, VStack } from "@seed-design/react";
 import {
@@ -123,13 +123,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Article.stories.tsx
+++ b/docs/stories/Article.stories.tsx
@@ -2,7 +2,7 @@ import preview from "../.storybook/preview";
 import { Article, Text, VStack } from "@seed-design/react";
 import type { ReactNode } from "react";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { SeedThemeDecorator } from "./components/decorator";
 
 const LONG_URL =
@@ -75,13 +75,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/AspectRatio.stories.tsx
+++ b/docs/stories/AspectRatio.stories.tsx
@@ -1,7 +1,7 @@
 import preview from "../.storybook/preview";
 import { AspectRatio, Text } from "@seed-design/react";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
 
@@ -35,13 +35,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/AttachmentDisplay.stories.tsx
+++ b/docs/stories/AttachmentDisplay.stories.tsx
@@ -2,7 +2,7 @@ import preview from "../.storybook/preview";
 import { attachmentInputVariantMap } from "@seed-design/css/recipes/attachment-input";
 import type { DisplayItemEntry } from "@seed-design/react/primitive";
 import { AttachmentDisplay, AttachmentDisplayField } from "seed-design/ui/attachment-display-field";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
 
@@ -105,13 +105,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/AttachmentDisplayReorderable.stories.tsx
+++ b/docs/stories/AttachmentDisplayReorderable.stories.tsx
@@ -3,7 +3,7 @@ import { attachmentInputVariantMap } from "@seed-design/css/recipes/attachment-i
 import type { DisplayItemEntry } from "@seed-design/react/primitive";
 import { AttachmentDisplayField } from "seed-design/ui/attachment-display-field";
 import { AttachmentDisplayReorderable } from "seed-design/ui/attachment-display-field-reorderable";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
 
@@ -82,5 +82,5 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });

--- a/docs/stories/AttachmentField.stories.tsx
+++ b/docs/stories/AttachmentField.stories.tsx
@@ -1,5 +1,5 @@
 import preview from "../.storybook/preview";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
 import { AttachmentField, AttachmentInput } from "seed-design/ui/attachment-field";
@@ -106,13 +106,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/AttachmentFieldDropzone.stories.tsx
+++ b/docs/stories/AttachmentFieldDropzone.stories.tsx
@@ -1,5 +1,5 @@
 import preview from "../.storybook/preview";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
 import { AttachmentField, AttachmentDropzone } from "seed-design/ui/attachment-field";
@@ -106,13 +106,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/AttachmentFieldDropzoneReorderable.stories.tsx
+++ b/docs/stories/AttachmentFieldDropzoneReorderable.stories.tsx
@@ -1,5 +1,5 @@
 import preview from "../.storybook/preview";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
 import { AttachmentField } from "seed-design/ui/attachment-field";
@@ -79,5 +79,5 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });

--- a/docs/stories/AttachmentFieldReorderable.stories.tsx
+++ b/docs/stories/AttachmentFieldReorderable.stories.tsx
@@ -1,5 +1,5 @@
 import preview from "../.storybook/preview";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
 import { AttachmentField } from "seed-design/ui/attachment-field";
@@ -79,5 +79,5 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });

--- a/docs/stories/AttachmentInputItemBadge.stories.tsx
+++ b/docs/stories/AttachmentInputItemBadge.stories.tsx
@@ -3,7 +3,7 @@ import { AttachmentInput, Icon } from "@seed-design/react";
 import type { FileEntry } from "@seed-design/react/primitive";
 import { IconXmarkFill } from "@karrotmarket/react-monochrome-icon";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { SeedThemeDecorator } from "./components/decorator";
 
 // 1x1 pixel PNG (valid image so ItemImage renders without broken icon)
@@ -60,13 +60,13 @@ const Template = meta.story({});
 export const LightTheme = Template.extend({});
 
 export const DarkTheme = Template.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = Template.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = Template.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Avatar.stories.tsx
+++ b/docs/stories/Avatar.stories.tsx
@@ -5,7 +5,7 @@ import { IdentityPlaceholder } from "seed-design/ui/identity-placeholder";
 import { avatarVariantMap } from "@seed-design/css/recipes/avatar";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { Box } from "@seed-design/react";
 
 const meta = preview.meta({
@@ -108,13 +108,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/AvatarStack.stories.tsx
+++ b/docs/stories/AvatarStack.stories.tsx
@@ -4,7 +4,7 @@ import { Avatar, AvatarStack } from "seed-design/ui/avatar";
 import { avatarStackVariantMap } from "@seed-design/css/recipes/avatar-stack";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: AvatarStack,
@@ -27,13 +27,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Badge.stories.tsx
+++ b/docs/stories/Badge.stories.tsx
@@ -4,7 +4,7 @@ import { Badge } from "@seed-design/react";
 import { badgeVariantMap } from "@seed-design/css/recipes/badge";
 import { VariantTable } from "./components/variant-table";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: Badge,
@@ -22,13 +22,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/BottomSheet.stories.tsx
+++ b/docs/stories/BottomSheet.stories.tsx
@@ -1,5 +1,5 @@
 import preview from "../.storybook/preview";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import {
   bottomSheetVariantMap,
   type BottomSheetVariantProps,
@@ -120,13 +120,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Box.stories.tsx
+++ b/docs/stories/Box.stories.tsx
@@ -3,7 +3,7 @@ import preview from "../.storybook/preview";
 import { Box } from "@seed-design/react";
 import { VariantTable } from "./components/variant-table";
 import { SeedThemeDecorator } from "./components/decorator";
-import { VIEWPORT_MODES } from "./utils/parameters";
+import { VISUAL_VIEWPORT_PARAMETERS } from "./utils/parameters";
 
 const meta = preview.meta({
   component: Box,
@@ -102,7 +102,7 @@ export const LightTheme = meta.story({
     <VariantTable Component={component!} variantMap={{}} conditionMap={conditionMap} {...args} />
   ),
   parameters: {
-    chromatic: { modes: VIEWPORT_MODES },
+    ...VISUAL_VIEWPORT_PARAMETERS,
   },
 });
 
@@ -208,6 +208,6 @@ export const Nested = meta.story({
     />
   ),
   parameters: {
-    chromatic: { modes: VIEWPORT_MODES },
+    ...VISUAL_VIEWPORT_PARAMETERS,
   },
 });

--- a/docs/stories/Callout.stories.tsx
+++ b/docs/stories/Callout.stories.tsx
@@ -5,7 +5,7 @@ import { calloutVariantMap } from "@seed-design/css/recipes/callout";
 import { VariantTable } from "./components/variant-table";
 import { IconBellFill } from "@karrotmarket/react-monochrome-icon";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: Callout,
@@ -26,13 +26,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/CheckSelectBox.stories.tsx
+++ b/docs/stories/CheckSelectBox.stories.tsx
@@ -9,7 +9,7 @@ import { Box, Text } from "@seed-design/react";
 
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: CheckSelectBox,
@@ -93,13 +93,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Checkbox.stories.tsx
+++ b/docs/stories/Checkbox.stories.tsx
@@ -4,7 +4,7 @@ import { Checkbox } from "seed-design/ui/checkbox";
 import { checkboxVariantMap } from "@seed-design/css/recipes/checkbox";
 import { VariantTable } from "./components/variant-table";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: Checkbox,
@@ -38,13 +38,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Checkmark.stories.tsx
+++ b/docs/stories/Checkmark.stories.tsx
@@ -7,7 +7,7 @@ import {
 } from "@seed-design/css/recipes/checkmark";
 import { VariantTable } from "./components/variant-table";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { Checkbox } from "@seed-design/react/primitive";
 
 function CustomCheckbox(props: CheckmarkVariantProps & Checkbox.RootProps) {
@@ -64,13 +64,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Chip.Button.stories.tsx
+++ b/docs/stories/Chip.Button.stories.tsx
@@ -1,7 +1,7 @@
 import preview from "../.storybook/preview";
 import { Chip } from "seed-design/ui/chip";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { IconHeartFill } from "@karrotmarket/react-monochrome-icon";
 import { chipVariantMap } from "@seed-design/css/recipes/chip";
 import { Icon } from "@seed-design/react";
@@ -46,13 +46,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Chip.Toggle.stories.tsx
+++ b/docs/stories/Chip.Toggle.stories.tsx
@@ -1,7 +1,7 @@
 import preview from "../.storybook/preview";
 import { Chip } from "seed-design/ui/chip";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { IconHeartFill } from "@karrotmarket/react-monochrome-icon";
 import { chipVariantMap } from "@seed-design/css/recipes/chip";
 import { Icon } from "@seed-design/react";
@@ -51,13 +51,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ChipTabs.stories.tsx
+++ b/docs/stories/ChipTabs.stories.tsx
@@ -9,7 +9,7 @@ import {
 import { chipTabsVariantMap } from "@seed-design/css/recipes/chip-tabs";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const TAB_VALUES = Array.from({ length: 20 }, (_, i) => String(i + 1));
 
@@ -46,13 +46,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ContentPlaceholder.stories.tsx
+++ b/docs/stories/ContentPlaceholder.stories.tsx
@@ -1,7 +1,7 @@
 import preview from "../.storybook/preview";
 import { ContentPlaceholder } from "seed-design/ui/content-placeholder";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { contentPlaceholderVariantMap } from "@seed-design/css/recipes/content-placeholder";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
@@ -75,13 +75,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ContextualFloatingButton.stories.tsx
+++ b/docs/stories/ContextualFloatingButton.stories.tsx
@@ -2,7 +2,7 @@ import preview from "../.storybook/preview";
 import { ContextualFloatingButton } from "seed-design/ui/contextual-floating-button";
 import { Icon } from "@seed-design/react";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { IconBellFill } from "@karrotmarket/react-monochrome-icon";
 import { contextualFloatingButtonVariantMap } from "@seed-design/css/recipes/contextual-floating-button";
 import { PrefixIcon } from "@seed-design/react";
@@ -51,13 +51,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ControlChip.stories.tsx
+++ b/docs/stories/ControlChip.stories.tsx
@@ -5,7 +5,7 @@ import { IconBellFill, IconChevronDownFill } from "@karrotmarket/react-monochrom
 import { controlChipVariantMap } from "@seed-design/css/recipes/control-chip";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { Count, Icon, PrefixIcon, SuffixIcon } from "@seed-design/react";
 
 const meta = preview.meta({
@@ -48,13 +48,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/DatePicker.stories.tsx
+++ b/docs/stories/DatePicker.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from "@seed-design/react";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "./utils/parameters";
+import { withVisualTestParameters } from "./utils/parameters";
 
 type DatePickerPreviewProps = DatePickerProps & {
   previewWidth?: string;
@@ -106,15 +106,15 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });
 
 export const Continuous = meta.story({

--- a/docs/stories/Dialog.stories.tsx
+++ b/docs/stories/Dialog.stories.tsx
@@ -1,5 +1,5 @@
 import preview from "../.storybook/preview";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import {
   contentDialogVariantMap,
   type ContentDialogVariantProps,
@@ -115,13 +115,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/DismissibleCallout.stories.tsx
+++ b/docs/stories/DismissibleCallout.stories.tsx
@@ -4,7 +4,7 @@ import { DismissibleCallout } from "seed-design/ui/callout";
 import { calloutVariantMap } from "@seed-design/css/recipes/callout";
 import { VariantTable } from "./components/variant-table";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: DismissibleCallout,
@@ -24,13 +24,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/DismissibleInlineBanner.stories.tsx
+++ b/docs/stories/DismissibleInlineBanner.stories.tsx
@@ -5,7 +5,7 @@ import { inlineBannerVariantMap } from "@seed-design/css/recipes/inline-banner";
 import { VariantTable } from "./components/variant-table";
 import { IconBellFill } from "@karrotmarket/react-monochrome-icon";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: DismissibleInlineBanner,
@@ -26,13 +26,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/DismissiblePageBanner.stories.tsx
+++ b/docs/stories/DismissiblePageBanner.stories.tsx
@@ -5,7 +5,7 @@ import { pageBannerVariantMap } from "@seed-design/css/recipes/page-banner";
 import { VariantTable } from "./components/variant-table";
 import { IconBellFill } from "@karrotmarket/react-monochrome-icon";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: DismissiblePageBanner,
@@ -26,13 +26,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Divider.stories.tsx
+++ b/docs/stories/Divider.stories.tsx
@@ -2,7 +2,7 @@ import preview from "../.storybook/preview";
 import { Box, Divider, HStack, VStack } from "@seed-design/react";
 import type { ComponentProps } from "react";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
 
@@ -59,13 +59,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ExtendedFab.stories.tsx
+++ b/docs/stories/ExtendedFab.stories.tsx
@@ -5,7 +5,7 @@ import { IconBellFill } from "@karrotmarket/react-monochrome-icon";
 import { extendedFabVariantMap } from "@seed-design/css/recipes/extended-fab";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { PrefixIcon } from "@seed-design/react";
 
 const meta = preview.meta({
@@ -29,13 +29,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Field.stories.tsx
+++ b/docs/stories/Field.stories.tsx
@@ -1,7 +1,7 @@
 import preview from "../.storybook/preview";
 import { Field, VisuallyHidden, PrefixIcon, Box } from "@seed-design/react";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { fieldVariantMap } from "@seed-design/css/recipes/field";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
@@ -124,13 +124,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/FieldButton.stories.tsx
+++ b/docs/stories/FieldButton.stories.tsx
@@ -3,7 +3,7 @@ import { FieldButton, FieldButtonPlaceholder, FieldButtonValue } from "seed-desi
 import { inputButtonVariantMap } from "@seed-design/css/recipes/input-button";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { VIEWPORT_MODES, withChromaticParameters } from "@/stories/utils/parameters";
+import { VISUAL_VIEWPORT_PARAMETERS, withVisualTestParameters } from "@/stories/utils/parameters";
 import { IconPaperplaneLine } from "@karrotmarket/react-monochrome-icon";
 
 const meta = preview.meta({
@@ -76,18 +76,18 @@ const CommonStoryTemplate = meta.story({
 
 export const LightTheme = CommonStoryTemplate.extend({
   parameters: {
-    chromatic: { modes: VIEWPORT_MODES },
+    ...VISUAL_VIEWPORT_PARAMETERS,
   },
 });
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Fieldset.stories.tsx
+++ b/docs/stories/Fieldset.stories.tsx
@@ -1,7 +1,7 @@
 import preview from "../.storybook/preview";
 import { Fieldset, VisuallyHidden, PrefixIcon, Box } from "@seed-design/react";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { fieldVariantMap } from "@seed-design/css/recipes/field";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
@@ -108,13 +108,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Flex.stories.tsx
+++ b/docs/stories/Flex.stories.tsx
@@ -3,7 +3,7 @@ import preview from "../.storybook/preview";
 import { Flex } from "@seed-design/react";
 import { VariantTable } from "./components/variant-table";
 import { SeedThemeDecorator } from "./components/decorator";
-import { VIEWPORT_MODES } from "./utils/parameters";
+import { VISUAL_VIEWPORT_PARAMETERS } from "./utils/parameters";
 
 const meta = preview.meta({
   component: Flex,
@@ -69,6 +69,6 @@ export const LightTheme = meta.story({
     <VariantTable Component={component!} variantMap={{}} conditionMap={conditionMap} {...args} />
   ),
   parameters: {
-    chromatic: { modes: VIEWPORT_MODES },
+    ...VISUAL_VIEWPORT_PARAMETERS,
   },
 });

--- a/docs/stories/FloatingActionButton.stories.tsx
+++ b/docs/stories/FloatingActionButton.stories.tsx
@@ -1,7 +1,7 @@
 import preview from "../.storybook/preview";
 import { FloatingActionButton } from "seed-design/ui/floating-action-button";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { IconBellFill } from "@karrotmarket/react-monochrome-icon";
 import { floatingActionButtonVariantMap } from "@seed-design/css/recipes/floating-action-button";
 import { SeedThemeDecorator } from "./components/decorator";
@@ -24,13 +24,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/FooterLinkText.stories.tsx
+++ b/docs/stories/FooterLinkText.stories.tsx
@@ -1,7 +1,7 @@
 import preview from "../.storybook/preview";
 import { FooterLinkText, SuffixIcon } from "@seed-design/react";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { IconArrowUpRightLine } from "@karrotmarket/react-monochrome-icon";
 import { footerVariantMap } from "@seed-design/css/recipes/footer";
 import { SeedThemeDecorator } from "./components/decorator";
@@ -28,13 +28,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Grid.stories.tsx
+++ b/docs/stories/Grid.stories.tsx
@@ -3,7 +3,7 @@ import preview from "../.storybook/preview";
 import { Grid, GridItem } from "@seed-design/react";
 import { VariantTable } from "./components/variant-table";
 import { SeedThemeDecorator } from "./components/decorator";
-import { VIEWPORT_MODES } from "./utils/parameters";
+import { VISUAL_VIEWPORT_PARAMETERS } from "./utils/parameters";
 
 const meta = preview.meta({
   component: Grid,
@@ -62,7 +62,7 @@ export const LightTheme = meta.story({
     <VariantTable Component={component!} variantMap={{}} conditionMap={conditionMap} {...args} />
   ),
   parameters: {
-    chromatic: { modes: VIEWPORT_MODES },
+    ...VISUAL_VIEWPORT_PARAMETERS,
   },
 });
 

--- a/docs/stories/HelpBubble.stories.tsx
+++ b/docs/stories/HelpBubble.stories.tsx
@@ -1,5 +1,5 @@
 import preview from "../.storybook/preview";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { IconBellFill } from "@karrotmarket/react-monochrome-icon";
 import { helpBubbleVariantMap } from "@seed-design/css/recipes/help-bubble";
 import { HelpBubbleTrigger } from "seed-design/ui/help-bubble";
@@ -55,13 +55,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/HelpBubbleTooltip.stories.tsx
+++ b/docs/stories/HelpBubbleTooltip.stories.tsx
@@ -1,5 +1,5 @@
 import preview from "../.storybook/preview";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { IconBellFill } from "@karrotmarket/react-monochrome-icon";
 import { helpBubbleVariantMap } from "@seed-design/css/recipes/help-bubble";
 import { HelpBubbleTooltipTrigger } from "seed-design/ui/help-bubble-tooltip";
@@ -51,13 +51,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/IdentityPlaceholder.stories.tsx
+++ b/docs/stories/IdentityPlaceholder.stories.tsx
@@ -4,7 +4,7 @@ import { IdentityPlaceholder } from "seed-design/ui/identity-placeholder";
 import { identityPlaceholderVariantMap } from "@seed-design/css/recipes/identity-placeholder";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: IdentityPlaceholder,
@@ -19,13 +19,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ImageFrame.stories.tsx
+++ b/docs/stories/ImageFrame.stories.tsx
@@ -14,7 +14,7 @@ import {
 import { useState } from "react";
 
 import { imageFrameVariantMap } from "@seed-design/css/recipes/image-frame";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
 
@@ -148,15 +148,15 @@ const OverlayExamples = () => {
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });
 
 export const Overlay = meta.story({

--- a/docs/stories/InlineBanner.stories.tsx
+++ b/docs/stories/InlineBanner.stories.tsx
@@ -5,7 +5,7 @@ import { inlineBannerVariantMap } from "@seed-design/css/recipes/inline-banner";
 import { VariantTable } from "./components/variant-table";
 import { IconBellFill } from "@karrotmarket/react-monochrome-icon";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: InlineBanner,
@@ -26,13 +26,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/InternalWheelPicker.stories.tsx
+++ b/docs/stories/InternalWheelPicker.stories.tsx
@@ -9,7 +9,7 @@ import {
 import "./InternalWheelPicker.css";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "./utils/parameters";
+import { withVisualTestParameters } from "./utils/parameters";
 
 interface ColumnCase {
   label: string;
@@ -262,13 +262,13 @@ const CommonStory = meta.story({
 export const LightTheme = CommonStory.extend({});
 
 export const DarkTheme = CommonStory.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStory.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStory.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Layout.stories.tsx
+++ b/docs/stories/Layout.stories.tsx
@@ -4,7 +4,7 @@ import { Layout, Box } from "@seed-design/react";
 import { layoutVariantMap } from "@seed-design/css/recipes/layout";
 import { VariantTable } from "./components/variant-table";
 import { SeedThemeDecorator } from "./components/decorator";
-import { VIEWPORT_MODES } from "./utils/parameters";
+import { VISUAL_VIEWPORT_PARAMETERS } from "./utils/parameters";
 
 const meta = preview.meta({
   component: Layout.Root,
@@ -50,6 +50,6 @@ export const LightTheme = meta.story({
     <VariantTable Component={component!} variantMap={layoutVariantMap} {...args} />
   ),
   parameters: {
-    chromatic: { modes: VIEWPORT_MODES },
+    ...VISUAL_VIEWPORT_PARAMETERS,
   },
 });

--- a/docs/stories/LinkContent.stories.tsx
+++ b/docs/stories/LinkContent.stories.tsx
@@ -1,7 +1,7 @@
 import preview from "../.storybook/preview";
 import { LinkContent } from "@seed-design/react";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { IconChevronRightLine } from "@karrotmarket/react-monochrome-icon";
 import { linkContentVariantMap } from "@seed-design/css/recipes/link-content";
 import { SuffixIcon } from "@seed-design/react";
@@ -41,13 +41,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ListButtonItem.stories.tsx
+++ b/docs/stories/ListButtonItem.stories.tsx
@@ -4,7 +4,7 @@ import { Fragment } from "react";
 import { List, ListButtonItem, ListDivider } from "seed-design/ui/list";
 
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import {
   IconChevronRightLine,
   IconILowercaseSerifCircleLine,
@@ -112,13 +112,13 @@ const CommonTemplate = meta.story({
 export const LightTheme = CommonTemplate.extend({});
 
 export const DarkTheme = CommonTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ListCheckItem.stories.tsx
+++ b/docs/stories/ListCheckItem.stories.tsx
@@ -5,7 +5,7 @@ import { List, ListCheckItem, ListDivider } from "seed-design/ui/list";
 import { Checkmark } from "seed-design/ui/checkbox";
 
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import {
   IconChevronRightLine,
   IconILowercaseSerifCircleLine,
@@ -239,13 +239,13 @@ const CommonTemplate = meta.story({
 export const LightTheme = CommonTemplate.extend({});
 
 export const DarkTheme = CommonTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ListItem.stories.tsx
+++ b/docs/stories/ListItem.stories.tsx
@@ -4,7 +4,7 @@ import { Fragment } from "react";
 import { List, ListItem, ListDivider } from "seed-design/ui/list";
 
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import {
   IconChevronRightLine,
   IconILowercaseSerifCircleLine,
@@ -108,13 +108,13 @@ const CommonTemplate = meta.story({
 export const LightTheme = CommonTemplate.extend({});
 
 export const DarkTheme = CommonTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ListLinkItem.stories.tsx
+++ b/docs/stories/ListLinkItem.stories.tsx
@@ -4,7 +4,7 @@ import { Fragment } from "react";
 import { List, ListLinkItem, ListDivider } from "seed-design/ui/list";
 
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import {
   IconChevronRightLine,
   IconILowercaseSerifCircleLine,
@@ -111,13 +111,13 @@ const CommonTemplate = meta.story({
 export const LightTheme = CommonTemplate.extend({});
 
 export const DarkTheme = CommonTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ListRadioItem.stories.tsx
+++ b/docs/stories/ListRadioItem.stories.tsx
@@ -8,7 +8,7 @@ import { List, ListRadioItem, ListDivider } from "seed-design/ui/list";
 import { Radiomark } from "seed-design/ui/radio-group";
 
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import {
   IconChevronRightLine,
   IconILowercaseSerifCircleLine,
@@ -139,13 +139,13 @@ const CommonTemplate = meta.story({
 export const LightTheme = CommonTemplate.extend({});
 
 export const DarkTheme = CommonTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/MannerTemp.stories.tsx
+++ b/docs/stories/MannerTemp.stories.tsx
@@ -4,7 +4,7 @@ import { MannerTemp } from "seed-design/ui/manner-temp";
 import { mannerTempVariantMap } from "@seed-design/css/recipes/manner-temp";
 import { VariantTable } from "./components/variant-table";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: MannerTemp,
@@ -61,13 +61,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/MannerTempBadge.stories.tsx
+++ b/docs/stories/MannerTempBadge.stories.tsx
@@ -4,7 +4,7 @@ import { MannerTempBadge } from "seed-design/ui/manner-temp-badge";
 import { mannerTempBadgeVariantMap } from "@seed-design/css/recipes/manner-temp-badge";
 import { VariantTable } from "./components/variant-table";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: MannerTempBadge,
@@ -61,13 +61,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Menu.stories.tsx
+++ b/docs/stories/Menu.stories.tsx
@@ -1,5 +1,5 @@
 import preview from "../.storybook/preview";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import {
   IconDiamondLine,
   IconPlusLine,
@@ -11,7 +11,7 @@ import { useCallback, useRef, useState } from "react";
 import { MenuContent, MenuGroup, MenuGroupLabel, MenuItem, MenuRoot } from "seed-design/ui/menu";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { VIEWPORT_MODES } from "./utils/parameters";
+import { VISUAL_VIEWPORT_PARAMETERS } from "./utils/parameters";
 
 const MenuPreview = ({ size }: MenuVariantProps) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -85,18 +85,18 @@ const CommonStoryTemplate = meta.story({
 
 export const LightTheme = CommonStoryTemplate.extend({
   parameters: {
-    chromatic: { modes: VIEWPORT_MODES },
+    ...VISUAL_VIEWPORT_PARAMETERS,
   },
 });
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/MenuSheet.stories.tsx
+++ b/docs/stories/MenuSheet.stories.tsx
@@ -1,5 +1,5 @@
 import preview from "../.storybook/preview";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { IconEyeSlashLine } from "@karrotmarket/react-monochrome-icon";
 import { menuSheetVariantMap } from "@seed-design/css/recipes/menu-sheet";
 import { Box } from "@seed-design/react";
@@ -101,13 +101,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/MiddleTruncate.stories.tsx
+++ b/docs/stories/MiddleTruncate.stories.tsx
@@ -1,7 +1,7 @@
 import preview from "../.storybook/preview";
 import { MiddleTruncate, type MiddleTruncateProps } from "@seed-design/react/primitive";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { VariantTable } from "./components/variant-table";
 
 const MiddleTruncateForStory = ({
@@ -62,9 +62,9 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/NotificationBadge.stories.tsx
+++ b/docs/stories/NotificationBadge.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from "@seed-design/react";
 
 import type { NotificationBadgePositionerVariantProps } from "@seed-design/css/recipes/notification-badge-positioner";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
 import { IconBellLine } from "@karrotmarket/react-monochrome-icon";
@@ -61,13 +61,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/PageBanner.stories.tsx
+++ b/docs/stories/PageBanner.stories.tsx
@@ -5,7 +5,7 @@ import { pageBannerVariantMap } from "@seed-design/css/recipes/page-banner";
 import { VariantTable } from "./components/variant-table";
 import { IconBellFill } from "@karrotmarket/react-monochrome-icon";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: PageBanner,
@@ -27,13 +27,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ProgressCircle.stories.tsx
+++ b/docs/stories/ProgressCircle.stories.tsx
@@ -4,7 +4,7 @@ import { ProgressCircle } from "seed-design/ui/progress-circle";
 import { progressCircleVariantMap } from "@seed-design/css/recipes/progress-circle";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: ProgressCircle,
@@ -47,23 +47,23 @@ const Determinate100Template = meta.story({
 export const IndeterminateLightTheme = IndeterminateTemplate.extend({});
 
 export const IndeterminateDarkTheme = IndeterminateTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const Determinate0LightTheme = Determinate0Template.extend({});
 
 export const Determinate0DarkTheme = Determinate0Template.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const Determinate50LightTheme = Determinate50Template.extend({});
 
 export const Determinate50DarkTheme = Determinate50Template.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const Determinate100LightTheme = Determinate100Template.extend({});
 
 export const Determinate100DarkTheme = Determinate100Template.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });

--- a/docs/stories/QuantityPicker.stories.tsx
+++ b/docs/stories/QuantityPicker.stories.tsx
@@ -7,7 +7,7 @@ import { QuantityPicker } from "seed-design/ui/quantity-picker";
 
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "./utils/parameters";
+import { withVisualTestParameters } from "./utils/parameters";
 
 const meta = preview.meta({
   component: QuantityPicker,
@@ -60,24 +60,24 @@ const MaxValuesTemplate = meta.story({
   ),
 });
 
-export const LightTheme = Template.extend({ parameters: withChromaticParameters({}) });
+export const LightTheme = Template.extend({ parameters: withVisualTestParameters({}) });
 export const DarkTheme = Template.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 export const FontScalingExtraSmall = Template.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 export const FontScalingExtraExtraExtraLarge = Template.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });
-export const MaxValues = MaxValuesTemplate.extend({ parameters: withChromaticParameters({}) });
+export const MaxValues = MaxValuesTemplate.extend({ parameters: withVisualTestParameters({}) });
 
 export const MaxValuesFontScalingExtraSmall = MaxValuesTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const MaxValuesFontScalingExtraExtraExtraLarge = MaxValuesTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });
 
 export const LayoutFill = meta.story({

--- a/docs/stories/RadioGroup.stories.tsx
+++ b/docs/stories/RadioGroup.stories.tsx
@@ -4,7 +4,7 @@ import { RadioGroup, RadioGroupItem } from "seed-design/ui/radio-group";
 import { radioVariantMap } from "@seed-design/css/recipes/radio";
 import { VariantTable } from "./components/variant-table";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: RadioGroup,
@@ -44,13 +44,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/RadioGroupField.stories.tsx
+++ b/docs/stories/RadioGroupField.stories.tsx
@@ -1,7 +1,7 @@
 import preview from "../.storybook/preview";
 import { RadioGroupField, VisuallyHidden, PrefixIcon, Box } from "@seed-design/react";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { fieldVariantMap } from "@seed-design/css/recipes/field";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
@@ -111,13 +111,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/RadioSelectBox.stories.tsx
+++ b/docs/stories/RadioSelectBox.stories.tsx
@@ -9,7 +9,7 @@ import { Box, Text } from "@seed-design/react";
 
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 type RadioSelectBoxStoryArgs = React.ComponentProps<typeof RadioSelectBoxItem> & {
   columns?: number;
@@ -116,13 +116,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Radiomark.stories.tsx
+++ b/docs/stories/Radiomark.stories.tsx
@@ -7,7 +7,7 @@ import {
 } from "@seed-design/css/recipes/radiomark";
 import { VariantTable } from "./components/variant-table";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { RadioGroup } from "@seed-design/react/primitive";
 
 function CustomRadioGroup(
@@ -66,13 +66,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ReactionButton.stories.tsx
+++ b/docs/stories/ReactionButton.stories.tsx
@@ -5,7 +5,7 @@ import { IconBellFill } from "@karrotmarket/react-monochrome-icon";
 import { reactionButtonVariantMap } from "@seed-design/css/recipes/reaction-button";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { Count, PrefixIcon } from "@seed-design/react";
 
 const meta = preview.meta({
@@ -60,13 +60,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ResponsiveDialog.stories.tsx
+++ b/docs/stories/ResponsiveDialog.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from "seed-design/ui/responsive-dialog";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { VIEWPORT_MODES } from "./utils/parameters";
+import { VISUAL_VIEWPORT_PARAMETERS } from "./utils/parameters";
 
 const ResponsiveDialogPreview = ({
   showCloseButton,
@@ -99,6 +99,6 @@ export const LightTheme = meta.story({
     <VariantTable Component={component!} variantMap={{}} conditionMap={conditionMap} {...args} />
   ),
   parameters: {
-    chromatic: { modes: VIEWPORT_MODES },
+    ...VISUAL_VIEWPORT_PARAMETERS,
   },
 });

--- a/docs/stories/ResponsivePair.stories.tsx
+++ b/docs/stories/ResponsivePair.stories.tsx
@@ -3,7 +3,7 @@ import preview from "../.storybook/preview";
 import { Box, ResponsivePair } from "@seed-design/react";
 import { VariantTable } from "./components/variant-table";
 import { SeedThemeDecorator } from "./components/decorator";
-import { VIEWPORT_MODES } from "./utils/parameters";
+import { VISUAL_VIEWPORT_PARAMETERS } from "./utils/parameters";
 
 const meta = preview.meta({
   component: ResponsivePair,
@@ -52,6 +52,6 @@ export const LightTheme = meta.story({
     <VariantTable Component={component!} variantMap={{}} conditionMap={conditionMap} {...args} />
   ),
   parameters: {
-    chromatic: { modes: VIEWPORT_MODES },
+    ...VISUAL_VIEWPORT_PARAMETERS,
   },
 });

--- a/docs/stories/ResponsiveSidePanel.stories.tsx
+++ b/docs/stories/ResponsiveSidePanel.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from "seed-design/ui/responsive-side-panel";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { VIEWPORT_MODES } from "./utils/parameters";
+import { VISUAL_VIEWPORT_PARAMETERS } from "./utils/parameters";
 
 const ResponsiveSidePanelPreview = ({
   showCloseButton,
@@ -109,6 +109,6 @@ export const LightTheme = meta.story({
     <VariantTable Component={component!} variantMap={{}} conditionMap={conditionMap} {...args} />
   ),
   parameters: {
-    chromatic: { modes: VIEWPORT_MODES },
+    ...VISUAL_VIEWPORT_PARAMETERS,
   },
 });

--- a/docs/stories/ResultSection.stories.tsx
+++ b/docs/stories/ResultSection.stories.tsx
@@ -1,7 +1,7 @@
 import preview from "../.storybook/preview";
 import { ResultSection } from "seed-design/ui/result-section";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { Box, Icon } from "@seed-design/react";
 import { SeedThemeDecorator } from "./components/decorator";
 import { IconDiamond } from "@karrotmarket/react-multicolor-icon";
@@ -77,13 +77,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/ScrollFog.stories.tsx
+++ b/docs/stories/ScrollFog.stories.tsx
@@ -1,7 +1,7 @@
 import preview from "../.storybook/preview";
 import { Box, HStack, ScrollFog, VStack } from "@seed-design/react";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
 
@@ -91,13 +91,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/SegmentedControl.stories.tsx
+++ b/docs/stories/SegmentedControl.stories.tsx
@@ -5,7 +5,7 @@ import { segmentedControlVariantMap } from "@seed-design/css/recipes/segmented-c
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
 import { useState } from "react";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const Component = ({ disabled }: { disabled: boolean }) => {
   const values = ["dolor", "magna", "sint"];
@@ -54,13 +54,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Select.stories.tsx
+++ b/docs/stories/Select.stories.tsx
@@ -9,10 +9,10 @@ import {
   SelectTrigger,
 } from "seed-design/ui/select";
 import type { SelectRootProps, SelectTriggerProps } from "seed-design/ui/select";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { VIEWPORT_MODES } from "./utils/parameters";
+import { VISUAL_VIEWPORT_PARAMETERS } from "./utils/parameters";
 
 interface ClosedSelectProps
   extends SelectRootProps,
@@ -88,18 +88,18 @@ const CommonStoryTemplate = meta.story({
 
 export const LightTheme = CommonStoryTemplate.extend({
   parameters: {
-    chromatic: { modes: VIEWPORT_MODES },
+    ...VISUAL_VIEWPORT_PARAMETERS,
   },
 });
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/SelectContent.stories.tsx
+++ b/docs/stories/SelectContent.stories.tsx
@@ -10,10 +10,10 @@ import {
   SelectRoot,
   SelectTrigger,
 } from "seed-design/ui/select";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { VIEWPORT_MODES } from "./utils/parameters";
+import { VISUAL_VIEWPORT_PARAMETERS } from "./utils/parameters";
 
 // The listbox is forced open for snapshots. It normally portals to the body and
 // is positioned by floating-ui (flip/shift/size, viewport-dependent). Here it is
@@ -112,18 +112,18 @@ const CommonStoryTemplate = meta.story({
 
 export const LightTheme = CommonStoryTemplate.extend({
   parameters: {
-    chromatic: { modes: VIEWPORT_MODES },
+    ...VISUAL_VIEWPORT_PARAMETERS,
   },
 });
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/SideNavigation.stories.tsx
+++ b/docs/stories/SideNavigation.stories.tsx
@@ -20,7 +20,7 @@ import {
   SideNavigationTrigger,
 } from "seed-design/ui/side-navigation";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
 
@@ -94,13 +94,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/SidePanel.stories.tsx
+++ b/docs/stories/SidePanel.stories.tsx
@@ -1,5 +1,5 @@
 import preview from "../.storybook/preview";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import {
   sidePanelVariantMap,
   type SidePanelVariantProps,
@@ -111,13 +111,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Skeleton.stories.tsx
+++ b/docs/stories/Skeleton.stories.tsx
@@ -4,7 +4,7 @@ import { Skeleton } from "@seed-design/react";
 import { skeletonVariantMap } from "@seed-design/css/recipes/skeleton";
 import { VariantTable } from "./components/variant-table";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: Skeleton,
@@ -23,13 +23,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Slider.stories.tsx
+++ b/docs/stories/Slider.stories.tsx
@@ -1,7 +1,7 @@
 import preview from "../.storybook/preview";
 import { Slider } from "seed-design/ui/slider";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { sliderVariantMap } from "@seed-design/css/recipes/slider";
 import { sliderTickVariantMap } from "@seed-design/css/recipes/slider-tick";
 import { SeedThemeDecorator } from "./components/decorator";
@@ -57,13 +57,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Snackbar.stories.tsx
+++ b/docs/stories/Snackbar.stories.tsx
@@ -3,7 +3,7 @@ import { snackbarVariantMap } from "@seed-design/css/recipes/snackbar";
 import { Box } from "@seed-design/react";
 import { Snackbar, SnackbarProvider } from "seed-design/ui/snackbar";
 
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
 
@@ -55,13 +55,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Stack.stories.tsx
+++ b/docs/stories/Stack.stories.tsx
@@ -3,7 +3,7 @@ import preview from "../.storybook/preview";
 import { VStack, HStack } from "@seed-design/react";
 import { VariantTable } from "./components/variant-table";
 import { SeedThemeDecorator } from "./components/decorator";
-import { VIEWPORT_MODES } from "./utils/parameters";
+import { VISUAL_VIEWPORT_PARAMETERS } from "./utils/parameters";
 
 const meta = preview.meta({
   component: VStack,
@@ -56,7 +56,7 @@ export const VStackLightTheme = meta.story({
     <VariantTable Component={VStack} variantMap={{}} conditionMap={vstackConditionMap} {...args} />
   ),
   parameters: {
-    chromatic: { modes: VIEWPORT_MODES },
+    ...VISUAL_VIEWPORT_PARAMETERS,
   },
 });
 
@@ -79,6 +79,6 @@ export const HStackLightTheme = meta.story({
     <VariantTable Component={HStack} variantMap={{}} conditionMap={hstackConditionMap} {...args} />
   ),
   parameters: {
-    chromatic: { modes: VIEWPORT_MODES },
+    ...VISUAL_VIEWPORT_PARAMETERS,
   },
 });

--- a/docs/stories/SwipeableMenuSheet.stories.tsx
+++ b/docs/stories/SwipeableMenuSheet.stories.tsx
@@ -1,5 +1,5 @@
 import preview from "../.storybook/preview";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { IconEyeSlashLine } from "@karrotmarket/react-monochrome-icon";
 import { menuSheetVariantMap } from "@seed-design/css/recipes/menu-sheet";
 import { Box } from "@seed-design/react";
@@ -101,13 +101,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Switch.stories.tsx
+++ b/docs/stories/Switch.stories.tsx
@@ -4,7 +4,7 @@ import { Switch } from "seed-design/ui/switch";
 import { switchVariantMap } from "@seed-design/css/recipes/switch";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: Switch,
@@ -34,13 +34,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/SwitchMark.stories.tsx
+++ b/docs/stories/SwitchMark.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from "@seed-design/css/recipes/switchmark";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { Switch } from "@seed-design/react/primitive";
 
 function CustomSwitch(props: SwitchmarkVariantProps & Switch.RootProps) {
@@ -51,13 +51,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/Tabs.stories.tsx
+++ b/docs/stories/Tabs.stories.tsx
@@ -4,7 +4,7 @@ import { TabsRoot, TabsRootProps, TabsTrigger, TabsList } from "seed-design/ui/t
 import { tabsVariantMap } from "@seed-design/css/recipes/tabs";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 
 const Component = (props: TabsRootProps) => {
   return (
@@ -36,13 +36,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/TagGroup.stories.tsx
+++ b/docs/stories/TagGroup.stories.tsx
@@ -4,7 +4,7 @@ import { tagGroupItemVariantMap } from "@seed-design/css/recipes/tag-group-item"
 
 import { VariantTable } from "./components/variant-table";
 import { SeedThemeDecorator } from "./components/decorator";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { IconCheckmarkCircleFill, IconMegaphoneFill } from "@karrotmarket/react-monochrome-icon";
 import { TagGroupRoot, TagGroupItem } from "seed-design/ui/tag-group";
 
@@ -90,13 +90,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/TextFieldInput.stories.tsx
+++ b/docs/stories/TextFieldInput.stories.tsx
@@ -5,7 +5,7 @@ import { IconPaperplaneLine } from "@karrotmarket/react-monochrome-icon";
 import { textInputVariantMap } from "@seed-design/css/recipes/text-input";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { VIEWPORT_MODES, withChromaticParameters } from "@/stories/utils/parameters";
+import { VISUAL_VIEWPORT_PARAMETERS, withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: TextField,
@@ -64,18 +64,18 @@ const CommonStoryTemplate = meta.story({
 
 export const LightTheme = CommonStoryTemplate.extend({
   parameters: {
-    chromatic: { modes: VIEWPORT_MODES },
+    ...VISUAL_VIEWPORT_PARAMETERS,
   },
 });
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/TextFieldTextarea.stories.tsx
+++ b/docs/stories/TextFieldTextarea.stories.tsx
@@ -4,7 +4,7 @@ import { TextField, TextFieldTextarea } from "seed-design/ui/text-field";
 import { textInputVariantMap } from "@seed-design/css/recipes/text-input";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { VIEWPORT_MODES, withChromaticParameters } from "@/stories/utils/parameters";
+import { VISUAL_VIEWPORT_PARAMETERS, withVisualTestParameters } from "@/stories/utils/parameters";
 
 const meta = preview.meta({
   component: TextField,
@@ -64,18 +64,18 @@ const CommonStoryTemplate = meta.story({
 
 export const LightTheme = CommonStoryTemplate.extend({
   parameters: {
-    chromatic: { modes: VIEWPORT_MODES },
+    ...VISUAL_VIEWPORT_PARAMETERS,
   },
 });
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/TimePicker.stories.tsx
+++ b/docs/stories/TimePicker.stories.tsx
@@ -2,7 +2,7 @@ import preview from "../.storybook/preview";
 import { Box, TimePicker, type TimePickerProps } from "@seed-design/react";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "./utils/parameters";
+import { withVisualTestParameters } from "./utils/parameters";
 
 type TimePickerPreviewProps = TimePickerProps & {
   previewWidth?: string;
@@ -64,5 +64,5 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });

--- a/docs/stories/ToggleButton.stories.tsx
+++ b/docs/stories/ToggleButton.stories.tsx
@@ -5,7 +5,7 @@ import { IconBellFill, IconChevronRightFill } from "@karrotmarket/react-monochro
 import { toggleButtonVariantMap } from "@seed-design/css/recipes/toggle-button";
 import { SeedThemeDecorator } from "./components/decorator";
 import { VariantTable } from "./components/variant-table";
-import { withChromaticParameters } from "@/stories/utils/parameters";
+import { withVisualTestParameters } from "@/stories/utils/parameters";
 import { PrefixIcon, SuffixIcon } from "@seed-design/react";
 
 const meta = preview.meta({
@@ -59,13 +59,13 @@ const CommonStoryTemplate = meta.story({
 export const LightTheme = CommonStoryTemplate.extend({});
 
 export const DarkTheme = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ theme: "dark" }),
+  parameters: withVisualTestParameters({ theme: "dark" }),
 });
 
 export const FontScalingExtraSmall = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Small" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Small" }),
 });
 
 export const FontScalingExtraExtraExtraLarge = CommonStoryTemplate.extend({
-  parameters: withChromaticParameters({ fontScale: "Extra Extra Extra Large" }),
+  parameters: withVisualTestParameters({ fontScale: "Extra Extra Extra Large" }),
 });

--- a/docs/stories/utils/parameters.test.ts
+++ b/docs/stories/utils/parameters.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { breakpointNames } from "@seed-design/css/breakpoints";
+import { VISUAL_VIEWPORT_PARAMETERS, withVisualTestParameters } from "./parameters";
+
+describe("visual test provider parameters", () => {
+  test("keeps Chromatic and Kapture configuration in independent provider trees", () => {
+    const parameters = withVisualTestParameters({ theme: "dark" as const });
+
+    expect(parameters.chromatic).toEqual({
+      diffThreshold: 0.2,
+      delay: 300,
+      pauseAnimationAtEnd: true,
+    });
+    expect(parameters.kapture).toEqual({
+      diff: { pixel: 0.2 },
+      delayMs: 300,
+      animation: "end",
+    });
+    expect(parameters.theme).toBe("dark");
+  });
+
+  test("maps responsive captures independently for both providers", () => {
+    expect(VISUAL_VIEWPORT_PARAMETERS.kapture.viewports).toEqual([...breakpointNames]);
+    expect(Object.keys(VISUAL_VIEWPORT_PARAMETERS.chromatic.modes)).toEqual([...breakpointNames]);
+  });
+});

--- a/docs/stories/utils/parameters.ts
+++ b/docs/stories/utils/parameters.ts
@@ -1,4 +1,5 @@
 import { breakpointNames } from "@seed-design/css/breakpoints";
+import type { KaptureStoryParameters } from "@kaptures/storybook";
 
 export const FONT_SCALE_MAP = {
   "Extra Small": "14px",
@@ -15,23 +16,34 @@ export type FontScales = keyof typeof FONT_SCALE_MAP;
 export type StoryParameters = {
   theme?: "light" | "dark";
   fontScale?: FontScales;
+  kapture?: KaptureStoryParameters;
 };
 
-export const VIEWPORT_MODES = Object.fromEntries(
-  breakpointNames.map((name) => [name, { viewport: name }]),
-);
+export const VISUAL_VIEWPORT_PARAMETERS = {
+  chromatic: {
+    modes: Object.fromEntries(breakpointNames.map((name) => [name, { viewport: name }])),
+  },
+  kapture: {
+    viewports: breakpointNames,
+  },
+} satisfies { kapture: KaptureStoryParameters; chromatic: { modes: object } };
 
-const CHROMATIC_PARAMETERS = {
+const VISUAL_TEST_PARAMETERS = {
   chromatic: {
     diffThreshold: 0.2, // 20% 미만의 픽셀 차이는 무시
     delay: 300, // 렌더링 안정화를 위한 딜레이 (ms)
     pauseAnimationAtEnd: true, // 애니메이션 종료 시점에서 스냅샷
   },
-};
+  kapture: {
+    diff: { pixel: 0.2 },
+    delayMs: 300,
+    animation: "end",
+  },
+} satisfies { kapture: KaptureStoryParameters; chromatic: object };
 
-export function withChromaticParameters<R>(parameters: R): R {
+export function withVisualTestParameters<R>(parameters: R): R & typeof VISUAL_TEST_PARAMETERS {
   return {
-    ...CHROMATIC_PARAMETERS,
+    ...VISUAL_TEST_PARAMETERS,
     ...parameters,
   };
 }


### PR DESCRIPTION
## 변경 사항
- Storybook에 exact `@kaptures/storybook@0.0.6` adapter와 dependency preset을 연결합니다.
- Chromatic과 Kapture parameter tree를 독립적으로 유지하고 responsive visual-test helper를 양쪽 provider에 매핑합니다.
- 소비자인 SEED가 base/head build, capture, Cloudflare Pages 배포, PR 댓글/status, full-SHA+digest 승인을 위한 workflow를 소유합니다.
- Kapture 실행 로직은 Changesets/OIDC로 공개된 exact `@kaptures/cli@0.0.6`만 사용하며 private Kapture 저장소 Action을 참조하지 않습니다.
- trusted report와 exact head Storybook을 기존 `seed-design-storybook` Pages 프로젝트의 동일 immutable deployment에 배포합니다.

## 레이어 경계
- Kapture: Storybook lifecycle adapter, affected-story 계획, 픽셀 캡처/비교, provenance 검증, report/status/comment/approval 명령
- SEED: Storybook 콘텐츠와 빌드, 변경 trigger, runner 격리, 권한/secret, Cloudflare provider 설정
- Chromatic: 기존 workflow와 parameter는 shadow 평가 기간 동안 유지

## 검증
- `bun generate:all`
- `bun test:all` (일반 1845, Lynx 192 통과)
- docs test 282개 및 sandbox 밖 port hook 3개 통과
- Storybook production build 및 dependency manifest 632 stories/modules, diagnostics 0
- provider 독립성 테스트 2개 통과
- workflow YAML parse 및 `git diff --check`
- 공개 npm registry에서 CLI/Storybook 0.0.6 확인, Node 24 `bunx` 실행 확인

## Bootstrap
이 PR은 base `dev`에 capture marker가 없으므로 최초 실행은 `bootstrap-skip`이 정상입니다. 병합 뒤 별도 visual probe PR에서 실제 캡처 → immutable dashboard/Storybook → 댓글/status → `/kapture approve <full-sha> <digest>` 전체 lifecycle을 검증합니다.

Changesets는 Kapture 라이브러리 저장소에서 public npm package를 배포할 때 사용하며, 이 소비자 PR에는 별도 changeset이 필요하지 않습니다.