### PR TITLE
ci: support Lynx peer dependency bumps

### DIFF
--- a/.github/scripts/bump-peer-deps.test.ts
+++ b/.github/scripts/bump-peer-deps.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import {
   compareStableVersions,
   parseStableVersion,
+  synchronizeLynxPeerDependencyText,
   synchronizePeerDependencyText,
 } from "./bump-peer-deps";
 
@@ -25,6 +26,25 @@ function createFixture(peerRange = "^2.4.0") {
       2,
     )}\n`,
     lockfile: `{\n  "lockfileVersion": 1,\n  "workspaces": {\n    "packages/lynx-react": {\n      "peerDependencies": {\n        "@seed-design/lynx-css": "0.0.0 || >=0.1.0 <1.0.0",\n      },\n    },\n    "packages/react": {\n      "dependencies": {},\n      "peerDependencies": {\n        "@seed-design/css": "${peerRange}",\n        "react": ">=18.0.0",\n      },\n    },\n    "packages/react-headless/accordion": {\n      "peerDependencies": {\n        "react": ">=18.0.0",\n      },\n    },\n  },\n}\n`,
+  };
+}
+
+function createLynxFixture(peerRange = "0.0.0 || >=0.1.0 <1.0.0", version = "0.8.0") {
+  return {
+    lynxCssManifest: `${JSON.stringify({ name: "@seed-design/lynx-css", version }, null, 2)}\n`,
+    lynxReactManifest: `${JSON.stringify(
+      {
+        name: "@seed-design/lynx-react",
+        version: "0.4.0",
+        peerDependencies: {
+          "@lynx-js/react": ">=0.117.0",
+          "@seed-design/lynx-css": peerRange,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    lockfile: `{\n  "lockfileVersion": 1,\n  "workspaces": {\n    "packages/lynx-react": {\n      "peerDependencies": {\n        "@lynx-js/react": ">=0.117.0",\n        "@seed-design/lynx-css": "${peerRange}",\n      },\n    },\n    "packages/react": {\n      "peerDependencies": {\n        "@seed-design/css": "^2.5.0",\n      },\n    },\n  },\n}\n`,
   };
 }
 
@@ -80,6 +100,72 @@ describe("peer dependency 동기화", () => {
   });
 });
 
