### PR TITLE
docs(lynx): add ProgressCircle documentation and previews

### DIFF
--- a/.changeset/bright-circles-render.md
+++ b/.changeset/bright-circles-render.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/lynx-css": patch
+---
+
+iOS Lynx에서 `ProgressCircle`의 색상이 표시되지 않는 문제를 수정합니다.

--- a/.changeset/steady-circles-spin.md
+++ b/.changeset/steady-circles-spin.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/lynx-react": patch
+---
+
+Lynx `ProgressCircle`의 indeterminate 상태가 첫 화면부터 표시되도록 수정합니다.

--- a/docs/content/lynx/components/progress-circle.mdx
+++ b/docs/content/lynx/components/progress-circle.mdx
@@ -5,6 +5,15 @@ description: 작업이 진행 중임을 알리거나 작업 시간을 시각적�
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />
 
+<LynxComponentExample name="lynx/progress-circle/preview">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/progress-circle/preview.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
 ## Installation
 
 ```package-install
@@ -13,49 +22,110 @@ npx @seed-design/cli add ui:progress-circle
 
 <LynxManualInstallation name="progress-circle" />
 
-## Usage
+## Props
 
-```tsx
-import { ProgressCircle } from "@/components/ui/progress-circle";
+<react-type-table
+  path="../packages/lynx-react/src/components/ProgressCircle/ProgressCircle.tsx"
+  name="ProgressCircleRootProps"
+/>
 
-export function App() {
-  return <ProgressCircle tone="brand" size="40" />;
-}
-```
+## Examples
+
+### Neutral
+
+<LynxComponentExample name="lynx/progress-circle/neutral">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/progress-circle/neutral.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Brand
+
+<LynxComponentExample name="lynx/progress-circle/brand">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/progress-circle/brand.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Static White
+
+`staticWhite`는 어두운 배경 위에서 사용합니다.
+
+<LynxComponentExample name="lynx/progress-circle/static-white">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/progress-circle/static-white.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Size=40
+
+<LynxComponentExample name="lynx/progress-circle/40">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/progress-circle/40.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Size=24
+
+<LynxComponentExample name="lynx/progress-circle/24">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/progress-circle/24.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
 
 ### Determinate
 
-`minValue`, `maxValue`, `value`를 지정하면 determinate 모드로 동작합니다.
+`minValue`, `maxValue`, `value`를 모두 지정하면 정해진 진행률을 표시합니다.
 
-```tsx
-import { ProgressCircle } from "@/components/ui/progress-circle";
+<LynxComponentExample name="lynx/progress-circle/determinate">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/progress-circle/determinate.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
 
