### PR TITLE
docs(lynx): add TagGroup runnable examples

### DIFF
--- a/.changeset/calm-separators-align.md
+++ b/.changeset/calm-separators-align.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/lynx-react": patch
+---
+
+Lynx `TagGroup`의 문자열 구분자 앞뒤 공백을 제거해 브라우저 프리뷰와 네이티브 Lynx에서 항목 간격이 다르게 보이는 문제를 수정합니다.

--- a/docs/content/lynx/components/tag-group.mdx
+++ b/docs/content/lynx/components/tag-group.mdx
@@ -40,7 +40,7 @@ export function App() {
 }
 ```
 
-`TagGroupRoot`의 `size`·`weight`·`tone`은 Context로 하위 `TagGroupItem`에 전파되며, 개별 `TagGroupItem`에서 prop으로 덮어쓸 수 있습니다. 구분자는 기본 `" · "`이고 `separator` prop으로 바꿀 수 있습니다.
+`TagGroupRoot`의 `size`·`weight`·`tone`은 Context로 하위 `TagGroupItem`에 전파되며, 개별 `TagGroupItem`에서 prop으로 덮어쓸 수 있습니다. 구분자는 기본 `"·"`이고 `separator` prop으로 바꿀 수 있습니다.
 
 `TagGroupItem`은 `flexShrink`를 지원합니다. 긴 태그가 있는 레이아웃에서 item의 축소 우선순위를 조정해야 할 때 사용하세요.
 
@@ -116,6 +116,8 @@ export function App() {
 
 `TagGroupRoot`의 `separator`로 구분 기호를 바꿀 수 있습니다. 의미가 있는 정보는 구분자 대신 `TagGroupItem`으로 표현하세요.
 
+문자열 구분자의 앞뒤 공백은 Lynx에서 제거됩니다. 예를 들어 `separator=" / "`와 `separator="/"`는 동일하게 렌더링되며, 항목과 구분자 사이의 간격은 컴포넌트가 일관되게 적용합니다.
+
 <LynxComponentExample name="lynx/tag-group/customizing-separators">
   ```json doc-gen:file
   {
@@ -157,6 +159,10 @@ Lynx TagGroup은 Lynx view 엔진(Yoga 기반 flex)의 제약으로 React 웹 �
 
 - **웹**: `display: inline` 기반 text flow. 컨테이너가 좁으면 마지막 item 내부 label text가 word 단위로 자연스럽게 wrap됩니다 (예: `"Ut minim laboris enim"` → `"Ut minim"` / `"laboris enim"` 두 줄로 쪼개짐).
 - **Lynx**: flex 기반 item 단위 wrap. item은 content-size를 유지하고, 한 줄에 들어가지 않으면 item 전체가 다음 줄로 이동합니다. item 내부 text가 item 경계를 넘어 word-break되는 동작은 재현할 수 없습니다. Lynx `TagGroupRoot`는 이를 자연스럽게 보이도록 separator를 뒤따르는 item과 하나의 wrap 단위로 묶어 다음 줄로 함께 이동시킵니다.
+
+### 구분자 공백 처리
+
+웹은 `white-space: pre`로 문자열 구분자의 앞뒤 공백을 보존합니다. Lynx는 `white-space: pre`를 지원하지 않고 브라우저 프리뷰와 네이티브 Lynx의 기본 공백 계측도 서로 다릅니다. 두 실행 환경에서 같은 간격을 만들기 위해 Lynx `TagGroup`은 문자열 구분자의 앞뒤 공백을 제거하고 컴포넌트 스타일의 간격을 적용합니다. 문자열이 아닌 `ReactNode` 구분자는 변경하지 않습니다.
 
 ### 미지원 prop
 

--- a/docs/content/lynx/components/tag-group.mdx
+++ b/docs/content/lynx/components/tag-group.mdx
@@ -5,6 +5,15 @@ description: 텍스트 태그를 수평으로 나열해 여러 속성·상태·�
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />
 
+<LynxComponentExample name="lynx/tag-group/preview">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/tag-group/preview.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
 ## Installation
 
 ```package-install
@@ -35,22 +44,9 @@ export function App() {
 
 `TagGroupItem`은 `flexShrink`를 지원합니다. 긴 태그가 있는 레이아웃에서 item의 축소 우선순위를 조정해야 할 때 사용하세요.
 
-### Tone / Separator
+### 상호작용
 
-`TagGroupRoot`의 `tone`, `weight`, `separator`는 그룹 기본값으로 전달되고, 개별 `TagGroupItem`에서 필요한 값만 덮어쓸 수 있습니다.
-
-```tsx
-import { TagGroupRoot, TagGroupItem } from "@/components/ui/tag-group";
-
-export function TagGroupVariants() {
-  return (
-    <TagGroupRoot size="t2" tone="neutralSubtle" separator=" / ">
-      <TagGroupItem tone="brand" weight="bold" label="NEW" />
-      <TagGroupItem label="무료 나눔" />
-    </TagGroupRoot>
-  );
-}
-```
+`TagGroup`은 정보를 읽기 전용으로 나열하는 컴포넌트입니다. 단일·다중 선택, 선택 값 변경, 비활성화 상태를 위한 API는 제공하지 않습니다. 사용자가 값을 선택해야 한다면 단일 선택에는 `RadioGroup`, 다중 선택에는 `Checkbox`를 사용하세요.
 
 ## Props
 
@@ -67,6 +63,80 @@ export function TagGroupVariants() {
   path="./registry/lynx/ui/tag-group.tsx"
   name="TagGroupItemProps"
 />
+
+## Examples
+
+### Sizes
+
+<LynxComponentExample name="lynx/tag-group/sizes">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/tag-group/sizes.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Weights
+
+<LynxComponentExample name="lynx/tag-group/weights">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/tag-group/weights.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Tones
+
+<LynxComponentExample name="lynx/tag-group/tones">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/tag-group/tones.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Customizing `TagGroupItem`
+
+`TagGroupRoot`의 `tone`과 `weight`은 그룹 기본값으로 전달됩니다. 개별 `TagGroupItem`에서 필요한 값만 덮어쓸 수 있습니다.
+
+<LynxComponentExample name="lynx/tag-group/customizing-item">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/tag-group/customizing-item.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Customizing Separators
+
+`TagGroupRoot`의 `separator`로 구분 기호를 바꿀 수 있습니다. 의미가 있는 정보는 구분자 대신 `TagGroupItem`으로 표현하세요.
+
+<LynxComponentExample name="lynx/tag-group/customizing-separators">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/tag-group/customizing-separators.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Wrapping Behavior
+
+컨테이너 너비를 초과하면 구분자와 뒤따르는 item이 하나의 단위로 다음 줄에 배치됩니다.
+
+<LynxComponentExample name="lynx/tag-group/wrapping-behavior">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/tag-group/wrapping-behavior.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
 
 ## 웹 버전과의 차이
 
@@ -98,5 +168,5 @@ Lynx TagGroup은 Lynx view 엔진(Yoga 기반 flex)의 제약으로 React 웹 �
 
 ### 이벤트·ref
 
-- 이벤트: Lynx는 `onClick`이 없고 `bindtap` / `main-thread:bindtap`을 사용합니다. TagGroup은 기본적으로 정적 표시라 인터랙션 prop이 노출되지는 않지만, `TagGroupItem`을 눌러야 한다면 호출부에서 직접 view 속성으로 처리하세요.
+- 이벤트: Lynx는 `onClick` 대신 `bindtap` / `main-thread:bindtap`을 사용합니다. `TagGroup`은 정적 표시 컴포넌트이므로 선택 값이나 비활성화 상태를 관리하는 인터랙션 prop은 노출하지 않습니다.
 - ref: `React.forwardRef`로 ref가 전달됩니다 (`SVGViewElement` 타입으로 캐스트됨).

--- a/docs/examples/lynx/tag-group/customizing-item.tsx
+++ b/docs/examples/lynx/tag-group/customizing-item.tsx
@@ -1,0 +1,28 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { TagGroup, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <view className="tag-group-preview">
+        <TagGroup.Root tone="neutral" className="tag-group-preview__group">
+          <TagGroup.Item tone="brand" weight="bold">
+            <TagGroup.ItemLabel>NEW</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>무료 나눔</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item tone="neutralSubtle">
+            <TagGroup.ItemLabel>방금 전</TagGroup.ItemLabel>
+          </TagGroup.Item>
+        </TagGroup.Root>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/tag-group/customizing-separators.tsx
+++ b/docs/examples/lynx/tag-group/customizing-separators.tsx
@@ -1,0 +1,39 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { TagGroup, VStack, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack className="tag-group-preview" gap="spacingY.componentDefault">
+        <TagGroup.Root separator=" | " size="t4" className="tag-group-preview__group">
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>가</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>나</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>다</TagGroup.ItemLabel>
+          </TagGroup.Item>
+        </TagGroup.Root>
+        <TagGroup.Root separator=" / " size="t4" className="tag-group-preview__group">
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>서울</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>서초구</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>서초4동</TagGroup.ItemLabel>
+          </TagGroup.Item>
+        </TagGroup.Root>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/tag-group/preview.css
+++ b/docs/examples/lynx/tag-group/preview.css
@@ -1,0 +1,27 @@
+/* biome-ignore lint/correctness/noUnknownTypeSelector: Lynx의 page 요소입니다. */
+page {
+  height: 100%;
+  background-color: var(--seed-color-bg-layer-default);
+}
+
+.tag-group-preview {
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+}
+
+.tag-group-preview__group {
+  max-width: 280px;
+  justify-content: center;
+}
+
+.tag-group-preview__wrapping-container {
+  width: 220px;
+  padding: 16px;
+  border-radius: 8px;
+  background-color: var(--seed-color-bg-neutral-weak);
+}
+
+.tag-group-preview__wrapping-group {
+  justify-content: flex-start;
+}

--- a/docs/examples/lynx/tag-group/preview.tsx
+++ b/docs/examples/lynx/tag-group/preview.tsx
@@ -1,0 +1,28 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { TagGroup, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <view className="tag-group-preview">
+        <TagGroup.Root className="tag-group-preview__group">
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>500m</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>서초4동</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>3분 전</TagGroup.ItemLabel>
+          </TagGroup.Item>
+        </TagGroup.Root>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/tag-group/sizes.tsx
+++ b/docs/examples/lynx/tag-group/sizes.tsx
@@ -1,0 +1,50 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { TagGroup, VStack, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack className="tag-group-preview" gap="spacingY.componentDefault">
+        <TagGroup.Root size="t2" className="tag-group-preview__group">
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>거리 500m</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>서초4동</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>3분 전</TagGroup.ItemLabel>
+          </TagGroup.Item>
+        </TagGroup.Root>
+        <TagGroup.Root size="t3" className="tag-group-preview__group">
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>거리 500m</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>서초4동</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>3분 전</TagGroup.ItemLabel>
+          </TagGroup.Item>
+        </TagGroup.Root>
+        <TagGroup.Root size="t4" className="tag-group-preview__group">
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>거리 500m</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>서초4동</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>3분 전</TagGroup.ItemLabel>
+          </TagGroup.Item>
+        </TagGroup.Root>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/tag-group/styles.ts
+++ b/docs/examples/lynx/tag-group/styles.ts
@@ -1,0 +1,3 @@
+// 각 엔트리에서 컴포넌트보다 먼저 불러와야 base CSS 뒤에 recipe CSS가 등록됩니다.
+import "@seed-design/lynx-css/base.css";
+import "./preview.css";

--- a/docs/examples/lynx/tag-group/tones.tsx
+++ b/docs/examples/lynx/tag-group/tones.tsx
@@ -1,0 +1,41 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { TagGroup, VStack, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack className="tag-group-preview" gap="spacingY.componentDefault">
+        <TagGroup.Root tone="neutralSubtle" className="tag-group-preview__group">
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>neutralSubtle</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>3분 전</TagGroup.ItemLabel>
+          </TagGroup.Item>
+        </TagGroup.Root>
+        <TagGroup.Root tone="neutral" className="tag-group-preview__group">
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>neutral</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>서초4동</TagGroup.ItemLabel>
+          </TagGroup.Item>
+        </TagGroup.Root>
+        <TagGroup.Root tone="brand" className="tag-group-preview__group">
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>brand</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>추천</TagGroup.ItemLabel>
+          </TagGroup.Item>
+        </TagGroup.Root>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/tag-group/weights.tsx
+++ b/docs/examples/lynx/tag-group/weights.tsx
@@ -1,0 +1,33 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { TagGroup, VStack, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack className="tag-group-preview" gap="spacingY.componentDefault">
+        <TagGroup.Root weight="regular" className="tag-group-preview__group">
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>regular</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>서초4동</TagGroup.ItemLabel>
+          </TagGroup.Item>
+        </TagGroup.Root>
+        <TagGroup.Root weight="bold" className="tag-group-preview__group">
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>bold</TagGroup.ItemLabel>
+          </TagGroup.Item>
+          <TagGroup.Item>
+            <TagGroup.ItemLabel>서초4동</TagGroup.ItemLabel>
+          </TagGroup.Item>
+        </TagGroup.Root>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/tag-group/wrapping-behavior.tsx
+++ b/docs/examples/lynx/tag-group/wrapping-behavior.tsx
@@ -1,0 +1,30 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { TagGroup, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <view className="tag-group-preview">
+        <view className="tag-group-preview__wrapping-container">
+          <TagGroup.Root className="tag-group-preview__wrapping-group">
+            <TagGroup.Item>
+              <TagGroup.ItemLabel>부산광역시 해운대구</TagGroup.ItemLabel>
+            </TagGroup.Item>
+            <TagGroup.Item>
+              <TagGroup.ItemLabel>인증 5회</TagGroup.ItemLabel>
+            </TagGroup.Item>
+            <TagGroup.Item>
+              <TagGroup.ItemLabel>3분 전</TagGroup.ItemLabel>
+            </TagGroup.Item>
+          </TagGroup.Root>
+        </view>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/packages/lynx-react/src/components/TagGroup/TagGroup.test.tsx
+++ b/packages/lynx-react/src/components/TagGroup/TagGroup.test.tsx
@@ -1,0 +1,73 @@
+import "@testing-library/jest-dom";
+import type { ReactNode } from "@lynx-js/react";
+import { render } from "@lynx-js/react/testing-library";
+import { describe, expect, it } from "vitest";
+
+import * as TagGroup from "./TagGroup.namespace";
+
+function getRenderedRoot() {
+  const root = elementTree.root;
+
+  if (!root) {
+    throw new Error("Expected Lynx render root to exist.");
+  }
+
+  return root;
+}
+
+function renderTagGroup(separator?: ReactNode) {
+  render(
+    <TagGroup.Root separator={separator}>
+      <TagGroup.Item>
+        <TagGroup.ItemLabel>첫 번째</TagGroup.ItemLabel>
+      </TagGroup.Item>
+      <TagGroup.Item>
+        <TagGroup.ItemLabel>두 번째</TagGroup.ItemLabel>
+      </TagGroup.Item>
+      <TagGroup.Item>
+        <TagGroup.ItemLabel>세 번째</TagGroup.ItemLabel>
+      </TagGroup.Item>
+    </TagGroup.Root>,
+  );
+}
+
+describe("TagGroup", () => {
+  it("trims surrounding whitespace from the default string separator", () => {
+    renderTagGroup();
+
+    const separators = getRenderedRoot().querySelectorAll(".seed-tag-group__separator");
+
+    expect(separators).toHaveLength(2);
+    expect(Array.from(separators, (separator) => separator.textContent)).toEqual(["·", "·"]);
+  });
+
+  it("trims surrounding whitespace from a custom string separator", () => {
+    renderTagGroup(" \n / \t ");
+
+    const separators = getRenderedRoot().querySelectorAll(".seed-tag-group__separator");
+
+    expect(Array.from(separators, (separator) => separator.textContent)).toEqual(["/", "/"]);
+  });
+
+  it("preserves a non-string separator node", () => {
+    renderTagGroup(<text className="custom-separator"> 구분 </text>);
+
+    const customSeparators = getRenderedRoot().querySelectorAll(".custom-separator");
+
+    expect(customSeparators).toHaveLength(2);
+    expect(Array.from(customSeparators, (separator) => separator.textContent)).toEqual([
+      " 구분 ",
+      " 구분 ",
+    ]);
+  });
+
+  it("keeps each separator and following item in the same wrapper", () => {
+    renderTagGroup();
+
+    const wrappers = getRenderedRoot().querySelectorAll(".seed-tag-group__separatorWrapper");
+
+    expect(wrappers).toHaveLength(2);
+    expect(wrappers[0]?.textContent).toBe("·두 번째");
+    expect(wrappers[1]?.textContent).toBe("·세 번째");
+  });
+});

--- a/packages/lynx-react/src/components/TagGroup/TagGroup.tsx
+++ b/packages/lynx-react/src/components/TagGroup/TagGroup.tsx
@@ -31,7 +31,8 @@ export interface TagGroupRootProps
     TagGroupItemVariantProps,
     LynxStyledElementProps {
   /**
-   * children 사이에 삽입되는 구분자. 기본값 `" · "`.
+   * children 사이에 삽입되는 구분자. 기본값 `"·"`.
+   * 문자열을 전달하면 앞뒤 공백을 제거합니다.
    */
   separator?: React.ReactNode;
 }
@@ -41,6 +42,7 @@ export const TagGroupRoot = React.forwardRef<unknown, TagGroupRootProps>((props,
     splitMultipleVariantsProps(props, { tagGroup, tagGroupItem });
   const { children, className, separator = " · ", ...nativeProps } = otherProps;
   const classes = tagGroup(tagGroupVariantProps);
+  const normalizedSeparator = typeof separator === "string" ? separator.trim() : separator;
 
   const visibleChildren = toArray(children);
 
@@ -61,7 +63,7 @@ export const TagGroupRoot = React.forwardRef<unknown, TagGroupRootProps>((props,
               key={(child as React.ReactElement).key ?? index}
               className={classes.separatorWrapper}
             >
-              <text className={classes.separator}>{separator}</text>
+              <text className={classes.separator}>{normalizedSeparator}</text>
               {child}
             </view>
           );


### PR DESCRIPTION
## 작업 내용

- Lynx `TagGroup` 문서에 `LynxComponentExample` 기반 미리보기와 실행 예제를 추가했습니다.
- 크기, 굵기, 색상, 개별 항목 재정의, 사용자 지정 구분자, 줄바꿈 동작을 예제로 다룹니다.
- `TagGroup`이 읽기 전용 정보 표시 컴포넌트임을 명시하고, 단일·다중 선택에는 `RadioGroup`과 `Checkbox`를 안내합니다.
- 브라우저 프리뷰, QR 코드, Lynx Explorer 실행 주소, 코드 탭을 구성했습니다.
- Lynx 문자열 구분자의 앞뒤 공백을 제거해 브라우저 프리뷰와 네이티브 Lynx의 간격 차이를 수정했습니다. 문자열이 아닌 `ReactNode`는 그대로 유지합니다.
- 웹과 Lynx의 레이아웃 및 문자열 구분자 공백 처리 차이를 문서에 정리했습니다.

## 검증

- 브라우저 프리뷰에서 기본·사용자 지정 구분자와 미리보기·QR 코드·코드 탭 확인
- PlayLynx iOS에서 기본 `·`와 사용자 지정 `|`, `/`의 공백 정규화 및 레이아웃 확인
- `bun generate:all`
- `bun test:all`
- `bun packages:build`
- `bun docs:test`
- `@seed-design/lynx-react` 타입 검사 및 TagGroup 단위 테스트
- Lynx 예제 타입 검사와 development bundle 빌드

## 변경 패키지

- `@seed-design/lynx-react`: patch changeset

## 관련 작업

- DES-2324


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - TagGroup 문자열 구분자의 앞뒤 공백을 자동으로 정리해 브라우저 미리보기와 네이티브 Lynx에서 항목 간격이 일관되도록 개선했습니다.
  - 기본 구분자를 `·`로 변경했습니다.

- **문서**
  - TagGroup의 크기, 굵기, 톤, 구분자, 개별 항목, 줄바꿈 동작을 설명하는 문서와 미리보기를 추가했습니다.
  - 다양한 사용자 설정 예제를 제공하고 읽기 전용 컴포넌트의 상호작용 제약을 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->