+describe("Lynx peer dependency 동기화", () => {
+  test("Lynx CSS 버전에 맞춰 범위의 마이너 하한만 갱신한다", () => {
+    const fixture = createLynxFixture();
+    const result = synchronizeLynxPeerDependencyText(fixture);
+    const desiredRange = "0.0.0 || >=0.8.0 <1.0.0";
+
+    expect(result).toMatchObject({
+      changed: true,
+      cssVersion: "0.8.0",
+      previousRange: "0.0.0 || >=0.1.0 <1.0.0",
+      desiredRange,
+    });
+    expect(result.reactManifest).toBe(
+      fixture.lynxReactManifest.replace("0.0.0 || >=0.1.0 <1.0.0", desiredRange),
+    );
+    expect(result.lockfile).toBe(fixture.lockfile.replace("0.0.0 || >=0.1.0 <1.0.0", desiredRange));
+  });
+
+  test("patch 버전은 peer 범위에 반영하지 않는다", () => {
+    const fixture = createLynxFixture("0.0.0 || >=0.7.0 <1.0.0", "0.8.3");
+    const result = synchronizeLynxPeerDependencyText(fixture);
+
+    expect(result.desiredRange).toBe("0.0.0 || >=0.8.0 <1.0.0");
+  });
+
+  test("이미 같은 마이너 범위이면 변경하지 않는다", () => {
+    const fixture = createLynxFixture("0.0.0 || >=0.8.0 <1.0.0", "0.8.3");
+    const result = synchronizeLynxPeerDependencyText(fixture);
+
+    expect(result.changed).toBe(false);
+    expect(result.reactManifest).toBe(fixture.lynxReactManifest);
+    expect(result.lockfile).toBe(fixture.lockfile);
+  });
+
+  test("지원하는 Lynx 범위 형식이 아니면 실패한다", () => {
+    expect(() => synchronizeLynxPeerDependencyText(createLynxFixture("^0.8.0"))).toThrow(
+      "peerDependency 범위가 올바르지 않습니다",
+    );
+  });
+
+  test("Lynx CSS 1.0.0 이상은 실패한다", () => {
+    expect(() => synchronizeLynxPeerDependencyText(createLynxFixture(undefined, "1.0.0"))).toThrow(
+      "major가 0이 아닙니다",
+    );
+  });
+
+  test("CSS와 Lynx CSS 범위를 같은 lockfile에 함께 반영한다", () => {
+    const reactFixture = createFixture();
+    const lynxFixture = createLynxFixture();
+    const reactResult = synchronizePeerDependencyText(reactFixture);
+    const lynxResult = synchronizeLynxPeerDependencyText({
+      ...lynxFixture,
+      lockfile: reactResult.lockfile,
+    });
+
+    expect(lynxResult.lockfile).toBe(
+      reactFixture.lockfile
+        .replace('"@seed-design/css": "^2.4.0"', '"@seed-design/css": "^2.5.0"')
+        .replace(
+          '"@seed-design/lynx-css": "0.0.0 || >=0.1.0 <1.0.0"',
+          '"@seed-design/lynx-css": "0.0.0 || >=0.8.0 <1.0.0"',
+        ),
+    );
+  });
+});
+
 describe("bump peer dependencies workflow", () => {
   test("신뢰된 버전 PR에서만 최소 권한으로 동기화한다", async () => {
     const workflow = await Bun.file(
@@ -108,6 +194,9 @@ describe("bump peer dependencies workflow", () => {
     expect(workflow).toContain("Bind automation to trusted dev history");
     expect(workflow).toContain("git merge-base --is-ancestor");
     expect(workflow).toContain("bun ../control/.github/scripts/bump-peer-deps.ts");
+    expect(workflow).toContain("steps.sync.outputs.react-changed");
+    expect(workflow).toContain("steps.sync.outputs.lynx-react-changed");
+    expect(workflow).toContain("packages/lynx-react/package.json");
     expect(workflow).toContain(`git push origin "HEAD:${["$", "{HEAD_REF}"].join("")}"`);
   });
 });

--- a/.github/scripts/bump-peer-deps.ts
+++ b/.github/scripts/bump-peer-deps.ts
@@ -5,10 +5,14 @@ import { parseArgs } from "node:util";
 const CSS_PACKAGE = "@seed-design/css";
 const CSS_MANIFEST_PATH = "packages/css/package.json";
 const REACT_MANIFEST_PATH = "packages/react/package.json";
+const LYNX_CSS_PACKAGE = "@seed-design/lynx-css";
+const LYNX_CSS_MANIFEST_PATH = "packages/lynx-css/package.json";
+const LYNX_REACT_MANIFEST_PATH = "packages/lynx-react/package.json";
 const LOCKFILE_PATH = "bun.lock";
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
 const STABLE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const CARET_STABLE_RANGE_PATTERN = /^\^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const LYNX_RANGE_PATTERN = /^0\.0\.0 \|\| >=0\.(0|[1-9]\d*)\.0 <1\.0\.0$/;
 
 type JsonRecord = Record<string, unknown>;
 
@@ -19,6 +23,12 @@ interface SyncResult {
   desiredRange: string;
   reactManifest: string;
   lockfile: string;
+}
+
+interface WorkflowResult {
+  changed: boolean;
+  reactChanged: boolean;
+  lynxReactChanged: boolean;
 }
 
 function isRecord(value: unknown): value is JsonRecord {
@@ -80,6 +90,7 @@ function findWorkspaceBlock(lockfile: string, workspacePath: string): [number, n
 function updateLockfilePeerRange(
   lockfile: string,
   workspacePath: string,
+  dependencyName: string,
   currentRange: string,
   desiredRange: string,
 ): string {
@@ -97,13 +108,13 @@ function updateLockfilePeerRange(
   }
 
   const peerDependencies = workspace.slice(peerDependenciesStart, peerDependenciesEnd);
-  const currentEntry = `        "${CSS_PACKAGE}": "${currentRange}",`;
-  const desiredEntry = `        "${CSS_PACKAGE}": "${desiredRange}",`;
+  const currentEntry = `        "${dependencyName}": "${currentRange}",`;
+  const desiredEntry = `        "${dependencyName}": "${desiredRange}",`;
   const entryCount = peerDependencies.split(currentEntry).length - 1;
 
   if (entryCount !== 1) {
     throw new Error(
-      `bun.lock의 ${workspacePath} peerDependencies에서 ${CSS_PACKAGE}@${currentRange} 항목을 정확히 하나 찾지 못했습니다.`,
+      `bun.lock의 ${workspacePath} peerDependencies에서 ${dependencyName}@${currentRange} 항목을 정확히 하나 찾지 못했습니다.`,
     );
   }
 
@@ -146,6 +157,7 @@ export function synchronizePeerDependencyText(input: {
   const nextLockfile = updateLockfilePeerRange(
     input.lockfile,
     REACT_MANIFEST_PATH.replace("/package.json", ""),
+    CSS_PACKAGE,
     previousRange,
     desiredRange,
   );
@@ -179,6 +191,76 @@ export function synchronizePeerDependencyText(input: {
   };
 }
 
+export function synchronizeLynxPeerDependencyText(input: {
+  lynxCssManifest: string;
+  lynxReactManifest: string;
+  lockfile: string;
+}): SyncResult {
+  const lynxCssManifest = readManifest(input.lynxCssManifest, LYNX_CSS_MANIFEST_PATH);
+  const lynxReactManifest = readManifest(input.lynxReactManifest, LYNX_REACT_MANIFEST_PATH);
+  const lynxCssVersion = lynxCssManifest.version;
+
+  if (typeof lynxCssVersion !== "string") {
+    throw new Error(`${LYNX_CSS_MANIFEST_PATH}에 문자열 version이 없습니다.`);
+  }
+
+  const [major, minor] = parseStableVersion(lynxCssVersion);
+  if (major !== 0) {
+    throw new Error(`${LYNX_CSS_PACKAGE} 버전의 major가 0이 아닙니다: ${lynxCssVersion}`);
+  }
+
+  if (!isRecord(lynxReactManifest.peerDependencies)) {
+    throw new Error(`${LYNX_REACT_MANIFEST_PATH}에 peerDependencies가 없습니다.`);
+  }
+
+  const previousRange = lynxReactManifest.peerDependencies[LYNX_CSS_PACKAGE];
+  if (typeof previousRange !== "string") {
+    throw new Error(`${LYNX_REACT_MANIFEST_PATH}에 ${LYNX_CSS_PACKAGE} peerDependency가 없습니다.`);
+  }
+  if (!LYNX_RANGE_PATTERN.test(previousRange)) {
+    throw new Error(
+      `${LYNX_CSS_PACKAGE} peerDependency 범위가 올바르지 않습니다: ${previousRange}`,
+    );
+  }
+
+  const desiredRange = `0.0.0 || >=0.${minor}.0 <1.0.0`;
+  const nextLockfile = updateLockfilePeerRange(
+    input.lockfile,
+    LYNX_REACT_MANIFEST_PATH.replace("/package.json", ""),
+    LYNX_CSS_PACKAGE,
+    previousRange,
+    desiredRange,
+  );
+
+  if (previousRange === desiredRange) {
+    return {
+      changed: false,
+      cssVersion: lynxCssVersion,
+      previousRange,
+      desiredRange,
+      reactManifest: input.lynxReactManifest,
+      lockfile: input.lockfile,
+    };
+  }
+
+  const nextLynxReactManifest = {
+    ...lynxReactManifest,
+    peerDependencies: {
+      ...lynxReactManifest.peerDependencies,
+      [LYNX_CSS_PACKAGE]: desiredRange,
+    },
+  };
+
+  return {
+    changed: true,
+    cssVersion: lynxCssVersion,
+    previousRange,
+    desiredRange,
+    reactManifest: `${JSON.stringify(nextLynxReactManifest, null, 2)}\n`,
+    lockfile: nextLockfile,
+  };
+}
+
 async function runGit(root: string, args: string[]): Promise<string> {
   const process = Bun.spawn(["git", "-C", root, ...args], {
     stdout: "pipe",
@@ -197,12 +279,11 @@ async function runGit(root: string, args: string[]): Promise<string> {
   return stdout;
 }
 
-async function writeOutputs(result: SyncResult): Promise<void> {
+async function writeOutputs(result: WorkflowResult): Promise<void> {
   const output = [
     `changed=${result.changed}`,
-    `css-version=${result.cssVersion}`,
-    `previous-range=${result.previousRange}`,
-    `desired-range=${result.desiredRange}`,
+    `react-changed=${result.reactChanged}`,
+    `lynx-react-changed=${result.lynxReactChanged}`,
     "",
   ].join("\n");
   const githubOutput = process.env.GITHUB_OUTPUT;
@@ -244,7 +325,7 @@ async function main(): Promise<void> {
     throw new Error("PR base와 head의 공통 조상을 찾지 못했습니다.");
   }
 
-  const changedCssFiles = (
+  const changedDependencyManifests = (
     await runGit(root, [
       "diff",
       "--name-only",
@@ -253,47 +334,92 @@ async function main(): Promise<void> {
       sourceSha,
       "--",
       CSS_MANIFEST_PATH,
+      LYNX_CSS_MANIFEST_PATH,
     ])
   )
     .split("\n")
     .filter(Boolean);
 
-  if (changedCssFiles.length !== 1 || changedCssFiles[0] !== CSS_MANIFEST_PATH) {
-    throw new Error(`${CSS_MANIFEST_PATH} 버전 변경이 포함된 PR에서만 실행할 수 있습니다.`);
-  }
-
-  const baseCssManifest = readManifest(
-    await runGit(root, ["show", `${mergeBaseSha}:${CSS_MANIFEST_PATH}`]),
-    `${mergeBaseSha}:${CSS_MANIFEST_PATH}`,
-  );
-  const baseCssVersion = baseCssManifest.version;
-  if (typeof baseCssVersion !== "string") {
-    throw new Error(`base의 ${CSS_MANIFEST_PATH}에 문자열 version이 없습니다.`);
+  if (changedDependencyManifests.length === 0) {
+    throw new Error(
+      `${CSS_MANIFEST_PATH} 또는 ${LYNX_CSS_MANIFEST_PATH} 버전 변경이 포함된 PR에서만 실행할 수 있습니다.`,
+    );
   }
 
   const cssManifestPath = resolve(root, CSS_MANIFEST_PATH);
   const reactManifestPath = resolve(root, REACT_MANIFEST_PATH);
+  const lynxCssManifestPath = resolve(root, LYNX_CSS_MANIFEST_PATH);
+  const lynxReactManifestPath = resolve(root, LYNX_REACT_MANIFEST_PATH);
   const lockfilePath = resolve(root, LOCKFILE_PATH);
-  const result = synchronizePeerDependencyText({
-    cssManifest: await Bun.file(cssManifestPath).text(),
-    reactManifest: await Bun.file(reactManifestPath).text(),
-    lockfile: await Bun.file(lockfilePath).text(),
-  });
+  let lockfile = await Bun.file(lockfilePath).text();
+  let nextReactManifest: string | undefined;
+  let nextLynxReactManifest: string | undefined;
+  let reactChanged = false;
+  let lynxReactChanged = false;
 
-  if (compareStableVersions(result.cssVersion, baseCssVersion) <= 0) {
-    throw new Error(
-      `${CSS_PACKAGE} 버전이 올라가지 않았습니다: ${baseCssVersion} -> ${result.cssVersion}`,
+  if (changedDependencyManifests.includes(CSS_MANIFEST_PATH)) {
+    const baseManifest = readManifest(
+      await runGit(root, ["show", `${mergeBaseSha}:${CSS_MANIFEST_PATH}`]),
+      `${mergeBaseSha}:${CSS_MANIFEST_PATH}`,
     );
+    const baseVersion = baseManifest.version;
+    const result = synchronizePeerDependencyText({
+      cssManifest: await Bun.file(cssManifestPath).text(),
+      reactManifest: await Bun.file(reactManifestPath).text(),
+      lockfile,
+    });
+
+    if (typeof baseVersion !== "string") {
+      throw new Error(`base의 ${CSS_MANIFEST_PATH}에 문자열 version이 없습니다.`);
+    }
+    if (compareStableVersions(result.cssVersion, baseVersion) <= 0) {
+      throw new Error(
+        `${CSS_PACKAGE} 버전이 올라가지 않았습니다: ${baseVersion} -> ${result.cssVersion}`,
+      );
+    }
+
+    reactChanged = result.changed;
+    lockfile = result.lockfile;
+    if (result.changed) nextReactManifest = result.reactManifest;
   }
 
-  if (result.changed) {
-    await Promise.all([
-      Bun.write(reactManifestPath, result.reactManifest),
-      Bun.write(lockfilePath, result.lockfile),
-    ]);
+  if (changedDependencyManifests.includes(LYNX_CSS_MANIFEST_PATH)) {
+    const baseManifest = readManifest(
+      await runGit(root, ["show", `${mergeBaseSha}:${LYNX_CSS_MANIFEST_PATH}`]),
+      `${mergeBaseSha}:${LYNX_CSS_MANIFEST_PATH}`,
+    );
+    const baseVersion = baseManifest.version;
+    const result = synchronizeLynxPeerDependencyText({
+      lynxCssManifest: await Bun.file(lynxCssManifestPath).text(),
+      lynxReactManifest: await Bun.file(lynxReactManifestPath).text(),
+      lockfile,
+    });
+
+    if (typeof baseVersion !== "string") {
+      throw new Error(`base의 ${LYNX_CSS_MANIFEST_PATH}에 문자열 version이 없습니다.`);
+    }
+    if (compareStableVersions(result.cssVersion, baseVersion) <= 0) {
+      throw new Error(
+        `${LYNX_CSS_PACKAGE} 버전이 올라가지 않았습니다: ${baseVersion} -> ${result.cssVersion}`,
+      );
+    }
+
+    lynxReactChanged = result.changed;
+    lockfile = result.lockfile;
+    if (result.changed) nextLynxReactManifest = result.reactManifest;
   }
 
-  await writeOutputs(result);
+  const changed = reactChanged || lynxReactChanged;
+  if (changed) {
+    const writes = [Bun.write(lockfilePath, lockfile)];
+    if (nextReactManifest) writes.push(Bun.write(reactManifestPath, nextReactManifest));
+    if (nextLynxReactManifest) {
+      writes.push(Bun.write(lynxReactManifestPath, nextLynxReactManifest));
+    }
+    await Promise.all(writes);
+  }
+
+  await writeOutputs({ changed, reactChanged, lynxReactChanged });
 }
 
 if (import.meta.main) {

--- a/.github/workflows/bump-peer-deps.yml
+++ b/.github/workflows/bump-peer-deps.yml
@@ -113,7 +113,7 @@ jobs:
         with:
           bun-version: "1.3.13"
 
-      - name: Align React's CSS peer dependency
+      - name: Align CSS peer dependencies
         id: sync
         working-directory: source
         env:
@@ -130,25 +130,47 @@ jobs:
         working-directory: source
         env:
           HEAD_REF: ${{ steps.pull.outputs.head-ref }}
+          REACT_CHANGED: ${{ steps.sync.outputs.react-changed }}
+          LYNX_REACT_CHANGED: ${{ steps.sync.outputs.lynx-react-changed }}
         run: |
           git diff --check
 
-          UNEXPECTED_FILES="$(git status --porcelain | awk '{print $2}' | grep -vE '^(bun.lock|packages/react/package.json)$' || true)"
+          UNEXPECTED_FILES="$(git status --porcelain | awk '{print $2}' | grep -vE '^(bun.lock|packages/react/package.json|packages/lynx-react/package.json)$' || true)"
           if [ -n "$UNEXPECTED_FILES" ]; then
             echo "예상하지 않은 파일이 변경되었습니다:"
             echo "$UNEXPECTED_FILES"
             exit 1
           fi
 
-          if git diff --quiet -- bun.lock || git diff --quiet -- packages/react/package.json; then
-            echo "bun.lock과 packages/react/package.json이 모두 변경되어야 합니다."
+          if git diff --quiet -- bun.lock; then
+            echo "bun.lock이 변경되어야 합니다."
+            exit 1
+          fi
+
+          CHANGED_MANIFESTS=()
+          if [ "$REACT_CHANGED" = "true" ]; then
+            if git diff --quiet -- packages/react/package.json; then
+              echo "packages/react/package.json이 변경되어야 합니다."
+              exit 1
+            fi
+            CHANGED_MANIFESTS+=(packages/react/package.json)
+          fi
+          if [ "$LYNX_REACT_CHANGED" = "true" ]; then
+            if git diff --quiet -- packages/lynx-react/package.json; then
+              echo "packages/lynx-react/package.json이 변경되어야 합니다."
+              exit 1
+            fi
+            CHANGED_MANIFESTS+=(packages/lynx-react/package.json)
+          fi
+          if [ "${#CHANGED_MANIFESTS[@]}" -eq 0 ]; then
+            echo "변경할 peer dependency manifest가 없습니다."
             exit 1
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add bun.lock packages/react/package.json
-          git commit -m "chore(react): bump @seed-design/css peer dependency"
+          git add bun.lock "${CHANGED_MANIFESTS[@]}"
+          git commit -m "chore: bump peer dependencies"
           git push origin "HEAD:${HEAD_REF}"
 
       - name: Mark command success


### PR DESCRIPTION
## 변경 내용

- `/bump-peer-deps`가 `lynx-css` 버전 변경도 감지하도록 확장했습니다.
- `lynx-react`의 `@seed-design/lynx-css` peer dependency를 `0.0.0 || >=0.{minor}.0 <1.0.0` 형식으로 갱신합니다.
- `css`와 `lynx-css`가 함께 변경되는 경우 두 소비 패키지와 `bun.lock`을 한 번에 반영합니다.
- 실제로 변경된 manifest만 검증하고 커밋하도록 워크플로를 조정했습니다.

## 검증

- `bun test ./.github/scripts/bump-peer-deps.test.ts`
- `bun generate:all`
- `bun test:all`
- 워크플로 YAML 및 셸 문법 검사

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - CSS와 Lynx CSS 패키지의 peer dependency 버전을 자동으로 동기화합니다.
  - React 및 Lynx React 패키지의 버전 변경을 각각 감지하고 관련 파일만 갱신합니다.

- **버그 수정**
  - 잘못된 버전 범위와 major 버전 오류를 검증해 부적절한 업데이트를 방지합니다.
  - 변경 사항이 없거나 패치 버전만 변경된 경우 불필요한 파일 수정을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->