### PR TITLE
docs(lynx): clarify text field keyboard defaults

### DIFF
--- a/.changeset/safe-keyboards-focus.md
+++ b/.changeset/safe-keyboards-focus.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/lynx-react": patch
+---
+
+`TextFieldInput`과 `TextFieldTextarea`의 소프트 키보드 관련 기본값을 문서화하고, `undefined`가 전달되어도 안전한 native 값으로 대체되는 동작을 보장합니다.

--- a/.changeset/safe-keyboards-focus.md
+++ b/.changeset/safe-keyboards-focus.md
@@ -1,5 +1,0 @@
----
-"@seed-design/lynx-react": patch
----
-
-`TextFieldInput`과 `TextFieldTextarea`의 소프트 키보드 관련 기본값을 문서화하고, `undefined`가 전달되어도 안전한 native 값으로 대체되는 동작을 보장합니다.

--- a/docs/content/lynx/components/text-field-input.mdx
+++ b/docs/content/lynx/components/text-field-input.mdx
@@ -136,7 +136,9 @@ export function Form() {
 - `onChange` 대신 snippet `TextField`의 `onValueChange`를 사용합니다. 원문과 grapheme 단위로 자른 값을 함께 제공합니다.
 - native `bindinput`은 `TextFieldInput`에 추가로 전달할 수 있습니다.
 - `Field.Label`과 입력의 DOM id 연결이 없으므로 `accessibility-label`을 입력에 직접 제공합니다.
-- `KeyboardAvoidingScrollView`가 키보드 회피를 전담하는 화면에서는 Android host window의 별도 pan/resize를 막기 위해 `android-set-soft-input-mode="nothing"`을 명시할 수 있습니다. 이 값은 host window 전역에 영향을 주므로 컴포넌트가 자동으로 적용하지 않습니다.
+- 포커스 시 키보드가 나타나도록 `show-soft-input-on-focus`의 기본값은 `true`입니다. `undefined`가 native attribute로 전달되지 않도록 컴포넌트가 이 기본값을 명시적으로 적용합니다. 커스텀 키보드를 사용하는 경우에는 `false`로 재정의할 수 있습니다.
+- `android-set-soft-input-mode`의 기본값은 `"unspecified"`입니다. Android에서 `undefined`가 native attribute로 전달되면 오류가 발생할 수 있어 컴포넌트가 이 기본값을 명시적으로 적용합니다.
+- `android-set-soft-input-mode`는 입력 요소가 포함된 host window 전역에 영향을 줍니다. 기본값인 `"unspecified"`도 기존 Activity 설정을 그대로 보존하는 값이 아니라 시스템 판단 모드로 다시 설정합니다. `KeyboardAvoidingScrollView`가 키보드 회피를 전담하는 화면에서는 별도 pan/resize를 막기 위해 `"nothing"`으로 재정의합니다. 같은 window에 있는 입력 요소에는 가능한 한 같은 값을 사용합니다.
 - `size="responsive"`는 CSS viewport breakpoint가 없는 Lynx에서 지원하지 않습니다. `large` 또는 `medium`을 명시합니다.
 
 ## Unsupported Lynx Features

--- a/docs/content/lynx/components/text-field-textarea.mdx
+++ b/docs/content/lynx/components/text-field-textarea.mdx
@@ -188,9 +188,10 @@ export function Form() {
 - autoresize는 DOM `scrollHeight` 대신 native intrinsic height를 사용합니다. 별도 wrapper 없이 native textarea가 세로 여백과 최소 높이를 함께 소유합니다.
 - Android에서는 CSS `line-height`가 native textarea에 적용되지 않아 `line-spacing="3.2px"`를 기본 적용합니다. 명시적인 `line-spacing` 값이 이 기본값보다 우선합니다.
 - controlled textarea도 native 입력 이벤트를 그대로 유지하고, 외부에서 값이 달라진 경우에만 `setValue`로 동기화합니다. 입력마다 `readonly`를 토글하지 않아 줄 추가 시 native scroll offset과 높이 측정이 초기화되지 않습니다.
-- 포커스 시 키보드가 나타나도록 `show-soft-input-on-focus`의 기본값은 `true`입니다.
+- 포커스 시 키보드가 나타나도록 `show-soft-input-on-focus`의 기본값은 `true`입니다. `undefined`가 native attribute로 전달되지 않도록 컴포넌트가 이 기본값을 명시적으로 적용합니다. 커스텀 키보드를 사용하는 경우에는 `false`로 재정의할 수 있습니다.
 - Android의 fullscreen extract input은 기본적으로 비활성화합니다. 필요한 경우 `android-fullscreen-mode={true}`를 명시합니다.
-- `android-set-soft-input-mode`의 기본값은 `"unspecified"`입니다. `KeyboardAvoidingScrollView`가 키보드 회피를 전담하는 화면에서는 host window의 별도 pan/resize를 막기 위해 `"nothing"`을 명시할 수 있습니다. 이 값은 host window 전역에 영향을 줍니다.
+- `android-set-soft-input-mode`의 기본값은 `"unspecified"`입니다. Android에서 `undefined`가 native attribute로 전달되면 오류가 발생할 수 있어 컴포넌트가 이 기본값을 명시적으로 적용합니다.
+- `android-set-soft-input-mode`는 입력 요소가 포함된 host window 전역에 영향을 줍니다. 기본값인 `"unspecified"`도 기존 Activity 설정을 그대로 보존하는 값이 아니라 시스템 판단 모드로 다시 설정합니다. `KeyboardAvoidingScrollView`가 키보드 회피를 전담하는 화면에서는 별도 pan/resize를 막기 위해 `"nothing"`으로 재정의합니다. 같은 window에 있는 입력 요소에는 가능한 한 같은 값을 사용합니다.
 - `size="responsive"`는 CSS viewport breakpoint가 없는 Lynx에서 지원하지 않습니다. `large` 또는 `medium`을 명시합니다.
 
 ## Unsupported Lynx Features

--- a/packages/lynx-react/src/components/TextField/TextField.test.tsx
+++ b/packages/lynx-react/src/components/TextField/TextField.test.tsx
@@ -198,10 +198,13 @@ describe("TextField", () => {
     expect(input).toHaveAttribute("default-value", "");
   });
 
-  it("passes safe soft keyboard defaults and preserves explicit overrides", () => {
+  it("replaces undefined soft keyboard props with safe native defaults", () => {
     const { rerender } = render(
       <TextField.Root>
-        <TextField.Input />
+        <TextField.Input
+          show-soft-input-on-focus={undefined}
+          android-set-soft-input-mode={undefined}
+        />
       </TextField.Root>,
     );
 
@@ -212,9 +215,31 @@ describe("TextField", () => {
     rerender(
       <TextField.Root>
         <TextField.Textarea
-          show-soft-input-on-focus={false}
-          android-set-soft-input-mode="resize"
+          show-soft-input-on-focus={undefined}
+          android-set-soft-input-mode={undefined}
         />
+      </TextField.Root>,
+    );
+
+    const textarea = getRenderedRoot().querySelector("textarea");
+    expect(textarea).toHaveAttribute("show-soft-input-on-focus", "true");
+    expect(textarea).toHaveAttribute("android-set-soft-input-mode", "unspecified");
+  });
+
+  it("preserves explicit soft keyboard overrides", () => {
+    const { rerender } = render(
+      <TextField.Root>
+        <TextField.Input show-soft-input-on-focus={false} android-set-soft-input-mode="nothing" />
+      </TextField.Root>,
+    );
+
+    const input = getRenderedRoot().querySelector("input");
+    expect(input).toHaveAttribute("show-soft-input-on-focus", "false");
+    expect(input).toHaveAttribute("android-set-soft-input-mode", "nothing");
+
+    rerender(
+      <TextField.Root>
+        <TextField.Textarea show-soft-input-on-focus={false} android-set-soft-input-mode="resize" />
       </TextField.Root>,
     );
 

--- a/packages/lynx-react/src/components/TextField/TextField.tsx
+++ b/packages/lynx-react/src/components/TextField/TextField.tsx
@@ -548,14 +548,22 @@ export interface TextFieldInputProps extends NativeTextControlProps {
   maxlength?: NativeInputProps["maxlength"];
   readonly?: NativeInputProps["readonly"];
   disabled?: NativeInputProps["disabled"];
-  /** 포커스할 때 시스템 키보드를 표시한다. @defaultValue true */
+  /**
+   * 포커스할 때 시스템 키보드를 표시한다.
+   * `undefined`가 native attribute로 전달되지 않도록 `true`를 명시적으로 적용한다.
+   * @defaultValue true
+   */
   "show-soft-input-on-focus"?: NativeInputProps["show-soft-input-on-focus"];
   "input-filter"?: NativeInputProps["input-filter"];
   type?: NativeInputProps["type"];
   "ios-auto-correct"?: NativeInputProps["ios-auto-correct"];
   "ios-spell-check"?: NativeInputProps["ios-spell-check"];
   "android-fullscreen-mode"?: NativeInputProps["android-fullscreen-mode"];
-  /** Android host window의 soft input mode를 지정한다. @defaultValue "unspecified" */
+  /**
+   * Android host window의 soft input mode를 지정한다.
+   * `undefined`가 native attribute로 전달되지 않도록 `"unspecified"`를 명시적으로 적용한다.
+   * @defaultValue "unspecified"
+   */
   "android-set-soft-input-mode"?: AndroidSetSoftInputMode;
   bindfocus?: NativeInputProps["bindfocus"];
   bindblur?: NativeInputProps["bindblur"];
@@ -673,7 +681,11 @@ export interface TextFieldTextareaProps extends NativeTextControlProps {
   "line-spacing"?: NativeTextareaProps["line-spacing"];
   readonly?: NativeTextareaProps["readonly"];
   disabled?: NativeTextareaProps["disabled"];
-  /** 포커스할 때 시스템 키보드를 표시한다. @defaultValue true */
+  /**
+   * 포커스할 때 시스템 키보드를 표시한다.
+   * `undefined`가 native attribute로 전달되지 않도록 `true`를 명시적으로 적용한다.
+   * @defaultValue true
+   */
   "show-soft-input-on-focus"?: NativeTextareaProps["show-soft-input-on-focus"];
   "input-filter"?: NativeTextareaProps["input-filter"];
   "enable-scroll-bar"?: NativeTextareaProps["enable-scroll-bar"];
@@ -682,7 +694,11 @@ export interface TextFieldTextareaProps extends NativeTextControlProps {
   "ios-spell-check"?: NativeTextareaProps["ios-spell-check"];
   /** Android의 fullscreen extract input을 활성화한다. @defaultValue false */
   "android-fullscreen-mode"?: NativeTextareaProps["android-fullscreen-mode"];
-  /** Android host window의 soft input mode를 지정한다. @defaultValue "unspecified" */
+  /**
+   * Android host window의 soft input mode를 지정한다.
+   * `undefined`가 native attribute로 전달되지 않도록 `"unspecified"`를 명시적으로 적용한다.
+   * @defaultValue "unspecified"
+   */
   "android-set-soft-input-mode"?: AndroidSetSoftInputMode;
   bindfocus?: NativeTextareaProps["bindfocus"];
   bindblur?: NativeTextareaProps["bindblur"];


### PR DESCRIPTION
## 배경

`TextFieldInput`과 `TextFieldTextarea`는 이미 `??` 연산자로 소프트 키보드 관련 안전 기본값을 적용하고 있습니다. 이 동작이 유지되도록 API 설명과 문서를 보강하고 회귀 테스트로 고정합니다.

## 변경 사항

- `show-soft-input-on-focus` 기본값 `true`와 명시적 재정의 방법을 문서화합니다.
- `android-set-soft-input-mode` 기본값 `"unspecified"`와 host window 전역 영향을 문서화합니다.
- `undefined` 입력을 안전 기본값으로 대체하고 명시적 재정의를 보존하는 회귀 테스트를 추가합니다.

## 검증

- `bun generate:all`
- `bun packages:build`
- `bun docs:test`
- `bun test:all`