### PR TITLE
docs(lynx): add keyboard avoiding scroll view previews

### DIFF
--- a/docs/content/lynx/components/keyboard-avoiding-scroll-view.mdx
+++ b/docs/content/lynx/components/keyboard-avoiding-scroll-view.mdx
@@ -39,7 +39,7 @@ Android에서 이 컴포넌트가 키보드 회피를 전담한다면 입력 요
 </LynxComponentExample>
 
 <Callout type="warning">
-시스템 키보드에 따른 입력 영역 회피는 WebLynx에서 재현되지 않습니다. QR 코드 탭에서 Lynx Explorer로 실행한 뒤 화면 아래의 주소 입력 영역을 탭해 확인해 주세요.
+이 예제는 네이티브 키보드 동작을 사용합니다. QR 코드 탭에서 Lynx Explorer로 실행한 뒤 화면 아래의 주소 입력 영역을 탭해 확인해 주세요.
 </Callout>
 
 ### 자동 높이 조절 textarea
@@ -56,7 +56,7 @@ Android에서 이 컴포넌트가 키보드 회피를 전담한다면 입력 요
 </LynxComponentExample>
 
 <Callout type="warning">
-자동 높이 조절 결과는 WebLynx에서도 볼 수 있습니다. 키보드가 열린 상태에서 입력 영역을 다시 회피하는 동작은 QR 코드 탭에서 Lynx Explorer로 확인해 주세요.
+이 예제는 네이티브 입력 요소의 자동 높이 조절과 키보드 회피 동작을 사용합니다. QR 코드 탭에서 Lynx Explorer로 실행한 뒤 여러 줄을 입력해 확인해 주세요.
 </Callout>
 
 ## 웹 버전과의 차이

--- a/docs/content/lynx/components/keyboard-avoiding-scroll-view.mdx
+++ b/docs/content/lynx/components/keyboard-avoiding-scroll-view.mdx
@@ -17,31 +17,55 @@ description: 소프트 키보드가 활성 입력을 가리지 않도록 세로 
 
 ## Usage
 
-```tsx
-import { KeyboardAvoidingScrollView, TextField } from "@seed-design/lynx-react";
-
-export function Form() {
-  return (
-    <KeyboardAvoidingScrollView keyboardGap={24} scrollBehavior="smooth">
-      <TextField.Root>
-        <TextField.Input accessibility-label="제목" />
-      </TextField.Root>
-      <TextField.Root>
-        <TextField.Textarea accessibility-label="내용" />
-      </TextField.Root>
-    </KeyboardAvoidingScrollView>
-  );
-}
-```
+세로로 스크롤되는 입력 화면의 가장 바깥 영역에 배치합니다. `keyboardGap`은 키보드와 활성 입력 영역 사이의 간격입니다. `scrollBehavior`는 회피 위치로 이동하는 방식을 정합니다.
 
 `TextField.Input`과 `TextField.Textarea`가 focus·blur·layout 변경을 자동으로 전달하므로 별도 등록 prop은 필요하지 않습니다.
 
-## Web Version Differences
+Android에서 이 컴포넌트가 키보드 회피를 전담한다면 입력 요소에 `android-set-soft-input-mode="nothing"`을 지정합니다. host window의 별도 pan이나 resize와 회피 동작이 겹치지 않게 합니다.
+
+## Examples
+
+### 한 줄 입력
+
+화면 아래쪽의 `TextField.Input`에 focus하면 입력 영역과 키보드 사이에 24px 간격이 생기도록 자동 스크롤합니다.
+
+<LynxComponentExample name="lynx/keyboard-avoiding-scroll-view/input" height={520}>
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/keyboard-avoiding-scroll-view/input.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+<Callout type="warning">
+시스템 키보드에 따른 입력 영역 회피는 WebLynx에서 재현되지 않습니다. QR 코드 탭에서 Lynx Explorer로 실행한 뒤 화면 아래의 주소 입력 영역을 탭해 확인해 주세요.
+</Callout>
+
+### 자동 높이 조절 textarea
+
+`TextField.Textarea`에 여러 줄을 입력해 높이가 달라지면 활성 입력 영역의 위치를 다시 계산합니다.
+
+<LynxComponentExample name="lynx/keyboard-avoiding-scroll-view/autoresizing-textarea" height={520}>
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/keyboard-avoiding-scroll-view/autoresizing-textarea.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+<Callout type="warning">
+자동 높이 조절 결과는 WebLynx에서도 볼 수 있습니다. 키보드가 열린 상태에서 입력 영역을 다시 회피하는 동작은 QR 코드 탭에서 Lynx Explorer로 확인해 주세요.
+</Callout>
+
+## 웹 버전과의 차이
 
 - 브라우저의 `visualViewport`나 CSS viewport unit 대신 Lynx keyboard global event와 native node 측정을 사용합니다.
 - 키보드가 열릴 때 필요한 하단 spacer만 추가하고, 사용자 스크롤 중에는 자동 이동을 잠시 중단합니다.
