### PR TITLE
docs(lynx): add AppBar documentation and examples

### DIFF
--- a/docs/content/lynx/components/app-bar.mdx
+++ b/docs/content/lynx/components/app-bar.mdx
@@ -5,6 +5,15 @@ description: 화면 상단에서 현재 화면의 제목과 탐색 액션을 보
 
 <AvailableSince packages="@seed-design/lynx-react@0.2.0, @seed-design/lynx-css@0.2.0" />
 
+<LynxComponentExample name="lynx/app-bar/preview">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/app-bar/preview.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
 ## Installation
 
 ```package-install
@@ -77,17 +86,14 @@ export function Header({ goBack }: { goBack: () => void }) {
 
 `AppBarMain`에 `title`, `subtitle`을 전달하면 내부에서 `AppBar.Title`, `AppBar.Subtitle`을 조립합니다. `subtitle`이 있으면 `layout="withSubtitle"`가 자동으로 적용됩니다.
 
-```tsx
-import { AppBar, AppBarMain } from "@/components/ui/app-bar";
-
-export function Header() {
-  return (
-    <AppBar>
-      <AppBarMain title="관심 목록" subtitle="3개의 새 소식" />
-    </AppBar>
-  );
-}
-```
+<LynxComponentExample name="lynx/app-bar/title-and-subtitle">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/app-bar/title-and-subtitle.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
 
 직접 슬롯을 조립하고 싶다면 `AppBarMain`의 children으로 compound 컴포넌트를 전달합니다.
 
@@ -111,34 +117,14 @@ export function Header() {
 
 왼쪽과 오른쪽에는 icon button 또는 custom slot을 배치할 수 있습니다. Cupertino theme에서는 좌우 슬롯 폭을 읽어 가운데 title이 치우치지 않도록 padding을 보정합니다.
 
-```tsx
-import {
-  AppBar,
-  AppBarBackButton,
-  AppBarCloseButton,
-  AppBarLeft,
-  AppBarMain,
-  AppBarRight,
-  AppBarSlot,
-} from "@/components/ui/app-bar";
-
-export function Header({ goBack, close }: { goBack: () => void; close: () => void }) {
-  return (
-    <AppBar>
-      <AppBarLeft>
-        <AppBarBackButton bindtap={goBack} />
-      </AppBarLeft>
-      <AppBarMain title="작성하기" />
-      <AppBarRight>
-        <AppBarSlot>
-          <text>완료</text>
-        </AppBarSlot>
-        <AppBarCloseButton bindtap={close} />
-      </AppBarRight>
-    </AppBar>
-  );
-}
-```
+<LynxComponentExample name="lynx/app-bar/left-and-right-actions">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/app-bar/left-and-right-actions.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
 
 ### Accessibility
 
@@ -164,11 +150,14 @@ import IconBellLine from "@karrotmarket/lynx-monochrome-icon/IconBellLine";
 
 수동으로 지정한 `theme`은 platform 기본값보다 우선합니다.
 
-```tsx
-<AppBar theme="android">
-  <AppBarMain title="Android layout" />
-</AppBar>
-```
+<LynxComponentExample name="lynx/app-bar/platform-layouts">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/app-bar/platform-layouts.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
 
 ## Web Version Differences
 

--- a/docs/examples/lynx/app-bar/left-and-right-actions.tsx
+++ b/docs/examples/lynx/app-bar/left-and-right-actions.tsx
@@ -1,0 +1,55 @@
+import "./styles";
+
+import IconChevronLeftLine from "@karrotmarket/lynx-monochrome-icon/IconChevronLeftLine";
+import IconXmarkLine from "@karrotmarket/lynx-monochrome-icon/IconXmarkLine";
+import { root, useState } from "@lynx-js/react";
+import { AppBar, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+  const [lastAction, setLastAction] = useState("없음");
+
+  function handleBack() {
+    "background only";
+    setLastAction("뒤로");
+  }
+
+  function handleClose() {
+    "background only";
+    setLastAction("닫기");
+  }
+
+  return (
+    <page className={seedClassName}>
+      <view className="app-bar-preview">
+        <AppBar.Root theme="cupertino">
+          <AppBar.Left>
+            <AppBar.IconButton
+              accessibility-label="뒤로"
+              icon={<IconChevronLeftLine />}
+              bindtap={handleBack}
+            />
+          </AppBar.Left>
+          <AppBar.Main>
+            <AppBar.Title>작성하기</AppBar.Title>
+          </AppBar.Main>
+          <AppBar.Right>
+            <AppBar.Slot>
+              <text>완료</text>
+            </AppBar.Slot>
+            <AppBar.IconButton
+              accessibility-label="닫기"
+              icon={<IconXmarkLine />}
+              bindtap={handleClose}
+            />
+          </AppBar.Right>
+        </AppBar.Root>
+        <view className="app-bar-preview__content">
+          <text className="app-bar-preview__status">마지막 액션: {lastAction}</text>
+        </view>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/app-bar/platform-layouts.tsx
+++ b/docs/examples/lynx/app-bar/platform-layouts.tsx
@@ -10,33 +10,42 @@ function Root() {
 
   return (
     <page className={seedClassName}>
-      <view className="app-bar-preview app-bar-preview__group">
-        <text className="app-bar-preview__label">Cupertino</text>
-        <AppBar.Root theme="cupertino">
-          <AppBar.Left>
-            <AppBar.IconButton accessibility-label="뒤로" icon={<IconChevronLeftLine />} />
-          </AppBar.Left>
-          <AppBar.Main>
-            <AppBar.Title>가운데 제목</AppBar.Title>
-          </AppBar.Main>
-          <AppBar.Right>
-            <AppBar.IconButton accessibility-label="닫기" icon={<IconXmarkLine />} />
-          </AppBar.Right>
-        </AppBar.Root>
+      <view className="app-bar-preview__platforms">
+        <view className="app-bar-preview__platform">
+          <text className="app-bar-preview__label">Cupertino</text>
+          <view className="app-bar-preview app-bar-preview--platform">
+            <AppBar.Root theme="cupertino">
+              <AppBar.Left>
+                <AppBar.IconButton accessibility-label="뒤로" icon={<IconChevronLeftLine />} />
+              </AppBar.Left>
+              <AppBar.Main layout="withSubtitle">
+                <AppBar.Title>화면 제목</AppBar.Title>
+                <AppBar.Subtitle>보조 제목</AppBar.Subtitle>
+              </AppBar.Main>
+              <AppBar.Right>
+                <AppBar.IconButton accessibility-label="닫기" icon={<IconXmarkLine />} />
+              </AppBar.Right>
+            </AppBar.Root>
+          </view>
+        </view>
 
-        <text className="app-bar-preview__label">Android</text>
-        <AppBar.Root theme="android">
-          <AppBar.Left>
-            <AppBar.IconButton accessibility-label="뒤로" icon={<IconChevronLeftLine />} />
-          </AppBar.Left>
-          <AppBar.Main layout="withSubtitle">
-            <AppBar.Title>왼쪽 제목</AppBar.Title>
-            <AppBar.Subtitle>부제목</AppBar.Subtitle>
-          </AppBar.Main>
-          <AppBar.Right>
-            <AppBar.IconButton accessibility-label="닫기" icon={<IconXmarkLine />} />
-          </AppBar.Right>
-        </AppBar.Root>
+        <view className="app-bar-preview__platform">
+          <text className="app-bar-preview__label">Android</text>
+          <view className="app-bar-preview app-bar-preview--platform">
+            <AppBar.Root theme="android">
+              <AppBar.Left>
+                <AppBar.IconButton accessibility-label="뒤로" icon={<IconChevronLeftLine />} />
+              </AppBar.Left>
+              <AppBar.Main layout="withSubtitle">
+                <AppBar.Title>화면 제목</AppBar.Title>
+                <AppBar.Subtitle>보조 제목</AppBar.Subtitle>
+              </AppBar.Main>
+              <AppBar.Right>
+                <AppBar.IconButton accessibility-label="닫기" icon={<IconXmarkLine />} />
+              </AppBar.Right>
+            </AppBar.Root>
+          </view>
+        </view>
       </view>
     </page>
   );

--- a/docs/examples/lynx/app-bar/platform-layouts.tsx
+++ b/docs/examples/lynx/app-bar/platform-layouts.tsx
@@ -1,0 +1,45 @@
+import "./styles";
+
+import IconChevronLeftLine from "@karrotmarket/lynx-monochrome-icon/IconChevronLeftLine";
+import IconXmarkLine from "@karrotmarket/lynx-monochrome-icon/IconXmarkLine";
+import { root } from "@lynx-js/react";
+import { AppBar, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <view className="app-bar-preview app-bar-preview__group">
+        <text className="app-bar-preview__label">Cupertino</text>
+        <AppBar.Root theme="cupertino">
+          <AppBar.Left>
+            <AppBar.IconButton accessibility-label="뒤로" icon={<IconChevronLeftLine />} />
+          </AppBar.Left>
+          <AppBar.Main>
+            <AppBar.Title>가운데 제목</AppBar.Title>
+          </AppBar.Main>
+          <AppBar.Right>
+            <AppBar.IconButton accessibility-label="닫기" icon={<IconXmarkLine />} />
+          </AppBar.Right>
+        </AppBar.Root>
+
+        <text className="app-bar-preview__label">Android</text>
+        <AppBar.Root theme="android">
+          <AppBar.Left>
+            <AppBar.IconButton accessibility-label="뒤로" icon={<IconChevronLeftLine />} />
+          </AppBar.Left>
+          <AppBar.Main layout="withSubtitle">
+            <AppBar.Title>왼쪽 제목</AppBar.Title>
+            <AppBar.Subtitle>부제목</AppBar.Subtitle>
+          </AppBar.Main>
+          <AppBar.Right>
+            <AppBar.IconButton accessibility-label="닫기" icon={<IconXmarkLine />} />
+          </AppBar.Right>
+        </AppBar.Root>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/app-bar/preview.css
+++ b/docs/examples/lynx/app-bar/preview.css
@@ -1,0 +1,33 @@
+/* biome-ignore lint/correctness/noUnknownTypeSelector: Lynx의 page 요소입니다. */
+page {
+  height: 100%;
+  background-color: var(--seed-color-bg-layer-default);
+}
+
+.app-bar-preview {
+  height: 100%;
+  background-color: var(--seed-color-bg-layer-default);
+}
+
+.app-bar-preview__content {
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.app-bar-preview__group {
+  gap: 16px;
+  padding: 24px 0;
+}
+
+.app-bar-preview__label {
+  padding: 0 16px;
+  color: var(--seed-color-fg-neutral-muted);
+  font-size: 13px;
+}
+
+.app-bar-preview__status {
+  color: var(--seed-color-fg-neutral-muted);
+  font-size: 14px;
+}

--- a/docs/examples/lynx/app-bar/preview.css
+++ b/docs/examples/lynx/app-bar/preview.css
@@ -1,12 +1,55 @@
 /* biome-ignore lint/correctness/noUnknownTypeSelector: Lynx의 page 요소입니다. */
 page {
+  width: 100%;
   height: 100%;
+  align-items: center;
+  justify-content: center;
   background-color: var(--seed-color-bg-layer-default);
 }
 
 .app-bar-preview {
-  height: 100%;
+  width: calc(100% - 48px);
+  max-width: 375px;
+  aspect-ratio: 1 / 1;
+  margin-top: 32px;
+  margin-bottom: 32px;
+  margin-left: auto;
+  margin-right: auto;
+  overflow: hidden;
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--seed-color-stroke-neutral-weak);
+  border-radius: var(--seed-radius-r4);
   background-color: var(--seed-color-bg-layer-default);
+}
+
+.app-bar-preview__platforms {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-content: center;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 24px;
+  padding: 32px 24px;
+}
+
+.app-bar-preview__platform {
+  flex-grow: 1;
+  width: calc(50% - 12px);
+  min-width: 280px;
+  max-width: 375px;
+  gap: 12px;
+}
+
+.app-bar-preview--platform {
+  width: 100%;
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .app-bar-preview__content {
@@ -22,7 +65,6 @@ page {
 }
 
 .app-bar-preview__label {
-  padding: 0 16px;
   color: var(--seed-color-fg-neutral-muted);
   font-size: 13px;
 }

--- a/docs/examples/lynx/app-bar/preview.tsx
+++ b/docs/examples/lynx/app-bar/preview.tsx
@@ -1,0 +1,33 @@
+import "./styles";
+
+import IconBellLine from "@karrotmarket/lynx-monochrome-icon/IconBellLine";
+import IconChevronLeftLine from "@karrotmarket/lynx-monochrome-icon/IconChevronLeftLine";
+import { root } from "@lynx-js/react";
+import { AppBar, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <view className="app-bar-preview">
+        <AppBar.Root theme="cupertino">
+          <AppBar.Left>
+            <AppBar.IconButton accessibility-label="뒤로" icon={<IconChevronLeftLine />} />
+          </AppBar.Left>
+          <AppBar.Main>
+            <AppBar.Title>동네생활</AppBar.Title>
+          </AppBar.Main>
+          <AppBar.Right>
+            <AppBar.IconButton accessibility-label="알림" icon={<IconBellLine />} />
+          </AppBar.Right>
+        </AppBar.Root>
+        <view className="app-bar-preview__content">
+          <text className="app-bar-preview__status">화면 콘텐츠</text>
+        </view>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/app-bar/styles.ts
+++ b/docs/examples/lynx/app-bar/styles.ts
@@ -1,0 +1,3 @@
+// 각 엔트리에서 컴포넌트보다 먼저 불러와야 base CSS 뒤에 recipe CSS가 등록됩니다.
+import "@seed-design/lynx-css/base.css";
+import "./preview.css";

--- a/docs/examples/lynx/app-bar/title-and-subtitle.tsx
+++ b/docs/examples/lynx/app-bar/title-and-subtitle.tsx
@@ -1,0 +1,26 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { AppBar, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <view className="app-bar-preview">
+        <AppBar.Root theme="cupertino">
+          <AppBar.Main layout="withSubtitle">
+            <AppBar.Title>관심 목록</AppBar.Title>
+            <AppBar.Subtitle>3개의 새 소식</AppBar.Subtitle>
+          </AppBar.Main>
+        </AppBar.Root>
+        <view className="app-bar-preview__content">
+          <text className="app-bar-preview__status">제목과 부제목을 함께 표시한 AppBar</text>
+        </view>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);


### PR DESCRIPTION
## 작업 내용

- Lynx AppBar 문서와 실행 가능한 예제를 추가했습니다.
- `LynxComponentExample`의 미리보기, QR 코드, 코드 탭을 연결했습니다.
- AppBar 미리보기를 최대 375px 정사각형으로 제한했습니다.
- Cupertino와 Android 예제를 반응형 2열·1열 구조로 구성했습니다.
- 실제 배포되는 `@seed-design/lynx-react` 구현은 변경하지 않았습니다.

## 검증

- `bun generate:all`
- `bun --filter @seed-design/docs typecheck:lynx-examples`
- `bun --filter @seed-design/docs build:lynx-examples:development`
- `bun docs:test`
- `bun test:all`
- WebLynx 데스크톱·좁은 화면 미리보기 확인

Linear: DES-2322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * AppBar 문서의 코드 예제를 실제 실행 가능한 미리보기로 교체했습니다.
  * 미리보기, 제목·부제목, 좌우 액션, 플랫폼별 레이아웃 예제를 추가했습니다.

* **새로운 기능**
  * Cupertino 및 Android 스타일 AppBar 예제를 제공합니다.
  * 뒤로 가기·닫기·알림 액션과 시스템 색상 모드 예제를 확인할 수 있습니다.
  * AppBar 미리보기 화면과 상태 콘텐츠를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->