### PR TITLE
docs(lynx): add text field input examples

### DIFF
--- a/docs/content/lynx/components/text-field-input.mdx
+++ b/docs/content/lynx/components/text-field-input.mdx
@@ -5,6 +5,15 @@ description: 한 줄 텍스트를 입력받고 Field의 레이블·설명·오�
 
 <AvailableSince packages="@seed-design/lynx-react@0.4.0, @seed-design/lynx-css@0.7.0" />
 
+<LynxComponentExample name="lynx/text-field-input/preview">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/text-field-input/preview.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
 ## Installation
 
 ```package-install
@@ -23,42 +32,61 @@ npx @seed-design/cli add ui:text-field
 
 <react-type-table path="./registry/lynx/ui/text-field.tsx" name="TextFieldInputProps" />
 
-## Usage
+## Examples
 
-Snippet의 `TextField`가 label, description, required indicator와 한 줄 입력 영역을 조합합니다. Lynx에는 HTML `label for` 연결이 없으므로 native 입력에는 `accessibility-label`을 함께 지정합니다.
+### Listening to Value Changes
 
-```tsx
-import { TextField, TextFieldInput } from "@/components/ui/text-field";
+`TextField.Root`에 `value`와 `onValueChange`를 전달하면 입력값을 직접 관리할 수 있습니다. Lynx native 입력에는 `value` attribute가 없으므로 컴포넌트가 `setValue` UI method로 값을 동기화합니다.
 
-export function TitleField() {
-  return (
-    <TextField label="제목" required showRequiredIndicator name="title">
-      <TextFieldInput accessibility-label="제목" placeholder="제목을 입력해 주세요" />
-    </TextField>
-  );
-}
-```
+<LynxComponentExample name="lynx/text-field-input/value-changes">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/text-field-input/value-changes.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
 
-### Controlled value
+### State
 
-`value`와 `onValueChange`를 전달하면 controlled mode로 동작합니다. Lynx native 입력에는 `value` attribute가 없으므로 컴포넌트가 `setValue` UI method로 값을 동기화합니다.
+`Field.Root`의 `disabled`, `readOnly`, `invalid` 상태는 내부 `TextField.Root`와 `TextField.Input`에 전달됩니다.
 
-```tsx
-import { useState } from "@lynx-js/react";
-import { TextField, TextFieldInput } from "@/components/ui/text-field";
+<LynxComponentExample name="lynx/text-field-input/states" height={520}>
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/text-field-input/states.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
 
