### PR TITLE
fix(docs): improve updates title wrapping

### DIFF
--- a/docs/app/updates/[slug]/page.tsx
+++ b/docs/app/updates/[slug]/page.tsx
@@ -88,9 +88,13 @@ export default async function Page(props: { params: Promise<{ slug: string }> })
           ? undefined
           : "prose-h2:text-[1.75rem] prose-h3:text-[1.5rem] prose-p:text-[1.125rem] prose-li:text-[1.125rem] prose-p:leading-[1.7] prose-li:leading-[1.7] prose-em:text-[color:var(--seed-color-palette-gray-700)]"
       }
-      // 타이틀 h1 중앙 정렬(날짜 메타는 위 meta에서 이미 flex center). DocsTitle은 전역 공유
-      // 컴포넌트라 CSS로 박지 않고, 이 prop이 전달된 Updates 라우트에서만 text-center를 얹는다.
-      titleClassName={isRelease ? undefined : "text-center"}
+      // Updates의 모든 상세 제목은 한국어 어절 단위 줄바꿈을 우선하고 균형 있게 배치한다.
+      // `auto-phrase` 미지원 브라우저에서는 `text-balance`만 적용된다.
+      // 블로그 글은 날짜 메타와 함께 중앙 정렬하고, 릴리즈 노트는 기본 좌측 정렬을 유지한다.
+      titleClassName={clsx(
+        "text-balance [word-break:auto-phrase]",
+        !isRelease && "text-center",
+      )}
       meta={
         publishedDate ? (
           <div

--- a/docs/app/updates/page.tsx
+++ b/docs/app/updates/page.tsx
@@ -126,7 +126,9 @@ function UpdateCardLink({ card }: { card: UpdateCard }) {
         </time>
       )}
       <div className="mt-1 flex items-start justify-between gap-2">
-        <h3 className="text-lg font-medium">{card.title}</h3>
+        <h3 className="text-balance text-lg font-medium [word-break:auto-phrase]">
+          {card.title}
+        </h3>
         {/* 내부 링크는 클릭하면 같은 사이트 안에서 이동하므로 화살표가 정보를 더하지 않는다.
             새 탭으로 나가는 외부 글에만 ↗를 남긴다. */}
         {card.external && (
@@ -165,7 +167,11 @@ export default async function Page() {
   const posts = cards.filter((card) => card.category !== "release");
 
   return (
-    <ProsePage title={UPDATES_TITLE} description={UPDATES_DESCRIPTION}>
+    <ProsePage
+      title={UPDATES_TITLE}
+      titleClassName="text-balance [word-break:auto-phrase]"
+      description={UPDATES_DESCRIPTION}
+    >
       <LlmsLinkRels section="updates" markdownUrl={getLLMMarkdownUrl("updates", [])} />
       <div className="not-prose mb-8 md:mb-10">
         <img

--- a/docs/app/updates/release-card.test.tsx
+++ b/docs/app/updates/release-card.test.tsx
@@ -22,8 +22,11 @@ describe("ReleaseCard", () => {
     expect(link.getAttribute("href")).toBe("/updates/pickers-dialog-select");
     expect(screen.getByText("2026. 8. 10")).toBeDefined();
     expect(Array.from(metadataAndTitle, (element) => element.tagName)).toEqual(["TIME", "H3"]);
-    expect(screen.getByRole("heading", { level: 3 }).className).toContain("text-lg");
-    expect(screen.getByRole("heading", { level: 3 }).className).toContain("font-medium");
+    const heading = screen.getByRole("heading", { level: 3 });
+    expect(heading.className).toContain("text-lg");
+    expect(heading.className).toContain("font-medium");
+    expect(heading.className).toContain("text-balance");
+    expect(heading.className).toContain("[word-break:auto-phrase]");
     expect(link.className).not.toContain("min-h-");
     expect(link.querySelector("p")).toBeNull();
     expect(link.querySelector("svg")).toBeNull();

--- a/docs/app/updates/release-card.tsx
+++ b/docs/app/updates/release-card.tsx
@@ -26,7 +26,9 @@ export function ReleaseCard({ href, title, description, publishedAt }: ReleaseCa
             {formatPublishedDate(published)}
           </time>
         )}
-        <h3 className="min-w-0 break-words text-balance text-lg font-medium">{title}</h3>
+        <h3 className="min-w-0 break-words text-balance text-lg font-medium [word-break:auto-phrase]">
+          {title}
+        </h3>
       </div>
       {description && (
         <p className="t4-regular mt-x2 line-clamp-2 break-words text-fg-neutral-muted">

--- a/docs/components/layout/prose-page.tsx
+++ b/docs/components/layout/prose-page.tsx
@@ -5,6 +5,8 @@ import { SiteFooter } from "./site-footer";
 
 interface ProsePageProps {
   title: ReactNode;
+  /** 제목(h1)에 덧붙일 라우트 전용 클래스. */
+  titleClassName?: string;
   description?: ReactNode;
   /** 제목 위 전체폭 하이라이트(커버 이미지 등). main 컬럼 전체 폭(≈헤더 폭)까지 넓게 쓴다. */
   hero?: ReactNode;
@@ -23,6 +25,7 @@ interface ProsePageProps {
  */
 export function ProsePage({
   title,
+  titleClassName,
   description,
   hero,
   children,
@@ -38,7 +41,12 @@ export function ProsePage({
         >
           <header className="not-prose mb-10 md:mb-14">
             {/* get-started/updates 제목 스케일: text-3xl→md:text-[40px] (데스크탑 40px 고정). */}
-            <h1 className="text-fd-foreground text-3xl font-medium tracking-tight text-balance md:text-[40px]">
+            <h1
+              className={clsx(
+                "text-fd-foreground text-3xl font-medium tracking-tight text-balance md:text-[40px]",
+                titleClassName,
+              )}
+            >
               {title}
             </h1>
             {description ? (


### PR DESCRIPTION
## 변경 사항

- Updates 루트와 블로그·릴리즈 카드 제목에 균형 줄바꿈과 한국어 어절 단위 줄바꿈을 적용했습니다.
- 블로그·릴리즈 상세 제목에도 같은 줄바꿈 규칙을 적용했습니다.
- `ProsePage`에서 라우트별 제목 클래스를 전달할 수 있도록 확장했습니다.
- 릴리즈 카드 제목 스타일 회귀 테스트를 추가했습니다.

## 검증

- `bun generate:all`
- `bun docs:test`
- `bun --filter @seed-design/docs typecheck:web`
- 로컬 브라우저 계산 스타일 확인 (`text-wrap-style: balance`, `word-break: auto-phrase`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 업데이트 및 릴리즈 페이지의 제목에 균형 잡힌 줄바꿈과 자연스러운 단어 분리를 적용했습니다.
  - 긴 제목도 더욱 읽기 쉽게 표시됩니다.
  - 릴리즈 노트 제목은 왼쪽 정렬을 유지하고, 블로그 제목은 중앙 정렬됩니다.
  - 릴리즈 카드 제목의 스타일과 배치를 일관되게 개선했습니다.

- **테스트**
  - 제목에 적용되는 텍스트 스타일 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->