### PR TITLE
chore(config): separate Karrot icon dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,11 +19,14 @@
     },
     {
       "matchPackageNames": [
+        "@karrotmarket/icon-data",
+        "@karrotmarket/lynx-monochrome-icon",
+        "@karrotmarket/lynx-multicolor-icon",
         "@karrotmarket/react-monochrome-icon",
-        "@karrotmarket/react-multicolor-icon",
-        "@karrotmarket/icon-data"
+        "@karrotmarket/react-multicolor-icon"
       ],
       "groupName": "karrot-icon-updates",
+      "groupSlug": "karrot-icon-updates",
       "allowedVersions": "*"
     },
     {


### PR DESCRIPTION
## 배경

전체 non-major 업데이트에 적용되는 `groupSlug`가 `all-minor-patch`인 상태에서, 기존 Karrot 아이콘 규칙은 `groupName`만 덮어쓰고 Lynx 아이콘 패키지 2종을 포함하지 않았습니다.

그 결과 #1247을 닫은 뒤 재생성된 #2061에도 Lynx 아이콘 업데이트가 전체 non-major 그룹으로 다시 들어갔습니다.

## 변경 사항

- Karrot 아이콘 그룹에 React·Lynx·icon-data 직접 의존성 5종을 명시합니다.
- `groupSlug`를 `karrot-icon-updates`로 고정해 `all-minor-patch` 브랜치와 분리합니다.

## 기대 결과

- 업데이트가 필요한 Karrot 아이콘 패키지는 `renovate/karrot-icon-updates` 브랜치와 PR로 생성됩니다.
- 전체 non-major PR에는 해당 아이콘 패키지가 포함되지 않습니다.

## 검증

- `bunx --package renovate@latest renovate-config-validator --no-global renovate.json`
- `bun generate:all`
- `bun packages:build`
- `bun test:all`
- `git diff --check`

모든 검증을 통과했고, 생성·빌드 과정에서 추가 tracked diff가 생기지 않았습니다. Validator가 기존 `baseBranches`를 `baseBranchPatterns`로 마이그레이션하도록 안내하지만 이번 변경 범위와 무관해 포함하지 않았습니다.

## 후속 작업

이 PR을 `dev`에 병합한 뒤 Dependency Dashboard의 manual job으로 Renovate를 다시 실행하고, #2061을 새 설정으로 rebase/retry합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Karrot 아이콘 관련 패키지의 업데이트 관리 범위를 확장했습니다.
  - 아이콘 업데이트가 일관된 그룹으로 관리되도록 자동화 설정을 정비했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->