### PR TITLE
docs(rootage): describe when to use each neutral stroke token

### DIFF
--- a/packages/css/vars/color/stroke.d.ts
+++ b/packages/css/vars/color/stroke.d.ts
@@ -13,13 +13,13 @@ export declare const informativeSolid = "var(--seed-color-stroke-informative-sol
 export declare const informativeWeak = "var(--seed-color-stroke-informative-weak)";
 /** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (contrast) */
 export declare const neutralContrast = "var(--seed-color-stroke-neutral-contrast)";
-/** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (muted) */
+/** 의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다. */
 export declare const neutralMuted = "var(--seed-color-stroke-neutral-muted)";
 /** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (solid) */
 export declare const neutralSolid = "var(--seed-color-stroke-neutral-solid)";
-/** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (subtle) */
+/** 반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다. */
 export declare const neutralSubtle = "var(--seed-color-stroke-neutral-subtle)";
-/** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (weak) */
+/** 요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다. */
 export declare const neutralWeak = "var(--seed-color-stroke-neutral-weak)";
 /** 성공적인 작업, 확인, 또는 긍정적인 상태를 나타내는 데 사용됩니다. (solid) */
 export declare const positiveSolid = "var(--seed-color-stroke-positive-solid)";

--- a/packages/css/vars/color/stroke.d.ts
+++ b/packages/css/vars/color/stroke.d.ts
@@ -13,13 +13,13 @@ export declare const informativeSolid = "var(--seed-color-stroke-informative-sol
 export declare const informativeWeak = "var(--seed-color-stroke-informative-weak)";
 /** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (contrast) */
 export declare const neutralContrast = "var(--seed-color-stroke-neutral-contrast)";
-/** 의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다. */
+/** 의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다. (muted) */
 export declare const neutralMuted = "var(--seed-color-stroke-neutral-muted)";
 /** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (solid) */
 export declare const neutralSolid = "var(--seed-color-stroke-neutral-solid)";
-/** 반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다. */
+/** 반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다. (subtle) */
 export declare const neutralSubtle = "var(--seed-color-stroke-neutral-subtle)";
-/** 요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다. */
+/** 요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다. (weak) */
 export declare const neutralWeak = "var(--seed-color-stroke-neutral-weak)";
 /** 성공적인 작업, 확인, 또는 긍정적인 상태를 나타내는 데 사용됩니다. (solid) */
 export declare const positiveSolid = "var(--seed-color-stroke-positive-solid)";

--- a/packages/lynx-css/vars/color/stroke.d.ts
+++ b/packages/lynx-css/vars/color/stroke.d.ts
@@ -13,13 +13,13 @@ export declare const informativeSolid = "var(--seed-color-stroke-informative-sol
 export declare const informativeWeak = "var(--seed-color-stroke-informative-weak)";
 /** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (contrast) */
 export declare const neutralContrast = "var(--seed-color-stroke-neutral-contrast)";
-/** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (muted) */
+/** 의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다. */
 export declare const neutralMuted = "var(--seed-color-stroke-neutral-muted)";
 /** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (solid) */
 export declare const neutralSolid = "var(--seed-color-stroke-neutral-solid)";
-/** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (subtle) */
+/** 반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다. */
 export declare const neutralSubtle = "var(--seed-color-stroke-neutral-subtle)";
-/** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (weak) */
+/** 요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다. */
 export declare const neutralWeak = "var(--seed-color-stroke-neutral-weak)";
 /** 성공적인 작업, 확인, 또는 긍정적인 상태를 나타내는 데 사용됩니다. (solid) */
 export declare const positiveSolid = "var(--seed-color-stroke-positive-solid)";

--- a/packages/lynx-css/vars/color/stroke.d.ts
+++ b/packages/lynx-css/vars/color/stroke.d.ts
@@ -13,13 +13,13 @@ export declare const informativeSolid = "var(--seed-color-stroke-informative-sol
 export declare const informativeWeak = "var(--seed-color-stroke-informative-weak)";
 /** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (contrast) */
 export declare const neutralContrast = "var(--seed-color-stroke-neutral-contrast)";
-/** 의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다. */
+/** 의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다. (muted) */
 export declare const neutralMuted = "var(--seed-color-stroke-neutral-muted)";
 /** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (solid) */
 export declare const neutralSolid = "var(--seed-color-stroke-neutral-solid)";
-/** 반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다. */
+/** 반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다. (subtle) */
 export declare const neutralSubtle = "var(--seed-color-stroke-neutral-subtle)";
