### PR TITLE
fix(storybook): stabilize sheet story layouts

### DIFF
--- a/docs/stories/BottomSheet.stories.tsx
+++ b/docs/stories/BottomSheet.stories.tsx
@@ -36,11 +36,6 @@ const BottomSheetPreview = ({
         html {
           overflow: auto !important;
         }
-        /* 컴포넌트 셀을 표 레이아웃에 포함하면서 기존 flex 셀 높이를 유지합니다. */
-        .bottom-sheet-variant-table tbody > tr > td:last-child {
-          display: table-cell !important;
-          padding-bottom: 17px !important;
-        }
         .seed-bottom-sheet__positioner {
           position: relative !important;
           inset: unset !important;
@@ -112,14 +107,13 @@ const conditionMap = {
 
 const CommonStoryTemplate = meta.story({
   render: (args, { component }) => (
-    <div className="bottom-sheet-variant-table">
-      <VariantTable
-        Component={component!}
-        variantMap={restVariantMap}
-        conditionMap={conditionMap}
-        {...args}
-      />
-    </div>
+    <VariantTable
+      Component={component!}
+      variantMap={restVariantMap}
+      conditionMap={conditionMap}
+      layout="grid"
+      {...args}
+    />
   ),
 });
 

--- a/docs/stories/BottomSheet.stories.tsx
+++ b/docs/stories/BottomSheet.stories.tsx
@@ -111,7 +111,7 @@ const CommonStoryTemplate = meta.story({
       Component={component!}
       variantMap={restVariantMap}
       conditionMap={conditionMap}
-      layout="grid"
+      rowLayout="grid"
       {...args}
     />
   ),

--- a/docs/stories/BottomSheet.stories.tsx
+++ b/docs/stories/BottomSheet.stories.tsx
@@ -36,26 +36,22 @@ const BottomSheetPreview = ({
         .seed-bottom-sheet__positioner {
           position: relative !important;
           inset: unset !important;
+          display: block !important;
         }
         .seed-bottom-sheet__backdrop {
           display: none !important;
         }
         .seed-bottom-sheet__content {
           animation: none !important;
+          width: 100% !important;
+          height: auto !important;
+          flex: none !important;
         }
         .seed-bottom-sheet__content::after {
           height: unset !important;
         }
       `}</style>
-      <BottomSheetRoot
-        open
-        modal={false}
-        autoFocus={false}
-        lazyMount={false}
-        unmountOnExit={false}
-        skipAnimation
-        headerAlign={headerAlign}
-      >
+      <BottomSheetRoot open modal={false} autoFocus={false} headerAlign={headerAlign}>
         <BottomSheetContent
           title={title}
           description={description}

--- a/docs/stories/BottomSheet.stories.tsx
+++ b/docs/stories/BottomSheet.stories.tsx
@@ -33,9 +33,6 @@ const BottomSheetPreview = ({
   return (
     <Box width="400px" p="x4">
       <style>{`
-        html {
-          overflow: auto !important;
-        }
         .seed-bottom-sheet__positioner {
           position: relative !important;
           inset: unset !important;
@@ -50,7 +47,15 @@ const BottomSheetPreview = ({
           height: unset !important;
         }
       `}</style>
-      <BottomSheetRoot open autoFocus={false} headerAlign={headerAlign}>
+      <BottomSheetRoot
+        open
+        modal={false}
+        autoFocus={false}
+        lazyMount={false}
+        unmountOnExit={false}
+        skipAnimation
+        headerAlign={headerAlign}
+      >
         <BottomSheetContent
           title={title}
           description={description}
@@ -111,7 +116,6 @@ const CommonStoryTemplate = meta.story({
       Component={component!}
       variantMap={restVariantMap}
       conditionMap={conditionMap}
-      rowLayout="grid"
       {...args}
     />
   ),

--- a/docs/stories/BottomSheet.stories.tsx
+++ b/docs/stories/BottomSheet.stories.tsx
@@ -36,6 +36,11 @@ const BottomSheetPreview = ({
         html {
           overflow: auto !important;
         }
+        /* 컴포넌트 셀을 표 레이아웃에 포함하면서 기존 flex 셀 높이를 유지합니다. */
+        .bottom-sheet-variant-table tbody > tr > td:last-child {
+          display: table-cell !important;
+          padding-bottom: 17px !important;
+        }
         .seed-bottom-sheet__positioner {
           position: relative !important;
           inset: unset !important;
@@ -107,12 +112,14 @@ const conditionMap = {
 
 const CommonStoryTemplate = meta.story({
   render: (args, { component }) => (
-    <VariantTable
-      Component={component!}
-      variantMap={restVariantMap}
-      conditionMap={conditionMap}
-      {...args}
-    />
+    <div className="bottom-sheet-variant-table">
+      <VariantTable
+        Component={component!}
+        variantMap={restVariantMap}
+        conditionMap={conditionMap}
+        {...args}
+      />
+    </div>
   ),
 });
 

--- a/docs/stories/BottomSheet.stories.tsx
+++ b/docs/stories/BottomSheet.stories.tsx
@@ -33,6 +33,9 @@ const BottomSheetPreview = ({
   return (
     <Box width="400px" p="x4">
       <style>{`
+        html {
+          overflow: auto !important;
+        }
         .seed-bottom-sheet__positioner {
           position: relative !important;
           inset: unset !important;
@@ -47,7 +50,7 @@ const BottomSheetPreview = ({
           height: unset !important;
         }
       `}</style>
-      <BottomSheetRoot open modal={false} autoFocus={false} headerAlign={headerAlign}>
+      <BottomSheetRoot open autoFocus={false} headerAlign={headerAlign}>
         <BottomSheetContent
           title={title}
           description={description}

--- a/docs/stories/ResponsiveSidePanel.stories.tsx
+++ b/docs/stories/ResponsiveSidePanel.stories.tsx
@@ -28,6 +28,9 @@ const ResponsiveSidePanelPreview = ({
         position: relative !important;
         inset: unset !important;
       }
+      .seed-bottom-sheet__positioner {
+        display: block !important;
+      }
       .seed-side-panel__backdrop,
       .seed-bottom-sheet__backdrop {
         display: none !important;
@@ -45,6 +48,9 @@ const ResponsiveSidePanelPreview = ({
       }
       .seed-bottom-sheet__content {
         animation: none !important;
+        width: 100% !important;
+        height: auto !important;
+        flex: none !important;
       }
       .seed-bottom-sheet__content::after {
         height: unset !important;

--- a/docs/stories/components/variant-table.tsx
+++ b/docs/stories/components/variant-table.tsx
@@ -1,5 +1,3 @@
-import type { CSSProperties } from "react";
-
 type VariantMap = Record<string, string[] | boolean[]>;
 type ConditionMap = Record<string, Record<string, Record<string, unknown>>>;
 
@@ -8,7 +6,6 @@ interface Props {
   conditionMap?: ConditionMap;
   Component: React.ComponentType | React.ElementType;
   children?: React.ReactNode;
-  rowLayout?: "table" | "grid";
 }
 
 const Boolish = {
@@ -48,38 +45,23 @@ const generateCombinations = (variantMap: VariantMap, conditionMap: ConditionMap
 };
 
 export const VariantTable = (props: Props) => {
-  const { variantMap, conditionMap = {}, Component, rowLayout = "table", ...rest } = props;
+  const { variantMap, conditionMap = {}, Component, ...rest } = props;
 
   const combinations = generateCombinations(variantMap, conditionMap);
   const keys = [...new Set([...Object.keys(variantMap), ...Object.keys(conditionMap)])];
-  const sectionStyle: CSSProperties | undefined =
-    rowLayout === "grid" ? { display: "block" } : undefined;
-  const rowStyle: CSSProperties | undefined =
-    rowLayout === "grid"
-      ? {
-          display: "grid",
-          gridTemplateColumns: `repeat(${keys.length}, 10%) minmax(0, 1fr)`,
-        }
-      : undefined;
 
   return (
     <div>
-      <table
-        style={{
-          width: "100%",
-          borderCollapse: "collapse",
-          ...(rowLayout === "grid" && { display: "block" }),
-        }}
-      >
-        <thead data-chromatic="ignore" style={sectionStyle}>
-          <tr style={{ fontSize: "14px", ...rowStyle }}>
+      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <thead data-chromatic="ignore">
+          <tr style={{ fontSize: "14px" }}>
             {keys.map((key) => (
               <th key={key}>{key}</th>
             ))}
             <th>Component</th>
           </tr>
         </thead>
-        <tbody style={sectionStyle}>
+        <tbody>
           {combinations.map((combination) => {
             const conditionedProps = Object.entries(combination).reduce(
               (acc, [key, value]) => {
@@ -104,13 +86,9 @@ export const VariantTable = (props: Props) => {
 
             const combinationKey = Object.values(combination).join("-");
             return (
-              <tr key={combinationKey} style={rowStyle}>
+              <tr key={combinationKey}>
                 {keys.map((key) => (
-                  <td
-                    data-chromatic="ignore"
-                    key={key}
-                    style={rowLayout === "table" ? { width: "10%" } : undefined}
-                  >
+                  <td data-chromatic="ignore" key={key} style={{ width: "10%" }}>
                     <div style={{ display: "flex", flexDirection: "column" }}>
                       <span
                         style={{

--- a/docs/stories/components/variant-table.tsx
+++ b/docs/stories/components/variant-table.tsx
@@ -8,7 +8,7 @@ interface Props {
   conditionMap?: ConditionMap;
   Component: React.ComponentType | React.ElementType;
   children?: React.ReactNode;
-  layout?: "table" | "grid";
+  rowLayout?: "table" | "grid";
 }
 
 const Boolish = {
@@ -48,14 +48,14 @@ const generateCombinations = (variantMap: VariantMap, conditionMap: ConditionMap
 };
 
 export const VariantTable = (props: Props) => {
-  const { variantMap, conditionMap = {}, Component, layout = "table", ...rest } = props;
+  const { variantMap, conditionMap = {}, Component, rowLayout = "table", ...rest } = props;
 
   const combinations = generateCombinations(variantMap, conditionMap);
   const keys = [...new Set([...Object.keys(variantMap), ...Object.keys(conditionMap)])];
   const sectionStyle: CSSProperties | undefined =
-    layout === "grid" ? { display: "block" } : undefined;
+    rowLayout === "grid" ? { display: "block" } : undefined;
   const rowStyle: CSSProperties | undefined =
-    layout === "grid"
+    rowLayout === "grid"
       ? {
           display: "grid",
           gridTemplateColumns: `repeat(${keys.length}, 10%) minmax(0, 1fr)`,
@@ -68,7 +68,7 @@ export const VariantTable = (props: Props) => {
         style={{
           width: "100%",
           borderCollapse: "collapse",
-          ...(layout === "grid" && { display: "block" }),
+          ...(rowLayout === "grid" && { display: "block" }),
         }}
       >
         <thead data-chromatic="ignore" style={sectionStyle}>
@@ -109,7 +109,7 @@ export const VariantTable = (props: Props) => {
                   <td
                     data-chromatic="ignore"
                     key={key}
-                    style={layout === "table" ? { width: "10%" } : undefined}
+                    style={rowLayout === "table" ? { width: "10%" } : undefined}
                   >
                     <div style={{ display: "flex", flexDirection: "column" }}>
                       <span

--- a/docs/stories/components/variant-table.tsx
+++ b/docs/stories/components/variant-table.tsx
@@ -1,3 +1,5 @@
+import type { CSSProperties } from "react";
+
 type VariantMap = Record<string, string[] | boolean[]>;
 type ConditionMap = Record<string, Record<string, Record<string, unknown>>>;
 
@@ -6,6 +8,7 @@ interface Props {
   conditionMap?: ConditionMap;
   Component: React.ComponentType | React.ElementType;
   children?: React.ReactNode;
+  layout?: "table" | "grid";
 }
 
 const Boolish = {
@@ -45,23 +48,38 @@ const generateCombinations = (variantMap: VariantMap, conditionMap: ConditionMap
 };
 
 export const VariantTable = (props: Props) => {
-  const { variantMap, conditionMap = {}, Component, ...rest } = props;
+  const { variantMap, conditionMap = {}, Component, layout = "table", ...rest } = props;
 
   const combinations = generateCombinations(variantMap, conditionMap);
   const keys = [...new Set([...Object.keys(variantMap), ...Object.keys(conditionMap)])];
+  const sectionStyle: CSSProperties | undefined =
+    layout === "grid" ? { display: "block" } : undefined;
+  const rowStyle: CSSProperties | undefined =
+    layout === "grid"
+      ? {
+          display: "grid",
+          gridTemplateColumns: `repeat(${keys.length}, 10%) minmax(0, 1fr)`,
+        }
+      : undefined;
 
   return (
     <div>
-      <table style={{ width: "100%", borderCollapse: "collapse" }}>
-        <thead data-chromatic="ignore">
-          <tr style={{ fontSize: "14px" }}>
+      <table
+        style={{
+          width: "100%",
+          borderCollapse: "collapse",
+          ...(layout === "grid" && { display: "block" }),
+        }}
+      >
+        <thead data-chromatic="ignore" style={sectionStyle}>
+          <tr style={{ fontSize: "14px", ...rowStyle }}>
             {keys.map((key) => (
               <th key={key}>{key}</th>
             ))}
             <th>Component</th>
           </tr>
         </thead>
-        <tbody>
+        <tbody style={sectionStyle}>
           {combinations.map((combination) => {
             const conditionedProps = Object.entries(combination).reduce(
               (acc, [key, value]) => {
@@ -86,9 +104,13 @@ export const VariantTable = (props: Props) => {
 
             const combinationKey = Object.values(combination).join("-");
             return (
-              <tr key={combinationKey}>
+              <tr key={combinationKey} style={rowStyle}>
                 {keys.map((key) => (
-                  <td data-chromatic="ignore" key={key} style={{ width: "10%" }}>
+                  <td
+                    data-chromatic="ignore"
+                    key={key}
+                    style={layout === "table" ? { width: "10%" } : undefined}
+                  >
                     <div style={{ display: "flex", flexDirection: "column" }}>
                       <span
                         style={{


### PR DESCRIPTION
## 변경 내용

- Bottom Sheet 스토리의 포지셔너를 정적 블록 흐름으로 렌더링합니다.
- Bottom Sheet 콘텐츠에 `width: 100%`, `height: auto`, `flex: none`을 적용해 실제 내용 높이가 표 행 계산에 포함되게 합니다.
- Responsive Side Panel 스토리의 작은 화면 Bottom Sheet 분기에도 같은 처리를 적용합니다.
- 큰 화면 Side Panel 분기, 제품 컴포넌트, 공용 `VariantTable` 구현은 바꾸지 않습니다.
- 이전의 `lazyMount`, `unmountOnExit`, `skipAnimation` 실험은 효과가 없어 되돌렸습니다.

## 원인과 접근

Bottom Sheet의 오버레이용 flex 레이아웃이 Chromatic의 초기 전체 페이지 측정에서 콘텐츠 높이에 기여하지 않는 상태가 발생했습니다. 표 행은 낮은 높이로 확정되지만 Bottom Sheet는 그 영역 밖에 그려져 이후 행과 겹쳤습니다.

Responsive Side Panel도 작은 화면에서 같은 Bottom Sheet 구조를 사용하므로 동일한 문제가 나타났습니다. 각 스토리에서 고정 오버레이 배치만 해제하고 콘텐츠를 고유 높이로 렌더링하도록 범위를 좁혔습니다.

## 기준 스냅숏

- Bottom Sheet: `4287600` 커밋의 Chromatic Build 1587
- Responsive Side Panel: Chromatic Build 2824
- 최종 판정: `385ad22d4` 커밋에서 생성되는 Chromatic 빌드

## 검증

- `bun generate:all`
- `bun --filter @seed-design/docs typecheck`
- `bun storybook:build`
- 사용자 요청에 따라 추가 테스트는 생략
