### PR TITLE
fix(docs): remove temporary textarea preview

### DIFF
--- a/docs/examples/lynx/text-field-textarea/preview.tsx
+++ b/docs/examples/lynx/text-field-textarea/preview.tsx
@@ -18,11 +18,6 @@ function Root() {
           >
             <TextFieldTextarea accessibility-label="소개" placeholder="소개를 입력해 주세요" />
           </TextField>
-          <textarea
-            className="pure-textarea"
-            accessibility-label="Pure textarea"
-            placeholder="Pure textarea에 입력해 주세요"
-          />
         </VStack>
       </VStack>
     </page>


### PR DESCRIPTION
## 변경 사항

- Lynx TextFieldTextarea 미리보기에서 임시로 추가했던 순수 `textarea`를 제거했습니다.
- 문서 예제에는 SEED TextFieldTextarea만 표시됩니다.

## 검증

- `bun generate:all`
- `bun docs:test`
- `bun test:all`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 예제에서 기존의 순수 `<textarea>` 사용 사례를 제거하고 `TextFieldTextarea` 예제만 유지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->