### PR TITLE
fix(storybook): allow bottom sheet story scrolling

### DIFF
--- a/docs/stories/BottomSheet.stories.tsx
+++ b/docs/stories/BottomSheet.stories.tsx
@@ -47,7 +47,7 @@ const BottomSheetPreview = ({
           height: unset !important;
         }
       `}</style>
-      <BottomSheetRoot open headerAlign={headerAlign}>
+      <BottomSheetRoot open modal={false} headerAlign={headerAlign}>
         <BottomSheetContent
           title={title}
           description={description}


### PR DESCRIPTION
## 변경 사항

- Bottom Sheet 시각 회귀 스토리에서 `modal={false}`를 사용합니다.
- 실제 Bottom Sheet와 `useDrawer`의 모달 스크롤 잠금 동작은 변경하지 않습니다.

## 배경

열린 모달 Bottom Sheet를 Variant Table에 여러 개 렌더링하면서 `usePreventScroll`이 Storybook iframe의 루트 스크롤을 잠그고 있었습니다. 시각 검증용 스토리를 비모달로 렌더링해 Storybook과 Chromatic이 전체 표를 정상적으로 스크롤하고 캡처할 수 있게 했습니다.

## 검증

- `bun generate:all`
- `bun docs:test` — 265개 통과
- `bun test:all` — unit 1,825개, Lynx React 176개 통과
- Storybook iframe에서 실제 마우스 휠 입력으로 스크롤 위치가 `0 → 800`으로 이동하는 것을 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * BottomSheet 스토리 미리보기에서 비모달 동작을 확인할 수 있도록 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->