-/** 요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다. */
+/** 요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다. (weak) */
 export declare const neutralWeak = "var(--seed-color-stroke-neutral-weak)";
 /** 성공적인 작업, 확인, 또는 긍정적인 상태를 나타내는 데 사용됩니다. (solid) */
 export declare const positiveSolid = "var(--seed-color-stroke-positive-solid)";

--- a/packages/lynx-qvism-preset/src/vars/color/stroke.d.ts
+++ b/packages/lynx-qvism-preset/src/vars/color/stroke.d.ts
@@ -13,13 +13,13 @@ export declare const informativeSolid = "var(--seed-color-stroke-informative-sol
 export declare const informativeWeak = "var(--seed-color-stroke-informative-weak)";
 /** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (contrast) */
 export declare const neutralContrast = "var(--seed-color-stroke-neutral-contrast)";
-/** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (muted) */
+/** 의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다. */
 export declare const neutralMuted = "var(--seed-color-stroke-neutral-muted)";
 /** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (solid) */
 export declare const neutralSolid = "var(--seed-color-stroke-neutral-solid)";
-/** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (subtle) */
+/** 반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다. */
 export declare const neutralSubtle = "var(--seed-color-stroke-neutral-subtle)";
-/** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (weak) */
+/** 요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다. */
 export declare const neutralWeak = "var(--seed-color-stroke-neutral-weak)";
 /** 성공적인 작업, 확인, 또는 긍정적인 상태를 나타내는 데 사용됩니다. (solid) */
 export declare const positiveSolid = "var(--seed-color-stroke-positive-solid)";

--- a/packages/lynx-qvism-preset/src/vars/color/stroke.d.ts
+++ b/packages/lynx-qvism-preset/src/vars/color/stroke.d.ts
@@ -13,13 +13,13 @@ export declare const informativeSolid = "var(--seed-color-stroke-informative-sol
 export declare const informativeWeak = "var(--seed-color-stroke-informative-weak)";
 /** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (contrast) */
 export declare const neutralContrast = "var(--seed-color-stroke-neutral-contrast)";
-/** 의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다. */
+/** 의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다. (muted) */
 export declare const neutralMuted = "var(--seed-color-stroke-neutral-muted)";
 /** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (solid) */
 export declare const neutralSolid = "var(--seed-color-stroke-neutral-solid)";
-/** 반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다. */
+/** 반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다. (subtle) */
 export declare const neutralSubtle = "var(--seed-color-stroke-neutral-subtle)";
-/** 요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다. */
+/** 요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다. (weak) */
 export declare const neutralWeak = "var(--seed-color-stroke-neutral-weak)";
 /** 성공적인 작업, 확인, 또는 긍정적인 상태를 나타내는 데 사용됩니다. (solid) */
 export declare const positiveSolid = "var(--seed-color-stroke-positive-solid)";

--- a/packages/qvism-preset/src/vars/color/stroke.d.ts
+++ b/packages/qvism-preset/src/vars/color/stroke.d.ts
@@ -13,13 +13,13 @@ export declare const informativeSolid = "var(--seed-color-stroke-informative-sol
 export declare const informativeWeak = "var(--seed-color-stroke-informative-weak)";
 /** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (contrast) */
 export declare const neutralContrast = "var(--seed-color-stroke-neutral-contrast)";
-/** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (muted) */
+/** 의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다. */
 export declare const neutralMuted = "var(--seed-color-stroke-neutral-muted)";
 /** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (solid) */
 export declare const neutralSolid = "var(--seed-color-stroke-neutral-solid)";
-/** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (subtle) */
+/** 반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다. */
 export declare const neutralSubtle = "var(--seed-color-stroke-neutral-subtle)";
-/** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (weak) */
+/** 요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다. */
 export declare const neutralWeak = "var(--seed-color-stroke-neutral-weak)";
 /** 성공적인 작업, 확인, 또는 긍정적인 상태를 나타내는 데 사용됩니다. (solid) */
 export declare const positiveSolid = "var(--seed-color-stroke-positive-solid)";

--- a/packages/qvism-preset/src/vars/color/stroke.d.ts
+++ b/packages/qvism-preset/src/vars/color/stroke.d.ts
@@ -13,13 +13,13 @@ export declare const informativeSolid = "var(--seed-color-stroke-informative-sol
 export declare const informativeWeak = "var(--seed-color-stroke-informative-weak)";
 /** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (contrast) */
 export declare const neutralContrast = "var(--seed-color-stroke-neutral-contrast)";
