### PR TITLE
fix(lynx): restore textarea native input

### DIFF
--- a/docs/content/lynx/components/text-field-textarea.mdx
+++ b/docs/content/lynx/components/text-field-textarea.mdx
@@ -69,7 +69,7 @@ export function ControlledIntroduction() {
 
 ### Autoresizing
 
-`TextFieldTextarea`는 기본적으로 native textarea의 intrinsic height를 사용해 내용에 맞춰 높이가 늘어납니다. iOS에서는 wrapper가, Android에서는 native textarea가 최소 높이와 세로 여백을 담당합니다. 실제 wrapper 높이가 달라질 때만 Keyboard Avoiding 위치를 다시 계산합니다. 고정 높이가 필요하면 `autoresize={false}`와 명시적인 `height`를 함께 사용합니다.
+`TextFieldTextarea`는 기본적으로 Lynx native textarea의 측정 기능을 사용해 내용에 맞춰 높이가 늘어납니다. 별도 측정 요소나 wrapper를 만들지 않습니다. native textarea의 실제 높이가 달라지면 Keyboard Avoiding 위치를 다시 계산합니다. 고정 높이가 필요하면 `autoresize={false}`와 명시적인 `height`를 함께 사용합니다.
 
 Android에서는 SEED typography의 줄 높이를 맞추기 위해 `line-spacing="3.2px"`를 기본 적용합니다. `line-spacing`을 명시하면 모든 플랫폼에서 해당 값이 우선하며, Android의 기본 보정은 `line-spacing={0}`으로 해제할 수 있습니다. `fontSize`나 `lineHeight`를 직접 변경한다면 이에 맞는 `line-spacing`도 함께 지정해야 합니다.
 
@@ -185,11 +185,12 @@ export function Form() {
 - `onChange` 대신 snippet `TextField`의 `onValueChange`를 사용합니다. 원문과 grapheme 단위로 자른 값을 함께 제공합니다.
 - native `bindinput`은 `TextFieldTextarea`에 추가로 전달할 수 있습니다.
 - `Field.Label`과 입력의 DOM id 연결이 없으므로 `accessibility-label`을 입력에 직접 제공합니다.
-- autoresize는 DOM `scrollHeight` 대신 native intrinsic height를 사용합니다. iOS는 wrapper가 세로 여백을 소유하고, Android는 `EditText` 자체가 세로 여백과 최소 높이를 소유해 native drawing 경계에서 첫 줄이 잘리지 않도록 합니다.
+- autoresize는 DOM `scrollHeight` 대신 native intrinsic height를 사용합니다. 별도 wrapper 없이 native textarea가 세로 여백과 최소 높이를 함께 소유합니다.
 - Android에서는 CSS `line-height`가 native textarea에 적용되지 않아 `line-spacing="3.2px"`를 기본 적용합니다. 명시적인 `line-spacing` 값이 이 기본값보다 우선합니다.
 - controlled textarea도 native 입력 이벤트를 그대로 유지하고, 외부에서 값이 달라진 경우에만 `setValue`로 동기화합니다. 입력마다 `readonly`를 토글하지 않아 줄 추가 시 native scroll offset과 높이 측정이 초기화되지 않습니다.
+- 포커스 시 키보드가 나타나도록 `show-soft-input-on-focus`의 기본값은 `true`입니다.
 - Android의 fullscreen extract input은 기본적으로 비활성화합니다. 필요한 경우 `android-fullscreen-mode={true}`를 명시합니다.
-- `KeyboardAvoidingScrollView`가 키보드 회피를 전담하는 화면에서는 Android host window의 별도 pan/resize를 막기 위해 `android-set-soft-input-mode="nothing"`을 명시할 수 있습니다. 이 값은 host window 전역에 영향을 주므로 컴포넌트가 자동으로 적용하지 않습니다.
+- `android-set-soft-input-mode`의 기본값은 `"unspecified"`입니다. `KeyboardAvoidingScrollView`가 키보드 회피를 전담하는 화면에서는 host window의 별도 pan/resize를 막기 위해 `"nothing"`을 명시할 수 있습니다. 이 값은 host window 전역에 영향을 줍니다.
 - `size="responsive"`는 CSS viewport breakpoint가 없는 Lynx에서 지원하지 않습니다. `large` 또는 `medium`을 명시합니다.
 
 ## Unsupported Lynx Features

--- a/docs/examples/lynx/text-field-textarea/preview.css
+++ b/docs/examples/lynx/text-field-textarea/preview.css
@@ -5,3 +5,14 @@ page {
   padding: 24px;
   background-color: var(--seed-color-bg-layer-default);
 }
+
+.pure-textarea {
+  width: 100%;
+  min-height: 96px;
+  padding: 14px 12px;
+  border: 1px solid var(--seed-color-stroke-neutral-muted);
+  border-radius: 12px;
+  background-color: var(--seed-color-bg-layer-default);
+  color: var(--seed-color-fg-neutral);
+  font-size: 16px;
+}

--- a/docs/examples/lynx/text-field-textarea/preview.tsx
+++ b/docs/examples/lynx/text-field-textarea/preview.tsx
@@ -18,6 +18,11 @@ function Root() {
           >
             <TextFieldTextarea accessibility-label="소개" placeholder="소개를 입력해 주세요" />
           </TextField>
+          <textarea
+            className="pure-textarea"
+            accessibility-label="Pure textarea"
+            placeholder="Pure textarea에 입력해 주세요"
+          />
         </VStack>
       </VStack>
     </page>

--- a/docs/public/__docs__/index.json
+++ b/docs/public/__docs__/index.json
@@ -804,6 +804,12 @@
               "title": "디자인 시스템에도 브랜딩이 필요할까",
               "description": "우리끼리 쓰는 디자인 시스템에 정말 브랜딩이 필요할까요. SEED가 당근에 기반하면서도 전혀 다른 얼굴을 한 하나의 브랜드로 완성되기까지 과정을 담았습니다.",
               "docUrl": "/updates/why-design-system-needs-branding"
+            },
+            {
+              "id": "why-we-hired-a-design-engineer",
+              "title": "우리는 왜 디자인 엔지니어를 찾게 됐을까",
+              "description": "당근 디자인 시스템 팀에 디자인 엔지니어라는 새로운 직군이 생겼습니다. 왜 이 역할이 필요했고, 어떤 기준으로 정의했는지 그 고민의 과정을 담았습니다.",
+              "docUrl": "/updates/why-we-hired-a-design-engineer"
             }
           ]
         },

