### PR TITLE
docs(divider): clarify when to use each tone

### DIFF
--- a/docs/content/components/divider.mdx
+++ b/docs/content/components/divider.mdx
@@ -23,8 +23,10 @@ coverImage: /og/components/divider
   alt="Divider의 Tone Property - Neutral Muted, Neutral Subtle"
 />
 
-- **Neutral Muted**: 의미 단위가 바뀌는 경계를 나눠요. 섹션과 섹션 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 써요.
-- **Neutral Subtle**: 반복되는 동일 성격 항목 사이를 나눠요. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 써요.
+- **Neutral Muted**: 의미 단위가 바뀌는 경계를 나눕니다. 섹션과 섹션 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 사용합니다.
+- **Neutral Subtle**: 반복되는 동일 성격 항목 사이를 나눕니다. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 사용합니다.
+
+필요에 따라 다른 stroke 토큰을 넣어 사용할 수 있습니다.
 
 ### Orientation Property
 

--- a/docs/content/components/divider.mdx
+++ b/docs/content/components/divider.mdx
@@ -23,7 +23,8 @@ coverImage: /og/components/divider
   alt="Divider의 Tone Property - Neutral Muted, Neutral Subtle"
 />
 
-일반적인 상황에서 사용하는 Neutral Muted, 약한 구분을 위해 사용하는 Neutral Subtle 톤이 있으며, 필요에 따라 다른 stroke 토큰을 넣어 사용할 수 있습니다.
+- **Neutral Muted**: 의미 단위가 바뀌는 경계를 나눠요. 섹션과 섹션 사이, 헤더와 본문 경계처럼 한 화면에 한두 번만 등장하는 구분에 써요.
+- **Neutral Subtle**: 반복되는 동일 성격 항목 사이를 나눠요. 리스트 아이템, 테이블 row, 설정 메뉴 항목처럼 한 화면에 여러 번 등장하는 구분에 써요.
 
 ### Orientation Property
 


### PR DESCRIPTION
## Summary

Divider 문서의 Tone 섹션 설명을 톤별 사용 기준으로 다시 씁니다.

기존에는 "일반적인 상황 / 약한 구분"이라는 상대적인 강도 표현만 있어서 어떤 상황에 어떤 톤을 골라야 하는지 판단하기 어려웠습니다. 경계의 성격(의미 단위 vs 반복 항목)과 한 화면에 등장하는 빈도를 기준으로 바꿨습니다.

- **Neutral Muted**: 의미 단위가 바뀌는 경계 — 섹션 사이, 헤더/본문 경계 등 한 화면에 한두 번
- **Neutral Subtle**: 반복되는 동일 성격 항목 사이 — 리스트 아이템, 테이블 row, 설정 메뉴 항목 등 한 화면에 여러 번

## Test plan

- `bun docs:test` — 97 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * Divider의 `Tone` 속성 문서를 업데이트했습니다.
  * `Neutral Muted` 및 `Neutral Subtle` 톤 설명을 존댓말 문체로 다듬고, 각 톤의 사용 상황을 구체적으로 안내했습니다.
  * 필요에 따라 다른 스트로크 토큰을 사용할 수 있다는 안내를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->