### PR TITLE
fix(lynx): stabilize textarea autosizing and keyboard avoidance

### DIFF
--- a/.changeset/bright-keyboards-follow.md
+++ b/.changeset/bright-keyboards-follow.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/lynx-react": patch
+---
+
+iOS에서 `TextFieldTextarea`의 첫 입력 시 자동 높이가 세로 여백만큼 불필요하게 늘어나는 문제를 수정합니다.

--- a/docs/content/lynx/components/keyboard-avoiding-scroll-view.mdx
+++ b/docs/content/lynx/components/keyboard-avoiding-scroll-view.mdx
@@ -11,6 +11,12 @@ description: 소프트 키보드가 활성 입력을 가리지 않도록 세로 
 @seed-design/lynx-react
 ```
 
+아래 예제에서 사용하는 Text Field 레지스트리 스니펫도 추가합니다.
+
+```package-install
+npx @seed-design/cli add ui:text-field
+```
+
 ## Props
 
 <react-type-table path="../packages/lynx-react/src/components/KeyboardAvoidingScrollView/KeyboardAvoidingScrollView.tsx" name="KeyboardAvoidingScrollViewProps" />
@@ -19,7 +25,7 @@ description: 소프트 키보드가 활성 입력을 가리지 않도록 세로 
 
 세로로 스크롤되는 입력 화면의 가장 바깥 영역에 배치합니다. `keyboardGap`은 키보드와 활성 입력 영역 사이의 간격입니다. `scrollBehavior`는 회피 위치로 이동하는 방식을 정합니다.
 
-`TextField.Input`과 `TextField.Textarea`가 focus·blur·layout 변경을 자동으로 전달하므로 별도 등록 prop은 필요하지 않습니다.
+Text Field Input과 Text Field Textarea의 레지스트리 스니펫이 제공하는 `TextField` 안에 입력 요소를 배치합니다. 이 `TextField`가 내부에 만드는 Field 경계를 기준으로 입력 영역과 하단을 추적합니다. 입력 요소가 focus·blur·layout 변경을 자동으로 전달하므로 별도 등록 prop은 필요하지 않습니다.
 
 Android에서 이 컴포넌트가 키보드 회피를 전담한다면 입력 요소에 `android-set-soft-input-mode="nothing"`을 지정합니다. host window의 별도 pan이나 resize와 회피 동작이 겹치지 않게 합니다.
 

--- a/docs/content/lynx/components/text-field-textarea.mdx
+++ b/docs/content/lynx/components/text-field-textarea.mdx
@@ -69,7 +69,7 @@ export function ControlledIntroduction() {
 
 ### Autoresizing
 
-`TextFieldTextarea`는 기본적으로 Lynx native textarea의 측정 기능을 사용해 내용에 맞춰 높이가 늘어납니다. 별도 측정 요소나 wrapper를 만들지 않습니다. native textarea의 실제 높이가 달라지면 Keyboard Avoiding 위치를 다시 계산합니다. 고정 높이가 필요하면 `autoresize={false}`와 명시적인 `height`를 함께 사용합니다.
+`TextFieldTextarea`는 기본적으로 Lynx native textarea의 측정 기능을 사용해 내용에 맞춰 높이가 늘어납니다. iOS에서는 크기 측정용 래퍼가 최소 높이와 세로 여백을 맡고, Android에서는 native textarea가 직접 맡습니다. 실제 영역의 높이가 달라지면 `KeyboardAvoidingScrollView`의 회피 위치를 다시 계산합니다. 고정 높이가 필요하면 `autoresize={false}`와 명시적인 `height`를 함께 사용합니다.
 
 Android에서는 SEED typography의 줄 높이를 맞추기 위해 `line-spacing="3.2px"`를 기본 적용합니다. `line-spacing`을 명시하면 모든 플랫폼에서 해당 값이 우선하며, Android의 기본 보정은 `line-spacing={0}`으로 해제할 수 있습니다. `fontSize`나 `lineHeight`를 직접 변경한다면 이에 맞는 `line-spacing`도 함께 지정해야 합니다.
 
@@ -185,7 +185,7 @@ export function Form() {
 - `onChange` 대신 snippet `TextField`의 `onValueChange`를 사용합니다. 원문과 grapheme 단위로 자른 값을 함께 제공합니다.
 - native `bindinput`은 `TextFieldTextarea`에 추가로 전달할 수 있습니다.
 - `Field.Label`과 입력의 DOM id 연결이 없으므로 `accessibility-label`을 입력에 직접 제공합니다.
-- autoresize는 DOM `scrollHeight` 대신 native intrinsic height를 사용합니다. 별도 wrapper 없이 native textarea가 세로 여백과 최소 높이를 함께 소유합니다.
+- autoresize는 DOM `scrollHeight` 대신 native intrinsic height를 사용합니다. iOS에서는 크기 측정용 래퍼가 세로 여백과 최소 높이를 소유해 첫 입력 시 native content size에 여백이 중복되지 않게 합니다. Android에서는 native textarea가 세로 여백과 최소 높이를 직접 소유합니다.
 - Android에서는 CSS `line-height`가 native textarea에 적용되지 않아 `line-spacing="3.2px"`를 기본 적용합니다. 명시적인 `line-spacing` 값이 이 기본값보다 우선합니다.
 - controlled textarea도 native 입력 이벤트를 그대로 유지하고, 외부에서 값이 달라진 경우에만 `setValue`로 동기화합니다. 입력마다 `readonly`를 토글하지 않아 줄 추가 시 native scroll offset과 높이 측정이 초기화되지 않습니다.
 - 포커스 시 키보드가 나타나도록 `show-soft-input-on-focus`의 기본값은 `true`입니다. `undefined`가 native attribute로 전달되지 않도록 컴포넌트가 이 기본값을 명시적으로 적용합니다. 커스텀 키보드를 사용하는 경우에는 `false`로 재정의할 수 있습니다.

--- a/docs/examples/lynx/keyboard-avoiding-scroll-view/autoresizing-textarea.tsx
+++ b/docs/examples/lynx/keyboard-avoiding-scroll-view/autoresizing-textarea.tsx
@@ -1,7 +1,8 @@
 import "./styles";
 
 import { root } from "@lynx-js/react";
-import { KeyboardAvoidingScrollView, TextField, useSeedClassName } from "@seed-design/lynx-react";
+import { KeyboardAvoidingScrollView, useSeedClassName } from "@seed-design/lynx-react";
+import { TextField, TextFieldTextarea } from "@/components/ui/text-field";
 
 function Root() {
   const seedClassName = useSeedClassName({ colorMode: "system" });
@@ -26,15 +27,14 @@ function Root() {
           </view>
 
           <view className="keyboard-avoiding-scroll-view-preview__field">
-            <text className="keyboard-avoiding-scroll-view-preview__field-label">자기소개</text>
-            <TextField.Root>
-              <TextField.Textarea
+            <TextField label="자기소개">
+              <TextFieldTextarea
                 accessibility-label="자기소개"
                 android-set-soft-input-mode="nothing"
                 maxlength={300}
                 placeholder="여러 줄을 입력해 보세요"
               />
-            </TextField.Root>
+            </TextField>
           </view>
 
           <view className="keyboard-avoiding-scroll-view-preview__footer-space" />

--- a/docs/examples/lynx/keyboard-avoiding-scroll-view/input.tsx
+++ b/docs/examples/lynx/keyboard-avoiding-scroll-view/input.tsx
@@ -1,7 +1,8 @@
 import "./styles";
 
 import { root } from "@lynx-js/react";
-import { KeyboardAvoidingScrollView, TextField, useSeedClassName } from "@seed-design/lynx-react";
+import { KeyboardAvoidingScrollView, useSeedClassName } from "@seed-design/lynx-react";
+import { TextField, TextFieldInput } from "@/components/ui/text-field";
 
 function Root() {
   const seedClassName = useSeedClassName({ colorMode: "system" });
@@ -26,15 +27,14 @@ function Root() {
           </view>
 
           <view className="keyboard-avoiding-scroll-view-preview__field">
-            <text className="keyboard-avoiding-scroll-view-preview__field-label">주소</text>
-            <TextField.Root>
-              <TextField.Input
+            <TextField label="주소">
+              <TextFieldInput
                 accessibility-label="주소"
                 android-set-soft-input-mode="nothing"
                 maxlength={80}
                 placeholder="동네 이름을 입력해 주세요"
               />
-            </TextField.Root>
+            </TextField>
           </view>
 
           <view className="keyboard-avoiding-scroll-view-preview__footer-space" />

--- a/docs/examples/lynx/keyboard-avoiding-scroll-view/preview.css
+++ b/docs/examples/lynx/keyboard-avoiding-scroll-view/preview.css
@@ -22,7 +22,6 @@ page {
 }
 
 .keyboard-avoiding-scroll-view-preview__description,
-.keyboard-avoiding-scroll-view-preview__field-label,
 .keyboard-avoiding-scroll-view-preview__spacer-label {
   color: var(--seed-color-fg-neutral-muted);
   font-size: 14px;
@@ -30,9 +29,6 @@ page {
 }
 
 .keyboard-avoiding-scroll-view-preview__field {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
   flex-shrink: 0;
 }
 

--- a/packages/lynx-react/src/components/TextField/TextField.test.tsx
+++ b/packages/lynx-react/src/components/TextField/TextField.test.tsx
@@ -63,11 +63,17 @@ function getTextFieldRoot() {
   return textFieldRoot;
 }
 
-function fireNativeEvent(nativeRef: NodesRef, element: Element, eventName: string, detail: object) {
+function fireNativeEvent(
+  nativeRef: NodesRef,
+  element: Element,
+  eventName: string,
+  detail: object,
+  bubbles = true,
+) {
   const EventConstructor = element.ownerDocument.defaultView?.CustomEvent;
   if (!EventConstructor) throw new Error("Expected CustomEvent constructor to exist.");
 
-  const event = new EventConstructor(`bindEvent:${eventName}`, { bubbles: true, detail });
+  const event = new EventConstructor(`bindEvent:${eventName}`, { bubbles, detail });
   Object.assign(event, { eventType: "bindEvent", eventName });
   fireEvent(nativeRef as unknown as Element, event);
 }
@@ -680,7 +686,9 @@ describe("TextField", () => {
     expect(getRenderedQueries().queryByText("secret")).toBeNull();
   });
 
-  it("uses native intrinsic autoresize without a sizing wrapper", () => {
+  it("uses direct native autoresize on Android", () => {
+    setSystemInfo({ platform: "Android" });
+
     const textareaRef = createRef<NodesRef>();
     const bindlayoutchange = vi.fn();
     const actions = {
@@ -788,26 +796,98 @@ describe("TextField", () => {
     expect(uncorrectedTextarea).toHaveAttribute("line-spacing", "0");
   });
 
-  it("keeps iOS native autoresize without the Android line-spacing correction", () => {
+  it("uses an iOS-only sizing wrapper without intercepting native textarea taps", () => {
     setSystemInfo({ platform: "iOS" });
 
+    const textareaRef = createRef<NodesRef>();
+    const bindlayoutchange = vi.fn();
+    const actions = {
+      focus: vi.fn(),
+      blur: vi.fn(),
+      layoutChanged: vi.fn(),
+      unregister: vi.fn(),
+    };
     render(
-      <TextField.Root defaultValue={"첫 줄\n"}>
-        <TextField.Textarea />
-      </TextField.Root>,
+      <KeyboardAvoidanceActionsContext.Provider value={actions}>
+        <TextField.Root defaultValue={"첫 줄\n"}>
+          <TextField.Textarea ref={textareaRef} bindlayoutchange={bindlayoutchange} />
+        </TextField.Root>
+      </KeyboardAvoidanceActionsContext.Provider>,
     );
 
     const root = getRenderedRoot();
     const textarea = root.querySelector("textarea");
-    if (!textarea) throw new Error("Expected native textarea to exist.");
+    const textareaRoot = root.querySelector(".seed-text-input__textareaRoot");
+    if (!textarea || !textareaRoot || !textareaRef.current) {
+      throw new Error("Expected native textarea and its iOS sizing wrapper to exist.");
+    }
 
-    expect(textarea).not.toHaveClass("seed-text-input__textareaNativeAutoresize");
-    expect(textarea).toHaveClass("seed-text-input__textareaAndroidAutoresize--size_large");
+    expect(textarea).toHaveClass("seed-text-input__textareaNativeAutoresize");
+    expect(textarea).not.toHaveClass("seed-text-input__textareaAndroidAutoresize--size_large");
     expect(textarea).not.toHaveAttribute("line-spacing");
-    expect(root.querySelector(".seed-text-input__textareaRoot")).toBeNull();
+    expect(textareaRoot).toHaveClass("seed-text-input__textareaAutoresizeRoot--size_large");
+    expect(textareaRoot).toHaveAttribute("ignore-focus", "true");
+
+    const exec = vi.fn();
+    const invoke = vi.fn(() => ({ exec }));
+    textareaRef.current.invoke = invoke as unknown as NodesRef["invoke"];
+
+    fireEvent.tap(textareaRef.current as unknown as Element);
+    expect(invoke).not.toHaveBeenCalled();
+
+    fireEvent.tap(textareaRoot);
+    expect(invoke).toHaveBeenCalledWith(expect.objectContaining({ method: "focus" }));
+    expect(exec).toHaveBeenCalledOnce();
+
+    actions.layoutChanged.mockClear();
+    fireNativeEvent(
+      textareaRef.current,
+      textarea,
+      "layoutchange",
+      {
+        width: 200,
+        height: 80,
+      },
+      false,
+    );
+    expect(bindlayoutchange).toHaveBeenCalledOnce();
+    expect(actions.layoutChanged).not.toHaveBeenCalled();
+
+    fireNativeEvent(textareaRoot as unknown as NodesRef, textareaRoot, "layoutchange", {
+      width: 200,
+      height: 94,
+    });
+    expect(actions.layoutChanged).toHaveBeenCalledOnce();
   });
 
-  it("does not restore the previous value after an accepted controlled textarea newline", async () => {
+  it("does not invoke focus from disabled iOS textarea wrapper padding", () => {
+    setSystemInfo({ platform: "iOS" });
+
+    const textareaRef = createRef<NodesRef>();
+    render(
+      <TextField.Root disabled>
+        <TextField.Textarea ref={textareaRef} />
+      </TextField.Root>,
+    );
+
+    const textareaRoot = getRenderedRoot().querySelector(".seed-text-input__textareaRoot");
+    if (!textareaRoot || !textareaRef.current) {
+      throw new Error("Expected disabled native textarea and its iOS sizing wrapper to exist.");
+    }
+
+    const invoke = vi.fn(() => ({ exec: vi.fn() }));
+    textareaRef.current.invoke = invoke as unknown as NodesRef["invoke"];
+
+    fireEvent.tap(textareaRoot);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "Android",
+    "iOS",
+  ] as const)("does not restore the previous value after an accepted controlled textarea newline on %s", async (platform) => {
+    setSystemInfo({ platform });
+
     const textareaRef = createRef<NodesRef>();
     const onValueChange = vi.fn();
     const bindinput = vi.fn();
@@ -836,8 +916,13 @@ describe("TextField", () => {
       throw new Error("Expected native textarea to exist.");
     }
 
-    expect(textarea).not.toHaveClass("seed-text-input__textareaNativeAutoresize");
-    expect(root.querySelector(".seed-text-input__textareaRoot")).toBeNull();
+    if (platform === "iOS") {
+      expect(textarea).toHaveClass("seed-text-input__textareaNativeAutoresize");
+      expect(root.querySelector(".seed-text-input__textareaRoot")).not.toBeNull();
+    } else {
+      expect(textarea).not.toHaveClass("seed-text-input__textareaNativeAutoresize");
+      expect(root.querySelector(".seed-text-input__textareaRoot")).toBeNull();
+    }
 
     const invoke = vi.fn(() => ({ exec: vi.fn() }));
     textareaRef.current.invoke = invoke as unknown as NodesRef["invoke"];
@@ -853,6 +938,7 @@ describe("TextField", () => {
     expect(invoke).not.toHaveBeenCalled();
 
     await flushControlledReconciliation();
+    expect(getRenderedRoot().querySelector("textarea")).toBe(textarea);
     expect(invoke).not.toHaveBeenCalled();
   });
 

--- a/packages/lynx-react/src/components/TextField/TextField.tsx
+++ b/packages/lynx-react/src/components/TextField/TextField.tsx
@@ -17,13 +17,21 @@ declare const SystemInfo: LynxSystemInfo | undefined;
 
 const ANDROID_TEXTAREA_DEFAULT_LINE_SPACING = "3.2px" as const;
 
-function isAndroidRuntime(): boolean {
+function getRuntimePlatform(): string | undefined {
   const globalSystemInfo = (globalThis as typeof globalThis & { SystemInfo?: LynxSystemInfo })
     .SystemInfo;
   const systemInfo =
     globalSystemInfo ?? (typeof SystemInfo === "undefined" ? undefined : SystemInfo);
 
-  return systemInfo?.platform === "Android";
+  return systemInfo?.platform;
+}
+
+function isAndroidRuntime(): boolean {
+  return getRuntimePlatform() === "Android";
+}
+
+function isIOSRuntime(): boolean {
+  return getRuntimePlatform() === "iOS";
 }
 
 const { ClassNamesProvider, useClassNames } = createSlotRecipeContext(textInput);
@@ -461,6 +469,19 @@ function useNativeTextControl({
     keyboardAvoidance?.layoutChanged(ownerRef.current);
   }, [keyboardAvoidance]);
 
+  const focusNativeControl = React.useCallback(() => {
+    "background only";
+
+    const node = nativeRef.current;
+    if (!node || typeof node.invoke !== "function") return;
+
+    try {
+      node.invoke({ method: "focus" }).exec();
+    } catch {
+      // Native node가 아직 commit되지 않았으면 실제 textarea 탭이 focus를 처리한다.
+    }
+  }, []);
+
   return {
     context: textFieldContext,
     disabled,
@@ -471,6 +492,7 @@ function useNativeTextControl({
     handleFocus,
     handleBlur,
     notifyLayoutChanged,
+    focusNativeControl,
     handleSelectionChange,
     nativeInsertionMaxLength:
       wasInsertionMaxLengthManaged &&
@@ -742,6 +764,7 @@ export const TextFieldTextarea = React.forwardRef<NodesRef, TextFieldTextareaPro
       control.nativeInsertionMaxLength,
     );
     const isAndroid = isAndroidRuntime();
+    const usesIOSAutoresizeWrapper = autoresize && isIOSRuntime();
     // Android native textarea는 CSS line-height를 무시한다. 실기기에서 관측한
     // native font metrics와 SEED line box의 차이를 line-spacing으로 보정한다.
     // 명시적인 값(0 포함)은 내부 기본값보다 우선한다.
@@ -773,6 +796,17 @@ export const TextFieldTextarea = React.forwardRef<NodesRef, TextFieldTextareaPro
       },
       [autoresize, bindlayoutchange, control.notifyLayoutChanged],
     );
+    const handleTextareaRootTap = React.useCallback<
+      NonNullable<IntrinsicElements["view"]["bindtap"]>
+    >(
+      (event) => {
+        "background only";
+
+        if (control.disabled || event.target.uid !== event.currentTarget.uid) return;
+        control.focusNativeControl();
+      },
+      [control.disabled, control.focusNativeControl],
+    );
 
     if (control.readOnly) {
       const value = control.context.value;
@@ -801,9 +835,9 @@ export const TextFieldTextarea = React.forwardRef<NodesRef, TextFieldTextareaPro
       );
     }
 
-    // Lynx native textarea가 내용 높이를 측정하고 shadow node를 다시 배치한다.
-    // 높이를 고정하지 않는 autoresize 모드에서는 별도 sizing wrapper를 두지 않는다.
-    return (
+    // iOS textarea는 첫 편집에서 native contentSize를 높이에 반영한다.
+    // 디자인 padding을 wrapper로 분리해 이때 padding만큼 높이가 중복되지 않게 한다.
+    const textarea = (
       <textarea
         {...control.defaultValueProps}
         ref={control.mergedRef}
@@ -811,7 +845,8 @@ export const TextFieldTextarea = React.forwardRef<NodesRef, TextFieldTextareaPro
           classes.value,
           classes.textareaValue,
           !autoresize && classes.textareaFixed,
-          autoresize && classes.textareaAndroidAutoresize,
+          usesIOSAutoresizeWrapper && classes.textareaNativeAutoresize,
+          autoresize && !usesIOSAutoresizeWrapper && classes.textareaAndroidAutoresize,
           className,
         )}
         disabled={control.disabled}
@@ -827,9 +862,22 @@ export const TextFieldTextarea = React.forwardRef<NodesRef, TextFieldTextareaPro
         bindselection={handleSelection}
         bindfocus={control.handleFocus}
         bindblur={control.handleBlur}
-        bindlayoutchange={handleLayoutChange}
+        bindlayoutchange={usesIOSAutoresizeWrapper ? bindlayoutchange : handleLayoutChange}
         {...nativeProps}
       />
+    );
+
+    if (!usesIOSAutoresizeWrapper) return textarea;
+
+    return (
+      <view
+        ignore-focus={true}
+        className={clsx(classes.textareaRoot, classes.textareaAutoresizeRoot)}
+        bindtap={handleTextareaRootTap}
+        bindlayoutchange={control.notifyLayoutChanged}
+      >
+        {textarea}
+      </view>
     );
   },
 );


### PR DESCRIPTION
## 변경 사항

- iOS의 자동 높이 `TextFieldTextarea`에서 최소 높이와 세로 여백을 크기 측정용 래퍼가 맡도록 변경했습니다.
- 래퍼 여백을 눌렀을 때 native textarea로 포커스를 전달하고, 비활성 상태에서는 포커스하지 않도록 했습니다.
- Android에서는 기존 native autoresize와 `line-spacing` 처리 경로를 유지합니다.
- `KeyboardAvoidingScrollView` 예제의 입력 요소를 Field 경계를 제공하는 Text Field 레지스트리 스니펫으로 구성했습니다.
- 플랫폼별 렌더링, 레이아웃 변경 알림, controlled 줄바꿈을 확인하는 회귀 테스트와 patch changeset을 추가했습니다.

## 원인

Lynx iOS native textarea는 첫 입력 시 `contentSize`를 intrinsic height에 반영합니다. 최소 높이와 세로 여백을 native textarea가 직접 소유하면 첫 입력에서 위아래 여백이 중복되어 높이가 일시적으로 늘어났습니다.

기존 `KeyboardAvoidingScrollView` 예제는 `TextField`를 Field 경계 없이 사용했습니다. textarea가 키보드 위의 안전 영역보다 커지면 Field body와 하단을 회피 대상으로 선택할 수 없어 자동 스크롤이 더 이상 입력 영역을 따라가지 못했습니다.

## 영향

- iOS에서 첫 글자를 입력할 때 textarea 높이가 세로 여백만큼 불필요하게 늘어나지 않습니다.
- 자동 높이 textarea의 래퍼 여백을 눌러도 입력 포커스와 키보드가 유지됩니다.
- Field를 포함한 예제에서는 textarea가 안전 영역보다 커진 뒤에도 Field 하단을 기준으로 스크롤을 이어갑니다.
- Android의 native autoresize 동작과 공개 API는 바뀌지 않습니다.

현재 caret 위치만 기준으로 큰 textarea를 회피하는 기능과 호스트 앱 변경은 이번 범위에 포함하지 않습니다.

## 검증

- `bun generate:all`
- `bun run --filter @seed-design/lynx-react test -- src/components/TextField/TextField.test.tsx src/components/KeyboardAvoidingScrollView/KeyboardAvoidingScrollView.test.tsx` — 42개 통과
- `bun test:all`
- `bun docs:test`
- `bun --filter @seed-design/docs build:lynx-examples:development` — 예시 76개 생성
- `git diff --check origin/dev...HEAD`
- iOS Simulator에서 첫 입력 시 높이 유지와 25줄 이상의 textarea 하단 추적 확인
- Android 실기기에서 35줄 입력과 키보드를 내린 뒤 하단 재포커스 시 커서·하단선이 키보드 위에 유지되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * iOS에서 `TextFieldTextarea`에 첫 입력 시 세로 여백만큼 높이가 불필요하게 증가하던 문제를 수정했습니다.
  * iOS 및 Android에서 자동 높이 조정과 키보드 회피 위치가 더욱 안정적으로 동작합니다.

* **문서**
  * `TextField` 설치 및 사용 방법을 업데이트했습니다.
  * 플랫폼별 텍스트 영역 자동 크기 조정 동작을 명확히 안내합니다.

* **예제**
  * 주소 입력 및 자동 크기 조정 예제를 최신 `TextField` 사용 방식으로 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->