+- 브라우저의 form 제출과 자동 focus 이동은 제공하지 않습니다.
 
-## Unsupported Lynx Features
+## Lynx 미지원 기능
 
 - 가로·중첩 scroll view는 지원하지 않습니다.
 - 키보드 toolbar 높이와 큰 textarea의 caret 단위 회피는 아직 반영하지 않습니다.

--- a/docs/examples/lynx/keyboard-avoiding-scroll-view/autoresizing-textarea.tsx
+++ b/docs/examples/lynx/keyboard-avoiding-scroll-view/autoresizing-textarea.tsx
@@ -1,0 +1,47 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { KeyboardAvoidingScrollView, TextField, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <KeyboardAvoidingScrollView
+        className="keyboard-avoiding-scroll-view-preview"
+        keyboardGap={24}
+        scrollBehavior="smooth"
+      >
+        <view className="keyboard-avoiding-scroll-view-preview__content">
+          <text className="keyboard-avoiding-scroll-view-preview__title">여러 줄 입력</text>
+          <text className="keyboard-avoiding-scroll-view-preview__description">
+            줄을 추가해 입력 영역이 커져도 키보드 위의 안전한 위치를 다시 계산합니다.
+          </text>
+
+          <view className="keyboard-avoiding-scroll-view-preview__spacer">
+            <text className="keyboard-avoiding-scroll-view-preview__spacer-label">
+              입력 영역이 화면 아래에 오도록 확보한 공간
+            </text>
+          </view>
+
+          <view className="keyboard-avoiding-scroll-view-preview__field">
+            <text className="keyboard-avoiding-scroll-view-preview__field-label">자기소개</text>
+            <TextField.Root>
+              <TextField.Textarea
+                accessibility-label="자기소개"
+                android-set-soft-input-mode="nothing"
+                maxlength={300}
+                placeholder="여러 줄을 입력해 보세요"
+              />
+            </TextField.Root>
+          </view>
+
+          <view className="keyboard-avoiding-scroll-view-preview__footer-space" />
+        </view>
+      </KeyboardAvoidingScrollView>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/keyboard-avoiding-scroll-view/input.tsx
+++ b/docs/examples/lynx/keyboard-avoiding-scroll-view/input.tsx
@@ -1,0 +1,47 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { KeyboardAvoidingScrollView, TextField, useSeedClassName } from "@seed-design/lynx-react";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <KeyboardAvoidingScrollView
+        className="keyboard-avoiding-scroll-view-preview"
+        keyboardGap={24}
+        scrollBehavior="smooth"
+      >
+        <view className="keyboard-avoiding-scroll-view-preview__content">
+          <text className="keyboard-avoiding-scroll-view-preview__title">한 줄 입력</text>
+          <text className="keyboard-avoiding-scroll-view-preview__description">
+            아래 입력 영역을 탭하면 키보드 위로 자동 스크롤됩니다.
+          </text>
+
+          <view className="keyboard-avoiding-scroll-view-preview__spacer">
+            <text className="keyboard-avoiding-scroll-view-preview__spacer-label">
+              입력 영역이 화면 아래에 오도록 확보한 공간
+            </text>
+          </view>
+
+          <view className="keyboard-avoiding-scroll-view-preview__field">
+            <text className="keyboard-avoiding-scroll-view-preview__field-label">주소</text>
+            <TextField.Root>
+              <TextField.Input
+                accessibility-label="주소"
+                android-set-soft-input-mode="nothing"
+                maxlength={80}
+                placeholder="동네 이름을 입력해 주세요"
+              />
+            </TextField.Root>
+          </view>
+
+          <view className="keyboard-avoiding-scroll-view-preview__footer-space" />
+        </view>
+      </KeyboardAvoidingScrollView>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/keyboard-avoiding-scroll-view/preview.css
+++ b/docs/examples/lynx/keyboard-avoiding-scroll-view/preview.css
@@ -1,0 +1,51 @@
+/* biome-ignore lint/correctness/noUnknownTypeSelector: Lynx의 page 요소입니다. */
+page {
+  height: 100%;
+  background-color: var(--seed-color-bg-layer-default);
+}
+
+.keyboard-avoiding-scroll-view-preview {
+  height: 100%;
+}
+
+.keyboard-avoiding-scroll-view-preview__content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+}
+
+.keyboard-avoiding-scroll-view-preview__title {
+  color: var(--seed-color-fg-neutral);
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.keyboard-avoiding-scroll-view-preview__description,
+.keyboard-avoiding-scroll-view-preview__field-label,
+.keyboard-avoiding-scroll-view-preview__spacer-label {
+  color: var(--seed-color-fg-neutral-muted);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.keyboard-avoiding-scroll-view-preview__field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.keyboard-avoiding-scroll-view-preview__spacer {
+  height: 52vh;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--seed-color-bg-neutral-weak);
+  border-radius: 12px;
+}
+
+.keyboard-avoiding-scroll-view-preview__footer-space {
+  height: 48px;
+  flex-shrink: 0;
+}

--- a/docs/examples/lynx/keyboard-avoiding-scroll-view/styles.ts
+++ b/docs/examples/lynx/keyboard-avoiding-scroll-view/styles.ts
@@ -1,0 +1,2 @@
+import "@seed-design/lynx-css/base.css";
+import "./preview.css";

--- a/docs/scripts/lynx-examples/web-core-styles.test.ts
+++ b/docs/scripts/lynx-examples/web-core-styles.test.ts
@@ -9,6 +9,7 @@ describe("Lynx Web Shadow DOM CSS", () => {
     expect(css).toContain("box-sizing: border-box");
     expect(css).toContain("var(--flex-direction)");
     expect(css).toContain('lynx-default-display-linear="false"');
+    expect(css).toContain("x-textarea:defined::part(textarea) {\n  padding: 0;\n}");
     expect(css).toContain(".seed-radio__label--size_medium");
     expect(css).toContain(".seed-radio__label--size_large");
     expect(css).toContain(".seed-checkbox__label--size_medium");

--- a/docs/scripts/lynx-examples/web-core-styles.ts
+++ b/docs/scripts/lynx-examples/web-core-styles.ts
@@ -6,6 +6,11 @@ import { LYNX_WEB_CORE_STYLES_FILENAME } from "./constants.js";
 const require = createRequire(import.meta.url);
 
 const SEED_LYNX_WEB_PREVIEW_OVERRIDES = `
+/* 브라우저 기본 textarea padding이 TextField의 내부 여백과 겹치지 않도록 제거합니다. */
+x-textarea:defined::part(textarea) {
+  padding: 0;
+}
+
 /* WebLynx는 flex item인 text를 상단에 배치하므로 선택 컴포넌트 label의 첫 줄만 중앙에 맞춥니다. */
 .seed-radio__label--size_medium,
 .seed-checkbox__label--size_medium {


### PR DESCRIPTION
## 변경 내용

- Lynx KeyboardAvoidingScrollView 문서에 한 줄 입력과 자동 높이 조절 textarea 실행 예제를 추가합니다.
- LynxComponentExample의 미리보기, QR 코드, 코드 탭을 구성합니다.
- 네이티브 키보드 회피와 자동 높이 조절은 Lynx Explorer에서 확인하도록 안내합니다.
- 웹과 Lynx의 동작 차이와 미지원 범위를 문서화합니다.

## 검증

- bun generate:all
- bun docs:test
- bun test:all
- Lynx 예제 타입 검사
- 문서 예제 기본 렌더링 확인
- PlayLynx 네이티브 번들 및 입력 노드 확인

## 참고

- 실제 배포되는 @seed-design/lynx-react 구현은 변경하지 않습니다.
- Linear: DES-2320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 키보드 회피 스크롤 뷰 예제를 추가했습니다.
  - 한 줄 입력과 자동 높이 조절 다중 행 입력 예제를 제공합니다.
  - 부드러운 스크롤, 키보드 간격, Android 소프트 입력 모드 설정을 보여줍니다.

- **문서**
  - 키보드 간격과 스크롤 동작 설명을 보강했습니다.
  - 웹 지원 차이, 미지원 기능, 네이티브 키보드 및 Lynx Explorer 실행 안내를 추가했습니다.

- **버그 수정**
  - 웹 환경에서 다중 행 입력 필드의 기본 안쪽 여백을 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->