### PR TITLE
feat(date-picker): add continuous month range

### DIFF
--- a/.changeset/calm-months-scroll.md
+++ b/.changeset/calm-months-scroll.md
@@ -1,0 +1,10 @@
+---
+"@seed-design/react-date-picker": minor
+"@seed-design/react": minor
+---
+
+`ContinuousDatePicker`의 노출 범위를 월 단위로 제한할 수 있습니다.
+
+- `monthRange`로 처음과 마지막 노출 월을 지정할 수 있습니다.
+- `monthRange`를 생략하면 기존처럼 `yearRange`의 시작 연도 1월부터 종료 연도 12월까지 노출합니다.
+- 날짜별 선택 가능 여부는 기존 `constraints`와 함께 설정할 수 있습니다.

--- a/docs/content/react/components/date-picker.mdx
+++ b/docs/content/react/components/date-picker.mdx
@@ -60,7 +60,7 @@ Date Picker는 레이아웃에 따라 다음 공개 컴포넌트로 나뉩니다
 - `DatePicker`: 현재 월의 실제 주 수만 렌더링합니다.
 - `TwoMonthDatePicker`: 연속한 두 달을 가로로 표시합니다. 이전·다음 버튼은 한 달씩 이동합니다.
 - `WeekDatePicker`: 한 주만 표시하며 이전·다음 버튼은 한 주씩 이동합니다.
-- `ContinuousDatePicker`: `yearRange` 안의 월을 세로로 가상화합니다. `height`, `minHeight`, `maxHeight` 중 하나를 반드시 지정합니다.
+- `ContinuousDatePicker`: `monthRange` 안의 월을 세로로 가상화합니다. `monthRange`를 생략하면 `yearRange`를 월 범위로 변환합니다. `height`, `minHeight`, `maxHeight` 중 하나를 반드시 지정합니다.
 
 한 달과 두 달 레이아웃은 항상 6주 높이를 확보하지 않고 각 월에 필요한 4~6주만 렌더링합니다.
 
@@ -70,6 +70,21 @@ Date Picker는 자체적으로 고정 폭이나 최대 폭을 제한하지 않�
   ```json doc-gen:file
   {
     "file": "examples/react/date-picker/visible-ranges.tsx",
+    "codeblock": true
+  }
+  ```
+</ComponentExample>
+
+### 연속 달력의 노출 월 제한
+
+`ContinuousDatePicker`의 `monthRange`로 스크롤해서 볼 수 있는 첫 월과 마지막 월을 제한할 수 있습니다. 양끝 월을 모두 포함합니다. `yearRange`만 전달하면 시작 연도의 1월부터 종료 연도의 12월까지로 변환합니다. 두 prop을 함께 사용하면 `monthRange`는 `yearRange` 안에 있어야 합니다.
+
+`monthRange`는 노출되는 월을 정하고 `constraints`는 날짜별 선택 가능 여부를 정합니다. 아래 예시는 12월 15일부터 30일 뒤인 1월 14일까지만 선택할 수 있게 하면서, 스크롤 범위도 12월과 1월로 제한합니다.
+
+<ComponentExample name="react/date-picker/continuous-month-range">
+  ```json doc-gen:file
+  {
+    "file": "examples/react/date-picker/continuous-month-range.tsx",
     "codeblock": true
   }
   ```

--- a/docs/examples/react/date-picker/continuous-month-range.tsx
+++ b/docs/examples/react/date-picker/continuous-month-range.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Box, ContinuousDatePicker, dateOnOrAfter, dateOnOrBefore } from "@seed-design/react";
+
+const today = { year: 2026, month: 12, day: 15 };
+const thirtyDaysLater = { year: 2027, month: 1, day: 14 };
+
+export default function ContinuousDatePickerMonthRange() {
+  return (
+    <Box width="358px" height="420px" maxWidth="full">
+      <ContinuousDatePicker
+        selectionMode="range"
+        today={today}
+        yearRange={{ start: 2026, end: 2027 }}
+        monthRange={{
+          start: { year: today.year, month: today.month },
+          end: { year: thirtyDaysLater.year, month: thirtyDaysLater.month },
+        }}
+        constraints={[dateOnOrAfter(today), dateOnOrBefore(thirtyDaysLater)]}
+        height="full"
+      />
+    </Box>
+  );
+}

--- a/docs/stories/DatePicker.stories.tsx
+++ b/docs/stories/DatePicker.stories.tsx
@@ -130,6 +130,28 @@ export const Continuous = meta.story({
   ),
 });
 
