### PR TITLE
fix(docs): smooth fonts in Lynx previews

### DIFF
--- a/docs/scripts/lynx-examples/web-core-styles.test.ts
+++ b/docs/scripts/lynx-examples/web-core-styles.test.ts
@@ -9,6 +9,9 @@ describe("Lynx Web Shadow DOM CSS", () => {
     expect(css).toContain("box-sizing: border-box");
     expect(css).toContain("var(--flex-direction)");
     expect(css).toContain('lynx-default-display-linear="false"');
+    expect(css).toContain(
+      ":host {\n  font-smoothing: antialiased;\n  -webkit-font-smoothing: antialiased;\n  -moz-osx-font-smoothing: grayscale;\n}",
+    );
     expect(css).toContain("x-textarea:defined::part(textarea) {\n  padding: 0;\n}");
     expect(css).toContain(".seed-radio__label--size_medium");
     expect(css).toContain(".seed-radio__label--size_large");

--- a/docs/scripts/lynx-examples/web-core-styles.ts
+++ b/docs/scripts/lynx-examples/web-core-styles.ts
@@ -6,6 +6,13 @@ import { LYNX_WEB_CORE_STYLES_FILENAME } from "./constants.js";
 const require = createRequire(import.meta.url);
 
 const SEED_LYNX_WEB_PREVIEW_OVERRIDES = `
+/* 문서 사이트와 같은 방식으로 Lynx 미리보기의 글꼴을 렌더링합니다. */
+:host {
+  font-smoothing: antialiased;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 /* 브라우저 기본 textarea padding이 TextField의 내부 여백과 겹치지 않도록 제거합니다. */
 x-textarea:defined::part(textarea) {
   padding: 0;


### PR DESCRIPTION
## 변경 내용

- Lynx 웹 미리보기 Shadow DOM의 `:host`에 `font-smoothing` 속성을 추가합니다.
- WebKit과 Firefox용 속성도 함께 적용합니다.
- 생성된 Shadow DOM CSS에 속성이 포함되는지 테스트합니다.

## 검증

- [x] `bun test docs/scripts/lynx-examples/web-core-styles.test.ts`
- [x] `bun biome check docs/scripts/lynx-examples/web-core-styles.ts docs/scripts/lynx-examples/web-core-styles.test.ts`
- [x] `bun generate:all`
- [ ] `bun docs:test` — Lynx 도구 타입 검사에서 `@seed-design/rsbuild-plugin-lynx-icon` 모듈을 찾지 못함
- [ ] `bun test:all` — 내부 워크스페이스 패키지 모듈 해석 오류로 864개 통과, 41개 실패

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - Lynx 웹 미리보기에서 호스트 요소의 글꼴 안티앨리어싱을 적용해 텍스트가 더욱 부드럽고 선명하게 표시됩니다.
  - 미리보기 환경에서 글꼴 렌더링이 일관되도록 스타일이 보완되었습니다.

- **테스트**
  - 웹 코어 스타일 번들에 글꼴 스무딩 규칙이 올바르게 적용되는지 확인하는 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->