### PR TITLE
fix(docs): emit llms link relations on the ProsePage section roots

### DIFF
--- a/docs/app/get-started/[[...slug]]/page.tsx
+++ b/docs/app/get-started/[[...slug]]/page.tsx
@@ -1,8 +1,10 @@
+import { getLLMMarkdownUrl } from "@/app/_llms/config";
 import { getGetStartedSource } from "@/app/source";
 import { ProsePage } from "@/components/layout/prose-page";
 import { loadMarkdownPage } from "@/lib/load-markdown-page";
 import { getComponentStatus } from "@/lib/rootage";
 import { JsonLd } from "@/components/json-ld";
+import { LlmsLinkRels } from "@/components/llms-link-rels";
 import {
   buildDocsPageJsonLd,
   buildDocsPageMetadata,
@@ -33,6 +35,10 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
 
   return (
     <ProsePage title={displayTitle} description={page.data.description}>
+      <LlmsLinkRels
+        section="get-started"
+        markdownUrl={getLLMMarkdownUrl("get-started", params.slug ?? [])}
+      />
       <JsonLd data={buildDocsPageJsonLd(page)} />
       {cover ? (
         <div className="not-prose mb-8 md:mb-10">

--- a/docs/app/updates/page.tsx
+++ b/docs/app/updates/page.tsx
@@ -1,4 +1,5 @@
 import { env } from "@/app/env";
+import { getLLMMarkdownUrl } from "@/app/_llms/config";
 import { getUpdatesSource } from "@/app/source";
 import {
   createFigmaClient,
@@ -6,6 +7,7 @@ import {
 } from "@/components/figma-image/fetch-figma-image-urls";
 import { BLOG_POSTS } from "@/components/landing/lib/landing-content";
 import { ProsePage } from "@/components/layout/prose-page";
+import { LlmsLinkRels } from "@/components/llms-link-rels";
 import { formatPublishedDate } from "@/lib/format-date";
 import { buildSeoMetadata, resolveCoverImage } from "@/lib/seo";
 import { IconSeedArrow } from "@/components/icon-seed-arrow";
@@ -164,6 +166,7 @@ export default async function Page() {
 
   return (
     <ProsePage title={UPDATES_TITLE} description={UPDATES_DESCRIPTION}>
+      <LlmsLinkRels section="updates" markdownUrl={getLLMMarkdownUrl("updates", [])} />
       <div className="not-prose mb-8 md:mb-10">
         <img
           src={cover.thumbnail}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **문서**
  - Get Started 및 Updates 페이지에 각 문서의 Markdown URL을 포함한 LLM 링크 정보를 추가했습니다.
  - LLM 기반 도구가 관련 문서의 Markdown 콘텐츠를 더욱 쉽게 찾고 활용할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->