### PR TITLE
test(storybook): Kapture 시각 변경을 검증한다

### DIFF
--- a/docs/stories/ActionButton.stories.tsx
+++ b/docs/stories/ActionButton.stories.tsx
@@ -10,7 +10,14 @@ import { VariantTable } from "./components/variant-table";
 
 const meta = preview.meta({
   component: ActionButton,
-  decorators: [SeedThemeDecorator],
+  decorators: [
+    SeedThemeDecorator,
+    (Story) => (
+      <div style={{ border: "8px solid #ff00b8", padding: 16 }}>
+        <Story />
+      </div>
+    ),
+  ],
 });
 const conditionMap = {
   disabled: {


### PR DESCRIPTION
## 목적
Kapture의 실제 visual-review lifecycle을 검증하기 위한 일회성 probe PR입니다. 병합하지 않습니다.

## 의도된 변경
- ActionButton stories 전체에 8px magenta border와 padding을 추가해 명확한 픽셀 차이를 만듭니다.
- production component 코드는 변경하지 않습니다.

## 확인할 흐름
1. exact base/head Storybook을 별도 read-only runner에서 build
2. affected stories만 fresh browser로 capture/compare
3. trusted workflow가 report와 exact head Storybook을 같은 immutable Cloudflare Pages deployment에 배포
4. PR 댓글과 SEED Kapture Visual Review pending status 확인
5. full head SHA와 report digest를 포함한 kapture approve 명령으로 승인 후 success 확인

검증 완료 후 이 PR은 닫고 브랜치 변경은 dev에 병합하지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * `ActionButton` 스토리의 시각적 미리보기를 개선했습니다.
  * 스토리에 8px 분홍색 테두리와 16px 여백이 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->