### PR TITLE
fix(ci): fail the job when a Slack notification is rejected

### DIFF
--- a/.github/workflows/deploy-seed-design-docs-prod-pages.yml
+++ b/.github/workflows/deploy-seed-design-docs-prod-pages.yml
@@ -148,6 +148,7 @@ jobs:
               ]
             }' > /tmp/slack-failure-payload.json
 
+      # `errors` 기본값이 false라, 켜지 않으면 Slack이 거절해도 스텝이 성공으로 넘어간다.
       - name: 실패를 Slack에 알려요
         if: failure()
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
@@ -155,3 +156,4 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload-file-path: /tmp/slack-failure-payload.json
+          errors: true

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -200,11 +200,13 @@ jobs:
           PACKAGE_VERSIONS="$(jq -cn --argjson packages "$PUBLISHED_PACKAGES" '$packages | map({name: .name, value: .version}) | from_entries')"
           echo "packageVersions=$PACKAGE_VERSIONS" >> "$GITHUB_OUTPUT"
 
+      # `errors` 기본값이 false라, 켜지 않으면 Slack이 거절해도 스텝이 성공으로 넘어간다.
       - name: Notify Slack
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
+          errors: true
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
             text: "새 Rootage 버전이 배포되었어요."

--- a/.github/workflows/sync-figma-entities.yml
+++ b/.github/workflows/sync-figma-entities.yml
@@ -267,6 +267,7 @@ jobs:
               ]
             }' > /tmp/slack-payload.json
 
+      # `errors` 기본값이 false라, 켜지 않으면 Slack이 거절해도 스텝이 성공으로 넘어간다.
       - name: Slack에 알려요
         if: steps.check-diff.outputs.has_changes == 'true'
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
@@ -274,6 +275,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload-file-path: /tmp/slack-payload.json
+          errors: true
 
       - name: 실패하면 Slack payload를 빌드해요
         if: failure()
@@ -301,3 +303,4 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload-file-path: /tmp/slack-failure-payload.json
+          errors: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * Slack 알림 전송이 거부되거나 실패하면 관련 자동화 작업도 실패하도록 변경했습니다.
  * 알림 전송 오류가 성공으로 잘못 처리되지 않아 배포 및 동기화 상태를 더 정확하게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->