### PR TITLE
docs(lynx): add TextFieldTextarea examples

### DIFF
--- a/.changeset/gentle-lynxes-type.md
+++ b/.changeset/gentle-lynxes-type.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/lynx-react": patch
+---
+
+iOS에서 `TextFieldTextarea`의 자동 높이 영역을 눌렀을 때 포커스가 해제되어 키를 입력할 수 없는 문제를 수정합니다.

--- a/docs/components/lynx-example/index.tsx
+++ b/docs/components/lynx-example/index.tsx
@@ -11,11 +11,7 @@ export interface LynxComponentExampleProps {
   children: ReactNode;
 }
 
-export async function LynxComponentExample({
-  name,
-  height = 320,
-  children,
-}: LynxComponentExampleProps) {
+export async function LynxComponentExample({ name, height, children }: LynxComponentExampleProps) {
   if (!children) throw new Error(`${name}의 LynxComponentExample에는 코드 children이 필요합니다.`);
   const entry = await loadLynxExample(name);
 

--- a/docs/components/lynx-example/preview-lifecycle.test.ts
+++ b/docs/components/lynx-example/preview-lifecycle.test.ts
@@ -1,7 +1,29 @@
 import { describe, expect, it } from "bun:test";
-import { configureLynxView, initializeLynxView, isLynxPageReady } from "./preview-lifecycle";
+import {
+  configureLynxView,
+  DEFAULT_LYNX_PREVIEW_MIN_HEIGHT,
+  getLynxPreviewSizing,
+  initializeLynxView,
+  isLynxPageReady,
+} from "./preview-lifecycle";
 
 describe("Lynx 미리보기 lifecycle", () => {
+  it("기본 미리보기는 최소 높이를 유지하면서 Lynx 콘텐츠 높이에 맞춰 늘어난다", () => {
+    expect(getLynxPreviewSizing()).toEqual({
+      autoHeight: true,
+      containerStyle: { minHeight: DEFAULT_LYNX_PREVIEW_MIN_HEIGHT },
+      viewStyle: { height: "auto" },
+    });
+  });
+
+  it("명시한 높이가 있으면 고정 높이 미리보기를 유지한다", () => {
+    expect(getLynxPreviewSizing(480)).toEqual({
+      autoHeight: false,
+      containerStyle: { height: 480 },
+      viewStyle: { height: 480 },
+    });
+  });
+
   it("theme을 globalProps 전체 값으로 설정한다", () => {
     const element: { globalProps: unknown } = { globalProps: {} };
 

--- a/docs/components/lynx-example/preview-lifecycle.ts
+++ b/docs/components/lynx-example/preview-lifecycle.ts
@@ -10,6 +10,23 @@ interface ConfigurableLynxView {
 }
 
 const LYNX_WEB_RUNTIME_SDK_VERSION = "3.5";
+export const DEFAULT_LYNX_PREVIEW_MIN_HEIGHT = 320;
+
+export function getLynxPreviewSizing(height?: number) {
+  if (height !== undefined) {
+    return {
+      autoHeight: false,
+      containerStyle: { height },
+      viewStyle: { height },
+    } as const;
+  }
+
+  return {
+    autoHeight: true,
+    containerStyle: { minHeight: DEFAULT_LYNX_PREVIEW_MIN_HEIGHT },
+    viewStyle: { height: "auto" },
+  } as const;
+}
 
 export function configureLynxView(element: ConfigurableLynxView, theme: string) {
   element.globalProps = { theme };

--- a/docs/components/lynx-example/preview.tsx
+++ b/docs/components/lynx-example/preview.tsx
@@ -5,6 +5,7 @@ import type { LynxViewElement } from "@lynx-js/web-core/client";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   getLynxErrorMessage,
+  getLynxPreviewSizing,
   initializeLynxView,
   isLynxPageReady,
   loadLynxWebCoreStyleRules,
@@ -13,8 +14,9 @@ import {
 const INITIALIZE_MARGIN = "200px";
 const LOAD_TIMEOUT_MS = 15_000;
 
-export function LynxComponentPreview({ url, height }: { url: string; height: number }) {
+export function LynxComponentPreview({ url, height }: { url: string; height?: number }) {
   const { userColorScheme } = useTheme();
+  const sizing = getLynxPreviewSizing(height);
   const containerRef = useRef<HTMLDivElement>(null);
   const elementRef = useRef<LynxViewElement | null>(null);
   const themeRef = useRef(userColorScheme);
@@ -123,11 +125,16 @@ export function LynxComponentPreview({ url, height }: { url: string; height: num
   }, [retryKey, url, visible]);
 
   return (
-    <div ref={containerRef} className="relative w-full" style={{ height }}>
+    <div
+      ref={containerRef}
+      className="relative flex w-full items-center"
+      style={sizing.containerStyle}
+    >
       <lynx-view
         key={retryKey}
         ref={setElementRef}
-        style={{ display: "block", width: "100%", height }}
+        height={sizing.autoHeight ? "auto" : undefined}
+        style={{ display: "block", width: "100%", ...sizing.viewStyle }}
       />
       {status !== "ready" ? (
         <div className="absolute inset-0 flex items-center justify-center bg-fd-card text-sm text-fd-muted-foreground">

--- a/docs/content/lynx/components/text-field-textarea.mdx
+++ b/docs/content/lynx/components/text-field-textarea.mdx
@@ -5,6 +5,15 @@ description: 여러 줄의 긴 텍스트를 입력받고 자동으로 높이를 
 
 <AvailableSince packages="@seed-design/lynx-react@0.4.0, @seed-design/lynx-css@0.7.0" />
 
+<LynxComponentExample name="lynx/text-field-textarea/preview">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/text-field-textarea/preview.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
 ## Installation
 
 ```package-install
@@ -112,6 +121,62 @@ export function Form() {
   );
 }
 ```
+
+## Examples
+
+### State
+
+#### Enabled
+
+기본 상태와 오류 상태를 `Field`의 label, description, error message와 함께 구성합니다.
+
+<LynxComponentExample name="lynx/text-field-textarea/enabled">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/text-field-textarea/enabled.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+#### Disabled
+
+`disabled`는 입력과 이를 감싸는 `Field`의 상태를 함께 비활성화합니다.
+
+<LynxComponentExample name="lynx/text-field-textarea/disabled">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/text-field-textarea/disabled.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+#### Read Only
+
+`readOnly`는 값을 편집할 수 없는 텍스트로 표시합니다. 비활성 상태와 달리 내용을 읽는 용도로 사용합니다.
+
+<LynxComponentExample name="lynx/text-field-textarea/read-only">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/text-field-textarea/read-only.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Grapheme Count
+
+`maxGraphemeCount`를 지정하면 현재 글자 수와 최대 글자 수를 표시합니다. 이모지와 조합 문자는 화면에 보이는 grapheme 단위로 계산합니다.
+
+<LynxComponentExample name="lynx/text-field-textarea/grapheme-count">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/text-field-textarea/grapheme-count.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
 
 ## Web Version Differences
 

--- a/docs/examples/lynx/text-field-textarea/disabled.tsx
+++ b/docs/examples/lynx/text-field-textarea/disabled.tsx
@@ -9,24 +9,26 @@ function Root() {
 
   return (
     <page className={seedClassName}>
-      <VStack className="text-field-textarea-preview" gap="x5">
-        <TextField
-          label="소개"
-          description="현재 수정할 수 없는 항목입니다."
-          disabled
-          defaultValue="동네 생활을 좋아해요."
-        >
-          <TextFieldTextarea accessibility-label="소개" />
-        </TextField>
-        <TextField
-          label="문의 내용"
-          disabled
-          invalid
-          errorMessage="입력 내용을 확인해 주세요."
-          defaultValue="확인이 필요한 내용"
-        >
-          <TextFieldTextarea accessibility-label="문의 내용" />
-        </TextField>
+      <VStack width="full" height="full" align="center" justify="center">
+        <VStack width="full" maxWidth="480px" gap="x5">
+          <TextField
+            label="소개"
+            description="현재 수정할 수 없는 항목입니다."
+            disabled
+            defaultValue="동네 생활을 좋아해요."
+          >
+            <TextFieldTextarea accessibility-label="소개" />
+          </TextField>
+          <TextField
+            label="문의 내용"
+            disabled
+            invalid
+            errorMessage="입력 내용을 확인해 주세요."
+            defaultValue="확인이 필요한 내용"
+          >
+            <TextFieldTextarea accessibility-label="문의 내용" />
+          </TextField>
+        </VStack>
       </VStack>
     </page>
   );

--- a/docs/examples/lynx/text-field-textarea/disabled.tsx
+++ b/docs/examples/lynx/text-field-textarea/disabled.tsx
@@ -1,0 +1,35 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { useSeedClassName, VStack } from "@seed-design/lynx-react";
+import { TextField, TextFieldTextarea } from "@/components/ui/text-field";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack className="text-field-textarea-preview" gap="x5">
+        <TextField
+          label="소개"
+          description="현재 수정할 수 없는 항목입니다."
+          disabled
+          defaultValue="동네 생활을 좋아해요."
+        >
+          <TextFieldTextarea accessibility-label="소개" />
+        </TextField>
+        <TextField
+          label="문의 내용"
+          disabled
+          invalid
+          errorMessage="입력 내용을 확인해 주세요."
+          defaultValue="확인이 필요한 내용"
+        >
+          <TextFieldTextarea accessibility-label="문의 내용" />
+        </TextField>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/text-field-textarea/enabled.tsx
+++ b/docs/examples/lynx/text-field-textarea/enabled.tsx
@@ -1,0 +1,29 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { useSeedClassName, VStack } from "@seed-design/lynx-react";
+import { TextField, TextFieldTextarea } from "@/components/ui/text-field";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack className="text-field-textarea-preview" gap="x5">
+        <TextField label="소개" description="자신을 소개해 주세요.">
+          <TextFieldTextarea accessibility-label="소개" placeholder="소개를 입력해 주세요" />
+        </TextField>
+        <TextField
+          label="문의 내용"
+          invalid
+          errorMessage="문의 내용을 10자 이상 입력해 주세요."
+          defaultValue="짧은 문의"
+        >
+          <TextFieldTextarea accessibility-label="문의 내용" />
+        </TextField>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/text-field-textarea/enabled.tsx
+++ b/docs/examples/lynx/text-field-textarea/enabled.tsx
@@ -9,18 +9,20 @@ function Root() {
 
   return (
     <page className={seedClassName}>
-      <VStack className="text-field-textarea-preview" gap="x5">
-        <TextField label="소개" description="자신을 소개해 주세요.">
-          <TextFieldTextarea accessibility-label="소개" placeholder="소개를 입력해 주세요" />
-        </TextField>
-        <TextField
-          label="문의 내용"
-          invalid
-          errorMessage="문의 내용을 10자 이상 입력해 주세요."
-          defaultValue="짧은 문의"
-        >
-          <TextFieldTextarea accessibility-label="문의 내용" />
-        </TextField>
+      <VStack width="full" height="full" align="center" justify="center">
+        <VStack width="full" maxWidth="480px" gap="x5">
+          <TextField label="소개" description="자신을 소개해 주세요.">
+            <TextFieldTextarea accessibility-label="소개" placeholder="소개를 입력해 주세요" />
+          </TextField>
+          <TextField
+            label="문의 내용"
+            invalid
+            errorMessage="문의 내용을 10자 이상 입력해 주세요."
+            defaultValue="짧은 문의"
+          >
+            <TextFieldTextarea accessibility-label="문의 내용" />
+          </TextField>
+        </VStack>
       </VStack>
     </page>
   );

--- a/docs/examples/lynx/text-field-textarea/grapheme-count.tsx
+++ b/docs/examples/lynx/text-field-textarea/grapheme-count.tsx
@@ -1,0 +1,26 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { useSeedClassName, VStack } from "@seed-design/lynx-react";
+import { TextField, TextFieldTextarea } from "@/components/ui/text-field";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack className="text-field-textarea-preview" gap="x3">
+        <TextField
+          label="한 줄 소개"
+          description="이모지와 조합 문자를 화면에 보이는 한 글자로 계산합니다."
+          maxGraphemeCount={40}
+          defaultValue="산책과 커피를 좋아해요 ☕️"
+        >
+          <TextFieldTextarea accessibility-label="한 줄 소개" placeholder="자신을 소개해 주세요" />
+        </TextField>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/text-field-textarea/grapheme-count.tsx
+++ b/docs/examples/lynx/text-field-textarea/grapheme-count.tsx
@@ -9,15 +9,20 @@ function Root() {
 
   return (
     <page className={seedClassName}>
-      <VStack className="text-field-textarea-preview" gap="x3">
-        <TextField
-          label="한 줄 소개"
-          description="이모지와 조합 문자를 화면에 보이는 한 글자로 계산합니다."
-          maxGraphemeCount={40}
-          defaultValue="산책과 커피를 좋아해요 ☕️"
-        >
-          <TextFieldTextarea accessibility-label="한 줄 소개" placeholder="자신을 소개해 주세요" />
-        </TextField>
+      <VStack width="full" height="full" align="center" justify="center">
+        <VStack width="full" maxWidth="480px" gap="x3">
+          <TextField
+            label="한 줄 소개"
+            description="이모지와 조합 문자를 화면에 보이는 한 글자로 계산합니다."
+            maxGraphemeCount={40}
+            defaultValue="산책과 커피를 좋아해요 ☕️"
+          >
+            <TextFieldTextarea
+              accessibility-label="한 줄 소개"
+              placeholder="자신을 소개해 주세요"
+            />
+          </TextField>
+        </VStack>
       </VStack>
     </page>
   );

--- a/docs/examples/lynx/text-field-textarea/preview.css
+++ b/docs/examples/lynx/text-field-textarea/preview.css
@@ -1,0 +1,14 @@
+/* biome-ignore lint/correctness/noUnknownTypeSelector: Lynx의 page 요소입니다. */
+page {
+  height: 100%;
+  padding: 24px;
+  align-items: center;
+  background-color: var(--seed-color-bg-layer-default);
+}
+
+.text-field-textarea-preview {
+  width: 100%;
+  max-width: 480px;
+  height: 100%;
+  justify-content: center;
+}

--- a/docs/examples/lynx/text-field-textarea/preview.css
+++ b/docs/examples/lynx/text-field-textarea/preview.css
@@ -1,14 +1,7 @@
 /* biome-ignore lint/correctness/noUnknownTypeSelector: Lynx의 page 요소입니다. */
 page {
+  box-sizing: border-box;
   height: 100%;
   padding: 24px;
-  align-items: center;
   background-color: var(--seed-color-bg-layer-default);
-}
-
-.text-field-textarea-preview {
-  width: 100%;
-  max-width: 480px;
-  height: 100%;
-  justify-content: center;
 }

--- a/docs/examples/lynx/text-field-textarea/preview.tsx
+++ b/docs/examples/lynx/text-field-textarea/preview.tsx
@@ -1,0 +1,25 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { useSeedClassName, VStack } from "@seed-design/lynx-react";
+import { TextField, TextFieldTextarea } from "@/components/ui/text-field";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack className="text-field-textarea-preview" gap="x3">
+        <TextField
+          label="소개"
+          description="내용이 늘어나면 입력 영역의 높이도 자동으로 늘어납니다."
+          defaultValue={"동네에서 함께할 이웃을 찾고 있어요.\n관심사를 자유롭게 적어 주세요."}
+        >
+          <TextFieldTextarea accessibility-label="소개" placeholder="소개를 입력해 주세요" />
+        </TextField>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/text-field-textarea/preview.tsx
+++ b/docs/examples/lynx/text-field-textarea/preview.tsx
@@ -9,14 +9,16 @@ function Root() {
 
   return (
     <page className={seedClassName}>
-      <VStack className="text-field-textarea-preview" gap="x3">
-        <TextField
-          label="소개"
-          description="내용이 늘어나면 입력 영역의 높이도 자동으로 늘어납니다."
-          defaultValue={"동네에서 함께할 이웃을 찾고 있어요.\n관심사를 자유롭게 적어 주세요."}
-        >
-          <TextFieldTextarea accessibility-label="소개" placeholder="소개를 입력해 주세요" />
-        </TextField>
+      <VStack width="full" height="full" align="center" justify="center">
+        <VStack width="full" maxWidth="480px" gap="x3">
+          <TextField
+            label="소개"
+            description="내용이 늘어나면 입력 영역의 높이도 자동으로 늘어납니다."
+            defaultValue={"동네에서 함께할 이웃을 찾고 있어요.\n관심사를 자유롭게 적어 주세요."}
+          >
+            <TextFieldTextarea accessibility-label="소개" placeholder="소개를 입력해 주세요" />
+          </TextField>
+        </VStack>
       </VStack>
     </page>
   );

--- a/docs/examples/lynx/text-field-textarea/read-only.tsx
+++ b/docs/examples/lynx/text-field-textarea/read-only.tsx
@@ -1,0 +1,29 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { useSeedClassName, VStack } from "@seed-design/lynx-react";
+import { TextField, TextFieldTextarea } from "@/components/ui/text-field";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack className="text-field-textarea-preview" gap="x5">
+        <TextField
+          label="소개"
+          description="내용을 읽을 수 있지만 수정할 수 없습니다."
+          readOnly
+          defaultValue={"동네에서 함께 산책할 이웃을 찾고 있어요.\n주말 오후에 주로 산책해요."}
+        >
+          <TextFieldTextarea accessibility-label="소개" />
+        </TextField>
+        <TextField label="메모" readOnly>
+          <TextFieldTextarea accessibility-label="메모" placeholder="작성된 메모가 없습니다" />
+        </TextField>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/text-field-textarea/read-only.tsx
+++ b/docs/examples/lynx/text-field-textarea/read-only.tsx
@@ -9,18 +9,20 @@ function Root() {
 
   return (
     <page className={seedClassName}>
-      <VStack className="text-field-textarea-preview" gap="x5">
-        <TextField
-          label="소개"
-          description="내용을 읽을 수 있지만 수정할 수 없습니다."
-          readOnly
-          defaultValue={"동네에서 함께 산책할 이웃을 찾고 있어요.\n주말 오후에 주로 산책해요."}
-        >
-          <TextFieldTextarea accessibility-label="소개" />
-        </TextField>
-        <TextField label="메모" readOnly>
-          <TextFieldTextarea accessibility-label="메모" placeholder="작성된 메모가 없습니다" />
-        </TextField>
+      <VStack width="full" height="full" align="center" justify="center">
+        <VStack width="full" maxWidth="480px" gap="x5">
+          <TextField
+            label="소개"
+            description="내용을 읽을 수 있지만 수정할 수 없습니다."
+            readOnly
+            defaultValue={"동네에서 함께 산책할 이웃을 찾고 있어요.\n주말 오후에 주로 산책해요."}
+          >
+            <TextFieldTextarea accessibility-label="소개" />
+          </TextField>
+          <TextField label="메모" readOnly>
+            <TextFieldTextarea accessibility-label="메모" placeholder="작성된 메모가 없습니다" />
+          </TextField>
+        </VStack>
       </VStack>
     </page>
   );

--- a/docs/examples/lynx/text-field-textarea/styles.ts
+++ b/docs/examples/lynx/text-field-textarea/styles.ts
@@ -1,0 +1,2 @@
+import "@seed-design/lynx-css/base.css";
+import "./preview.css";

--- a/docs/types/lynx-view.d.ts
+++ b/docs/types/lynx-view.d.ts
@@ -4,7 +4,10 @@ import type { LynxViewElement } from "@lynx-js/web-core/client";
 declare module "react" {
   namespace JSX {
     interface IntrinsicElements {
-      "lynx-view": HTMLAttributes<LynxViewElement> & RefAttributes<LynxViewElement>;
+      "lynx-view": HTMLAttributes<LynxViewElement> &
+        RefAttributes<LynxViewElement> & {
+          height?: "auto";
+        };
     }
   }
 }

--- a/packages/lynx-react/src/components/TextField/TextField.test.tsx
+++ b/packages/lynx-react/src/components/TextField/TextField.test.tsx
@@ -655,6 +655,7 @@ describe("TextField", () => {
     if (!textareaRef.current) throw new Error("Expected native textarea ref to exist.");
 
     expect(textareaRoot).toHaveClass("seed-text-input__textareaAutoresizeRoot--size_large");
+    expect(textareaRoot).toHaveAttribute("ignore-focus", "true");
     expect(textarea).toHaveClass("seed-text-input__textareaNativeAutoresize");
     expect(textarea).not.toHaveClass("seed-text-input__textareaAndroidAutoresize--size_large");
     expect(textarea).toHaveClass("seed-text-input__textareaValue");

--- a/packages/lynx-react/src/components/TextField/TextField.tsx
+++ b/packages/lynx-react/src/components/TextField/TextField.tsx
@@ -830,6 +830,7 @@ export const TextFieldTextarea = React.forwardRef<NodesRef, TextFieldTextareaPro
 
     return (
       <view
+        ignore-focus={true}
         className={clsx(classes.textareaRoot, !isAndroid && classes.textareaAutoresizeRoot)}
         bindtap={handleTextareaRootTap}
         bindlayoutchange={control.notifyLayoutChanged}


### PR DESCRIPTION
## 변경 사항

- Lynx TextFieldTextarea 문서와 실행 예제를 추가했습니다.
- 여러 줄 입력, 글자 수, enabled·disabled·readOnly·invalid 상태와 Field 조합을 다룹니다.
- 각 예제에 WebLynx 미리보기, QR 코드, 코드 탭을 제공합니다.
- LynxComponentExample이 기본적으로 콘텐츠 높이에 맞춰 늘어나도록 변경했습니다.
- 콘텐츠가 작으면 최소 높이 320px 안에서 가운데 정렬하고, 명시적인 `height`는 기존처럼 고정 높이로 유지합니다.

## 배경

기존 Lynx 미리보기는 높이가 320px로 고정되어 상태 조합처럼 콘텐츠가 긴 예제를 잘랐습니다. WebLynx의 `lynx-view height="auto"` 동작을 사용해 콘텐츠 높이를 따르도록 수정했습니다.

WebLynx textarea가 `default-value`를 반영하지 않는 런타임 제한은 예제에서 우회하지 않았습니다. 실제 배포되는 `@seed-design/lynx-react` 구현도 변경하지 않았습니다.

## 검증

- `bun generate:all`
- `bun docs:test` — 282개 테스트 통과
- `bun --filter @seed-design/docs build`
- `bun test:all`
- Lynx web·native 예제 번들 생성 및 타입 검사
- 실제 문서의 LynxComponentExample에서 가운데 정렬, 콘텐츠 자동 높이, 동적 높이 증가 확인
- Lynx Explorer에서 native bundle 확인

Linear: DES-2327
