### PR TITLE
fix(docs): restore llms heading markers and check their fragments

### DIFF
--- a/.github/actions/check-docs-links/action.yml
+++ b/.github/actions/check-docs-links/action.yml
@@ -98,8 +98,9 @@ runs:
 
         echo "Mirrored $count llms text outputs to $MIRROR_DIR ($excluded excluded)"
 
-    # `--include-fragments`는 켜지 않는다. llms 사본에는 앵커가 없어서 페이지에 멀쩡히
-    # 있는 `#heading`까지 전부 깨진 걸로 잡힌다. 프래그먼트는 위 HTML 단계가 본다.
+    # 사본 안 `#heading` 링크는 사본 자신을 가리키므로, 이 단계의 프래그먼트 검사는 사본이
+    # 실제 heading을 담고 있어야만 성립한다. heading을 잃은 채로 켜면 페이지에 멀쩡히 있는
+    # 앵커가 전부 깨진 걸로 잡힌다.
     - name: Check links in the llms text outputs
       uses: lycheeverse/lychee-action@v2
       with:
@@ -112,6 +113,7 @@ runs:
           --extensions md
           --root-dir ${{ inputs.out-dir }}
           --fallback-extensions html
+          --include-fragments=anchor-only
           --remap 'https://seed-design.io/(.*) file://${{ inputs.out-dir }}/$1'
           --
           ${{ runner.temp }}/docs-llms-markdown

--- a/bun.lock
+++ b/bun.lock
@@ -81,6 +81,7 @@
         "gsap": "^3.15.0",
         "lenis": "^1.3.23",
         "mdast-util-mdx-jsx": "^3.2.0",
+        "mdast-util-to-markdown": "2.1.2",
         "motion": "^12.23.12",
         "next": "^16.2.0",
         "next-sanity": "^11.4.2",