-/** 의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다. */
+/** 의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다. (muted) */
 export declare const neutralMuted = "var(--seed-color-stroke-neutral-muted)";
 /** 일반적인 콘텐츠에 사용되는 기본 색상입니다. (solid) */
 export declare const neutralSolid = "var(--seed-color-stroke-neutral-solid)";
-/** 반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다. */
+/** 반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다. (subtle) */
 export declare const neutralSubtle = "var(--seed-color-stroke-neutral-subtle)";
-/** 요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다. */
+/** 요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다. (weak) */
 export declare const neutralWeak = "var(--seed-color-stroke-neutral-weak)";
 /** 성공적인 작업, 확인, 또는 긍정적인 상태를 나타내는 데 사용됩니다. (solid) */
 export declare const positiveSolid = "var(--seed-color-stroke-positive-solid)";

--- a/packages/rootage/__generated__/color.d.ts
+++ b/packages/rootage/__generated__/color.d.ts
@@ -1981,7 +1981,7 @@ declare const artifact: {
             "value": "$color.palette.static-white-alpha-100";
           };
         };
-        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (muted)";
+        "description": "의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다.";
       };
       "$color.stroke.neutral-solid": {
         "values": {
@@ -2007,7 +2007,7 @@ declare const artifact: {
             "value": "$color.palette.static-white-alpha-50";
           };
         };
-        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (subtle)";
+        "description": "반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다.";
       };
       "$color.stroke.neutral-weak": {
         "values": {
@@ -2020,7 +2020,7 @@ declare const artifact: {
             "value": "$color.palette.gray-400";
           };
         };
-        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (weak)";
+        "description": "요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다.";
       };
       "$color.stroke.positive-solid": {
         "values": {

--- a/packages/rootage/__generated__/color.d.ts
+++ b/packages/rootage/__generated__/color.d.ts
@@ -1981,7 +1981,7 @@ declare const artifact: {
             "value": "$color.palette.static-white-alpha-100";
           };
         };
-        "description": "의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다.";
+        "description": "의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다. (muted)";
       };
       "$color.stroke.neutral-solid": {
         "values": {
@@ -2007,7 +2007,7 @@ declare const artifact: {
             "value": "$color.palette.static-white-alpha-50";
           };
         };
-        "description": "반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다.";
+        "description": "반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다. (subtle)";
       };
       "$color.stroke.neutral-weak": {
         "values": {
@@ -2020,7 +2020,7 @@ declare const artifact: {
             "value": "$color.palette.gray-400";
           };
         };
-        "description": "요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다.";
+        "description": "요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다. (weak)";
       };
       "$color.stroke.positive-solid": {
         "values": {

--- a/packages/rootage/__generated__/color.json
+++ b/packages/rootage/__generated__/color.json
@@ -1981,7 +1981,7 @@
             "value": "$color.palette.static-white-alpha-100"
           }
         },
-        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (muted)"
+        "description": "의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다."
       },
       "$color.stroke.neutral-solid": {
         "values": {
@@ -2007,7 +2007,7 @@
             "value": "$color.palette.static-white-alpha-50"
           }
         },
-        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (subtle)"
+        "description": "반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다."
       },
       "$color.stroke.neutral-weak": {
         "values": {
@@ -2020,7 +2020,7 @@
             "value": "$color.palette.gray-400"
           }
         },
-        "description": "일반적인 콘텐츠에 사용되는 기본 색상입니다. (weak)"
+        "description": "요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다."
       },
       "$color.stroke.positive-solid": {
         "values": {

--- a/packages/rootage/__generated__/color.json
+++ b/packages/rootage/__generated__/color.json
@@ -1981,7 +1981,7 @@
             "value": "$color.palette.static-white-alpha-100"
           }
         },
-        "description": "의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다."
+        "description": "의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다. (muted)"
       },
       "$color.stroke.neutral-solid": {
         "values": {
@@ -2007,7 +2007,7 @@
             "value": "$color.palette.static-white-alpha-50"
           }
         },
-        "description": "반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다."
+        "description": "반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다. (subtle)"
       },
       "$color.stroke.neutral-weak": {
         "values": {
@@ -2020,7 +2020,7 @@
             "value": "$color.palette.gray-400"
           }
         },
