### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended",
     ":preserveSemverRanges",
+    "helpers:pinGitHubActionDigests",
     "security:minimumReleaseAgeNpm"
   ],
   "baseBranchPatterns": ["dev"],


### PR DESCRIPTION
## 변경 사항

- helpers:pinGitHubActionDigests preset을 추가했습니다.
- Renovate가 외부 GitHub Actions를 full commit SHA로 고정하고 digest 업데이트를 관리하도록 합니다.
- actions/checkout v7 전환과 현재 사용처 통일은 #1697에서 별도로 처리합니다.

## 배경

GitHub Action의 버전 태그는 이동할 수 있지만 full SHA는 불변이므로, 워크플로우 공급망 위험을 줄이고 저장소 전체 정책을 일관되게 유지할 수 있습니다.

## 검증

- bunx --package renovate renovate-config-validator renovate.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * GitHub Actions 의존성의 버전 다이제스트 고정을 지원하는 Renovate 설정을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->