### PR TITLE
fix(lynx-react): preserve textarea focus on iOS

### DIFF
--- a/.changeset/gentle-lynxes-type.md
+++ b/.changeset/gentle-lynxes-type.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/lynx-react": patch
+---
+
+iOS에서 `TextFieldTextarea`의 자동 높이 영역을 눌렀을 때 포커스가 해제되어 키를 입력할 수 없는 문제를 수정합니다.

--- a/packages/lynx-react/src/components/TextField/TextField.test.tsx
+++ b/packages/lynx-react/src/components/TextField/TextField.test.tsx
@@ -655,6 +655,7 @@ describe("TextField", () => {
     if (!textareaRef.current) throw new Error("Expected native textarea ref to exist.");
 
     expect(textareaRoot).toHaveClass("seed-text-input__textareaAutoresizeRoot--size_large");
+    expect(textareaRoot).toHaveAttribute("ignore-focus", "true");
     expect(textarea).toHaveClass("seed-text-input__textareaNativeAutoresize");
     expect(textarea).not.toHaveClass("seed-text-input__textareaAndroidAutoresize--size_large");
     expect(textarea).toHaveClass("seed-text-input__textareaValue");

--- a/packages/lynx-react/src/components/TextField/TextField.tsx
+++ b/packages/lynx-react/src/components/TextField/TextField.tsx
@@ -830,6 +830,7 @@ export const TextFieldTextarea = React.forwardRef<NodesRef, TextFieldTextareaPro
 
     return (
       <view
+        ignore-focus={true}
         className={clsx(classes.textareaRoot, !isAndroid && classes.textareaAutoresizeRoot)}
         bindtap={handleTextareaRootTap}
         bindlayoutchange={control.notifyLayoutChanged}


### PR DESCRIPTION
## 변경 사항

- `TextFieldTextarea`의 자동 높이 래퍼에 `ignore-focus={true}`를 적용했습니다.
- 자동 높이 래퍼가 포커스를 유지하는지 확인하는 회귀 테스트를 추가했습니다.
- `@seed-design/lynx-react` patch changeset을 추가했습니다.

## 원인

iOS에서 자동 높이 textarea의 여백을 누르면 실제 터치 대상이 네이티브 `UITextView`가 아니라 래퍼 `view`가 됩니다. Lynx는 일반 `view` 터치 시 `endEditing`을 예약하므로, SEED의 래퍼 `bindtap`이 호출하는 `focus()`와 경합하면서 포커스가 다시 해제됐습니다.

래퍼에 `ignore-focus`를 적용해 이 터치가 네이티브 입력 포커스를 해제하지 않도록 수정했습니다.

## 사용자 영향

PlayLynx iOS 환경에서 `TextFieldTextarea`의 자동 높이 영역을 눌러도 키보드와 입력 포커스가 유지됩니다.

## 검증

- `bun generate:all`
- `bun packages:build`
- `bun test:all`
- `bun docs:test`
- 최신 base 재배치 후 `bun test:lynx-react` — 186개 테스트 통과
- Lynx development bundle에서 래퍼의 `ignore-focus=true` 전달 확인
