### PR TITLE
docs(fab): 위치 가이드 여백 20 반영 및 이미지 alt 정정

### DIFF
--- a/docs/content/components/floating-action-button.mdx
+++ b/docs/content/components/floating-action-button.mdx
@@ -55,7 +55,10 @@ Extended 상태의 Floating Action Button은 스크롤을 내릴 경우 라벨�
 
 ### Floating Action Button의 위치
 
-<FigmaImage id="2:132238" alt="Floating Action Button 위치" />
+<FigmaImage
+  id="2:132238"
+  alt="화면 우측 가장자리와 하단 고정 요소로부터 20의 여백을 둔 Floating Action Button 예시"
+/>
 
 <DontImage
   figmaId="2:132254"
@@ -70,16 +73,13 @@ Extended 상태의 Floating Action Button은 스크롤을 내릴 경우 라벨�
   body="화면에 하나만 존재할 수 있습니다."
   alt="화면에 여러 개의 Floating Action Button이 존재하는 예시"
 />
-<FigmaImage
-  id="2:132273"
-  alt="Floating Action Button이 화면 우측 하단에 위치한 예시"
-/>
+<FigmaImage id="2:132273" alt="여러 선택지를 Menu Type으로 제공한 예시" />
 
 </Grid>
 
 Floating Action Button은 화면 우측 하단에 위치해야 하며, 화면 내 주요 액션으로 하나만 존재할 수 있습니다.
 
-하단에 고정된 요소가 있는 경우 고정된 요소를 기준으로 여백을 확보해야 합니다.
+화면 가장자리로부터 20의 여백을 두어야 하며, 하단에 고정된 요소가 있는 경우 고정된 요소를 기준으로 20의 여백을 확보해야 합니다.
 
 여러개의 선택지가 필요한 경우 Menu Type을 사용할 수 있습니다.
 


### PR DESCRIPTION
## 배경

Figma `SEED-Docs`의 Floating Action Button 위치 가이드 이미지가 갱신됐습니다. 배포본 이미지와 현재 Figma 렌더를 픽셀 단위로 전수 비교한 결과, 참조 노드 15개 중 실질 변경은 한 곳입니다.

- `2:132238` — 여백 주석 **16 → 20** (`$dimension.x4` → `$dimension.x5`), 화면 우측 가장자리·하단 고정 요소(홈 인디케이터 / 바텀 내비) 기준 모두
- 나머지 14장은 3~4px 위치 이동·의존 컴포넌트 리프레시 수준으로 의미 변화 없음
- 노드 id는 전부 그대로라 `FigmaImage` id 재매핑은 불필요

## 변경 사항

| 위치 | 변경 |
|---|---|
| 위치 섹션 본문 | 화면 가장자리·하단 고정 요소 기준 **20**의 여백을 명시 |
| `2:132238` alt | "Floating Action Button 위치" → 20 여백을 서술하도록 구체화 |
| `2:132273` alt | "화면 우측 하단에 위치한 예시" → "여러 선택지를 Menu Type으로 제공한 예시" (기존 불일치 정정) |

## ⚠️ 배포 시 필요한 조치

`FigmaImage` 캐시 키가 `nodeId:options`라 **노드 id가 그대로면 머지해도 옛 이미지(16)가 그대로 나갑니다.** 배포 후 해당 노드만 캐시 우회로 한 번 돌려주세요.

```bash
gh workflow run deploy-seed-design-docs-prod-pages.yml --ref dev -f bypass-cache-node-ids=2:132238
```

## 검증

- MDX 컴파일 통과(`@mdx-js/mdx` 3.1.1), prettier 포맷 적용
- 로컬 docs dev 서버는 클론의 네이티브 바이너리 누락(`Cannot find native binding`)으로 홈까지 500이라 라이브 렌더는 확인하지 못했습니다. 본 변경과 무관한 환경 이슈입니다.
- docs-only 변경이라 changeset 불필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 플로팅 액션 버튼의 위치 예시 이미지 설명을 보다 구체적으로 개선했습니다.
  * 메뉴 유형 선택지 예시를 추가했습니다.
  * 화면 가장자리와 하단 고정 요소 사이의 간격을 20으로 명시했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->