### PR TITLE
fix(react): raise @seed-design/css peer floor to ^2.6.0

### DIFF
--- a/.changeset/tidy-moons-align.md
+++ b/.changeset/tidy-moons-align.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/react": patch
+---
+
+`@seed-design/css`의 peer 버전 하한을 `^2.6.0`으로 올립니다.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -82,7 +82,7 @@
     "unicode-segmenter": "^0.17.3"
   },
   "peerDependencies": {
-    "@seed-design/css": "^2.5.0",
+    "@seed-design/css": "^2.6.0",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * `@seed-design/react`의 패치 릴리스가 제공됩니다.
  * `@seed-design/css` 호환 버전의 최소 기준이 `2.6.0`으로 상향되었습니다.
  * 최신 CSS 패키지 버전을 사용하면 업데이트된 React 패키지와 안정적으로 호환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->