### PR TITLE
fix(docs): improve Korean title wrapping in updates

### DIFF
--- a/docs/app/updates/[slug]/page.tsx
+++ b/docs/app/updates/[slug]/page.tsx
@@ -88,6 +88,9 @@ export default async function Page(props: { params: Promise<{ slug: string }> })
           ? undefined
           : "prose-h2:text-[1.75rem] prose-h3:text-[1.5rem] prose-p:text-[1.125rem] prose-li:text-[1.125rem] prose-p:leading-[1.7] prose-li:leading-[1.7] prose-em:text-[color:var(--seed-color-palette-gray-700)]"
       }
+      // 타이틀 h1 중앙 정렬(날짜 메타는 위 meta에서 이미 flex center). DocsTitle은 전역 공유
+      // 컴포넌트라 CSS로 박지 않고, 이 prop이 전달된 Updates 일반 포스트에서만 text-center,
+      // text-balance, break-keep, wrap-anywhere를 얹는다.
       titleClassName={isRelease ? undefined : "text-center text-balance break-keep wrap-anywhere"}
       meta={
         publishedDate ? (

--- a/docs/app/updates/[slug]/page.tsx
+++ b/docs/app/updates/[slug]/page.tsx
@@ -88,9 +88,7 @@ export default async function Page(props: { params: Promise<{ slug: string }> })
           ? undefined
           : "prose-h2:text-[1.75rem] prose-h3:text-[1.5rem] prose-p:text-[1.125rem] prose-li:text-[1.125rem] prose-p:leading-[1.7] prose-li:leading-[1.7] prose-em:text-[color:var(--seed-color-palette-gray-700)]"
       }
-      // 타이틀 h1 중앙 정렬(날짜 메타는 위 meta에서 이미 flex center). DocsTitle은 전역 공유
-      // 컴포넌트라 CSS로 박지 않고, 이 prop이 전달된 Updates 라우트에서만 text-center를 얹는다.
-      titleClassName={isRelease ? undefined : "text-center"}
+      titleClassName={isRelease ? undefined : "text-center text-balance break-keep wrap-anywhere"}
       meta={
         publishedDate ? (
           <div

--- a/docs/app/updates/page.tsx
+++ b/docs/app/updates/page.tsx
@@ -126,7 +126,7 @@ function UpdateCardLink({ card }: { card: UpdateCard }) {
         </time>
       )}
       <div className="mt-1 flex items-start justify-between gap-2">
-        <h3 className="text-lg font-medium">{card.title}</h3>
+        <h3 className="text-balance break-keep wrap-anywhere text-lg font-medium">{card.title}</h3>
         {/* 내부 링크는 클릭하면 같은 사이트 안에서 이동하므로 화살표가 정보를 더하지 않는다.
             새 탭으로 나가는 외부 글에만 ↗를 남긴다. */}
         {card.external && (

--- a/docs/app/updates/release-card.tsx
+++ b/docs/app/updates/release-card.tsx
@@ -17,7 +17,7 @@ export function ReleaseCard({ href, title, description, publishedAt }: ReleaseCa
       href={href}
       className="group flex h-full flex-col rounded-r3 bg-bg-transparent-selected px-x5 py-x3_5 text-fg-neutral transition-colors duration-color-transition hover:bg-bg-transparent-selected-pressed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-stroke-focus-ring"
     >
-      <div className="min-w-0 space-y-x1">
+      <div className="space-y-x1">
         {published && (
           <time
             dateTime={published.toISOString()}
@@ -26,7 +26,7 @@ export function ReleaseCard({ href, title, description, publishedAt }: ReleaseCa
             {formatPublishedDate(published)}
           </time>
         )}
-        <h3 className="min-w-0 break-words text-balance text-lg font-medium">{title}</h3>
+        <h3 className="text-balance break-keep wrap-anywhere text-lg font-medium">{title}</h3>
       </div>
       {description && (
         <p className="t4-regular mt-x2 line-clamp-2 break-words text-fg-neutral-muted">


### PR DESCRIPTION
안녕하세요, SEED 문서를 보다가 Updates에 제목이 줄바꿈되면 가독성이 더 좋아질 수 있을 것 같아 PR 남겨봅니다.

## 변경 배경

Updates의 한국어 제목이 글자 단위로 줄바꿈되면서 마지막 글자나 어절 일부가 다음 줄에 홀로 남는 문제가 있었습니다.

## 변경 내용

Updates에서 제목을 표시하는 다음 세 영역에 `text-balance break-keep wrap-anywhere`를 적용했습니다.

- 일반 포스트의 상세 페이지 제목
- Release Notes 카드 제목
- Blog 카드 제목

각 클래스는 다음과 같이 동작합니다.

- `text-balance`: 각 줄의 길이를 균형 있게 배치합니다.
- `break-keep`: 가능하면 한국어 어절을 유지합니다.
- `wrap-anywhere`: 정상적인 줄바꿈 지점이 없는 긴 문자열은 필요한 경우에만 줄바꿈합니다. `break-words`와 달리 `wrap-anywhere`를 사용하면 flex나 grid 안의 텍스트 요소에 별도로 `min-w-0`을 지정하지 않아도 레이아웃이 깨지지 않습니다. ([fine-grained-text-wrapping-with-overflow-wrap](https://tailwindcss.com/blog/tailwindcss-v4-1#fine-grained-text-wrapping-with-overflow-wrap))

이번 변경은 Updates의 제목 영역에만 적용했습니다. 동작과 방향성이 적절하다고 판단되면, 추후 공용 `DocsTitle`을 포함한 다른 제목 영역에도 같은 줄바꿈 패턴을 확대 적용할 수 있습니다.

## 변경 전후

### 아티클 제목

| As-is | To-be |
| --- | --- |
| ![변경 전 아티클 제목](https://github.com/user-attachments/assets/32f79bd1-a729-4189-86f9-c57ce2ba852e) | ![변경 후 아티클 제목](https://github.com/user-attachments/assets/9f83a1b6-919b-4fd8-aaa5-fc0142c4d268) |

### Release Notes 카드 제목

| As-is | To-be |
| --- | --- |
| ![변경 전 Release Notes 카드 제목](https://github.com/user-attachments/assets/638e8f4d-db82-4953-98d4-b5392def33ff) | ![변경 후 Release Notes 카드 제목](https://github.com/user-attachments/assets/3387eb6e-f7d0-41d5-af0f-a30511d2531b) |

### Blog 카드 제목

| As-is | To-be |
| --- | --- |
| ![변경 전 Blog 카드 제목](https://github.com/user-attachments/assets/505997ff-0b9e-4f91-9fce-c80eb493f0ec) | ![변경 후 Blog 카드 제목](https://github.com/user-attachments/assets/73a4590f-3ad1-4b29-b897-8ebca2b3373b) |

## 검증

- `bun docs:test` — 283개 테스트 통과
- `bun generate:all`
- `bun packages:build`
- Updates 목록과 포스트 상세 페이지에서 반응형 레이아웃 수동 확인

## Changeset

문서 사이트에만 적용되는 스타일 변경이므로 changeset은 추가하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 업데이트 및 릴리즈 카드 제목의 줄바꿈과 텍스트 배치를 개선했습니다.
  * 긴 단어나 문장도 카드 영역을 벗어나지 않고 자연스럽게 표시됩니다.
  * 일반 업데이트 게시물 제목의 가독성과 줄바꿈 균형을 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->