### PR TITLE
fix(docs): point divider Do/Don't images at the restored Figma nodes

### DIFF
--- a/docs/content/components/divider.mdx
+++ b/docs/content/components/divider.mdx
@@ -85,12 +85,12 @@ coverImage: /og/components/divider
 
 <Grid>
   <DoImage
-    figmaId="2:127801"
+    figmaId="4065:5116"
     body="마지막 섹션에 Divider가 없는 화면"
     alt="화면의 마지막 섹션에 Divider가 표시되지 않은 올바른 예시"
   />
   <DontImage
-    figmaId="2:127828"
+    figmaId="4065:5143"
     body="마지막 섹션의 Divider는 표시하지 않습니다."
     alt="화면의 마지막 섹션 하단에 불필요한 Divider가 표시된 잘못된 예시"
   />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * Divider 사용 예시의 Figma 식별자를 올바른 값으로 업데이트했습니다.
  * 올바른 예시와 잘못된 예시가 정확히 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->