### PR TITLE
fix(storybook): grant Kapture PR comment permission

### DIFF
--- a/.github/workflows/kapture-approve.yml
+++ b/.github/workflows/kapture-approve.yml
@@ -22,7 +22,7 @@ jobs:
       actions: read
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: write
 
     steps:

--- a/.github/workflows/kapture-report.yml
+++ b/.github/workflows/kapture-report.yml
@@ -65,7 +65,7 @@ jobs:
       actions: write
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: write
 
     steps:


### PR DESCRIPTION
## 변경 사항
- Kapture reporter가 시각 비교 결과를 PR 댓글로 게시할 수 있도록 `pull-requests: write` 권한을 부여합니다.
- `/kapture approve` 처리 결과도 PR 댓글로 남길 수 있도록 승인 워크플로우에 같은 권한을 부여합니다.

## 배경
실제 probe PR에서 캡처, 비교, 대시보드 배포까지 성공했지만 `POST /issues/{number}/comments`가 403으로 실패했습니다. 저장소의 기존 PR 댓글 워크플로우와 동일한 권한 모델로 맞춥니다.

## 검증
- `bun generate:all`
- `bun test:all` (1845 unit + 192 Lynx)
- Ruby YAML parse
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 풀 리퀘스트 자동 승인 및 보고 워크플로에서 리뷰 작성과 같은 쓰기 작업을 수행할 수 있도록 권한을 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->