### PR TITLE
docs(lynx): add Checkbox previews

### DIFF
--- a/docs/content/lynx/components/checkbox.mdx
+++ b/docs/content/lynx/components/checkbox.mdx
@@ -5,6 +5,19 @@ description: 사용자가 여러 옵션 중 하나 이상을 선택할 수 있�
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />
 
+<LynxComponentExample name="lynx/checkbox/preview">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/checkbox/preview.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+<Callout>
+문서 미리보기에서는 아이콘 색상이 적용되지 않아요. 아이콘의 실제 색상은 QR 코드 탭에서 Lynx Explorer를 실행해 확인할 수 있어요.
+</Callout>
+
 ## Installation
 
 ```package-install
@@ -128,6 +141,43 @@ export function CheckboxVariants() {
 ### `CheckboxGroup`
 
 <react-type-table path="./registry/lynx/ui/checkbox.tsx" name="CheckboxGroupProps" />
+
+## Examples
+
+### Sizes
+
+<LynxComponentExample name="lynx/checkbox/size">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/checkbox/size.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Disabled
+
+<LynxComponentExample name="lynx/checkbox/disabled">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/checkbox/disabled.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Listening to Value Changes
+
+`onCheckedChange`로 체크박스의 선택 상태 변경을 감지할 수 있습니다.
+
+<LynxComponentExample name="lynx/checkbox/value-changes">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/checkbox/value-changes.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
 
 ## 웹 버전과의 차이
 

--- a/docs/examples/lynx/checkbox/disabled.tsx
+++ b/docs/examples/lynx/checkbox/disabled.tsx
@@ -1,0 +1,50 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import IconCheckmarkFatFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkFatFill";
+import { Checkbox, VStack, useSeedClassName } from "@seed-design/lynx-react";
+
+function CheckboxItem({
+  label,
+  variant,
+  defaultChecked = false,
+}: {
+  label: string;
+  variant: Checkbox.RootProps["variant"];
+  defaultChecked?: boolean;
+}) {
+  return (
+    <Checkbox.Root
+      tone="neutral"
+      size="large"
+      variant={variant}
+      defaultChecked={defaultChecked}
+      disabled
+    >
+      <Checkbox.Control>
+        <Checkbox.Indicator
+          unchecked={variant === "ghost" ? <IconCheckmarkFatFill /> : undefined}
+          checked={<IconCheckmarkFatFill />}
+        />
+      </Checkbox.Control>
+      <Checkbox.Label>{label}</Checkbox.Label>
+    </Checkbox.Root>
+  );
+}
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack className="checkbox-preview" gap="spacingY.componentDefault">
+        <CheckboxItem label="선택 안 됨, Square" variant="square" />
+        <CheckboxItem label="선택됨, Square" variant="square" defaultChecked />
+        <CheckboxItem label="선택 안 됨, Ghost" variant="ghost" />
+        <CheckboxItem label="선택됨, Ghost" variant="ghost" defaultChecked />
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/checkbox/preview.css
+++ b/docs/examples/lynx/checkbox/preview.css
@@ -1,0 +1,17 @@
+/* biome-ignore lint/correctness/noUnknownTypeSelector: Lynx의 page 요소입니다. */
+page {
+  height: 100%;
+  padding: 24px;
+  background-color: var(--seed-color-bg-layer-default);
+}
+
+.checkbox-preview {
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+}
+
+.checkbox-preview__status {
+  color: var(--seed-color-fg-neutral-muted);
+  font-size: 14px;
+}

--- a/docs/examples/lynx/checkbox/preview.tsx
+++ b/docs/examples/lynx/checkbox/preview.tsx
@@ -1,0 +1,49 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import IconCheckmarkFatFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkFatFill";
+import IconMinusFatFill from "@karrotmarket/lynx-monochrome-icon/IconMinusFatFill";
+import { Checkbox, useSeedClassName } from "@seed-design/lynx-react";
+
+function CheckboxItem({
+  label,
+  defaultChecked = false,
+  indeterminate = false,
+}: {
+  label: string;
+  defaultChecked?: boolean;
+  indeterminate?: boolean;
+}) {
+  return (
+    <Checkbox.Root
+      tone="neutral"
+      size="large"
+      defaultChecked={defaultChecked}
+      indeterminate={indeterminate}
+    >
+      <Checkbox.Control>
+        <Checkbox.Indicator
+          checked={<IconCheckmarkFatFill />}
+          indeterminate={<IconMinusFatFill />}
+        />
+      </Checkbox.Control>
+      <Checkbox.Label>{label}</Checkbox.Label>
+    </Checkbox.Root>
+  );
+}
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <Checkbox.Group className="checkbox-preview">
+        <CheckboxItem label="선택 안 됨" />
+        <CheckboxItem label="선택됨" defaultChecked />
+        <CheckboxItem label="일부 선택됨" indeterminate />
+      </Checkbox.Group>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/checkbox/size.tsx
+++ b/docs/examples/lynx/checkbox/size.tsx
@@ -1,0 +1,48 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import IconCheckmarkFatFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkFatFill";
+import { Checkbox, HStack, VStack, useSeedClassName } from "@seed-design/lynx-react";
+
+function CheckboxItem({
+  label,
+  size,
+  variant,
+}: {
+  label: string;
+  size: Checkbox.RootProps["size"];
+  variant: Checkbox.RootProps["variant"];
+}) {
+  return (
+    <Checkbox.Root tone="neutral" size={size} variant={variant} defaultChecked>
+      <Checkbox.Control>
+        <Checkbox.Indicator
+          unchecked={variant === "ghost" ? <IconCheckmarkFatFill /> : undefined}
+          checked={<IconCheckmarkFatFill />}
+        />
+      </Checkbox.Control>
+      <Checkbox.Label>{label}</Checkbox.Label>
+    </Checkbox.Root>
+  );
+}
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <HStack className="checkbox-preview" gap="x8">
+        <VStack gap="spacingY.componentDefault">
+          <CheckboxItem label="Medium (default)" size="medium" variant="square" />
+          <CheckboxItem label="Large" size="large" variant="square" />
+        </VStack>
+        <VStack gap="spacingY.componentDefault">
+          <CheckboxItem label="Medium (default)" size="medium" variant="ghost" />
+          <CheckboxItem label="Large" size="large" variant="ghost" />
+        </VStack>
+      </HStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/checkbox/styles.ts
+++ b/docs/examples/lynx/checkbox/styles.ts
@@ -1,0 +1,2 @@
+import "@seed-design/lynx-css/base.css";
+import "./preview.css";

--- a/docs/examples/lynx/checkbox/value-changes.tsx
+++ b/docs/examples/lynx/checkbox/value-changes.tsx
@@ -1,0 +1,36 @@
+import "./styles";
+
+import { root, useState } from "@lynx-js/react";
+import IconCheckmarkFatFill from "@karrotmarket/lynx-monochrome-icon/IconCheckmarkFatFill";
+import { Checkbox, VStack, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+  const [count, setCount] = useState(0);
+  const [lastValue, setLastValue] = useState<boolean | null>(null);
+
+  return (
+    <page className={seedClassName}>
+      <VStack className="checkbox-preview" gap="x4">
+        <Checkbox.Root
+          tone="neutral"
+          size="large"
+          onCheckedChange={(checked) => {
+            setCount((previous) => previous + 1);
+            setLastValue(checked);
+          }}
+        >
+          <Checkbox.Control>
+            <Checkbox.Indicator checked={<IconCheckmarkFatFill />} />
+          </Checkbox.Control>
+          <Checkbox.Label>선택 상태 바꾸기</Checkbox.Label>
+        </Checkbox.Root>
+        <text className="checkbox-preview__status">
+          onCheckedChange 호출: {count}회, 마지막 값: {JSON.stringify(lastValue)}
+        </text>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/scripts/lynx-examples/web-core-styles.test.ts
+++ b/docs/scripts/lynx-examples/web-core-styles.test.ts
@@ -11,5 +11,7 @@ describe("Lynx Web Shadow DOM CSS", () => {
     expect(css).toContain('lynx-default-display-linear="false"');
     expect(css).toContain(".seed-radio__label--size_medium");
     expect(css).toContain(".seed-radio__label--size_large");
+    expect(css).toContain(".seed-checkbox__label--size_medium");
+    expect(css).toContain(".seed-checkbox__label--size_large");
   });
 });

--- a/docs/scripts/lynx-examples/web-core-styles.ts
+++ b/docs/scripts/lynx-examples/web-core-styles.ts
@@ -6,12 +6,14 @@ import { LYNX_WEB_CORE_STYLES_FILENAME } from "./constants.js";
 const require = createRequire(import.meta.url);
 
 const SEED_LYNX_WEB_PREVIEW_OVERRIDES = `