-export function App() {
-  return (
-    <ProgressCircle tone="brand" size="40" minValue={0} maxValue={1} value={0.5} />
-  );
-}
-```
+### Indeterminate
 
-## Props
+`value`를 생략하면 완료 시점을 알 수 없는 작업의 진행 상태를 표시합니다.
 
-<react-type-table path="./registry/lynx/ui/progress-circle.tsx" name="ProgressCircleProps" />
+<LynxComponentExample name="lynx/progress-circle/indeterminate">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/progress-circle/indeterminate.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
 
 ## 웹 버전과의 차이
 
-Lynx 버전은 플랫폼 제약으로 인해 웹(`@seed-design/react`) 버전과 내부 구현이 다릅니다. API는 동일하게 유지되지만, 아래 차이점을 참고하세요.
+Lynx 버전은 플랫폼 제약으로 인해 웹(`@seed-design/react`) 버전과 내부 구현이 다릅니다. 공개 variant와 진행률 API는 같지만 조합 방식과 렌더링 방식에 차이가 있습니다.
 
 | | 웹 (React) | Lynx |
 |---|---|---|
-| **렌더링** | SVG `<circle>` + `stroke-dasharray` | CSS `clip-path` 기반 pie sector |
-| **애니메이션** | CSS `@keyframes` + `animation` | Main thread `requestAnimationFrame` + `setStyleProperty` |
-| **Determinate 전환** | CSS `transition` (stroke-dashoffset) | Main thread `requestAnimationFrame` 기반 easing 애니메이션 |
-| **Headless 레이어** | `@seed-design/react-headless` 사용 | 자체 구현 (headless 미사용) |
-| **Track** | `<ProgressCircle.Track />` SVG circle 렌더링 | Root의 CSS `background` + `clip-path`로 대체 (Track 컴포넌트 없음) |
-| **다중 인스턴스** | CSS 기반 (GPU 가속) | 인스턴스별 독립 RAF 루프 |
+| **조합 방식** | 단일 `ProgressCircle` 컴포넌트 | `ProgressCircle.Root`와 `ProgressCircle.Range` 조합 |
+| **렌더링** | SVG `<circle>`과 `stroke-dasharray` | CSS `clip-path` 기반 pie sector |
+| **애니메이션** | CSS `@keyframes`와 `animation` | Main thread `requestAnimationFrame`과 `setStyleProperty` |
+| **Determinate 전환** | CSS `transition` | Main thread `requestAnimationFrame` 기반 easing 애니메이션 |
+| **Track** | `<ProgressCircle.Track />` SVG circle | Root의 CSS `background`와 `clip-path`로 렌더링하며 별도 Track 컴포넌트 없음 |
 
 <Callout type="warn">
-**성능 주의:** Lynx에서 `clip-path`가 animatable property가 아니므로 JS로 매 프레임 SVG path 문자열을 생성합니다.
-다수의 Indeterminate 인스턴스를 동시에 렌더링하면 성능 저하가 발생할 수 있습니다.
-Lynx에서 SVG + `stroke-dasharray` 지원이 추가되면 CSS-only 애니메이션으로 전환될 예정입니다.
+Lynx에서는 `clip-path`가 애니메이션 속성이 아니어서 매 프레임 path 문자열을 만듭니다. Indeterminate 인스턴스를 한 화면에 많이 렌더링하면 성능이 저하될 수 있습니다.
 </Callout>

--- a/docs/examples/lynx/progress-circle/24.tsx
+++ b/docs/examples/lynx/progress-circle/24.tsx
@@ -1,0 +1,20 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { ProgressCircle, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <view className="progress-circle-preview">
+        <ProgressCircle.Root size="24">
+          <ProgressCircle.Range />
+        </ProgressCircle.Root>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/progress-circle/40.tsx
+++ b/docs/examples/lynx/progress-circle/40.tsx
@@ -1,0 +1,20 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { ProgressCircle, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <view className="progress-circle-preview">
+        <ProgressCircle.Root size="40">
+          <ProgressCircle.Range />
+        </ProgressCircle.Root>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/progress-circle/brand.tsx
+++ b/docs/examples/lynx/progress-circle/brand.tsx
@@ -1,0 +1,20 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { ProgressCircle, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <view className="progress-circle-preview">
+        <ProgressCircle.Root tone="brand">
+          <ProgressCircle.Range />
+        </ProgressCircle.Root>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/progress-circle/determinate.tsx
+++ b/docs/examples/lynx/progress-circle/determinate.tsx
@@ -1,0 +1,20 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { ProgressCircle, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <view className="progress-circle-preview">
+        <ProgressCircle.Root minValue={0} maxValue={100} value={40}>
+          <ProgressCircle.Range />
+        </ProgressCircle.Root>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/progress-circle/indeterminate.tsx
+++ b/docs/examples/lynx/progress-circle/indeterminate.tsx
@@ -1,0 +1,20 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { ProgressCircle, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <view className="progress-circle-preview">
+        <ProgressCircle.Root>
+          <ProgressCircle.Range />
+        </ProgressCircle.Root>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/progress-circle/neutral.tsx
+++ b/docs/examples/lynx/progress-circle/neutral.tsx
@@ -1,0 +1,20 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { ProgressCircle, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <view className="progress-circle-preview">
+        <ProgressCircle.Root tone="neutral">
+          <ProgressCircle.Range />
+        </ProgressCircle.Root>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/progress-circle/preview.css
+++ b/docs/examples/lynx/progress-circle/preview.css
@@ -1,0 +1,15 @@
+/* biome-ignore lint/correctness/noUnknownTypeSelector: Lynx의 page 요소입니다. */
+page {
+  height: 100%;
+  background-color: var(--seed-color-bg-layer-default);
+}
+
+.progress-circle-preview {
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+}
+
+.progress-circle-preview--dark {
+  background-color: var(--seed-color-palette-static-black);
+}

--- a/docs/examples/lynx/progress-circle/preview.tsx
+++ b/docs/examples/lynx/progress-circle/preview.tsx
@@ -1,0 +1,20 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { ProgressCircle, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <view className="progress-circle-preview">
+        <ProgressCircle.Root tone="neutral" size="40">
+          <ProgressCircle.Range />
+        </ProgressCircle.Root>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/progress-circle/static-white.tsx
+++ b/docs/examples/lynx/progress-circle/static-white.tsx
@@ -1,0 +1,20 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { ProgressCircle, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <view className="progress-circle-preview progress-circle-preview--dark">
+        <ProgressCircle.Root tone="staticWhite">
+          <ProgressCircle.Range />
+        </ProgressCircle.Root>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/progress-circle/styles.ts
+++ b/docs/examples/lynx/progress-circle/styles.ts
@@ -1,0 +1,2 @@
+import "@seed-design/lynx-css/base.css";
+import "./preview.css";

--- a/packages/lynx-css/recipes/progress-circle.css
+++ b/packages/lynx-css/recipes/progress-circle.css
@@ -43,38 +43,38 @@
 }
 
 .seed-progress-circle__root--tone_neutral {
-  background: var(--seed-color-palette-gray-200);
+  background-color: var(--seed-color-palette-gray-200);
 }
 
 .seed-progress-circle__root--tone_brand {
-  background: var(--seed-color-palette-carrot-200);
+  background-color: var(--seed-color-palette-carrot-200);
 }
 
 .seed-progress-circle__root--tone_staticWhite {
-  background: var(--seed-color-palette-static-white-alpha-300);
+  background-color: var(--seed-color-palette-static-white-alpha-300);
 }
 
 .seed-progress-circle__range--tone_neutral,
 .seed-progress-circle__cap--tone_neutral {
-  background: var(--seed-color-palette-gray-500);
+  background-color: var(--seed-color-palette-gray-500);
 }
 
 .seed-progress-circle__range--tone_brand,
 .seed-progress-circle__cap--tone_brand {
-  background: var(--seed-color-bg-brand-solid);
+  background-color: var(--seed-color-bg-brand-solid);
 }
 
 .seed-progress-circle__range--tone_staticWhite,
 .seed-progress-circle__cap--tone_staticWhite {
-  background: var(--seed-color-palette-static-white);
+  background-color: var(--seed-color-palette-static-white);
 }
 
 /* inherit: inherits --track-color / --range-color from parent (e.g. action-button) */
 .seed-progress-circle__root--tone_inherit {
-  background: var(--track-color);
+  background-color: var(--track-color);
 }
 
 .seed-progress-circle__range--tone_inherit,
 .seed-progress-circle__cap--tone_inherit {
-  background: var(--range-color);
+  background-color: var(--range-color);
 }

--- a/packages/lynx-react/src/components/ProgressCircle/ProgressCircle.test.tsx
+++ b/packages/lynx-react/src/components/ProgressCircle/ProgressCircle.test.tsx
@@ -1,0 +1,58 @@
+import "@testing-library/jest-dom";
+import { render } from "@lynx-js/react/testing-library";
+import { describe, expect, it, vi } from "vitest";
+
+import { ProgressCircle } from "./index";
+
+vi.mock("@lynx-js/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lynx-js/react")>();
+
+  return {
+    ...actual,
+    runOnMainThread: () => () => undefined,
+  };
+});
+
+function getRenderedRoot() {
+  const root = elementTree.root;
+
+  if (!root) {
+    throw new Error("Expected Lynx render root to exist.");
+  }
+
+  return root;
+}
+
+describe("ProgressCircle", () => {
+  it("renders a visible indeterminate range before the main-thread animation starts", () => {
+    render(
+      <ProgressCircle.Root>
+        <ProgressCircle.Range />
+      </ProgressCircle.Root>,
+    );
+
+    const root = getRenderedRoot();
+    const range = root.querySelector<HTMLElement>(".seed-progress-circle__range");
+    const caps = root.querySelectorAll<HTMLElement>(".seed-progress-circle__cap");
+    const animationContainer = range?.parentElement;
+
+    expect(range).toBeInTheDocument();
+    expect(animationContainer?.style.transform).not.toBe("rotate(0deg)");
+    expect(range?.style.clipPath).toMatch(/^path\("M 20 20 L 20 -1 A 21 21/);
+    expect(caps).toHaveLength(2);
+    expect(caps[1]?.style.left).not.toBe(caps[0]?.style.left);
+    expect(caps[1]?.style.top).not.toBe(caps[0]?.style.top);
+  });
+
+  it("keeps the determinate range at the requested initial value", () => {
+    render(
+      <ProgressCircle.Root minValue={0} maxValue={100} value={40}>
+        <ProgressCircle.Range />
+      </ProgressCircle.Root>,
+    );
+
+    const range = getRenderedRoot().querySelector<HTMLElement>(".seed-progress-circle__range");
+
+    expect(range?.style.clipPath).toMatch(/^path\("M 20 20 L 20 -1 A 21 21/);
+  });
+});

--- a/packages/lynx-react/src/components/ProgressCircle/ProgressCircle.tsx
+++ b/packages/lynx-react/src/components/ProgressCircle/ProgressCircle.tsx
@@ -45,6 +45,37 @@ function computeRingGeometry(numSize: number) {
   return { halfSize, innerR, ringCenterR, capSize };
 }
 
+function bgCubicBezier(rawT: number, x1: number, y1: number, x2: number, y2: number): number {
+  const t = Math.max(0, Math.min(1, rawT));
+  const cx = 3 * x1;
+  const bx = 3 * (x2 - x1) - cx;
+  const ax = 1 - cx - bx;
+  let currentT = t;
+  for (let i = 0; i < 8; i++) {
+    const currentX = ((ax * currentT + bx) * currentT + cx) * currentT - t;
+    const currentDx = (3 * ax * currentT + 2 * bx) * currentT + cx;
+    if (Math.abs(currentDx) < 1e-6) break;
+    currentT = currentT - currentX / currentDx;
+  }
+  const cy = 3 * y1;
+  const by = 3 * (y2 - y1) - cy;
+  const ay = 1 - cy - by;
+  return ((ay * currentT + by) * currentT + cy) * currentT;
+}
+
+function bgSampleIndeterminate(t: number) {
+  const containerEased = bgCubicBezier(t, 0.35, 0.25, 0.65, 0.75);
+  const headEased = bgCubicBezier(t, 0.35, 0, 0.65, 1);
+  const tailEased = bgCubicBezier(t, 0.35, 0, 0.65, 0.6);
+
+  const headLength = headEased <= 0.75 ? (headEased / 0.75) * 360 : 360;
+  const tailOffset = tailEased <= 1 / 3 ? 0 : ((tailEased - 1 / 3) / (2 / 3)) * 360;
+  const arcLength = Math.max(0, headLength - tailOffset);
+  const containerDeg = containerEased * 360 + tailOffset;
+
+  return { containerDeg, arcLength };
+}
+
 function bgPieClipPath(size: number, angleDeg: number): string | undefined {
   if (angleDeg >= 360) return undefined;
   if (angleDeg <= 0) return 'path("M 0 0 Z")';
@@ -113,6 +144,7 @@ function sampleIndeterminate(t: number) {
 // --- Animation constants ---
 
 const INDETERMINATE_DURATION = 1200;
+const INDETERMINATE_INITIAL_PHASE = 1 / 6;
 const TRANSITION_DURATION = 300;
 
 ////////////////////////////////////////////////////////////////////////////////////
@@ -335,7 +367,10 @@ function IndeterminateRange({ numSize, classes }: { numSize: number; classes: Cl
       if (!startTs) startTs = Number(ts);
 
       const elapsed = ts - startTs;
-      const t = (elapsed % INDETERMINATE_DURATION) / INDETERMINATE_DURATION;
+      const t =
+        ((elapsed + INDETERMINATE_DURATION * INDETERMINATE_INITIAL_PHASE) %
+          INDETERMINATE_DURATION) /
+        INDETERMINATE_DURATION;
       const state = sampleIndeterminate(t);
 
       containerEl?.setStyleProperty("transform", `rotate(${state.containerDeg}deg)`);
@@ -373,7 +408,9 @@ function IndeterminateRange({ numSize, classes }: { numSize: number; classes: Cl
     };
   }, [numSize]);
 
-  const initialClipPath = 'path("M 0 0 Z")';
+  const initialState = bgSampleIndeterminate(INDETERMINATE_INITIAL_PHASE);
+  const initialClipPath = bgPieClipPath(numSize, initialState.arcLength);
+  const initialHeadRad = (initialState.arcLength * Math.PI) / 180;
 
   return (
     <view
@@ -382,7 +419,7 @@ function IndeterminateRange({ numSize, classes }: { numSize: number; classes: Cl
         position: "absolute",
         width: `${numSize}px`,
         height: `${numSize}px`,
-        transform: "rotate(0deg)",
+        transform: `rotate(${initialState.containerDeg}deg)`,
       }}
     >
       <view
@@ -412,8 +449,8 @@ function IndeterminateRange({ numSize, classes }: { numSize: number; classes: Cl
         style={{
           width: `${capSize}px`,
           height: `${capSize}px`,
-          left: `${halfSize - capSize / 2}px`,
-          top: `${halfSize - ringCenterR - capSize / 2}px`,
+          left: `${halfSize + ringCenterR * Math.sin(initialHeadRad) - capSize / 2}px`,
+          top: `${halfSize - ringCenterR * Math.cos(initialHeadRad) - capSize / 2}px`,
         }}
       />
     </view>


### PR DESCRIPTION
## 작업 내용

- Lynx `ProgressCircle` 문서와 실행 예제를 추가합니다.
- 대표 크기, 색상, determinate·indeterminate 상태를 다룹니다.
- `LynxComponentExample`의 WebLynx 미리보기, QR 코드, 코드 탭을 구성합니다.
- iOS Lynx에서 ProgressCircle 색상이 표시되지 않는 문제를 수정합니다.
- indeterminate 상태가 첫 화면부터 표시되도록 수정하고 회귀 테스트를 추가합니다.

## 검증

- `bun generate:all`
- `bun packages:build`
- `bun docs:test`
- `bun test:all`
- `bun docs:build`
- WebLynx 미리보기
- Lynx Explorer 앱 호스트

## 관련 작업

- DES-2323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Lynx 환경에서 Progress Circle의 색상이 정상적으로 표시되지 않던 문제를 수정했습니다.
  * Indeterminate Progress Circle이 첫 화면부터 올바른 위치와 애니메이션 상태로 표시됩니다.

* **문서**
  * Progress Circle의 Lynx 미리보기를 추가했습니다.
  * Neutral, Brand, Static White, 크기, Determinate, Indeterminate 사용 예제와 Props 안내를 보강했습니다.
  * Lynx와 웹 버전의 렌더링 및 성능 차이 설명을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->