--- a/docs/app/source.tsx
+++ b/docs/app/source.tsx
@@ -90,9 +90,29 @@ const llmsOptions: LLMsOptions = {
   // `remarkLlms`의 기본 heading 핸들러는 `#` 마커를 붙이지 않고 텍스트만 돌려주므로, 출력은
   // 첫 줄 제목 말고는 heading이 하나도 없는 평문이 된다. 마커가 없으면 llms.txt를 읽는 쪽도
   // 프래그먼트를 검사하는 링크 체커도 섹션을 짚을 수 없다.
+  //
+  // `mdast-util-to-markdown`의 이스케이프 규칙은 `state.stack`에 쌓인 construct로만 범위가
+  // 정해진다(`unsafe.js`의 `inConstruct`). 두 scope를 열지 않으면 `Foo #`로 끝나는 heading이
+  // `## Foo #`로 나가고, 파서가 뒤 `#`를 닫는 ATX 마커로 읽어 slug가 달라진다.
   handlers: {
-    heading: (node, _parent, state, info) =>
-      `${"#".repeat(node.depth)} ${state.containerPhrasing(node, info)}`,
+    heading(node, _parent, state, info) {
+      const sequence = "#".repeat(node.depth);
+      const tracker = state.createTracker(info);
+      const exitHeading = state.enter("headingAtx");
+      const exitPhrasing = state.enter("phrasing");
+
+      tracker.move(`${sequence} `);
+      const value = state.containerPhrasing(node, {
+        before: "# ",
+        after: "\n",
+        ...tracker.current(),
+      });
+
+      exitPhrasing();
+      exitHeading();
+
+      return value ? `${sequence} ${value}` : sequence;
+    },
   },
   // heading 뒤에 `[#id]`를 덧붙이면 그 문자열까지 heading 텍스트로 읽혀 slug가 달라진다.
   // 마커를 되살린 이상 slug는 heading 텍스트에서 그대로 나오므로 id를 적을 이유가 없다.

--- a/docs/app/source.tsx
+++ b/docs/app/source.tsx
@@ -87,6 +87,16 @@ const filterLlmsElement = preserveRuleElements(filterStructureElement);
 
 const llmsOptions: LLMsOptions = {
   as: "processed",
+  // `remarkLlms`의 기본 heading 핸들러는 `#` 마커를 붙이지 않고 텍스트만 돌려주므로, 출력은
+  // 첫 줄 제목 말고는 heading이 하나도 없는 평문이 된다. 마커가 없으면 llms.txt를 읽는 쪽도
+  // 프래그먼트를 검사하는 링크 체커도 섹션을 짚을 수 없다.
+  handlers: {
+    heading: (node, _parent, state, info) =>
+      `${"#".repeat(node.depth)} ${state.containerPhrasing(node, info)}`,
+  },
+  // heading 뒤에 `[#id]`를 덧붙이면 그 문자열까지 heading 텍스트로 읽혀 slug가 달라진다.
+  // 마커를 되살린 이상 slug는 heading 텍스트에서 그대로 나오므로 id를 적을 이유가 없다.
+  headingIds: false,
   filterElement: filterLlmsElement,
   filterMdxAttributes: structureStringify.filterMdxAttributes,
 };

--- a/docs/app/source.tsx
+++ b/docs/app/source.tsx
@@ -12,6 +12,7 @@ import {
 } from "fumadocs-core/source";
 import { metaSchema, pageSchema } from "fumadocs-core/source/schema";
 import { fileGenerator } from "fumadocs-docgen";
+import { defaultHandlers } from "mdast-util-to-markdown";
 import type { ComponentType, SVGProps } from "react";
 import z from "zod";
 import { env } from "@/app/env";
@@ -87,35 +88,10 @@ const filterLlmsElement = preserveRuleElements(filterStructureElement);
 
 const llmsOptions: LLMsOptions = {
   as: "processed",
-  // `remarkLlms`의 기본 heading 핸들러는 `#` 마커를 붙이지 않고 텍스트만 돌려주므로, 출력은
-  // 첫 줄 제목 말고는 heading이 하나도 없는 평문이 된다. 마커가 없으면 llms.txt를 읽는 쪽도
-  // 프래그먼트를 검사하는 링크 체커도 섹션을 짚을 수 없다.
-  //
-  // `mdast-util-to-markdown`의 이스케이프 규칙은 `state.stack`에 쌓인 construct로만 범위가
-  // 정해진다(`unsafe.js`의 `inConstruct`). 두 scope를 열지 않으면 `Foo #`로 끝나는 heading이
-  // `## Foo #`로 나가고, 파서가 뒤 `#`를 닫는 ATX 마커로 읽어 slug가 달라진다.
-  handlers: {
-    heading(node, _parent, state, info) {
-      const sequence = "#".repeat(node.depth);
-      const tracker = state.createTracker(info);
-      const exitHeading = state.enter("headingAtx");
-      const exitPhrasing = state.enter("phrasing");
-
-      tracker.move(`${sequence} `);
-      const value = state.containerPhrasing(node, {
-        before: "# ",
-        after: "\n",
-        ...tracker.current(),
-      });
-
-      exitPhrasing();
-      exitHeading();
-
-      return value ? `${sequence} ${value}` : sequence;
-    },
-  },
-  // heading 뒤에 `[#id]`를 덧붙이면 그 문자열까지 heading 텍스트로 읽혀 slug가 달라진다.
-  // 마커를 되살린 이상 slug는 heading 텍스트에서 그대로 나오므로 id를 적을 이유가 없다.
+  // 기본값 재지정이 아닙니다. `remarkLlms`가 heading 핸들러를 `#` 마커 없이 텍스트만
+  // 돌려주는 것으로 덮어쓰므로, 되돌리지 않으면 출력에 heading이 하나도 남지 않습니다.
+  handlers: { heading: defaultHandlers.heading },
+  // heading 뒤에 붙는 `[#id]`는 heading 텍스트의 일부로 읽혀 slug를 바꿉니다.
   headingIds: false,
   filterElement: filterLlmsElement,
   filterMdxAttributes: structureStringify.filterMdxAttributes,

--- a/docs/package.json
+++ b/docs/package.json
@@ -83,6 +83,7 @@
     "gsap": "^3.15.0",
     "lenis": "^1.3.23",
     "mdast-util-mdx-jsx": "^3.2.0",
+    "mdast-util-to-markdown": "2.1.2",
     "motion": "^12.23.12",
     "next": "^16.2.0",
     "next-sanity": "^11.4.2",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서 개선**
  * 생성된 Markdown 문서에서 제목의 깊이와 `#` 마커가 올바르게 표시됩니다.
  * 제목 텍스트에 불필요한 ID가 포함되지 않아 문서 가독성이 향상되었습니다.
  * 문서 내 앵커 링크가 실제 제목을 정확히 가리키는지 검증됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->