### PR TITLE
chore(config): split Renovate dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":preserveSemverRanges", "group:allNonMajor"],
-  "baseBranches": ["dev"],
+  "extends": [
+    "config:recommended",
+    ":preserveSemverRanges",
+    "security:minimumReleaseAgeNpm"
+  ],
+  "baseBranchPatterns": ["dev"],
   "ignorePaths": ["packages/archive/**"],
   "packageRules": [
     {
@@ -27,6 +31,7 @@
       ],
       "groupName": "karrot-icon-updates",
       "groupSlug": "karrot-icon-updates",
+      "minimumReleaseAge": "0 days",
       "allowedVersions": "*"
     },
     {


### PR DESCRIPTION
## 배경

`group:allNonMajor`로 인해 서로 무관한 non-major 업데이트가 하나의 PR에 묶였고, 저장소의 Bun 3일 release-age 정책과 Renovate가 어긋나 lockfile 생성과 CI 설치 단계가 실패했습니다.

## 변경 사항

- 모든 non-major 업데이트를 한 PR로 묶는 `group:allNonMajor` preset 제거
- npm 업데이트에 `security:minimumReleaseAgeNpm` 적용
- Karrot 아이콘 5종은 기존 Bun 예외와 동일하게 즉시 업데이트 유지
- `baseBranches`를 `baseBranchPatterns`로 마이그레이션

`config:recommended`는 유지하므로 알려진 monorepo와 권장 생태계 그룹은 계속 함께 업데이트됩니다.

## 검증

- `bunx --package renovate@latest renovate-config-validator --no-global renovate.json`
- `bun generate:all`
- `bun packages:build`
- `bun test:all`
- `git diff --check origin/dev...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 의존성 업데이트 대상 브랜치 설정을 개선했습니다.
  * 업데이트 그룹화 설정을 정리했습니다.
  * 보안 업데이트의 최소 대기 기간을 설정했습니다.
  * 아이콘 패키지는 출시 즉시 업데이트할 수 있도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->