-export function ControlledTitle() {
-  const [value, setValue] = useState("");
+### Prefix and Suffix
 
-  return (
-    <TextField value={value} onValueChange={({ value }) => setValue(value)}>
-      <TextFieldInput accessibility-label="제목" />
-    </TextField>
-  );
-}
-```
+`TextField.PrefixText`와 `TextField.SuffixText`를 입력 앞뒤에 조합할 수 있습니다.
 
-### Grapheme limit
+<LynxComponentExample name="lynx/text-field-input/affixes" height={360}>
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/text-field-input/affixes.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Composing with Field
+
+`Field`와 조합하면 레이블, 설명, 필수 표시, 오류 메시지를 함께 제공합니다. Lynx에는 HTML `label for` 연결이 없으므로 native 입력에는 `accessibility-label`을 직접 지정합니다.
+
+<LynxComponentExample name="lynx/text-field-input/field-composition" height={420}>
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/text-field-input/field-composition.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Grapheme Limit
 
 이모지·조합 문자를 사용자에게 보이는 한 글자로 계산하려면 snippet의 `maxGraphemeCount`와 `onValueChange`를 사용합니다.
 

--- a/docs/examples/lynx/text-field-input/affixes.tsx
+++ b/docs/examples/lynx/text-field-input/affixes.tsx
@@ -1,0 +1,47 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { Field, TextField, VStack, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack className="text-field-input-preview" gap="x4">
+        <VStack className="text-field-input-preview__content" gap="spacingY.componentDefault">
+          <Field.Root>
+            <Field.Header>
+              <Field.Label>프로필 주소</Field.Label>
+            </Field.Header>
+            <TextField.Root>
+              <TextField.PrefixText>https://</TextField.PrefixText>
+              <TextField.Input
+                accessibility-label="프로필 주소"
+                maxlength={100}
+                placeholder="example.com"
+              />
+            </TextField.Root>
+          </Field.Root>
+          <Field.Root>
+            <Field.Header>
+              <Field.Label>나이</Field.Label>
+            </Field.Header>
+            <TextField.Root>
+              <TextField.PrefixText>만</TextField.PrefixText>
+              <TextField.Input
+                accessibility-label="나이"
+                maxlength={3}
+                placeholder="20"
+                type="number"
+              />
+              <TextField.SuffixText>세</TextField.SuffixText>
+            </TextField.Root>
+          </Field.Root>
+        </VStack>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/text-field-input/field-composition.tsx
+++ b/docs/examples/lynx/text-field-input/field-composition.tsx
@@ -1,0 +1,44 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { Field, TextField, VStack, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack className="text-field-input-preview" gap="x4">
+        <VStack className="text-field-input-preview__content" gap="spacingY.componentDefault">
+          <Field.Root required>
+            <Field.Header>
+              <Field.Label weight="bold">
+                이름
+                <Field.RequiredIndicator />
+              </Field.Label>
+            </Field.Header>
+            <TextField.Root required>
+              <TextField.Input accessibility-label="이름" maxlength={30} placeholder="이름 입력" />
+            </TextField.Root>
+            <Field.Footer>
+              <Field.Description>실명을 입력해 주세요.</Field.Description>
+            </Field.Footer>
+          </Field.Root>
+          <Field.Root invalid>
+            <Field.Header>
+              <Field.Label>사용자 이름</Field.Label>
+            </Field.Header>
+            <TextField.Root defaultValue="이미 사용 중" invalid>
+              <TextField.Input accessibility-label="사용자 이름" maxlength={20} />
+            </TextField.Root>
+            <Field.Footer>
+              <Field.ErrorMessage>다른 사용자 이름을 입력해 주세요.</Field.ErrorMessage>
+            </Field.Footer>
+          </Field.Root>
+        </VStack>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/text-field-input/preview.css
+++ b/docs/examples/lynx/text-field-input/preview.css
@@ -1,0 +1,22 @@
+/* biome-ignore lint/correctness/noUnknownTypeSelector: Lynx의 page 요소입니다. */
+page {
+  height: 100%;
+  padding: 24px;
+  background-color: var(--seed-color-bg-layer-default);
+}
+
+.text-field-input-preview {
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+}
+
+.text-field-input-preview__content {
+  width: 100%;
+  max-width: 420px;
+}
+
+.text-field-input-preview__status {
+  color: var(--seed-color-fg-neutral-muted);
+  font-size: 14px;
+}

--- a/docs/examples/lynx/text-field-input/preview.tsx
+++ b/docs/examples/lynx/text-field-input/preview.tsx
@@ -1,0 +1,32 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { Field, TextField, VStack, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack className="text-field-input-preview" gap="x4">
+        <Field.Root className="text-field-input-preview__content">
+          <Field.Header>
+            <Field.Label>제목</Field.Label>
+          </Field.Header>
+          <TextField.Root>
+            <TextField.Input
+              accessibility-label="제목"
+              maxlength={100}
+              placeholder="제목을 입력해 주세요"
+            />
+          </TextField.Root>
+          <Field.Footer>
+            <Field.Description>한 줄로 제목을 입력해 주세요.</Field.Description>
+          </Field.Footer>
+        </Field.Root>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/text-field-input/states.tsx
+++ b/docs/examples/lynx/text-field-input/states.tsx
@@ -1,0 +1,45 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { Field, TextField, VStack, useSeedClassName } from "@seed-design/lynx-react";
+
+function StateField({
+  defaultValue,
+  label,
+  ...stateProps
+}: Field.RootProps & { defaultValue?: string; label: string }) {
+  return (
+    <Field.Root {...stateProps}>
+      <Field.Header>
+        <Field.Label>{label}</Field.Label>
+      </Field.Header>
+      <TextField.Root defaultValue={defaultValue}>
+        <TextField.Input accessibility-label={label} maxlength={100} placeholder="내용 입력" />
+      </TextField.Root>
+      {stateProps.invalid ? (
+        <Field.Footer>
+          <Field.ErrorMessage>입력 내용을 확인해 주세요.</Field.ErrorMessage>
+        </Field.Footer>
+      ) : null}
+    </Field.Root>
+  );
+}
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack className="text-field-input-preview" gap="x4">
+        <VStack className="text-field-input-preview__content" gap="spacingY.componentDefault">
+          <StateField label="Enabled" />
+          <StateField disabled label="Disabled" />
+          <StateField defaultValue="수정할 수 없는 값" label="Read only" readOnly />
+          <StateField invalid label="Invalid" />
+        </VStack>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/text-field-input/styles.ts
+++ b/docs/examples/lynx/text-field-input/styles.ts
@@ -1,0 +1,2 @@
+import "@seed-design/lynx-css/base.css";
+import "./preview.css";

--- a/docs/examples/lynx/text-field-input/value-changes.tsx
+++ b/docs/examples/lynx/text-field-input/value-changes.tsx
@@ -1,0 +1,38 @@
+import "./styles";
+
+import { root, useState } from "@lynx-js/react";
+import { TextField, VStack, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+  const [value, setValue] = useState("");
+  const [changeCount, setChangeCount] = useState(0);
+
+  function handleValueChange(nextValue: string) {
+    "background only";
+
+    setValue(nextValue);
+    setChangeCount((previous) => previous + 1);
+  }
+
+  return (
+    <page className={seedClassName}>
+      <VStack className="text-field-input-preview" gap="x4">
+        <VStack className="text-field-input-preview__content" gap="x3">
+          <TextField.Root value={value} onValueChange={handleValueChange}>
+            <TextField.Input
+              accessibility-label="닉네임"
+              maxlength={20}
+              placeholder="닉네임을 입력해 주세요"
+            />
+          </TextField.Root>
+          <text className="text-field-input-preview__status">
+            입력값: {JSON.stringify(value)}, 변경 횟수: {JSON.stringify(changeCount)}
+          </text>
+        </VStack>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);


### PR DESCRIPTION
## 작업 내용

- Lynx TextFieldInput 문서에 실행형 미리보기를 추가했습니다.
- 입력값 변경, enabled·disabled·readOnly·invalid 상태, Prefix·Suffix, Field 조합 예제를 추가했습니다.
- 각 예제를 `LynxComponentExample`로 연결해 WebLynx 미리보기, QR 코드, Lynx Explorer 링크, 코드 탭을 제공합니다.
- React 문서와 예제를 기준으로 Lynx가 실제 지원하는 사례만 선별했습니다.

## 배경

DES-2326에서 Lynx TextFieldInput의 사용법을 문서 안에서 직접 실행하고 확인할 수 있도록 요청했습니다.

## 영향

문서와 예제만 변경합니다. 실제 배포되는 `@seed-design/lynx-react` 컴포넌트 구현에는 변경이 없습니다.

## 검증

- `bun generate:all`
- `bun --filter @seed-design/docs typecheck:lynx-examples`
- `bun --filter @seed-design/docs typecheck:lynx-tooling`
- `bun --filter @seed-design/docs build:lynx-examples:development`
- WebLynx에서 5개 예제 렌더링과 입력값 변경 확인
- Lynx React 타입 검사 및 테스트 182건 통과
- 전체 단위 테스트 1,834건 통과
- 기본 5초 제한을 넘긴 기존 테스트 6건은 `--timeout 30000`으로 재실행해 통과

## 확인 제한

연결된 PlayLynx가 `App.openPage`를 지원하지 않고 물리 기기에 접근할 수 없어 Lynx Explorer 실기기 화면은 직접 확인하지 못했습니다. native 번들 생성과 QR·Explorer URL 구성은 확인했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 텍스트 필드 입력 컴포넌트의 인터랙티브 미리보기를 추가했습니다.
  * 값 변경 감지, 상태별 입력 필드, 접두사·접미사, 필드 조합 예제를 제공합니다.
  * 필수 입력, 오류 상태, 읽기 전용 및 비활성화 상태를 확인할 수 있습니다.

* **문서**
  * 기존 사용법을 주제별 예제 섹션으로 개편했습니다.
  * 최대 문자 수 제한과 입력값 변경 처리 예제를 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->