--- a/packages/lynx-react/src/components/TextField/TextField.test.tsx
+++ b/packages/lynx-react/src/components/TextField/TextField.test.tsx
@@ -171,7 +171,9 @@ describe("TextField", () => {
     expect(input).toHaveAttribute("name", "title");
     expect(input).toHaveAttribute("placeholder", "제목");
     expect(input).toHaveAttribute("default-value", "초기값");
-    expect(input).not.toHaveAttribute("android-set-soft-input-mode");
+    expect(input).toHaveAttribute("show-soft-input-on-focus", "true");
+    expect(input).toHaveAttribute("android-set-soft-input-mode", "unspecified");
+    expect(input).not.toHaveAttribute("maxlength");
 
     rerender(renderTextField());
 
@@ -194,6 +196,31 @@ describe("TextField", () => {
     if (!input) throw new Error("Expected native input to exist.");
 
     expect(input).toHaveAttribute("default-value", "");
+  });
+
+  it("passes safe soft keyboard defaults and preserves explicit overrides", () => {
+    const { rerender } = render(
+      <TextField.Root>
+        <TextField.Input />
+      </TextField.Root>,
+    );
+
+    const input = getRenderedRoot().querySelector("input");
+    expect(input).toHaveAttribute("show-soft-input-on-focus", "true");
+    expect(input).toHaveAttribute("android-set-soft-input-mode", "unspecified");
+
+    rerender(
+      <TextField.Root>
+        <TextField.Textarea
+          show-soft-input-on-focus={false}
+          android-set-soft-input-mode="resize"
+        />
+      </TextField.Root>,
+    );
+
+    const textarea = getRenderedRoot().querySelector("textarea");
+    expect(textarea).toHaveAttribute("show-soft-input-on-focus", "false");
+    expect(textarea).toHaveAttribute("android-set-soft-input-mode", "resize");
   });
 
   it("initializes a non-empty value without invoking a native UI method", () => {
@@ -543,8 +570,9 @@ describe("TextField", () => {
     );
 
     if (!inputRef.current) throw new Error("Expected native input ref to exist.");
-    expect(getRenderedRoot().querySelector("input")).not.toHaveAttribute(
+    expect(getRenderedRoot().querySelector("input")).toHaveAttribute(
       "android-set-soft-input-mode",
+      "unspecified",
     );
 
     // ReactLynx Testing Library runtime accepts NodesRef, but its public fireEvent type
@@ -627,8 +655,9 @@ describe("TextField", () => {
     expect(getRenderedQueries().queryByText("secret")).toBeNull();
   });
 
-  it("uses native intrinsic autoresize inside a padded sizing wrapper", () => {
+  it("uses native intrinsic autoresize without a sizing wrapper", () => {
     const textareaRef = createRef<NodesRef>();
+    const bindlayoutchange = vi.fn();
     const actions = {
       focus: vi.fn(),
       blur: vi.fn(),
@@ -642,6 +671,7 @@ describe("TextField", () => {
             ref={textareaRef}
             placeholder="내용"
             android-set-soft-input-mode="nothing"
+            bindlayoutchange={bindlayoutchange}
           />
         </TextField.Root>
       </KeyboardAvoidanceActionsContext.Provider>,
@@ -649,38 +679,27 @@ describe("TextField", () => {
 
     const root = getRenderedRoot();
     const textarea = root.querySelector("textarea");
-    const textareaRoot = root.querySelector(".seed-text-input__textareaRoot");
     if (!textarea) throw new Error("Expected native textarea to exist.");
-    if (!textareaRoot) throw new Error("Expected textarea sizing wrapper to exist.");
     if (!textareaRef.current) throw new Error("Expected native textarea ref to exist.");
 
-    expect(textareaRoot).toHaveClass("seed-text-input__textareaAutoresizeRoot--size_large");
-    expect(textareaRoot).toHaveAttribute("ignore-focus", "true");
-    expect(textarea).toHaveClass("seed-text-input__textareaNativeAutoresize");
-    expect(textarea).not.toHaveClass("seed-text-input__textareaAndroidAutoresize--size_large");
+    expect(textarea).not.toHaveClass("seed-text-input__textareaNativeAutoresize");
+    expect(textarea).toHaveClass("seed-text-input__textareaAndroidAutoresize--size_large");
     expect(textarea).toHaveClass("seed-text-input__textareaValue");
     expect(textarea).not.toHaveClass("seed-text-input__textareaFixed");
     expect(textarea).toHaveAttribute("bounces", "false");
+    expect(textarea).toHaveAttribute("show-soft-input-on-focus", "true");
     expect(textarea).toHaveAttribute("default-value", "첫 줄\n둘째 줄\n");
     expect(textarea).toHaveAttribute("android-fullscreen-mode", "false");
     expect(textarea).toHaveAttribute("android-set-soft-input-mode", "nothing");
-    expect(textareaRoot.querySelector("text")).toBeNull();
+    expect(textarea).not.toHaveAttribute("maxlength");
+    expect(root.querySelector(".seed-text-input__textareaRoot")).toBeNull();
 
-    fireNativeEvent(textareaRoot as unknown as NodesRef, textareaRoot, "layoutchange", {
+    fireNativeEvent(textareaRef.current, textarea, "layoutchange", {
       width: 200,
       height: 120,
     });
     expect(actions.layoutChanged).toHaveBeenCalledOnce();
-
-    const exec = vi.fn();
-    const invoke = vi.fn(() => ({ exec }));
-    textareaRef.current.invoke = invoke as unknown as NodesRef["invoke"];
-    fireEvent.tap(textareaRef.current as unknown as Element);
-    expect(invoke).not.toHaveBeenCalled();
-
-    fireEvent.tap(textareaRoot);
-    expect(invoke).toHaveBeenCalledWith(expect.objectContaining({ method: "focus" }));
-    expect(exec).toHaveBeenCalledOnce();
+    expect(bindlayoutchange).toHaveBeenCalledOnce();
   });
 
   it("uses native intrinsic autoresize with the Android-only line-spacing correction", () => {
@@ -696,7 +715,7 @@ describe("TextField", () => {
     const textarea = root.querySelector("textarea");
     if (!textarea) throw new Error("Expected native textarea to exist.");
 
-    expect(textarea).toHaveClass("seed-text-input__textareaNativeAutoresize");
+    expect(textarea).not.toHaveClass("seed-text-input__textareaNativeAutoresize");
     expect(textarea).toHaveClass("seed-text-input__textareaAndroidAutoresize--size_large");
     expect(textarea).toHaveAttribute("line-spacing", "3.2px");
     expect(root.querySelector(".seed-text-input__textareaAutoresizeRoot--size_large")).toBeNull();
@@ -757,13 +776,10 @@ describe("TextField", () => {
     const textarea = root.querySelector("textarea");
     if (!textarea) throw new Error("Expected native textarea to exist.");
 
-    expect(textarea).toHaveClass("seed-text-input__textareaNativeAutoresize");
-    expect(textarea).not.toHaveClass("seed-text-input__textareaAndroidAutoresize--size_large");
+    expect(textarea).not.toHaveClass("seed-text-input__textareaNativeAutoresize");
+    expect(textarea).toHaveClass("seed-text-input__textareaAndroidAutoresize--size_large");
     expect(textarea).not.toHaveAttribute("line-spacing");
-    expect(
-      root.querySelector(".seed-text-input__textareaAutoresizeRoot--size_large"),
-    ).not.toBeNull();
-    expect(root.querySelector(".seed-text-input__textareaRoot text")).toBeNull();
+    expect(root.querySelector(".seed-text-input__textareaRoot")).toBeNull();
   });
 
   it("does not restore the previous value after an accepted controlled textarea newline", async () => {
@@ -795,8 +811,8 @@ describe("TextField", () => {
       throw new Error("Expected native textarea to exist.");
     }
 
-    expect(textarea).toHaveClass("seed-text-input__textareaNativeAutoresize");
-    expect(root.querySelector(".seed-text-input__textareaRoot")).not.toBeNull();
+    expect(textarea).not.toHaveClass("seed-text-input__textareaNativeAutoresize");
+    expect(root.querySelector(".seed-text-input__textareaRoot")).toBeNull();
 
     const invoke = vi.fn(() => ({ exec: vi.fn() }));
     textareaRef.current.invoke = invoke as unknown as NodesRef["invoke"];

--- a/packages/lynx-react/src/components/TextField/TextField.tsx
+++ b/packages/lynx-react/src/components/TextField/TextField.tsx
@@ -461,19 +461,6 @@ function useNativeTextControl({
     keyboardAvoidance?.layoutChanged(ownerRef.current);
   }, [keyboardAvoidance]);
 
-  const focusNativeControl = React.useCallback(() => {
-    "background only";
-
-    const node = nativeRef.current;
-    if (!node || typeof node.invoke !== "function") return;
-
-    try {
-      node.invoke({ method: "focus" }).exec();
-    } catch {
-      // Native node가 아직 commit되지 않았으면 실제 textarea 탭이 focus를 처리한다.
-    }
-  }, []);
-
   return {
     context: textFieldContext,
     disabled,
@@ -484,7 +471,6 @@ function useNativeTextControl({
     handleFocus,
     handleBlur,
     notifyLayoutChanged,
-    focusNativeControl,
     handleSelectionChange,
     nativeInsertionMaxLength:
       wasInsertionMaxLengthManaged &&
@@ -562,13 +548,14 @@ export interface TextFieldInputProps extends NativeTextControlProps {
   maxlength?: NativeInputProps["maxlength"];
   readonly?: NativeInputProps["readonly"];
   disabled?: NativeInputProps["disabled"];
+  /** 포커스할 때 시스템 키보드를 표시한다. @defaultValue true */
   "show-soft-input-on-focus"?: NativeInputProps["show-soft-input-on-focus"];
   "input-filter"?: NativeInputProps["input-filter"];
   type?: NativeInputProps["type"];
   "ios-auto-correct"?: NativeInputProps["ios-auto-correct"];
   "ios-spell-check"?: NativeInputProps["ios-spell-check"];
   "android-fullscreen-mode"?: NativeInputProps["android-fullscreen-mode"];
-  /** Android host window의 soft input mode를 지정한다. */
+  /** Android host window의 soft input mode를 지정한다. @defaultValue "unspecified" */
   "android-set-soft-input-mode"?: AndroidSetSoftInputMode;
   bindfocus?: NativeInputProps["bindfocus"];
   bindblur?: NativeInputProps["bindblur"];
@@ -651,10 +638,10 @@ export const TextFieldInput = React.forwardRef<NodesRef, TextFieldInputProps>((p
       className={clsx(classes.value, className)}
       disabled={control.disabled}
       readonly={control.readOnly}
-      show-soft-input-on-focus={control.readOnly ? false : showSoftInputOnFocus}
-      android-set-soft-input-mode={androidSetSoftInputMode}
+      show-soft-input-on-focus={showSoftInputOnFocus ?? true}
+      android-set-soft-input-mode={androidSetSoftInputMode ?? "unspecified"}
       name={name ?? control.context.name}
-      maxlength={resolvedMaxLength}
+      {...(resolvedMaxLength === undefined ? {} : { maxlength: resolvedMaxLength })}
       bindinput={control.handleInput}
       bindselection={handleSelection}
       bindfocus={control.handleFocus}
@@ -686,6 +673,7 @@ export interface TextFieldTextareaProps extends NativeTextControlProps {
   "line-spacing"?: NativeTextareaProps["line-spacing"];
   readonly?: NativeTextareaProps["readonly"];
   disabled?: NativeTextareaProps["disabled"];
+  /** 포커스할 때 시스템 키보드를 표시한다. @defaultValue true */
   "show-soft-input-on-focus"?: NativeTextareaProps["show-soft-input-on-focus"];
   "input-filter"?: NativeTextareaProps["input-filter"];
   "enable-scroll-bar"?: NativeTextareaProps["enable-scroll-bar"];
@@ -694,7 +682,7 @@ export interface TextFieldTextareaProps extends NativeTextControlProps {
   "ios-spell-check"?: NativeTextareaProps["ios-spell-check"];
   /** Android의 fullscreen extract input을 활성화한다. @defaultValue false */
   "android-fullscreen-mode"?: NativeTextareaProps["android-fullscreen-mode"];
-  /** Android host window의 soft input mode를 지정한다. */
+  /** Android host window의 soft input mode를 지정한다. @defaultValue "unspecified" */
   "android-set-soft-input-mode"?: AndroidSetSoftInputMode;
   bindfocus?: NativeTextareaProps["bindfocus"];
   bindblur?: NativeTextareaProps["bindblur"];
@@ -756,16 +744,18 @@ export const TextFieldTextarea = React.forwardRef<NodesRef, TextFieldTextareaPro
       },
       [bindselection, control.handleSelectionChange],
     );
-    const handleTextareaRootTap = React.useCallback<
-      NonNullable<IntrinsicElements["view"]["bindtap"]>
+    const handleLayoutChange = React.useCallback<
+      NonNullable<NativeTextareaProps["bindlayoutchange"]>
     >(
       (event) => {
         "background only";
 
-        if (event.target.uid !== event.currentTarget.uid) return;
-        control.focusNativeControl();
+        if (autoresize) {
+          control.notifyLayoutChanged();
+        }
+        bindlayoutchange?.(event);
       },
-      [control.focusNativeControl],
+      [autoresize, bindlayoutchange, control.notifyLayoutChanged],
     );
 
     if (control.readOnly) {
@@ -795,48 +785,35 @@ export const TextFieldTextarea = React.forwardRef<NodesRef, TextFieldTextareaPro
       );
     }
 
-    // Android EditText는 자체 canvas 경계 안에서 text와 scroll offset을 먼저 자른다.
-    // autoresize 시 세로 padding을 wrapper가 아니라 native가 소유해야 첫 줄 여유가 유효하다.
-    const textarea = (
+    // Lynx native textarea가 내용 높이를 측정하고 shadow node를 다시 배치한다.
+    // 높이를 고정하지 않는 autoresize 모드에서는 별도 sizing wrapper를 두지 않는다.
+    return (
       <textarea
         {...control.defaultValueProps}
         ref={control.mergedRef}
         className={clsx(
           classes.value,
           classes.textareaValue,
-          autoresize ? classes.textareaNativeAutoresize : classes.textareaFixed,
-          autoresize && isAndroid && classes.textareaAndroidAutoresize,
+          !autoresize && classes.textareaFixed,
+          autoresize && classes.textareaAndroidAutoresize,
           className,
         )}
         disabled={control.disabled}
         readonly={control.readOnly}
-        show-soft-input-on-focus={control.readOnly ? false : showSoftInputOnFocus}
+        show-soft-input-on-focus={showSoftInputOnFocus ?? true}
         bounces={bounces ?? (autoresize ? false : undefined)}
         line-spacing={resolvedLineSpacing}
         android-fullscreen-mode={androidFullscreenMode ?? false}
-        android-set-soft-input-mode={androidSetSoftInputMode}
+        android-set-soft-input-mode={androidSetSoftInputMode ?? "unspecified"}
         name={name ?? control.context.name}
-        maxlength={resolvedMaxLength}
+        {...(resolvedMaxLength === undefined ? {} : { maxlength: resolvedMaxLength })}
         bindinput={control.handleInput}
         bindselection={handleSelection}
         bindfocus={control.handleFocus}
         bindblur={control.handleBlur}
-        bindlayoutchange={bindlayoutchange}
+        bindlayoutchange={handleLayoutChange}
         {...nativeProps}
       />
-    );
-
-    if (!autoresize) return textarea;
-
-    return (
-      <view
-        ignore-focus={true}
-        className={clsx(classes.textareaRoot, !isAndroid && classes.textareaAutoresizeRoot)}
-        bindtap={handleTextareaRootTap}
-        bindlayoutchange={control.notifyLayoutChanged}
-      >
-        {textarea}
-      </view>
     );
   },
 );


### PR DESCRIPTION
## 변경 사항

- Textarea의 별도 자동 높이 조절 로직을 제거하고 Lynx Native autosizing을 사용합니다.
- 값이 없는 maxlength를 Native attribute로 전달하지 않도록 수정합니다.
- show-soft-input-on-focus와 android-set-soft-input-mode에 안전한 기본값을 적용합니다.
- 문서와 프리뷰에 Native 동작 및 순수 textarea 예제를 반영합니다.

## 원인

maxlength가 지정되지 않은 경우에도 undefined가 Native attribute로 전달되었습니다. iOS Native setter에서 이 값이 0으로 변환되어 입력이 차단됐습니다. 전체 선택 후 입력하면 기존 내용만 삭제되는 증상도 같은 원인으로 발생했습니다.

Textarea의 자동 높이 조절은 Lynx Native에 이미 구현되어 있어 별도 래퍼와 크기 동기화 로직이 필요하지 않았습니다.

## 영향

기존 공개 API는 유지합니다. 기본 설정으로 렌더한 Input과 Textarea에서 iOS 키보드가 정상적으로 표시되고 Android의 soft input mode 처리 오류를 피합니다.

## 검증

- PlayLynx 실기기에서 한글 입력 및 선택 후 입력 확인
- Lynx DevTool 개발 번들 확인
- bun generate:all
- bun --filter @seed-design/lynx-react build
- bun test:all: 21개 파일, 187개 테스트 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - Textarea가 실제 높이에 맞춰 자동으로 크기를 조절하며, 높이 변경 시 키보드 회피 위치가 다시 계산됩니다.
  - Android에서 기본 줄 간격, 소프트 키보드 표시 및 입력 모드 동작이 명확해졌습니다.
  - 포커스 시 키보드 표시와 전체 화면 입력 추출 기능의 동작이 업데이트되었습니다.
  - 값이 없는 입력에는 불필요한 최대 길이 제한이 전달되지 않습니다.

- **문서 및 예제**
  - Textarea 자동 크기 조절과 플랫폼별 동작 설명을 보완했습니다.
  - 순수 `textarea` 사용 예제와 시각적 스타일을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->