### PR TITLE
fix(lynx-react): preserve Stack token gaps on iOS

### DIFF
--- a/.changeset/quiet-stacks-align.md
+++ b/.changeset/quiet-stacks-align.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/lynx-react": patch
+---
+
+iOS에서 `VStack`과 `HStack`의 `gap`에 SEED 간격 토큰을 사용하면 간격이 사라지는 문제를 수정합니다.

--- a/packages/lynx-react/src/components/Stack/Stack.test.tsx
+++ b/packages/lynx-react/src/components/Stack/Stack.test.tsx
@@ -1,0 +1,67 @@
+import "@testing-library/jest-dom";
+import { render } from "@lynx-js/react/testing-library";
+import { describe, expect, it } from "vitest";
+
+import { HStack, VStack } from "./Stack";
+
+function getRenderedRoot() {
+  const root = elementTree.root;
+
+  if (!root) {
+    throw new Error("Expected Lynx render root to exist.");
+  }
+
+  const stack = root.querySelector<HTMLElement>("view");
+
+  if (!stack) {
+    throw new Error("Expected Stack root view to exist.");
+  }
+
+  return stack;
+}
+
+describe("Stack", () => {
+  it("maps a VStack gap token to row-gap", () => {
+    render(<VStack gap="x3" />);
+
+    expect(getRenderedRoot()).toHaveStyle({
+      rowGap: "var(--seed-dimension-x3)",
+    });
+    expect(getRenderedRoot().style.getPropertyValue("gap")).toBe("");
+    expect(getRenderedRoot().style.getPropertyValue("column-gap")).toBe("");
+  });
+
+  it("maps an HStack gap token to column-gap", () => {
+    render(<HStack gap="x4" />);
+
+    expect(getRenderedRoot()).toHaveStyle({
+      columnGap: "var(--seed-dimension-x4)",
+    });
+    expect(getRenderedRoot().style.getPropertyValue("gap")).toBe("");
+    expect(getRenderedRoot().style.getPropertyValue("row-gap")).toBe("");
+  });
+
+  it("keeps a numeric zero gap value", () => {
+    render(<VStack gap={0} />);
+
+    expect(getRenderedRoot()).toHaveStyle({ rowGap: "0px" });
+  });
+
+  it("keeps an arbitrary string gap value", () => {
+    render(<HStack gap="1.5rem" />);
+
+    expect(getRenderedRoot()).toHaveStyle({ columnGap: "1.5rem" });
+  });
+
+  it("keeps style gap precedence over the gap prop", () => {
+    render(<VStack gap="x3" style={{ gap: "20px" }} />);
+
+    expect(getRenderedRoot()).toHaveStyle({ rowGap: "20px" });
+  });
+
+  it("keeps an axis longhand in style above the gap prop", () => {
+    render(<VStack gap="x3" style={{ rowGap: "24px" }} />);
+
+    expect(getRenderedRoot()).toHaveStyle({ rowGap: "24px" });
+  });
+});

--- a/packages/lynx-react/src/components/Stack/Stack.tsx
+++ b/packages/lynx-react/src/components/Stack/Stack.tsx
@@ -54,11 +54,25 @@ function getStackProps(props: StackProps) {
 }
 
 function useStackStyleProps(props: StackProps, flexDirection: "column" | "row") {
-  return useStyleProps({
+  const stackStyleProps = useStyleProps({
     display: "flex",
     flexDirection,
     ...getStackProps(props),
   });
+  // Lynx의 gap 단축 속성 파서는 var(...)를 0px로 확정하므로 축별 longhand를 사용합니다.
+  const { gap, ...style } = stackStyleProps.style;
+
+  if (gap == null) {
+    return stackStyleProps;
+  }
+
+  return {
+    ...stackStyleProps,
+    style: {
+      [flexDirection === "column" ? "rowGap" : "columnGap"]: gap,
+      ...style,
+    },
+  };
 }
 
 function renderStackView(


### PR DESCRIPTION
## 배경

`@seed-design/lynx-react`의 `VStack`과 `HStack`은 `gap="x3"` 같은 SEED 간격 토큰을 `gap: var(--seed-dimension-x3)` 형태의 인라인 스타일로 변환합니다.

PlayLynx iOS와 Lynx Go에서 이 값을 사용하면 computed style의 `gap`, `row-gap`, `column-gap`이 모두 `0px`가 되어 자식 간격이 사라졌습니다. 같은 노드에 `gap: 12px`를 지정하면 정상 동작하므로 flex gap 지원 여부가 원인은 아니었습니다.

로컬 Lynx 소스를 확인한 결과, `gap` 단축 속성 파서는 `var(...)`를 길이로 해석하지 못하면 기본값 `0px`를 반환하고 성공으로 처리합니다. 이 때문에 인라인 CSS 변수 해석 경로까지 도달하지 않습니다. 반면 `row-gap`과 `column-gap`은 길이 속성 처리 경로를 사용하므로 CSS 변수 fallback이 동작합니다.

## 수정 내용

- Stack 공통 구현에서 최종 `gap` 값을 축별 longhand로 변환합니다.
  - `VStack`: `rowGap`
  - `HStack`: `columnGap`
- 공개 사용 방식인 `<VStack gap="x3">`와 `<HStack gap="x4">`는 그대로 유지합니다.
- `useStyleProps`가 계산한 최종 스타일을 변환해 기존 우선순위를 보존합니다.
  - `style.gap`은 `gap` prop보다 우선합니다.
  - 명시적인 `style.rowGap`과 `style.columnGap`은 변환된 값보다 우선합니다.
- SEED 토큰, 숫자 `0`, 임의 문자열, 스타일 우선순위를 검증하는 Stack 단위 테스트를 추가합니다.
- `@seed-design/lynx-react` patch changeset을 추가합니다.

## 영향

iOS PlayLynx와 Lynx Go에서 Stack의 SEED 간격 토큰이 실제 레이아웃 간격으로 반영됩니다. 기존 Stack API와 축 의미는 바뀌지 않습니다.

## 검증

- `bun generate:all`
- `@seed-design/lynx-react` typecheck
- `@seed-design/lynx-react` 테스트: 20개 파일, 182개 테스트 통과
- `@seed-design/lynx-react` 빌드
- `bun packages:build`
- 문서 테스트: 265개 테스트 통과
- `bun test:all`
- ReactLynx 규칙 검사: 문제 없음

## 검증 제한

연결된 `lynx-spa` 예제 앱 번들은 Stack 처리 이전에 `@lynx-js/react@0.117.0`이 `preact@10.29.1`에서 제공하지 않는 `process` export를 참조해 중단됐습니다. 이 PR에서는 문서 전용 alias나 설정 우회를 추가하지 않았습니다. 패키지 빌드 산출물에는 `rowGap`과 `columnGap` 변환이 반영된 것을 확인했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * iOS에서 `VStack`과 `HStack`에 SEED 간격 토큰을 사용할 때 간격이 사라지는 문제를 수정했습니다.
  * 방향에 맞는 간격이 안정적으로 적용되도록 개선했습니다.

* **테스트**
  * 간격 토큰, 숫자·문자열 값 및 스타일 우선순위에 대한 검증을 추가했습니다.

* **릴리스**
  * `@seed-design/lynx-react` 패치 릴리스를 준비했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->