+export const ContinuousMonthRange = meta.story({
+  render: () => (
+    <Box width="358px" height="420px">
+      <ContinuousDatePicker
+        selectionMode="range"
+        height="full"
+        today={{ year: 2026, month: 12, day: 15 }}
+        yearRange={{ start: 2026, end: 2027 }}
+        monthRange={{
+          start: { year: 2026, month: 12 },
+          end: { year: 2027, month: 1 },
+        }}
+        constraints={[
+          (date) =>
+            (date.year === 2026 && date.month === 12 && date.day >= 15) ||
+            (date.year === 2027 && date.month === 1 && date.day <= 14),
+        ]}
+      />
+    </Box>
+  ),
+});
+
 export const ContinuousCustomCell = meta.story({
   render: () => (
     <Box width="358px" height="560px">

--- a/packages/react-headless/date-picker/src/date.test.ts
+++ b/packages/react-headless/date-picker/src/date.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
+  clampDateToMonthRange,
+  compareYearMonths,
   getDaysInMonth,
   getMonthWeekCount,
   getMonthWeekStarts,
@@ -24,6 +26,25 @@ describe("date utilities", () => {
     expect(
       inclusiveDayCount({ year: 2026, month: 7, day: 31 }, { year: 2026, month: 7, day: 30 }),
     ).toBe(0);
+  });
+
+  it("연월을 비교하고 monthRange 경계로 날짜를 보정한다", () => {
+    const monthRange = {
+      start: { year: 2026, month: 12 },
+      end: { year: 2027, month: 2 },
+    };
+
+    expect(compareYearMonths(monthRange.start, monthRange.end)).toBeLessThan(0);
+    expect(clampDateToMonthRange({ year: 2026, month: 11, day: 15 }, monthRange)).toEqual({
+      year: 2026,
+      month: 12,
+      day: 1,
+    });
+    expect(clampDateToMonthRange({ year: 2027, month: 3, day: 15 }, monthRange)).toEqual({
+      year: 2027,
+      month: 2,
+      day: 28,
+    });
   });
 
   it("월별 주 수를 locale과 주 시작일에 맞게 계산한다", () => {

--- a/packages/react-headless/date-picker/src/date.ts
+++ b/packages/react-headless/date-picker/src/date.ts
@@ -1,5 +1,10 @@
 import { CalendarDate, endOfWeek, startOfWeek } from "@internationalized/date";
-import type { DatePickerDate, DatePickerVisibleRange } from "./types";
+import type {
+  DatePickerDate,
+  DatePickerMonthRange,
+  DatePickerVisibleRange,
+  DatePickerYearMonth,
+} from "./types";
 
 export const DEFAULT_DATE_CELL_HEIGHT = 48;
 export const CONTINUOUS_WEEKDAY_HEIGHT = 48;
@@ -16,6 +21,10 @@ export function fromCalendarDate(date: CalendarDate): DatePickerDate {
 
 export function compareDates(a: DatePickerDate, b: DatePickerDate) {
   return toCalendarDate(a).compare(toCalendarDate(b));
+}
+
+export function compareYearMonths(a: DatePickerYearMonth, b: DatePickerYearMonth) {
+  return a.year === b.year ? a.month - b.month : a.year - b.year;
 }
 
 export function isSameDate(a: DatePickerDate | undefined, b: DatePickerDate | undefined) {
@@ -157,6 +166,33 @@ export function assertDateInYearRange(
   }
 }
 
+export function assertValidYearMonth(value: DatePickerYearMonth, propName: string) {
+  if (
+    !Number.isInteger(value.year) ||
+    !Number.isInteger(value.month) ||
+    value.month < 1 ||
+    value.month > 12
+  ) {
+    throw new RangeError(
+      `DatePicker: ${propName}은 정수 year와 1부터 12 사이의 month를 가져야 합니다.`,
+    );
+  }
+}
+
+export function assertDateInMonthRange(
+  date: DatePickerDate,
+  monthRange: DatePickerMonthRange,
+  propName: string,
+) {
+  assertValidDate(date, propName);
+  if (
+    compareYearMonths(date, monthRange.start) < 0 ||
+    compareYearMonths(date, monthRange.end) > 0
+  ) {
+    throw new RangeError(`DatePicker: ${propName}은 monthRange 안의 날짜여야 합니다.`);
+  }
+}
+
 export function eachDateInclusive(start: DatePickerDate, end: DatePickerDate) {
   const result: DatePickerDate[] = [];
   for (let cursor = start; compareDates(cursor, end) <= 0; cursor = addDays(cursor, 1)) {
@@ -179,5 +215,16 @@ export function clampDateToYearRange(
 ) {
   if (date.year < yearRange.start) return { year: yearRange.start, month: 1, day: 1 };
   if (date.year > yearRange.end) return { year: yearRange.end, month: 12, day: 31 };
+  return date;
+}
+
+export function clampDateToMonthRange(date: DatePickerDate, monthRange: DatePickerMonthRange) {
+  if (compareYearMonths(date, monthRange.start) < 0) {
+    return { ...monthRange.start, day: 1 };
+  }
+  if (compareYearMonths(date, monthRange.end) > 0) {
+    const end = { ...monthRange.end, day: 1 };
+    return { ...end, day: getDaysInMonth(end) };
+  }
   return date;
 }

--- a/packages/react-headless/date-picker/src/index.ts
+++ b/packages/react-headless/date-picker/src/index.ts
@@ -21,6 +21,7 @@ export {
   type DatePickerConstraintContext,
   type DatePickerDate,
   type DatePickerMonth,
+  type DatePickerMonthRange,
   type DatePickerMultipleProps,
   type DatePickerRangeProps,
   type DatePickerRangeValue,
@@ -28,6 +29,7 @@ export {
   type DatePickerSingleProps,
   type DatePickerValue,
   type DatePickerVisibleRange,
+  type DatePickerYearMonth,
   type DatePickerWeek,
   type UseDatePickerProps,
 } from "./types";

--- a/packages/react-headless/date-picker/src/types.ts
+++ b/packages/react-headless/date-picker/src/types.ts
@@ -17,6 +17,21 @@ export interface DatePickerRangeValue {
   end?: DatePickerDate;
 }
 
+/** Gregorian 달력의 연도와 월입니다. */
+export interface DatePickerYearMonth {
+  /** Gregorian 달력의 연도입니다. */
+  year: number;
+  /** 1부터 12까지의 월입니다. */
+  month: number;
+}
+
+export interface DatePickerMonthRange {
+  /** 노출 범위의 첫 번째 월입니다. */
+  start: DatePickerYearMonth;
+  /** 노출 범위의 마지막 월입니다. */
+  end: DatePickerYearMonth;
+}
+
 export type DatePickerSelectionMode = "single" | "range" | "multiple";
 export type DatePickerVisibleRange = "month" | "twoMonths" | "continuous" | "week";
 
@@ -120,6 +135,12 @@ interface DatePickerCommonProps {
     start: number;
     end: number;
   };
+  /**
+   * Continuous 레이아웃에서 노출하고 이동할 수 있는 월 범위입니다. 양끝 월을 포함합니다.
+   *
+   * 생략하면 `yearRange.start`의 1월부터 `yearRange.end`의 12월까지 노출합니다.
+   */
+  monthRange?: DatePickerMonthRange;
   /** 날짜 선택 조건입니다. 모든 함수가 `true`를 반환해야 선택할 수 있습니다. */
   constraints?: readonly DatePickerConstraint[];
   /** 모든 조작과 날짜 포커스를 비활성화합니다. */

--- a/packages/react-headless/date-picker/src/useDatePicker.test.tsx
+++ b/packages/react-headless/date-picker/src/useDatePicker.test.tsx
@@ -432,6 +432,82 @@ describe("useDatePicker", () => {
     );
   });
 
+  it("Continuous는 monthRange의 양끝 월만 렌더링한다", () => {
+    const { result } = renderDatePicker({
+      visibleRange: "continuous",
+      yearRange: { start: 2026, end: 2027 },
+      monthRange: {
+        start: { year: 2026, month: 12 },
+        end: { year: 2027, month: 1 },
+      },
+      defaultViewDate: { year: 2026, month: 12, day: 1 },
+    });
+
+    expect(result.current.months.map((month) => month.date)).toEqual([
+      { year: 2026, month: 12, day: 1 },
+      { year: 2027, month: 1, day: 1 },
+    ]);
+  });
+
+  it("Continuous의 monthRange가 좁아지면 비제어 view와 focus를 경계로 보정한다", () => {
+    const { result, rerender } = renderDatePicker({
+      visibleRange: "continuous",
+      monthRange: {
+        start: { year: 2026, month: 7 },
+        end: { year: 2026, month: 12 },
+      },
+    });
+
+    rerender({
+      today,
+      yearRange,
+      visibleRange: "continuous",
+      monthRange: {
+        start: { year: 2026, month: 9 },
+        end: { year: 2026, month: 10 },
+      },
+    });
+
+    expect(result.current.viewDate).toEqual({ year: 2026, month: 9, day: 1 });
+    expect(result.current.focusedDate).toEqual({ year: 2026, month: 9, day: 1 });
+  });
+
+  it("Continuous의 이동과 action은 monthRange 경계를 넘지 않는다", () => {
+    const { result } = renderDatePicker({
+      visibleRange: "continuous",
+      monthRange: {
+        start: { year: 2026, month: 7 },
+        end: { year: 2026, month: 8 },
+      },
+    });
+
+    expect(() => result.current.actions.navigateToDate({ year: 2026, month: 9, day: 1 })).toThrow(
+      "monthRange 안의 날짜",
+    );
+
+    const augustLastDay = result.current.months
+      .flatMap((month) => month.weeks)
+      .flatMap((week) => week.cells)
+      .find(
+        (cell): cell is DatePickerCell =>
+          cell?.date.year === 2026 && cell.date.month === 8 && cell.date.day === 31,
+      );
+    expect(augustLastDay).toBeDefined();
+
+    act(() => {
+      augustLastDay?.buttonProps.onKeyDown?.({
+        key: "ArrowRight",
+        shiftKey: false,
+        defaultPrevented: false,
+        nativeEvent: { isComposing: false },
+        preventDefault: () => {},
+      } as React.KeyboardEvent<HTMLButtonElement>);
+    });
+
+    expect(result.current.focusedDate).toEqual({ year: 2026, month: 8, day: 31 });
+    expect(result.current.viewDate).toEqual({ year: 2026, month: 8, day: 1 });
+  });
+
   it("Continuous는 현재 월의 라벨이 고정 요일 행 아래에 오도록 스크롤한다", () => {
     const { result } = renderDatePicker({
       visibleRange: "continuous",
@@ -619,6 +695,47 @@ describe("useDatePicker", () => {
     );
 
     act(() => result.current.refs.continuousMonth(measuredMonth?.key ?? "")(null));
+  });
+
+  it("유효하지 않은 monthRange와 범위 밖 값을 거부한다", () => {
+    expect(() =>
+      renderDatePicker({
+        visibleRange: "continuous",
+        monthRange: {
+          start: { year: 2026, month: 13 },
+          end: { year: 2027, month: 1 },
+        },
+      }),
+    ).toThrow("1부터 12 사이의 month");
+    expect(() =>
+      renderDatePicker({
+        visibleRange: "continuous",
+        monthRange: {
+          start: { year: 2027, month: 1 },
+          end: { year: 2026, month: 12 },
+        },
+      }),
+    ).toThrow("monthRange.start는 monthRange.end보다 늦을 수 없습니다");
+    expect(() =>
+      renderDatePicker({
+        visibleRange: "continuous",
+        yearRange: { start: 2026, end: 2026 },
+        monthRange: {
+          start: { year: 2026, month: 12 },
+          end: { year: 2027, month: 1 },
+        },
+      }),
+    ).toThrow("monthRange는 yearRange 안에 있어야 합니다");
+    expect(() =>
+      renderDatePicker({
+        visibleRange: "continuous",
+        monthRange: {
+          start: { year: 2026, month: 7 },
+          end: { year: 2026, month: 8 },
+        },
+        value: { year: 2026, month: 9, day: 1 },
+      }),
+    ).toThrow("monthRange 안의 날짜");
   });
 
   it("유효하지 않은 날짜와 범위를 엄격하게 거부한다", () => {

--- a/packages/react-headless/date-picker/src/useDatePicker.ts
+++ b/packages/react-headless/date-picker/src/useDatePicker.ts
@@ -8,9 +8,12 @@ import {
   addDays,
   addMonths,
   addYears,
+  assertDateInMonthRange,
   assertDateInYearRange,
-  clampDateToYearRange,
+  assertValidYearMonth,
+  clampDateToMonthRange,
   compareDates,
+  compareYearMonths,
   CONTINUOUS_MONTH_GAP,
   CONTINUOUS_MONTH_LABEL_HEIGHT,
   CONTINUOUS_WEEKDAY_HEIGHT,
@@ -36,6 +39,7 @@ import type {
   DatePickerConstraintContext,
   DatePickerDate,
   DatePickerMonth,
+  DatePickerMonthRange,
   DatePickerRangeValue,
   DatePickerSelectionMode,
   DatePickerValue,
@@ -106,24 +110,50 @@ function validateYearRange(yearRange: { start: number; end: number }) {
   }
 }
 
+function resolveMonthRange(
+  yearRange: { start: number; end: number },
+  monthRange: DatePickerMonthRange | undefined,
+): DatePickerMonthRange {
+  const resolved =
+    monthRange ??
+    ({
+      start: { year: yearRange.start, month: 1 },
+      end: { year: yearRange.end, month: 12 },
+    } satisfies DatePickerMonthRange);
+
+  assertValidYearMonth(resolved.start, "monthRange.start");
+  assertValidYearMonth(resolved.end, "monthRange.end");
+  if (compareYearMonths(resolved.start, resolved.end) > 0) {
+    throw new RangeError("DatePicker: monthRange.start는 monthRange.end보다 늦을 수 없습니다.");
+  }
+  if (resolved.start.year < yearRange.start || resolved.end.year > yearRange.end) {
+    throw new RangeError("DatePicker: monthRange는 yearRange 안에 있어야 합니다.");
+  }
+  return resolved;
+}
+
 function validateValue(
   mode: DatePickerSelectionMode,
   value: DatePickerValue,
   yearRange: { start: number; end: number },
+  monthRange: DatePickerMonthRange,
   propName: "value" | "defaultValue",
 ) {
   if (value === undefined) return;
 
   if (mode === "single") {
     assertDateInYearRange(value as DatePickerDate, yearRange, propName);
+    assertDateInMonthRange(value as DatePickerDate, monthRange, propName);
     return;
   }
 
   if (mode === "range") {
     const range = value as DatePickerRangeValue;
     assertDateInYearRange(range.start, yearRange, `${propName}.start`);
+    assertDateInMonthRange(range.start, monthRange, `${propName}.start`);
     if (range.end !== undefined) {
       assertDateInYearRange(range.end, yearRange, `${propName}.end`);
+      assertDateInMonthRange(range.end, monthRange, `${propName}.end`);
       if (compareDates(range.start, range.end) > 0) {
         throw new RangeError(`DatePicker: ${propName}.start는 end보다 늦을 수 없습니다.`);
       }
@@ -135,6 +165,7 @@ function validateValue(
   const keys = new Set<string>();
   dates.forEach((date, index) => {
     assertDateInYearRange(date, yearRange, `${propName}[${index}]`);
+    assertDateInMonthRange(date, monthRange, `${propName}[${index}]`);
     const key = dateKey(date);
     if (keys.has(key)) {
       throw new RangeError(`DatePicker: ${propName}에는 중복 날짜를 전달할 수 없습니다.`);
@@ -158,11 +189,11 @@ function isRtlLocale(locale: string) {
 }
 
 function getMonthDescriptorBases(
-  yearRange: { start: number; end: number },
+  monthRange: DatePickerMonthRange,
   locale: string,
   weekStartsOn: 0 | 1 | 2 | 3 | 4 | 5 | 6 | undefined,
 ) {
-  const cacheKey = `${yearRange.start}:${yearRange.end}:${locale}:${weekStartsOn ?? "locale"}`;
+  const cacheKey = `${monthRange.start.year}:${monthRange.start.month}:${monthRange.end.year}:${monthRange.end.month}:${locale}:${weekStartsOn ?? "locale"}`;
   const cached = monthDescriptorBasesCache.get(cacheKey);
   if (cached) {
     monthDescriptorBasesCache.delete(cacheKey);
@@ -173,13 +204,12 @@ function getMonthDescriptorBases(
   const result: MonthDescriptorBase[] = [];
   const resolvedWeekStartsOn = resolveWeekStartsOn(locale, weekStartsOn);
 
-  for (let year = yearRange.start; year <= yearRange.end; year++) {
-    for (let month = 1; month <= 12; month++) {
-      const date = { year, month, day: 1 };
-      const key = dateKey(date);
-      const weekCount = getMonthWeekCount(date, resolvedWeekStartsOn);
-      result.push({ date, key, weekCount });
-    }
+  const start = { ...monthRange.start, day: 1 };
+  const end = { ...monthRange.end, day: 1 };
+  for (let date = start; compareDates(date, end) <= 0; date = addMonths(date, 1)) {
+    const key = dateKey(date);
+    const weekCount = getMonthWeekCount(date, resolvedWeekStartsOn);
+    result.push({ date, key, weekCount });
   }
 
   if (monthDescriptorBasesCache.size >= MONTH_DESCRIPTOR_BASES_CACHE_LIMIT) {
@@ -258,11 +288,32 @@ export function useDatePicker(props: UseDatePickerProps) {
     () => ({ start: yearRangeStart, end: yearRangeEnd }),
     [yearRangeEnd, yearRangeStart],
   );
-
   validateYearRange(yearRange);
+
+  const monthRangeStartYear = props.monthRange?.start.year;
+  const monthRangeStartMonth = props.monthRange?.start.month;
+  const monthRangeEndYear = props.monthRange?.end.year;
+  const monthRangeEndMonth = props.monthRange?.end.month;
+  const monthRange = React.useMemo(
+    () =>
+      resolveMonthRange(
+        yearRange,
+        monthRangeStartYear === undefined ||
+          monthRangeStartMonth === undefined ||
+          monthRangeEndYear === undefined ||
+          monthRangeEndMonth === undefined
+          ? undefined
+          : {
+              start: { year: monthRangeStartYear, month: monthRangeStartMonth },
+              end: { year: monthRangeEndYear, month: monthRangeEndMonth },
+            },
+      ),
+    [monthRangeEndMonth, monthRangeEndYear, monthRangeStartMonth, monthRangeStartYear, yearRange],
+  );
+
   assertDateInYearRange(today, yearRange, "today");
-  validateValue(selectionMode, props.value, yearRange, "value");
-  validateValue(selectionMode, props.defaultValue, yearRange, "defaultValue");
+  validateValue(selectionMode, props.value, yearRange, monthRange, "value");
+  validateValue(selectionMode, props.defaultValue, yearRange, monthRange, "defaultValue");
   if (
     selectionMode === "range" &&
     props.rangeStartReadOnly === true &&
@@ -275,9 +326,11 @@ export function useDatePicker(props: UseDatePickerProps) {
   }
   if (props.viewDate !== undefined) {
     assertDateInYearRange(props.viewDate, yearRange, "viewDate");
+    assertDateInMonthRange(props.viewDate, monthRange, "viewDate");
   }
   if (props.defaultViewDate !== undefined) {
     assertDateInYearRange(props.defaultViewDate, yearRange, "defaultViewDate");
+    assertDateInMonthRange(props.defaultViewDate, monthRange, "defaultViewDate");
   }
 
   const defaultSelection = selectionMode === "multiple" ? [] : undefined;
@@ -291,7 +344,10 @@ export function useDatePicker(props: UseDatePickerProps) {
     selectionMode,
     props.value ?? props.defaultValue,
   );
-  const initialViewSource = props.viewDate ?? props.defaultViewDate ?? initialSelectedDate ?? today;
+  const initialViewSource = clampDateToMonthRange(
+    props.viewDate ?? props.defaultViewDate ?? initialSelectedDate ?? today,
+    monthRange,
+  );
   const viewDateYear = props.viewDate?.year;
   const viewDateMonth = props.viewDate?.month;
   const viewDateDay = props.viewDate?.day;
@@ -407,7 +463,12 @@ export function useDatePicker(props: UseDatePickerProps) {
 
   const isUnavailable = React.useCallback(
     (date: DatePickerDate) => {
-      if (date.year < yearRange.start || date.year > yearRange.end) return true;
+      if (
+        compareYearMonths(date, monthRange.start) < 0 ||
+        compareYearMonths(date, monthRange.end) > 0
+      ) {
+        return true;
+      }
       const rangeValue =
         selectionMode === "range" ? (value as DatePickerRangeValue | undefined) : undefined;
       if (rangeStartReadOnly && isSameDate(date, rangeValue?.start)) return false;
@@ -427,38 +488,48 @@ export function useDatePicker(props: UseDatePickerProps) {
       rangeStartReadOnly,
       selectionMode,
       value,
-      yearRange.end,
-      yearRange.start,
+      monthRange.end,
+      monthRange.start,
     ],
   );
 
   const setViewDate = React.useCallback(
     (date: DatePickerDate) => {
-      const normalized = normalizeViewDate(date, visibleRange, locale, props.weekStartsOn);
+      const clamped = clampDateToMonthRange(date, monthRange);
+      const normalized = normalizeViewDate(clamped, visibleRange, locale, props.weekStartsOn);
       if (!isSameDate(normalized, viewDate)) setViewDateState(normalized);
     },
-    [locale, props.weekStartsOn, setViewDateState, viewDate, visibleRange],
+    [locale, monthRange, props.weekStartsOn, setViewDateState, viewDate, visibleRange],
   );
+
+  useLayoutEffect(() => {
+    if (props.viewDate !== undefined) return;
+    const clampedViewDate = clampDateToMonthRange(viewDate, monthRange);
+    if (!isSameDate(clampedViewDate, viewDate)) setViewDate(clampedViewDate);
+    setFocusedDate((current) => clampDateToMonthRange(current, monthRange));
+  }, [monthRange, props.viewDate, setViewDate, viewDate]);
 
   const navigateToDate = React.useCallback(
     (date: DatePickerDate) => {
       assertDateInYearRange(date, yearRange, "actions.navigateToDate(date)");
+      assertDateInMonthRange(date, monthRange, "actions.navigateToDate(date)");
       shouldMoveDomFocusRef.current = false;
       setFocusedDate(date);
       setViewDate(date);
     },
-    [setViewDate, yearRange],
+    [monthRange, setViewDate, yearRange],
   );
 
   const focusDate = React.useCallback(
     (date: DatePickerDate) => {
       assertDateInYearRange(date, yearRange, "actions.focusDate(date)");
+      assertDateInMonthRange(date, monthRange, "actions.focusDate(date)");
       shouldMoveDomFocusRef.current = true;
       setFocusedDate(date);
       setViewDate(date);
       requestDomFocusCommit();
     },
-    [setViewDate, yearRange],
+    [monthRange, setViewDate, yearRange],
   );
 
   const actions: DatePickerActions = React.useMemo(
@@ -548,7 +619,7 @@ export function useDatePicker(props: UseDatePickerProps) {
 
   const moveFocus = React.useCallback(
     (nextDate: DatePickerDate) => {
-      const clamped = clampDateToYearRange(nextDate, yearRange);
+      const clamped = clampDateToMonthRange(nextDate, monthRange);
       shouldMoveDomFocusRef.current = true;
       setFocusedDate(clamped);
 
@@ -565,7 +636,7 @@ export function useDatePicker(props: UseDatePickerProps) {
         setViewDate(clamped);
       }
     },
-    [setViewDate, viewDate, visibleRange, yearRange],
+    [monthRange, setViewDate, viewDate, visibleRange],
   );
 
   React.useEffect(() => {
@@ -769,18 +840,12 @@ export function useDatePicker(props: UseDatePickerProps) {
   const [continuousMonthHeights, setContinuousMonthHeights] = React.useState<
     ReadonlyMap<string, number>
   >(() => new Map());
-  const continuousYearStart = yearRange.start;
-  const continuousYearEnd = yearRange.end;
   const continuousMonthDescriptorBases = React.useMemo(
     () =>
       visibleRange === "continuous"
-        ? getMonthDescriptorBases(
-            { start: continuousYearStart, end: continuousYearEnd },
-            locale,
-            props.weekStartsOn,
-          )
+        ? getMonthDescriptorBases(monthRange, locale, props.weekStartsOn)
         : [],
-    [continuousYearEnd, continuousYearStart, locale, props.weekStartsOn, visibleRange],
+    [locale, monthRange, props.weekStartsOn, visibleRange],
   );
   const { descriptors, totalHeight } = React.useMemo(
     () =>
@@ -950,11 +1015,11 @@ export function useDatePicker(props: UseDatePickerProps) {
       if (isWheelOpen) return;
       const next =
         visibleRange === "week" ? addDays(viewDate, direction * 7) : addMonths(viewDate, direction);
-      const clamped = clampDateToYearRange(next, yearRange);
+      const clamped = clampDateToMonthRange(next, monthRange);
       setViewDate(clamped);
       setFocusedDate(clamped);
     },
-    [isWheelOpen, setViewDate, viewDate, visibleRange, yearRange],
+    [isWheelOpen, monthRange, setViewDate, viewDate, visibleRange],
   );
 
   const headerLabel =
@@ -964,14 +1029,20 @@ export function useDatePicker(props: UseDatePickerProps) {
   const previousLabel =
     visibleRange === "week" ? ariaLabels.previousWeek : ariaLabels.previousMonth;
   const nextLabel = visibleRange === "week" ? ariaLabels.nextWeek : ariaLabels.nextMonth;
+  const monthRangeStartDate = { ...monthRange.start, day: 1 };
+  const monthRangeEndStartDate = { ...monthRange.end, day: 1 };
+  const monthRangeEndDate = {
+    ...monthRange.end,
+    day: getDaysInMonth(monthRangeEndStartDate),
+  };
   const canMovePrevious =
     visibleRange === "week"
-      ? compareDates(viewDate, { year: yearRange.start, month: 1, day: 1 }) > 0
-      : viewDate.year > yearRange.start || viewDate.month > 1;
+      ? compareDates(viewDate, monthRangeStartDate) > 0
+      : compareYearMonths(viewDate, monthRange.start) > 0;
   const canMoveNext =
     visibleRange === "week"
-      ? compareDates(addDays(viewDate, 6), { year: yearRange.end, month: 12, day: 31 }) < 0
-      : viewDate.year < yearRange.end || viewDate.month < 12;
+      ? compareDates(addDays(viewDate, 6), monthRangeEndDate) < 0
+      : compareYearMonths(viewDate, monthRange.end) < 0;
 
   const yearOptions = React.useMemo(() => {
     const formatter = new Intl.DateTimeFormat(locale, {

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -216,6 +216,26 @@ describe("DatePicker", () => {
     }
   });
 
+  it("ContinuousDatePicker는 monthRange에 포함된 월만 노출한다", () => {
+    const { getAllByRole, queryByRole } = render(
+      <ContinuousDatePicker
+        {...commonProps}
+        defaultViewDate={{ year: 2026, month: 12, day: 1 }}
+        monthRange={{
+          start: { year: 2026, month: 12 },
+          end: { year: 2027, month: 1 },
+        }}
+        height="400px"
+      />,
+    );
+
+    expect(getAllByRole("grid")).toHaveLength(2);
+    expect(queryByRole("grid", { name: "2026년 11월" })).not.toBeInTheDocument();
+    expect(queryByRole("grid", { name: "2026년 12월" })).toBeInTheDocument();
+    expect(queryByRole("grid", { name: "2027년 1월" })).toBeInTheDocument();
+    expect(queryByRole("grid", { name: "2027년 2월" })).not.toBeInTheDocument();
+  });
+
   it("navigateToDate는 외부 포커스를 유지하고 오늘을 다음 tab 진입점으로 지정한다", () => {
     const actionsRef = React.createRef<DatePickerActions>();
     const { getByRole } = render(

--- a/packages/react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.tsx
@@ -9,6 +9,7 @@ import {
   type DatePickerCell,
   type DatePickerCellState,
   type DatePickerMonth,
+  type DatePickerMonthRange,
   type DatePickerVisibleRange,
   type UseDatePickerProps,
 } from "@seed-design/react-date-picker";
@@ -43,7 +44,7 @@ export interface DatePickerCellContentRenderProps extends DatePickerCellState {}
 
 type DatePickerBehaviorProps = UseDatePickerProps extends infer Props
   ? Props extends UseDatePickerProps
-    ? Omit<Props, "visibleRange">
+    ? Omit<Props, "visibleRange" | "monthRange">
     : never
   : never;
 
@@ -82,10 +83,18 @@ export type WeekDatePickerProps = DatePickerSharedProps;
 type DatePickerPropsWithoutSize<Props = DatePickerSharedProps> = Props extends DatePickerSharedProps
   ? Omit<Props, "height" | "minHeight" | "maxHeight">
   : never;
-export type ContinuousDatePickerProps = DatePickerPropsWithoutSize & ContinuousSizeConstraint;
+export type ContinuousDatePickerProps = DatePickerPropsWithoutSize &
+  ContinuousSizeConstraint & {
+    /**
+     * 노출하고 이동할 수 있는 월 범위입니다. 양끝 월을 포함합니다.
+     * 생략하면 `yearRange.start`의 1월부터 `yearRange.end`의 12월까지 노출합니다.
+     */
+    monthRange?: DatePickerMonthRange;
+  };
 
 type DatePickerImplementationProps = DatePickerSharedProps & {
   visibleRange: DatePickerVisibleRange;
+  monthRange?: DatePickerMonthRange;
 };
 
 type NavigationChevronIconProps = React.SVGProps<SVGSVGElement> & {
@@ -409,6 +418,7 @@ const DatePickerImplementation = React.forwardRef<HTMLDivElement, DatePickerImpl
       locale: _locale,
       weekStartsOn: _weekStartsOn,
       yearRange: _yearRange,
+      monthRange: _monthRange,
       constraints: _constraints,
       disabled: _disabled,
       readOnly: _readOnly,
@@ -554,10 +564,12 @@ export type {
   DatePickerConstraint,
   DatePickerConstraintContext,
   DatePickerDate,
+  DatePickerMonthRange,
   DatePickerMultipleProps,
   DatePickerRangeProps,
   DatePickerRangeValue,
   DatePickerSelectionMode,
   DatePickerSingleProps,
   DatePickerValue,
+  DatePickerYearMonth,
 } from "@seed-design/react-date-picker";

--- a/packages/react/src/components/DatePicker/index.ts
+++ b/packages/react/src/components/DatePicker/index.ts
@@ -10,6 +10,7 @@ export {
   type DatePickerConstraint,
   type DatePickerConstraintContext,
   type DatePickerDate,
+  type DatePickerMonthRange,
   type DatePickerMultipleProps,
   type DatePickerProps,
   type DatePickerRangeProps,
@@ -17,6 +18,7 @@ export {
   type DatePickerSelectionMode,
   type DatePickerSingleProps,
   type DatePickerValue,
+  type DatePickerYearMonth,
   type TwoMonthDatePickerProps,
   type WeekDatePickerProps,
 } from "./DatePicker";


### PR DESCRIPTION
## Summary

- add `monthRange` to `ContinuousDatePicker` while preserving existing `yearRange` behavior
- constrain rendered months, scrolling, keyboard navigation, and actions to the resolved month range
- add boundary tests, documentation, Storybook coverage, and a minor changeset

## Verification

- `bun generate:all`
- `bun docs:test`
- `bun headless:test`
- `bun react:test`
- `bun packages:build`
- `bun storybook:build`
- focused Date Picker tests: 50 passed
- Storybook visual checks in light/dark themes and multiple font scales
- axe: 0 violations

`bun test:all` passed before rebasing. After rebasing onto `minor`, it is blocked by unrelated existing WheelPicker matcher failures (`Expected this to be instanceof ExpectMatcherUtils`); the focused Date Picker suite still passes.

## Issue

- DES-2465