-        "description": "요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다."
+        "description": "요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다. (weak)"
       },
       "$color.stroke.positive-solid": {
         "values": {

--- a/packages/rootage/color.yaml
+++ b/packages/rootage/color.yaml
@@ -709,7 +709,7 @@ data:
         theme-light: $color.palette.gray-1000
         theme-dark: $color.palette.gray-1000
     $color.stroke.neutral-muted:
-      description: 일반적인 콘텐츠에 사용되는 기본 색상입니다. (muted)
+      description: 의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다.
       values:
         theme-light: $color.palette.static-black-alpha-300
         theme-dark: $color.palette.static-white-alpha-100
@@ -719,12 +719,12 @@ data:
         theme-light: $color.palette.gray-800
         theme-dark: $color.palette.gray-800
     $color.stroke.neutral-subtle:
-      description: 일반적인 콘텐츠에 사용되는 기본 색상입니다. (subtle)
+      description: 반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다.
       values:
         theme-light: $color.palette.static-black-alpha-200
         theme-dark: $color.palette.static-white-alpha-50
     $color.stroke.neutral-weak:
-      description: 일반적인 콘텐츠에 사용되는 기본 색상입니다. (weak)
+      description: 요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다.
       values:
         theme-light: $color.palette.gray-400
         theme-dark: $color.palette.gray-400

--- a/packages/rootage/color.yaml
+++ b/packages/rootage/color.yaml
@@ -709,7 +709,7 @@ data:
         theme-light: $color.palette.gray-1000
         theme-dark: $color.palette.gray-1000
     $color.stroke.neutral-muted:
-      description: 의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다.
+      description: 의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다. (muted)
       values:
         theme-light: $color.palette.static-black-alpha-300
         theme-dark: $color.palette.static-white-alpha-100
@@ -719,12 +719,12 @@ data:
         theme-light: $color.palette.gray-800
         theme-dark: $color.palette.gray-800
     $color.stroke.neutral-subtle:
-      description: 반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다.
+      description: 반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다. (subtle)
       values:
         theme-light: $color.palette.static-black-alpha-200
         theme-dark: $color.palette.static-white-alpha-50
     $color.stroke.neutral-weak:
-      description: 요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다.
+      description: 요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다. (weak)
       values:
         theme-light: $color.palette.gray-400
         theme-dark: $color.palette.gray-400


### PR DESCRIPTION
## Summary

`$color.stroke.neutral-weak`, `-subtle`, and `-muted` all carried the same generic description — `일반적인 콘텐츠에 사용되는 기본 색상입니다.` — separated only by a `(weak)` / `(subtle)` / `(muted)` suffix. That told you nothing about which of the three to reach for.

This replaces the shared sentence with usage-oriented descriptions, written by the design team and matched to the tone of the surrounding tokens. The variant suffix stays at the end, following the convention of the sibling stroke tokens.

| Token | Description |
| --- | --- |
| `$color.stroke.neutral-weak` | 요소의 외곽을 그려 형태를 만드는 선입니다. 카드, 인풋 필드, 아웃라인 버튼처럼 선 자체가 요소의 경계를 정의할 때 사용됩니다. (weak) |
| `$color.stroke.neutral-subtle` | 반복되는 동일한 성격의 항목 사이를 나누는 선입니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용됩니다. (subtle) |
| `$color.stroke.neutral-muted` | 의미 단위가 바뀌는 경계를 나누는 선입니다. 섹션과 섹션 사이, 콘텐츠와 액션 영역 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용됩니다. (muted) |

## Scope

Descriptions only — no token values change. `packages/rootage/color.yaml` is the source edit; the generated `.d.ts` / `.json` artifacts are the output of `bun rootage:generate`.

These descriptions surface on the docs token reference page (`docs/app/foundations/design-token/reference/[id]`, which reads the authoring YAML at build time) and in the JSDoc of the published `vars/color/stroke.d.ts`.

No changeset, following the precedent of 5d809c1 (`feat: add some documented descriptions to rootage`).

## Test plan

- [x] `bun rootage:generate`
- [x] `bun rootage:test` — validation passed, 111 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * 스트로크 색상 토큰 3개의 설명을 실제 사용 목적에 맞게 명확히 개선했습니다.
  * 섹션·콘텐츠 영역 구분, 목록·테이블 항목 구분, 카드·입력 필드·버튼 외곽선 등 각 토큰의 용도가 더욱 분명해졌습니다.
  * 색상 값과 기능에는 변경이 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->