-/* WebLynx는 flex item인 text를 상단에 배치하므로 Radio label의 첫 줄만 중앙에 맞춥니다. */
-.seed-radio__label--size_medium {
+/* WebLynx는 flex item인 text를 상단에 배치하므로 선택 컴포넌트 label의 첫 줄만 중앙에 맞춥니다. */
+.seed-radio__label--size_medium,
+.seed-checkbox__label--size_medium {
   margin-top: calc(var(--seed-dimension-x8) / 2 - var(--seed-line-height-t4) / 2);
 }
 
-.seed-radio__label--size_large {
+.seed-radio__label--size_large,
+.seed-checkbox__label--size_large {
   margin-top: calc(var(--seed-dimension-x9) / 2 - var(--seed-line-height-t5) / 2);
 }
 `;


### PR DESCRIPTION
## 작업 내용

- 기존 React 문서와 예제를 기준으로 Lynx가 지원하는 Checkbox 사례를 선별했습니다.
- 선택 상태, 크기, 비활성화, 값 변경 예제를 추가했습니다.
- `LynxComponentExample`에 WebLynx 미리보기, Lynx Explorer QR 코드, 코드 탭을 구성했습니다.
- WebLynx에서 Checkbox 라벨의 첫 줄이 Control과 수직 중앙에 맞도록 미리보기 전용 스타일을 보정했습니다.
- 문서 미리보기의 아이콘 색상 제약을 안내하는 콜아웃을 추가했습니다.

## 변경 범위

- Lynx Checkbox 문서와 `docs/examples/lynx/checkbox` 예제
- WebLynx Shadow DOM에 주입되는 문서 미리보기 전용 스타일과 회귀 테스트
- 배포되는 `@seed-design/lynx-react` 컴포넌트 구현은 변경하지 않았습니다.

## 검증

- `bun generate:all`
- `bun docs:test`
- `bun --filter @seed-design/docs typecheck:lynx-examples`
- `bun --filter @seed-design/docs typecheck:lynx-tooling`
- `bun --filter @seed-design/docs build:lynx-examples:development`
- `bun docs:build`
- `bun test:all`
- WebLynx 미리보기 확인
- Lynx Explorer 실행 확인

## 관련 이슈

- [DES-2321](https://linear.app/daangn/issue/DES-2321)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * Lynx 체크박스 문서에 미리보기와 아이콘 색상 안내를 추가했습니다.
  * 크기, 비활성화, 선택 상태 변경을 확인할 수 있는 예제를 추가했습니다.
  * 일반, 선택됨, 부분 선택됨 상태와 Square·Ghost 변형을 제공합니다.

* **스타일**
  * 체크박스 미리보기의 레이아웃과 상태 표시 스타일을 개선했습니다.
  * Medium·Large 크기 체크박스에도 적절한 스타일이 적용됩니다.

* **테스트**
  * 체크박스 크기별 스타일 적용 여부를 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->