### PR TITLE
feat(docs): add Lynx compatibility metadata

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -47,18 +47,18 @@ Lynx 컴포넌트 문서를 작성할 때는 **웹 버전과의 차이점을 반
 - **API 차이**: props 차이, 컴파운드 컴포넌트 구조 차이, 이벤트 핸들링(`bindtap` 등)
 - **누락 기능**: 웹에는 있지만 Lynx에서 미지원인 기능
 
-Lynx Engine과 XElement의 최소 버전이 확정된 컴포넌트는 frontmatter에 `lynx`를 작성한다. 화면과 llms.txt는 이 값을 자동으로 렌더링한다.
+Lynx Engine 최소 버전과 사용 XElement가 확정된 컴포넌트는 frontmatter에 `lynx`를 작성한다. 화면과 llms.txt는 이 값을 자동으로 렌더링한다.
 
 ```yaml
 lynx:
   engine: "2.5"
   x-elements:
-    - name: viewpager
-      version: "2.5.1"
+    - viewpager
 ```
 
-- `engine`과 `x-elements[].version`에는 해당 컴포넌트를 사용할 수 있는 최소 버전을 적는다.
+- `engine`에는 해당 컴포넌트를 사용할 수 있는 실제 최소 버전을 적는다.
 - `engine`이 SEED의 최소 지원 버전인 3.6보다 낮으면 화면과 llms.txt에는 3.6으로 표시한다. frontmatter에는 조사한 실제 요구 버전을 유지한다.
+- `x-elements`에는 컴포넌트가 사용하는 XElement 태그 이름만 적는다. XElement별 버전은 관리하지 않는다.
 - XElement와 관련이 없으면 `x-elements`를 생략한다.
 - 직접 사용과 전이·조건부 사용을 구분하지 않고, 컴포넌트와 관련된 XElement를 모두 같은 형식으로 나열한다.
 - 확정된 버전이 없으면 `lynx`를 생략한다. `unknown`이나 추정값은 입력하지 않는다.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -47,6 +47,23 @@ Lynx 컴포넌트 문서를 작성할 때는 **웹 버전과의 차이점을 반
 - **API 차이**: props 차이, 컴파운드 컴포넌트 구조 차이, 이벤트 핸들링(`bindtap` 등)
 - **누락 기능**: 웹에는 있지만 Lynx에서 미지원인 기능
 
+Lynx Engine과 XElement의 최소 버전이 확정된 컴포넌트는 frontmatter에 `lynx`를 작성한다. 화면과 llms.txt는 이 값을 자동으로 렌더링한다.
+
+```yaml
+lynx:
+  engine: "2.5"
+  x-elements:
+    - name: viewpager
+      version: "2.5.1"
+```
+
+- `engine`과 `x-elements[].version`에는 해당 컴포넌트를 사용할 수 있는 최소 버전을 적는다.
+- `engine`이 SEED의 최소 지원 버전인 3.6보다 낮으면 화면과 llms.txt에는 3.6으로 표시한다. frontmatter에는 조사한 실제 요구 버전을 유지한다.
+- XElement와 관련이 없으면 `x-elements`를 생략한다.
+- 직접 사용과 전이·조건부 사용을 구분하지 않고, 컴포넌트와 관련된 XElement를 모두 같은 형식으로 나열한다.
+- 확정된 버전이 없으면 `lynx`를 생략한다. `unknown`이나 추정값은 입력하지 않는다.
+- `<AvailableSince />`는 SEED 패키지 출시 버전을 뜻하므로 그대로 유지한다.
+
 ## 콘텐츠 작성 룰 (`content/`)
 
 - 컴포넌트/훅 문서를 신설하면 frontmatter 직후에 `<AvailableSince />`를 넣는다.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -47,13 +47,14 @@ Lynx 컴포넌트 문서를 작성할 때는 **웹 버전과의 차이점을 반
 - **API 차이**: props 차이, 컴파운드 컴포넌트 구조 차이, 이벤트 핸들링(`bindtap` 등)
 - **누락 기능**: 웹에는 있지만 Lynx에서 미지원인 기능
 
-Lynx Engine 최소 버전과 사용 XElement가 확정된 컴포넌트는 frontmatter에 `lynx`를 작성한다. 화면과 llms.txt는 이 값을 자동으로 렌더링한다.
+Lynx Engine 최소 버전과 사용 XElement가 확정된 컴포넌트는 frontmatter의 `compatibility.lynx`에 작성한다. 화면과 llms.txt는 이 값을 자동으로 렌더링한다.
 
 ```yaml
-lynx:
-  engine: "2.5"
-  x-elements:
-    - viewpager
+compatibility:
+  lynx:
+    engine: "2.5"
+    x-elements:
+      - viewpager
 ```
 
 - `engine`에는 해당 컴포넌트를 사용할 수 있는 실제 최소 버전을 적는다.
@@ -61,7 +62,7 @@ lynx:
 - `x-elements`에는 컴포넌트가 사용하는 XElement 태그 이름만 적는다. XElement별 버전은 관리하지 않는다.
 - XElement와 관련이 없으면 `x-elements`를 생략한다.
 - 직접 사용과 전이·조건부 사용을 구분하지 않고, 컴포넌트와 관련된 XElement를 모두 같은 형식으로 나열한다.
-- 확정된 버전이 없으면 `lynx`를 생략한다. `unknown`이나 추정값은 입력하지 않는다.
+- 확정된 버전이 없으면 `compatibility.lynx`를 생략한다. `unknown`이나 추정값은 입력하지 않는다.
 - `<AvailableSince />`는 SEED 패키지 출시 버전을 뜻하므로 그대로 유지한다.
 
 ## 콘텐츠 작성 룰 (`content/`)

--- a/docs/app/_llms/get-llm-text.test.ts
+++ b/docs/app/_llms/get-llm-text.test.ts
@@ -3,13 +3,13 @@ import { getLynxCompatibilityBlock } from "./get-llm-text";
 
 const compatibility = {
   engine: "2.5",
-  "x-elements": [{ name: "viewpager", version: "2.5.1" }],
+  "x-elements": ["viewpager"],
 };
 
 describe("getLynxCompatibilityBlock", () => {
   it("Lynx 문서에 호환 정보 블록을 출력한다", () => {
     expect(getLynxCompatibilityBlock(compatibility, "lynx")).toBe(
-      "Lynx Engine 최소 버전: 3.6\nXElement 최소 버전: viewpager@2.5.1\n\n",
+      "Lynx Engine 최소 버전: 3.6\n사용 XElement: <viewpager>\n\n",
     );
   });
 

--- a/docs/app/_llms/get-llm-text.test.ts
+++ b/docs/app/_llms/get-llm-text.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test";
+import { getLynxCompatibilityBlock } from "./get-llm-text";
+
+const compatibility = {
+  engine: "2.5",
+  "x-elements": [{ name: "viewpager", version: "2.5.1" }],
+};
+
+describe("getLynxCompatibilityBlock", () => {
+  it("Lynx 문서에 호환 정보 블록을 출력한다", () => {
+    expect(getLynxCompatibilityBlock(compatibility, "lynx")).toBe(
+      "Lynx Engine 최소 버전: 3.6\nXElement 최소 버전: viewpager@2.5.1\n\n",
+    );
+  });
+
+  it("다른 섹션이나 호환 정보가 없는 문서에는 출력하지 않는다", () => {
+    expect(getLynxCompatibilityBlock(compatibility, "react")).toBe("");
+    expect(getLynxCompatibilityBlock(undefined, "lynx")).toBe("");
+  });
+});

--- a/docs/app/_llms/get-llm-text.ts
+++ b/docs/app/_llms/get-llm-text.ts
@@ -1,5 +1,7 @@
 import type { LLMPage, Section } from "./types";
 import { getGitHubSourceUrl } from "./config";
+import { getLynxCompatibilityMarkdown } from "@/lib/lynx-compatibility";
+import type { LynxCompatibility } from "@/lib/lynx-compatibility";
 import { ensureRulesReady, normalizeLLMBody } from "./normalize-llm-body";
 import { getPlatformStatusMarkdown } from "./rules/platform-status-rule";
 
@@ -17,6 +19,15 @@ async function platformStatusBlock(page: LLMPage, section: Section): Promise<str
   return table ? `${table}\n\n` : "";
 }
 
+export function getLynxCompatibilityBlock(
+  compatibility: LynxCompatibility | undefined,
+  section: Section,
+): string {
+  if (section !== "lynx" || !compatibility) return "";
+
+  return `${getLynxCompatibilityMarkdown(compatibility)}\n\n`;
+}
+
 export async function getLLMText(page: LLMPage, section: Section): Promise<string> {
   await ensureRulesReady();
   const renderer = await page.data.load();
@@ -24,6 +35,7 @@ export async function getLLMText(page: LLMPage, section: Section): Promise<strin
   const processed = normalizeLLMBody(exports.processed);
   const sourceUrl = getGitHubSourceUrl(section, page.path);
   const platformStatus = await platformStatusBlock(page, section);
+  const lynxCompatibility = getLynxCompatibilityBlock(page.data.frontmatter.lynx, section);
 
   return `# ${page.data.title}
 URL: ${page.url}
@@ -31,5 +43,5 @@ Source: ${sourceUrl}
 
 ${page.data.description ?? ""}
 
-${platformStatus}${processed}`;
+${platformStatus}${lynxCompatibility}${processed}`;
 }

--- a/docs/app/_llms/get-llm-text.ts
+++ b/docs/app/_llms/get-llm-text.ts
@@ -35,7 +35,10 @@ export async function getLLMText(page: LLMPage, section: Section): Promise<strin
   const processed = normalizeLLMBody(exports.processed);
   const sourceUrl = getGitHubSourceUrl(section, page.path);
   const platformStatus = await platformStatusBlock(page, section);
-  const lynxCompatibility = getLynxCompatibilityBlock(page.data.frontmatter.lynx, section);
+  const lynxCompatibility = getLynxCompatibilityBlock(
+    page.data.frontmatter.compatibility?.lynx,
+    section,
+  );
 
   return `# ${page.data.title}
 URL: ${page.url}

--- a/docs/app/_llms/types.ts
+++ b/docs/app/_llms/types.ts
@@ -1,5 +1,6 @@
 import type { MarkdownRenderer } from "@fumadocs/satteri/local-md";
 import type { Page } from "fumadocs-core/source";
+import type { LynxCompatibility } from "@/lib/lynx-compatibility";
 
 export type Section =
   | "get-started"
@@ -22,6 +23,8 @@ export type LLMPage = Page & {
       deprecated?: boolean;
       /** components 섹션: 헤더/llms에 상태를 보여줄 컴포넌트 id 목록. 생략 시 slug 하나로 간주. */
       componentIds?: string[];
+      /** lynx 섹션: 문서 헤더와 llms에 보여줄 Engine·XElement 최소 버전. */
+      lynx?: LynxCompatibility;
     };
     load: () => Promise<MarkdownRenderer<Record<string, unknown> & { processed?: string }>>;
   };

--- a/docs/app/_llms/types.ts
+++ b/docs/app/_llms/types.ts
@@ -23,7 +23,7 @@ export type LLMPage = Page & {
       deprecated?: boolean;
       /** components 섹션: 헤더/llms에 상태를 보여줄 컴포넌트 id 목록. 생략 시 slug 하나로 간주. */
       componentIds?: string[];
-      /** lynx 섹션: 문서 헤더와 llms에 보여줄 Engine·XElement 최소 버전. */
+      /** lynx 섹션: 문서 헤더와 llms에 보여줄 Engine 최소 버전과 사용 XElement. */
       lynx?: LynxCompatibility;
     };
     load: () => Promise<MarkdownRenderer<Record<string, unknown> & { processed?: string }>>;

--- a/docs/app/_llms/types.ts
+++ b/docs/app/_llms/types.ts
@@ -24,7 +24,9 @@ export type LLMPage = Page & {
       /** components 섹션: 헤더/llms에 상태를 보여줄 컴포넌트 id 목록. 생략 시 slug 하나로 간주. */
       componentIds?: string[];
       /** lynx 섹션: 문서 헤더와 llms에 보여줄 Engine 최소 버전과 사용 XElement. */
-      lynx?: LynxCompatibility;
+      compatibility?: {
+        lynx: LynxCompatibility;
+      };
     };
     load: () => Promise<MarkdownRenderer<Record<string, unknown> & { processed?: string }>>;
   };

--- a/docs/app/lynx/[[...slug]]/page.tsx
+++ b/docs/app/lynx/[[...slug]]/page.tsx
@@ -39,7 +39,7 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
       }
       layout={page.data.frontmatter.layout}
       full={page.data.frontmatter.full}
-      meta={<LynxCompatibilityBadges compatibility={page.data.frontmatter.lynx} />}
+      meta={<LynxCompatibilityBadges compatibility={page.data.frontmatter.compatibility?.lynx} />}
       toc={toc}
       lastUpdate={lastModified}
       showPageActions={page.slugs.length > 0}

--- a/docs/app/lynx/[[...slug]]/page.tsx
+++ b/docs/app/lynx/[[...slug]]/page.tsx
@@ -1,5 +1,6 @@
 import { getLLMMarkdownUrl } from "@/app/_llms/config";
 import { getLynxSource } from "@/app/source";
+import { LynxCompatibilityBadges } from "@/components/lynx-compatibility";
 import { DocsPageRenderer } from "@/components/layout/docs-page-renderer";
 import { loadMarkdownPage } from "@/lib/load-markdown-page";
 import { buildDocsPageJsonLd, buildDocsPageMetadata, resolveCoverImage } from "@/lib/seo";
@@ -38,6 +39,7 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
       }
       layout={page.data.frontmatter.layout}
       full={page.data.frontmatter.full}
+      meta={<LynxCompatibilityBadges compatibility={page.data.frontmatter.lynx} />}
       toc={toc}
       lastUpdate={lastModified}
       showPageActions={page.slugs.length > 0}

--- a/docs/app/source.tsx
+++ b/docs/app/source.tsx
@@ -206,7 +206,11 @@ const lynxDocs = localMd({
   frontmatterSchema: baseDocsSchema.extend({
     ...staticCoverImageSchema,
     ...headingSchema,
-    lynx: lynxCompatibilitySchema.optional(),
+    compatibility: z
+      .object({
+        lynx: lynxCompatibilitySchema,
+      })
+      .optional(),
   }),
   metaSchema: docsMetaSchema,
   satteriOptions: createSatteriOptions,

--- a/docs/app/source.tsx
+++ b/docs/app/source.tsx
@@ -21,6 +21,7 @@ import { readFigmaImageManifest } from "@/components/figma-image/figma-image-man
 import { remarkFigmaImage } from "@/components/figma-image/remark-figma-image";
 import { filteredTypeTableGenerator } from "@/components/type-table/generator";
 import { markFeatured } from "@/lib/featured";
+import { lynxCompatibilitySchema } from "@/lib/lynx-compatibility";
 import { COVER_IMAGE_PATH_ERROR_MESSAGE, isValidCoverImagePath } from "@/lib/cover-image";
 import { remarkDocGen } from "@/lib/satteri/remark-doc-gen";
 import { remarkApplyLlmsFilter } from "@/lib/satteri/remark-llms-filter";
@@ -202,7 +203,11 @@ const breezeDocs = localMd({
 
 const lynxDocs = localMd({
   dir: "content/lynx",
-  frontmatterSchema: baseDocsSchema.extend({ ...staticCoverImageSchema, ...headingSchema }),
+  frontmatterSchema: baseDocsSchema.extend({
+    ...staticCoverImageSchema,
+    ...headingSchema,
+    lynx: lynxCompatibilitySchema.optional(),
+  }),
   metaSchema: docsMetaSchema,
   satteriOptions: createSatteriOptions,
 });

--- a/docs/components/lynx-compatibility.test.tsx
+++ b/docs/components/lynx-compatibility.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import { LynxCompatibilityBadges } from "./lynx-compatibility";
+
+describe("LynxCompatibilityBadges", () => {
+  it("Engine과 모든 XElement 최소 버전을 표시한다", () => {
+    render(
+      <LynxCompatibilityBadges
+        compatibility={{
+          engine: "2.5",
+          "x-elements": [
+            { name: "viewpager", version: "2.5.1" },
+            { name: "viewpager-item", version: "2.5.1" },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Engine ≥ 3.6")).toBeDefined();
+    expect(screen.getByText("XElement · viewpager ≥ 2.5.1")).toBeDefined();
+    expect(screen.getByText("XElement · viewpager-item ≥ 2.5.1")).toBeDefined();
+  });
+
+  it("호환 정보가 없으면 아무것도 표시하지 않는다", () => {
+    const { container } = render(<LynxCompatibilityBadges />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/docs/components/lynx-compatibility.test.tsx
+++ b/docs/components/lynx-compatibility.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { LynxCompatibilityBadges } from "./lynx-compatibility";
 
 describe("LynxCompatibilityBadges", () => {
-  it("Engine과 모든 XElement 최소 버전을 표시한다", () => {
+  it("SEED 최소 Engine 버전과 모든 XElement 태그를 표시한다", () => {
     render(
       <LynxCompatibilityBadges
         compatibility={{
@@ -16,9 +16,17 @@ describe("LynxCompatibilityBadges", () => {
       />,
     );
 
+    expect(screen.getByRole("region", { name: "Lynx 호환 정보" })).toBeDefined();
     expect(screen.getByText("Engine ≥ 3.6")).toBeDefined();
-    expect(screen.getByText("XElement · viewpager ≥ 2.5.1")).toBeDefined();
-    expect(screen.getByText("XElement · viewpager-item ≥ 2.5.1")).toBeDefined();
+    expect(screen.getByText("<viewpager>", { selector: "code" })).toBeDefined();
+    expect(screen.getByText("<viewpager-item>", { selector: "code" })).toBeDefined();
+  });
+
+  it("SEED 최소 지원 버전보다 높은 Engine 버전은 그대로 표시한다", () => {
+    render(<LynxCompatibilityBadges compatibility={{ engine: "3.9" }} />);
+
+    expect(screen.getByText("Engine ≥ 3.9")).toBeDefined();
+    expect(screen.queryByText("Engine ≥ 3.6")).toBeNull();
   });
 
   it("호환 정보가 없으면 아무것도 표시하지 않는다", () => {

--- a/docs/components/lynx-compatibility.test.tsx
+++ b/docs/components/lynx-compatibility.test.tsx
@@ -8,10 +8,7 @@ describe("LynxCompatibilityBadges", () => {
       <LynxCompatibilityBadges
         compatibility={{
           engine: "2.5",
-          "x-elements": [
-            { name: "viewpager", version: "2.5.1" },
-            { name: "viewpager-item", version: "2.5.1" },
-          ],
+          "x-elements": ["viewpager", "viewpager-item"],
         }}
       />,
     );

--- a/docs/components/lynx-compatibility.tsx
+++ b/docs/components/lynx-compatibility.tsx
@@ -48,10 +48,3 @@ export function LynxCompatibilityBadges({ compatibility }: LynxCompatibilityBadg
     </section>
   );
 }
-
-// <span
-//   key={name}
-//   className="inline-flex items-center rounded-full bg-bg-transparent-selected px-x2 py-x1 text-xs font-medium text-fg-neutral"
-// >
-//   XElement · {name} ≥ {version}
-// </span>

--- a/docs/components/lynx-compatibility.tsx
+++ b/docs/components/lynx-compatibility.tsx
@@ -40,7 +40,7 @@ export function LynxCompatibilityBadges({ compatibility }: LynxCompatibilityBadg
       </Badge>
 
       {!!xElements &&
-        xElements.map(({ name }) => (
+        xElements.map((name) => (
           <Badge key={name}>
             <code>{`<${name}>`}</code>
           </Badge>

--- a/docs/components/lynx-compatibility.tsx
+++ b/docs/components/lynx-compatibility.tsx
@@ -1,0 +1,57 @@
+import { getEffectiveLynxCompatibility, type LynxCompatibility } from "@/lib/lynx-compatibility";
+import { Badge } from "./mdx-badge";
+
+interface LynxCompatibilityBadgesProps {
+  compatibility?: LynxCompatibility;
+}
+
+function LynxIcon() {
+  return (
+    <span
+      aria-hidden="true"
+      className="size-x4 shrink-0 bg-current"
+      style={{
+        WebkitMaskImage: "url('/lynx.svg')",
+        maskImage: "url('/lynx.svg')",
+        WebkitMaskPosition: "center",
+        maskPosition: "center",
+        WebkitMaskRepeat: "no-repeat",
+        maskRepeat: "no-repeat",
+        WebkitMaskSize: "contain",
+        maskSize: "contain",
+      }}
+    />
+  );
+}
+
+export function LynxCompatibilityBadges({ compatibility }: LynxCompatibilityBadgesProps) {
+  if (!compatibility) return null;
+  const effectiveCompatibility = getEffectiveLynxCompatibility(compatibility);
+  const xElements = effectiveCompatibility["x-elements"];
+
+  return (
+    <section
+      className="not-prose -mt-8 mb-3 flex flex-wrap items-center gap-x2 gap-y2"
+      aria-label="Lynx 호환 정보"
+    >
+      <Badge tone="positive" className="inline-flex items-center gap-x1">
+        <LynxIcon />
+        <span>Engine ≥ {effectiveCompatibility.engine}</span>
+      </Badge>
+
+      {!!xElements &&
+        xElements.map(({ name }) => (
+          <Badge key={name}>
+            <code>{`<${name}>`}</code>
+          </Badge>
+        ))}
+    </section>
+  );
+}
+
+// <span
+//   key={name}
+//   className="inline-flex items-center rounded-full bg-bg-transparent-selected px-x2 py-x1 text-xs font-medium text-fg-neutral"
+// >
+//   XElement · {name} ≥ {version}
+// </span>

--- a/docs/components/mdx-badge.tsx
+++ b/docs/components/mdx-badge.tsx
@@ -12,10 +12,11 @@ const TONES = {
 
 interface BadgeProps {
   tone?: keyof typeof TONES;
+  className?: string;
   children: ReactNode;
 }
 
-export function Badge({ tone = "neutral", children }: BadgeProps) {
+export function Badge({ tone = "neutral", children, ...props }: BadgeProps) {
   const className = TONES[tone] ?? TONES.neutral;
 
   return (
@@ -23,6 +24,7 @@ export function Badge({ tone = "neutral", children }: BadgeProps) {
       className={clsx(
         "not-prose inline-flex items-center rounded-full px-2 py-1 text-sm font-medium",
         className,
+        props.className,
       )}
     >
       {children}

--- a/docs/content/lynx/components/accordion.mdx
+++ b/docs/content/lynx/components/accordion.mdx
@@ -1,6 +1,8 @@
 ---
 title: Accordion
 description: 관련된 정보 섹션을 접고 펼쳐 화면을 간결하게 구성하는 컴포넌트입니다.
+lynx:
+  engine: "3.5"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.5.0, @seed-design/lynx-css@0.9.0" />

--- a/docs/content/lynx/components/accordion.mdx
+++ b/docs/content/lynx/components/accordion.mdx
@@ -1,8 +1,9 @@
 ---
 title: Accordion
 description: 관련된 정보 섹션을 접고 펼쳐 화면을 간결하게 구성하는 컴포넌트입니다.
-lynx:
-  engine: "3.5"
+compatibility:
+  lynx:
+    engine: "3.5"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.5.0, @seed-design/lynx-css@0.9.0" />

--- a/docs/content/lynx/components/action-button.mdx
+++ b/docs/content/lynx/components/action-button.mdx
@@ -1,8 +1,9 @@
 ---
 title: Action Button
 description: 명확한 액션을 쉽게 수행할 수 있도록 돕는 기본 인터랙션 컴포넌트입니다.
-lynx:
-  engine: "3.5"
+compatibility:
+  lynx:
+    engine: "3.5"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/action-button.mdx
+++ b/docs/content/lynx/components/action-button.mdx
@@ -1,6 +1,8 @@
 ---
 title: Action Button
 description: 명확한 액션을 쉽게 수행할 수 있도록 돕는 기본 인터랙션 컴포넌트입니다.
+lynx:
+  engine: "3.5"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/app-bar.mdx
+++ b/docs/content/lynx/components/app-bar.mdx
@@ -1,8 +1,9 @@
 ---
 title: AppBar
 description: 화면 상단에서 현재 화면의 제목과 탐색 액션을 보여주는 내비게이션 바 컴포넌트입니다.
-lynx:
-  engine: "3.5"
+compatibility:
+  lynx:
+    engine: "3.5"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.2.0, @seed-design/lynx-css@0.2.0" />

--- a/docs/content/lynx/components/app-bar.mdx
+++ b/docs/content/lynx/components/app-bar.mdx
@@ -1,6 +1,8 @@
 ---
 title: AppBar
 description: 화면 상단에서 현재 화면의 제목과 탐색 액션을 보여주는 내비게이션 바 컴포넌트입니다.
+lynx:
+  engine: "3.5"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.2.0, @seed-design/lynx-css@0.2.0" />

--- a/docs/content/lynx/components/badge.mdx
+++ b/docs/content/lynx/components/badge.mdx
@@ -1,6 +1,8 @@
 ---
 title: Badge
 description: 상태나 속성을 짧은 텍스트로 표시하는 정보성 컴포넌트입니다.
+lynx:
+  engine: "1.0"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.2.0, @seed-design/lynx-css@0.2.0" />

--- a/docs/content/lynx/components/badge.mdx
+++ b/docs/content/lynx/components/badge.mdx
@@ -1,8 +1,9 @@
 ---
 title: Badge
 description: 상태나 속성을 짧은 텍스트로 표시하는 정보성 컴포넌트입니다.
-lynx:
-  engine: "1.0"
+compatibility:
+  lynx:
+    engine: "1.0"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.2.0, @seed-design/lynx-css@0.2.0" />

--- a/docs/content/lynx/components/bottom-sheet.mdx
+++ b/docs/content/lynx/components/bottom-sheet.mdx
@@ -1,10 +1,11 @@
 ---
 title: Bottom Sheet
 description: 화면 하단에서 올라오는 시트 컴포넌트로, 드래그·snap·dismiss 상호작용을 제공합니다.
-lynx:
-  engine: "3.5"
-  x-elements:
-    - overlay
+compatibility:
+  lynx:
+    engine: "3.5"
+    x-elements:
+      - overlay
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/bottom-sheet.mdx
+++ b/docs/content/lynx/components/bottom-sheet.mdx
@@ -1,6 +1,11 @@
 ---
 title: Bottom Sheet
 description: 화면 하단에서 올라오는 시트 컴포넌트로, 드래그·snap·dismiss 상호작용을 제공합니다.
+lynx:
+  engine: "3.5"
+  x-elements:
+    - name: overlay
+      version: "3.6.0"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/bottom-sheet.mdx
+++ b/docs/content/lynx/components/bottom-sheet.mdx
@@ -4,8 +4,7 @@ description: 화면 하단에서 올라오는 시트 컴포넌트로, 드래그�
 lynx:
   engine: "3.5"
   x-elements:
-    - name: overlay
-      version: "3.6.0"
+    - overlay
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/callout.mdx
+++ b/docs/content/lynx/components/callout.mdx
@@ -1,6 +1,8 @@
 ---
 title: Callout
 description: 사용자에게 중요한 정보나 팁을 시각적으로 강조하여 전달하는 메시지 컴포넌트입니다.
+lynx:
+  engine: "3.5"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.5.0, @seed-design/lynx-css@0.9.0" />

--- a/docs/content/lynx/components/callout.mdx
+++ b/docs/content/lynx/components/callout.mdx
@@ -1,8 +1,9 @@
 ---
 title: Callout
 description: 사용자에게 중요한 정보나 팁을 시각적으로 강조하여 전달하는 메시지 컴포넌트입니다.
-lynx:
-  engine: "3.5"
+compatibility:
+  lynx:
+    engine: "3.5"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.5.0, @seed-design/lynx-css@0.9.0" />

--- a/docs/content/lynx/components/checkbox.mdx
+++ b/docs/content/lynx/components/checkbox.mdx
@@ -1,6 +1,8 @@
 ---
 title: Checkbox
 description: 사용자가 여러 옵션 중 하나 이상을 선택할 수 있게 하는 체크박스 컴포넌트입니다.
+lynx:
+  engine: "3.5"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/checkbox.mdx
+++ b/docs/content/lynx/components/checkbox.mdx
@@ -1,8 +1,9 @@
 ---
 title: Checkbox
 description: 사용자가 여러 옵션 중 하나 이상을 선택할 수 있게 하는 체크박스 컴포넌트입니다.
-lynx:
-  engine: "3.5"
+compatibility:
+  lynx:
+    engine: "3.5"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/chip.mdx
+++ b/docs/content/lynx/components/chip.mdx
@@ -1,6 +1,8 @@
 ---
 title: Chip
 description: 사용자가 선택하거나 실행할 수 있는 짧은 값을 표시하는 컴포넌트입니다.
+lynx:
+  engine: "3.5"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.5.0, @seed-design/lynx-css@0.9.0" />

--- a/docs/content/lynx/components/chip.mdx
+++ b/docs/content/lynx/components/chip.mdx
@@ -1,8 +1,9 @@
 ---
 title: Chip
 description: 사용자가 선택하거나 실행할 수 있는 짧은 값을 표시하는 컴포넌트입니다.
-lynx:
-  engine: "3.5"
+compatibility:
+  lynx:
+    engine: "3.5"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.5.0, @seed-design/lynx-css@0.9.0" />

--- a/docs/content/lynx/components/divider.mdx
+++ b/docs/content/lynx/components/divider.mdx
@@ -1,8 +1,9 @@
 ---
 title: Divider
 description: 시각적 구분자로써 역할을 하며, 콘텐츠 간의 구획을 명확히 나누는 데 사용하는 컴포넌트입니다.
-lynx:
-  engine: "1.0"
+compatibility:
+  lynx:
+    engine: "1.0"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.5.0, @seed-design/lynx-css@0.8.1" />

--- a/docs/content/lynx/components/divider.mdx
+++ b/docs/content/lynx/components/divider.mdx
@@ -1,6 +1,8 @@
 ---
 title: Divider
 description: 시각적 구분자로써 역할을 하며, 콘텐츠 간의 구획을 명확히 나누는 데 사용하는 컴포넌트입니다.
+lynx:
+  engine: "1.0"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.5.0, @seed-design/lynx-css@0.8.1" />

--- a/docs/content/lynx/components/keyboard-avoiding-scroll-view.mdx
+++ b/docs/content/lynx/components/keyboard-avoiding-scroll-view.mdx
@@ -1,6 +1,8 @@
 ---
 title: KeyboardAvoidingScrollView
 description: 소프트 키보드가 활성 입력을 가리지 않도록 세로 스크롤 위치와 하단 여백을 조정하는 컴포넌트입니다.
+lynx:
+  engine: "2.4"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.4.0" />

--- a/docs/content/lynx/components/keyboard-avoiding-scroll-view.mdx
+++ b/docs/content/lynx/components/keyboard-avoiding-scroll-view.mdx
@@ -1,8 +1,9 @@
 ---
 title: KeyboardAvoidingScrollView
 description: 소프트 키보드가 활성 입력을 가리지 않도록 세로 스크롤 위치와 하단 여백을 조정하는 컴포넌트입니다.
-lynx:
-  engine: "2.4"
+compatibility:
+  lynx:
+    engine: "2.4"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.4.0" />

--- a/docs/content/lynx/components/progress-circle.mdx
+++ b/docs/content/lynx/components/progress-circle.mdx
@@ -1,8 +1,9 @@
 ---
 title: Progress Circle
 description: 작업이 진행 중임을 알리거나 작업 시간을 시각적으로 나타내는 데 사용됩니다.
-lynx:
-  engine: "2.16"
+compatibility:
+  lynx:
+    engine: "2.16"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/progress-circle.mdx
+++ b/docs/content/lynx/components/progress-circle.mdx
@@ -1,6 +1,8 @@
 ---
 title: Progress Circle
 description: 작업이 진행 중임을 알리거나 작업 시간을 시각적으로 나타내는 데 사용됩니다.
+lynx:
+  engine: "2.16"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/radio-group.mdx
+++ b/docs/content/lynx/components/radio-group.mdx
@@ -1,6 +1,8 @@
 ---
 title: RadioGroup
 description: 사용자가 여러 옵션 중 하나만 선택할 수 있게 하는 라디오 그룹 컴포넌트입니다.
+lynx:
+  engine: "3.5"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/radio-group.mdx
+++ b/docs/content/lynx/components/radio-group.mdx
@@ -1,8 +1,9 @@
 ---
 title: RadioGroup
 description: 사용자가 여러 옵션 중 하나만 선택할 수 있게 하는 라디오 그룹 컴포넌트입니다.
-lynx:
-  engine: "3.5"
+compatibility:
+  lynx:
+    engine: "3.5"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/switch.mdx
+++ b/docs/content/lynx/components/switch.mdx
@@ -1,6 +1,8 @@
 ---
 title: Switch
 description: 특정 옵션이나 설정을 켜거나 끌 수 있도록 돕는 토글 컴포넌트입니다.
+lynx:
+  engine: "2.14"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/switch.mdx
+++ b/docs/content/lynx/components/switch.mdx
@@ -1,8 +1,9 @@
 ---
 title: Switch
 description: 특정 옵션이나 설정을 켜거나 끌 수 있도록 돕는 토글 컴포넌트입니다.
-lynx:
-  engine: "2.14"
+compatibility:
+  lynx:
+    engine: "2.14"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/tabs.mdx
+++ b/docs/content/lynx/components/tabs.mdx
@@ -4,10 +4,8 @@ description: 한 화면의 콘텐츠를 탭 단위로 구분하고, 탭 선택�
 lynx:
   engine: "3.9"
   x-elements:
-    - name: viewpager
-      version: "3.9.0"
-    - name: viewpager-item
-      version: "3.9.0"
+    - viewpager
+    - viewpager-item
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.5.0, @seed-design/lynx-css@0.9.0" />

--- a/docs/content/lynx/components/tabs.mdx
+++ b/docs/content/lynx/components/tabs.mdx
@@ -1,11 +1,12 @@
 ---
 title: Tabs
 description: 한 화면의 콘텐츠를 탭 단위로 구분하고, 탭 선택이나 좌우 스와이프로 전환하는 컴포넌트입니다.
-lynx:
-  engine: "3.9"
-  x-elements:
-    - viewpager
-    - viewpager-item
+compatibility:
+  lynx:
+    engine: "3.9"
+    x-elements:
+      - viewpager
+      - viewpager-item
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.5.0, @seed-design/lynx-css@0.9.0" />

--- a/docs/content/lynx/components/tabs.mdx
+++ b/docs/content/lynx/components/tabs.mdx
@@ -1,6 +1,13 @@
 ---
 title: Tabs
 description: 한 화면의 콘텐츠를 탭 단위로 구분하고, 탭 선택이나 좌우 스와이프로 전환하는 컴포넌트입니다.
+lynx:
+  engine: "3.9"
+  x-elements:
+    - name: viewpager
+      version: "3.9.0"
+    - name: viewpager-item
+      version: "3.9.0"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.5.0, @seed-design/lynx-css@0.9.0" />

--- a/docs/content/lynx/components/tag-group.mdx
+++ b/docs/content/lynx/components/tag-group.mdx
@@ -1,8 +1,9 @@
 ---
 title: Tag Group
 description: 텍스트 태그를 수평으로 나열해 여러 속성·상태·메타데이터를 한눈에 보여주는 정보 요약 컴포넌트입니다.
-lynx:
-  engine: "1.0"
+compatibility:
+  lynx:
+    engine: "1.0"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/tag-group.mdx
+++ b/docs/content/lynx/components/tag-group.mdx
@@ -1,6 +1,8 @@
 ---
 title: Tag Group
 description: 텍스트 태그를 수평으로 나열해 여러 속성·상태·메타데이터를 한눈에 보여주는 정보 요약 컴포넌트입니다.
+lynx:
+  engine: "1.0"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/text-field-input.mdx
+++ b/docs/content/lynx/components/text-field-input.mdx
@@ -4,8 +4,7 @@ description: 한 줄 텍스트를 입력받고 Field의 레이블·설명·오�
 lynx:
   engine: "3.5"
   x-elements:
-    - name: input
-      version: "3.6.0"
+    - input
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.4.0, @seed-design/lynx-css@0.7.0" />

--- a/docs/content/lynx/components/text-field-input.mdx
+++ b/docs/content/lynx/components/text-field-input.mdx
@@ -1,10 +1,11 @@
 ---
 title: Text Field Input
 description: 한 줄 텍스트를 입력받고 Field의 레이블·설명·오류 상태와 조합하는 컴포넌트입니다.
-lynx:
-  engine: "3.5"
-  x-elements:
-    - input
+compatibility:
+  lynx:
+    engine: "3.5"
+    x-elements:
+      - input
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.4.0, @seed-design/lynx-css@0.7.0" />

--- a/docs/content/lynx/components/text-field-input.mdx
+++ b/docs/content/lynx/components/text-field-input.mdx
@@ -1,6 +1,11 @@
 ---
 title: Text Field Input
 description: 한 줄 텍스트를 입력받고 Field의 레이블·설명·오류 상태와 조합하는 컴포넌트입니다.
+lynx:
+  engine: "3.5"
+  x-elements:
+    - name: input
+      version: "3.6.0"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.4.0, @seed-design/lynx-css@0.7.0" />

--- a/docs/content/lynx/components/text-field-textarea.mdx
+++ b/docs/content/lynx/components/text-field-textarea.mdx
@@ -4,8 +4,7 @@ description: 여러 줄의 긴 텍스트를 입력받고 자동으로 높이를 
 lynx:
   engine: "3.5"
   x-elements:
-    - name: textarea
-      version: "3.6.0"
+    - textarea
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.4.0, @seed-design/lynx-css@0.7.0" />

--- a/docs/content/lynx/components/text-field-textarea.mdx
+++ b/docs/content/lynx/components/text-field-textarea.mdx
@@ -1,10 +1,11 @@
 ---
 title: Text Field Textarea
 description: 여러 줄의 긴 텍스트를 입력받고 자동으로 높이를 조절하는 컴포넌트입니다.
-lynx:
-  engine: "3.5"
-  x-elements:
-    - textarea
+compatibility:
+  lynx:
+    engine: "3.5"
+    x-elements:
+      - textarea
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.4.0, @seed-design/lynx-css@0.7.0" />

--- a/docs/content/lynx/components/text-field-textarea.mdx
+++ b/docs/content/lynx/components/text-field-textarea.mdx
@@ -1,6 +1,11 @@
 ---
 title: Text Field Textarea
 description: 여러 줄의 긴 텍스트를 입력받고 자동으로 높이를 조절하는 컴포넌트입니다.
+lynx:
+  engine: "3.5"
+  x-elements:
+    - name: textarea
+      version: "3.6.0"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.4.0, @seed-design/lynx-css@0.7.0" />

--- a/docs/lib/lynx-compatibility.test.ts
+++ b/docs/lib/lynx-compatibility.test.ts
@@ -11,13 +11,10 @@ describe("lynxCompatibilitySchema", () => {
     expect(lynxCompatibilitySchema.parse({ engine: "2.5" })).toEqual({ engine: "2.5" });
   });
 
-  it("여러 XElement의 이름과 최소 버전을 허용한다", () => {
+  it("여러 XElement 이름을 허용한다", () => {
     const compatibility = {
       engine: "2.5",
-      "x-elements": [
-        { name: "viewpager", version: "2.5.1" },
-        { name: "viewpager-item", version: "2.5.1" },
-      ],
+      "x-elements": ["viewpager", "viewpager-item"],
     };
 
     expect(lynxCompatibilitySchema.parse(compatibility)).toEqual(compatibility);
@@ -26,13 +23,13 @@ describe("lynxCompatibilitySchema", () => {
   it("Engine 버전이 없거나 XElement 값이 비어 있으면 거부한다", () => {
     expect(
       lynxCompatibilitySchema.safeParse({
-        "x-elements": [{ name: "input", version: "3.4" }],
+        "x-elements": ["input"],
       }).success,
     ).toBe(false);
     expect(
       lynxCompatibilitySchema.safeParse({
         engine: "2.5",
-        "x-elements": [{ name: "", version: "" }],
+        "x-elements": [""],
       }).success,
     ).toBe(false);
   });
@@ -41,10 +38,16 @@ describe("lynxCompatibilitySchema", () => {
     expect(
       lynxCompatibilitySchema.safeParse({
         engine: "2.5",
-        "x-elements": [
-          { name: "input", version: "3.4" },
-          { name: "input", version: "3.5" },
-        ],
+        "x-elements": ["input", "input"],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("버전 객체 형식의 XElement를 거부한다", () => {
+    expect(
+      lynxCompatibilitySchema.safeParse({
+        engine: "2.5",
+        "x-elements": [{ name: "input", version: "3.6" }],
       }).success,
     ).toBe(false);
   });
@@ -63,15 +66,12 @@ describe("getEffectiveLynxCompatibility", () => {
 });
 
 describe("getLynxCompatibilityMarkdown", () => {
-  it("Engine과 XElement 최소 버전을 줄 단위로 출력한다", () => {
+  it("Engine 최소 버전과 사용 XElement를 줄 단위로 출력한다", () => {
     expect(
       getLynxCompatibilityMarkdown({
         engine: "2.5",
-        "x-elements": [
-          { name: "viewpager", version: "2.5.1" },
-          { name: "viewpager-item", version: "2.5.1" },
-        ],
+        "x-elements": ["viewpager", "viewpager-item"],
       }),
-    ).toBe("Lynx Engine 최소 버전: 3.6\nXElement 최소 버전: viewpager@2.5.1, viewpager-item@2.5.1");
+    ).toBe("Lynx Engine 최소 버전: 3.6\n사용 XElement: <viewpager>, <viewpager-item>");
   });
 });

--- a/docs/lib/lynx-compatibility.test.ts
+++ b/docs/lib/lynx-compatibility.test.ts
@@ -34,6 +34,12 @@ describe("lynxCompatibilitySchema", () => {
     ).toBe(false);
   });
 
+  it("숫자 점 표기법이 아닌 Engine 버전을 거부한다", () => {
+    for (const engine of ["2.x", "3.6.0-beta.1"]) {
+      expect(lynxCompatibilitySchema.safeParse({ engine }).success).toBe(false);
+    }
+  });
+
   it("중복된 XElement를 거부한다", () => {
     expect(
       lynxCompatibilitySchema.safeParse({
@@ -62,6 +68,12 @@ describe("getEffectiveLynxCompatibility", () => {
 
   it("SEED 최소 지원 버전 이상은 그대로 유지한다", () => {
     expect(getEffectiveLynxCompatibility({ engine: "3.9" })).toEqual({ engine: "3.9" });
+  });
+
+  it("잘못된 Engine 버전은 SEED 최소 지원 버전으로 보정한다", () => {
+    expect(getEffectiveLynxCompatibility({ engine: "2.x" })).toEqual({
+      engine: MINIMUM_SUPPORTED_LYNX_ENGINE_VERSION,
+    });
   });
 });
 

--- a/docs/lib/lynx-compatibility.test.ts
+++ b/docs/lib/lynx-compatibility.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import {
+  getEffectiveLynxCompatibility,
+  getLynxCompatibilityMarkdown,
+  lynxCompatibilitySchema,
+  MINIMUM_SUPPORTED_LYNX_ENGINE_VERSION,
+} from "./lynx-compatibility";
+
+describe("lynxCompatibilitySchema", () => {
+  it("Engine 최소 버전만 허용한다", () => {
+    expect(lynxCompatibilitySchema.parse({ engine: "2.5" })).toEqual({ engine: "2.5" });
+  });
+
+  it("여러 XElement의 이름과 최소 버전을 허용한다", () => {
+    const compatibility = {
+      engine: "2.5",
+      "x-elements": [
+        { name: "viewpager", version: "2.5.1" },
+        { name: "viewpager-item", version: "2.5.1" },
+      ],
+    };
+
+    expect(lynxCompatibilitySchema.parse(compatibility)).toEqual(compatibility);
+  });
+
+  it("Engine 버전이 없거나 XElement 값이 비어 있으면 거부한다", () => {
+    expect(
+      lynxCompatibilitySchema.safeParse({
+        "x-elements": [{ name: "input", version: "3.4" }],
+      }).success,
+    ).toBe(false);
+    expect(
+      lynxCompatibilitySchema.safeParse({
+        engine: "2.5",
+        "x-elements": [{ name: "", version: "" }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("중복된 XElement를 거부한다", () => {
+    expect(
+      lynxCompatibilitySchema.safeParse({
+        engine: "2.5",
+        "x-elements": [
+          { name: "input", version: "3.4" },
+          { name: "input", version: "3.5" },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("getEffectiveLynxCompatibility", () => {
+  it("SEED 최소 지원 버전보다 낮은 Engine 버전을 올린다", () => {
+    expect(getEffectiveLynxCompatibility({ engine: "2.5" })).toEqual({
+      engine: MINIMUM_SUPPORTED_LYNX_ENGINE_VERSION,
+    });
+  });
+
+  it("SEED 최소 지원 버전 이상은 그대로 유지한다", () => {
+    expect(getEffectiveLynxCompatibility({ engine: "3.9" })).toEqual({ engine: "3.9" });
+  });
+});
+
+describe("getLynxCompatibilityMarkdown", () => {
+  it("Engine과 XElement 최소 버전을 줄 단위로 출력한다", () => {
+    expect(
+      getLynxCompatibilityMarkdown({
+        engine: "2.5",
+        "x-elements": [
+          { name: "viewpager", version: "2.5.1" },
+          { name: "viewpager-item", version: "2.5.1" },
+        ],
+      }),
+    ).toBe("Lynx Engine 최소 버전: 3.6\nXElement 최소 버전: viewpager@2.5.1, viewpager-item@2.5.1");
+  });
+});

--- a/docs/lib/lynx-compatibility.ts
+++ b/docs/lib/lynx-compatibility.ts
@@ -2,14 +2,11 @@ import z from "zod";
 
 const versionSchema = z.string().trim().min(1, "최소 버전을 입력해 주세요.");
 
-const xElementSchema = z.object({
-  name: z
-    .string()
-    .trim()
-    .min(1, "XElement 이름을 입력해 주세요.")
-    .regex(/^[a-z][a-z0-9-]*$/, "XElement 이름은 kebab-case로 입력해 주세요."),
-  version: versionSchema,
-});
+const xElementSchema = z
+  .string()
+  .trim()
+  .min(1, "XElement 이름을 입력해 주세요.")
+  .regex(/^[a-z][a-z0-9-]*$/, "XElement 이름은 kebab-case로 입력해 주세요.");
 
 export const lynxCompatibilitySchema = z
   .object({
@@ -20,14 +17,14 @@ export const lynxCompatibilitySchema = z
     const names = new Set<string>();
 
     for (const [index, xElement] of (compatibility["x-elements"] ?? []).entries()) {
-      if (names.has(xElement.name)) {
+      if (names.has(xElement)) {
         context.addIssue({
           code: "custom",
-          message: `XElement "${xElement.name}"이 중복되었습니다.`,
-          path: ["x-elements", index, "name"],
+          message: `XElement "${xElement}"이 중복되었습니다.`,
+          path: ["x-elements", index],
         });
       }
-      names.add(xElement.name);
+      names.add(xElement);
     }
   });
 
@@ -70,9 +67,7 @@ export function getLynxCompatibilityMarkdown(compatibility: LynxCompatibility): 
   const xElements = effectiveCompatibility["x-elements"];
 
   if (xElements) {
-    lines.push(
-      `XElement 최소 버전: ${xElements.map(({ name, version }) => `${name}@${version}`).join(", ")}`,
-    );
+    lines.push(`사용 XElement: ${xElements.map((name) => `<${name}>`).join(", ")}`);
   }
 
   return lines.join("\n");

--- a/docs/lib/lynx-compatibility.ts
+++ b/docs/lib/lynx-compatibility.ts
@@ -1,6 +1,10 @@
 import z from "zod";
 
-const versionSchema = z.string().trim().min(1, "최소 버전을 입력해 주세요.");
+const versionSchema = z
+  .string()
+  .trim()
+  .min(1, "최소 버전을 입력해 주세요.")
+  .regex(/^\d+(?:\.\d+)*$/, "버전은 숫자 점 표기법으로 입력해 주세요.");
 
 const xElementSchema = z
   .string()
@@ -51,8 +55,10 @@ function isVersionLowerThan(version: string, minimum: string): boolean {
 }
 
 export function getEffectiveLynxCompatibility(compatibility: LynxCompatibility): LynxCompatibility {
-  if (!isVersionLowerThan(compatibility.engine, MINIMUM_SUPPORTED_LYNX_ENGINE_VERSION)) {
-    return compatibility;
+  const engine = versionSchema.safeParse(compatibility.engine);
+
+  if (engine.success && !isVersionLowerThan(engine.data, MINIMUM_SUPPORTED_LYNX_ENGINE_VERSION)) {
+    return { ...compatibility, engine: engine.data };
   }
 
   return {

--- a/docs/lib/lynx-compatibility.ts
+++ b/docs/lib/lynx-compatibility.ts
@@ -1,0 +1,79 @@
+import z from "zod";
+
+const versionSchema = z.string().trim().min(1, "최소 버전을 입력해 주세요.");
+
+const xElementSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "XElement 이름을 입력해 주세요.")
+    .regex(/^[a-z][a-z0-9-]*$/, "XElement 이름은 kebab-case로 입력해 주세요."),
+  version: versionSchema,
+});
+
+export const lynxCompatibilitySchema = z
+  .object({
+    engine: versionSchema,
+    "x-elements": z.array(xElementSchema).min(1).optional(),
+  })
+  .superRefine((compatibility, context) => {
+    const names = new Set<string>();
+
+    for (const [index, xElement] of (compatibility["x-elements"] ?? []).entries()) {
+      if (names.has(xElement.name)) {
+        context.addIssue({
+          code: "custom",
+          message: `XElement "${xElement.name}"이 중복되었습니다.`,
+          path: ["x-elements", index, "name"],
+        });
+      }
+      names.add(xElement.name);
+    }
+  });
+
+export type LynxCompatibility = z.infer<typeof lynxCompatibilitySchema>;
+
+export const MINIMUM_SUPPORTED_LYNX_ENGINE_VERSION = "3.6";
+
+function isVersionLowerThan(version: string, minimum: string): boolean {
+  const versionParts = version.split(".").map(Number);
+  const minimumParts = minimum.split(".").map(Number);
+
+  if (versionParts.some(Number.isNaN) || minimumParts.some(Number.isNaN)) return false;
+
+  const partCount = Math.max(versionParts.length, minimumParts.length);
+
+  for (let index = 0; index < partCount; index += 1) {
+    const versionPart = versionParts[index] ?? 0;
+    const minimumPart = minimumParts[index] ?? 0;
+
+    if (versionPart !== minimumPart) return versionPart < minimumPart;
+  }
+
+  return false;
+}
+
+export function getEffectiveLynxCompatibility(compatibility: LynxCompatibility): LynxCompatibility {
+  if (!isVersionLowerThan(compatibility.engine, MINIMUM_SUPPORTED_LYNX_ENGINE_VERSION)) {
+    return compatibility;
+  }
+
+  return {
+    ...compatibility,
+    engine: MINIMUM_SUPPORTED_LYNX_ENGINE_VERSION,
+  };
+}
+
+export function getLynxCompatibilityMarkdown(compatibility: LynxCompatibility): string {
+  const effectiveCompatibility = getEffectiveLynxCompatibility(compatibility);
+  const lines = [`Lynx Engine 최소 버전: ${effectiveCompatibility.engine}`];
+  const xElements = effectiveCompatibility["x-elements"];
+
+  if (xElements) {
+    lines.push(
+      `XElement 최소 버전: ${xElements.map(({ name, version }) => `${name}@${version}`).join(", ")}`,
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/skills/write-lynx-component-docs/SKILL.md
+++ b/skills/write-lynx-component-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-lynx-component-docs
-description: SEED Design의 Lynx 컴포넌트 문서와 실행 예제를 작성·수정·디버깅한다. docs/content/lynx, docs/examples/lynx, LynxComponentExample, WebLynx 미리보기, QR·Explorer 실행 주소, 네이티브 전용 동작 안내를 다룰 때 사용한다. 문서 미리보기와 Lynx Explorer·PlayLynx 결과가 다르거나 예제 변경이 실제 배포 컴포넌트에 영향을 주는지 판단해야 할 때도 사용한다.
+description: SEED Design의 Lynx 컴포넌트 문서와 실행 예제를 작성·수정·디버깅한다. docs/content/lynx, docs/examples/lynx, Lynx Engine·XElement 호환 frontmatter, LynxComponentExample, WebLynx 미리보기, QR·Explorer 실행 주소, 네이티브 전용 동작 안내를 다룰 때 사용한다. 문서 미리보기와 Lynx Explorer·PlayLynx 결과가 다르거나 예제 변경이 실제 배포 컴포넌트에 영향을 주는지 판단해야 할 때도 사용한다.
 ---
 
 # Lynx 컴포넌트 문서 작성
@@ -31,17 +31,19 @@ Lynx 컴포넌트 문서와 실행 가능한 예제를 저장소 규칙에 맞�
 ## 작업 흐름
 
 1. 같은 컴포넌트의 React 문서·예제와 Lynx 공개 API를 함께 확인한다.
-2. [작성 규칙](references/authoring.md)에 따라 MDX와 예제 엔트리를 작성한다.
-3. WebLynx는 실제 문서 개발 서버와 `docs/out`의 `LynxComponentExample`에서만 확인한다.
-4. 웹과 네이티브 결과가 다르면 [미리보기와 런타임](references/preview-runtime.md)에 따라 원인을 분류한다.
-5. 네이티브 전용 동작은 가능한 경우 Lynx Explorer 또는 PlayLynx에서 확인한다. 기기나 세션이 없으면 우회 구현 없이 환경 차단으로 보고한다.
-6. [검증 절차](references/verification.md)를 수행하고 확인한 환경과 남은 제약을 보고한다.
+2. 컴포넌트 소스에서 사용하는 Lynx API·구문·CSS·엘레먼트를 조사하고, 공식 Lynx API 문서와 호환성 데이터로 Engine·XElement 최소 버전을 확정한다.
+3. [작성 규칙](references/authoring.md)에 따라 호환성 frontmatter, MDX, 예제 엔트리를 작성한다.
+4. WebLynx는 실제 문서 개발 서버와 `docs/out`의 `LynxComponentExample`에서만 확인한다.
+5. 웹과 네이티브 결과가 다르면 [미리보기와 런타임](references/preview-runtime.md)에 따라 원인을 분류한다.
+6. 네이티브 전용 동작은 가능한 경우 Lynx Explorer 또는 PlayLynx에서 확인한다. 기기나 세션이 없으면 우회 구현 없이 환경 차단으로 보고한다.
+7. [검증 절차](references/verification.md)를 수행하고 확인한 환경과 남은 제약을 보고한다.
 
 ## 핵심 원칙
 
 - 예제는 실제 호스트 앱에서 권장하는 사용 패턴을 그대로 보여준다.
 - `@seed-design/lynx-react`의 공개 export만 사용한다.
 - 지원하지 않는 기능을 문서 예제에서 흉내 내지 않는다.
+- Lynx 컴포넌트 문서를 작성하거나 수정할 때 Engine·XElement 호환성 frontmatter를 함께 확인한다. 버전은 [공식 Lynx API 문서](https://lynxjs.org/api/index.html)와 [Lynx Compatibility Data](https://github.com/lynx-family/lynx-website/tree/main/packages/lynx-compat-data)에서 확인하며 추정하지 않는다.
 - 일반적인 문서 작성에서 독립 HTML, 별도 Vite 앱, 임시 React 페이지로 WebLynx 예제를 옮기지 않는다.
 - 독립 재현 환경은 사용자가 문서 런타임 진단을 요청했거나 프로덕션 문서에서도 재현되는 경우에만 고려한다. 시작 전에 작업 범위가 넓어짐을 알린다.
 - 웹 미리보기에서 표현할 수 없는 네이티브 동작은 짧은 콜아웃으로 안내한다.

--- a/skills/write-lynx-component-docs/SKILL.md
+++ b/skills/write-lynx-component-docs/SKILL.md
@@ -31,7 +31,7 @@ Lynx 컴포넌트 문서와 실행 가능한 예제를 저장소 규칙에 맞�
 ## 작업 흐름
 
 1. 같은 컴포넌트의 React 문서·예제와 Lynx 공개 API를 함께 확인한다.
-2. 컴포넌트 소스에서 사용하는 Lynx API·구문·CSS·엘레먼트를 조사하고, 공식 Lynx API 문서와 호환성 데이터로 Engine·XElement 최소 버전을 확정한다.
+2. 컴포넌트 소스에서 사용하는 Lynx API·구문·CSS·엘레먼트를 조사하고, 공식 Lynx API 문서와 호환성 데이터로 Engine 최소 버전과 사용 XElement를 확정한다.
 3. [작성 규칙](references/authoring.md)에 따라 호환성 frontmatter, MDX, 예제 엔트리를 작성한다.
 4. WebLynx는 실제 문서 개발 서버와 `docs/out`의 `LynxComponentExample`에서만 확인한다.
 5. 웹과 네이티브 결과가 다르면 [미리보기와 런타임](references/preview-runtime.md)에 따라 원인을 분류한다.

--- a/skills/write-lynx-component-docs/references/authoring.md
+++ b/skills/write-lynx-component-docs/references/authoring.md
@@ -4,6 +4,7 @@
 
 - [React 문서를 기준으로 삼기](#react-문서를-기준으로-삼기)
 - [문서 페이지](#문서-페이지)
+- [Lynx 호환성 frontmatter](#lynx-호환성-frontmatter)
 - [실행 예제 연결](#실행-예제-연결)
 - [엔트리 구성](#엔트리-구성)
 - [예제 설계](#예제-설계)
@@ -68,6 +69,43 @@ React에 대응 문서가 없으면 가까운 Lynx 컴포넌트의 문서 구조
 차이가 없는 섹션을 억지로 만들지 않는다. 웹 버전과 다르거나 Lynx에서 지원하지 않는 동작은 명시적으로 적는다.
 
 지원 범위가 같으면 React 문서의 예제 제목, 순서, 시나리오 파일명을 유지한다. 다르게 구성할 때는 Lynx API 차이 또는 미지원 사유가 문서에 드러나야 한다. Lynx에만 필요한 설치, 실행, 플랫폼 차이 안내는 별도 섹션으로 추가한다.
+
+## Lynx 호환성 frontmatter
+
+Lynx 컴포넌트 문서를 새로 쓰거나 기존 문서의 컴포넌트 사용법을 바꾸면 `lynx` frontmatter도 확인한다. 내부 서비스나 특정 앱의 지원 현황을 출처로 사용하지 않는다. 공개 저장소에 남아도 재현할 수 있도록 다음 공식 자료만 버전 근거로 사용한다.
+
+- [Lynx API 인덱스](https://lynxjs.org/api/index.html)
+- [Lynx Compatibility Data](https://github.com/lynx-family/lynx-website/tree/main/packages/lynx-compat-data)
+
+API 페이지의 Compatibility 표는 Lynx Compatibility Data를 렌더링한다. 표가 텍스트 추출 결과에 나오지 않으면 브라우저에서 표를 확인하거나 표의 `View Source` 링크로 연결된 JSON을 읽는다. 데이터는 용도에 따라 다음 경로에서 찾는다.
+
+| 사용 기능 | 호환성 데이터 경로 |
+| --- | --- |
+| Lynx 엘레먼트와 attribute·method·event | `elements/*.json` |
+| `lynx.*`, MainThread, SelectorQuery 등 | `lynx-api/**/*.json`, `react/**/*.json` |
+| CSS 속성·값·selector | `css/**/*.json` 또는 공식 API 페이지의 Compatibility 표 |
+| 그 밖의 렌더링 기능 | `features/*.json` |
+
+다음 순서로 frontmatter를 작성한다.
+
+1. `packages/lynx-react`의 대상 컴포넌트와 내부에서 호출하는 훅·하위 컴포넌트를 따라가며 Lynx API, main-thread API, 구문, CSS 기능, 엘레먼트를 목록으로 만든다.
+2. 기본 경로뿐 아니라 prop에 따라 실행되는 조건부 경로와 전이 의존성도 포함한다. 예제 파일만 보고 판단하지 않는다.
+3. 목록의 각 항목을 공식 API 상세 페이지와 대응하는 호환성 JSON에서 찾는다. 대상 컴포넌트가 실제로 쓰는 attribute·method·event의 항목까지 확인한다.
+4. Android와 iOS의 `version_added`를 비교한다. 두 플랫폼에서 필요한 버전 중 높은 값을 그 기능의 최소 버전으로 삼는다.
+5. 모든 사용 기능의 최소 버전 중 가장 높은 값을 `lynx.engine`에 적는다. SEED의 최소 지원 버전보다 낮아도 조사한 값을 그대로 적는다. 문서 렌더러가 표시값을 보정한다.
+6. 공식 엘레먼트 페이지 제목에 `XElement` 배지가 있으면 `x-elements`에 추가한다. `name`에는 태그 이름을 쓰고, `version`에는 그 엘레먼트에서 실제로 사용하는 항목의 Android·iOS `version_added` 중 가장 높은 값을 적는다.
+
+```yaml
+lynx:
+  engine: "3.9"
+  x-elements:
+    - name: viewpager
+      version: "3.9"
+```
+
+`version_added: true`는 버전 번호 없이 지원됨을 뜻하므로 최소 버전을 올리지 않는다. `false`는 미지원이다. Android나 iOS 중 하나가 `false`이면 지원되는 것으로 문서화하지 말고 플랫폼 제한 또는 대체 구현을 확인한다. 값이 없거나 공식 자료끼리 충돌하면 버전을 추정하지 않는다. 핵심 경로의 최소 버전을 확정하지 못한 경우 `lynx`를 작성하지 않고 확인하지 못한 항목과 출처를 작업 결과에 남긴다.
+
+일반 `<view>`, `<text>`처럼 내장 엘레먼트는 Engine 계산에는 포함하지만 `x-elements`에는 넣지 않는다. 직접 사용, 전이 사용, 조건부 사용으로 확인한 XElement는 모두 나열하며 이름이 같은 항목은 한 번만 적는다.
 
 ## 실행 예제 연결
 

--- a/skills/write-lynx-component-docs/references/authoring.md
+++ b/skills/write-lynx-component-docs/references/authoring.md
@@ -72,7 +72,7 @@ React에 대응 문서가 없으면 가까운 Lynx 컴포넌트의 문서 구조
 
 ## Lynx 호환성 frontmatter
 
-Lynx 컴포넌트 문서를 새로 쓰거나 기존 문서의 컴포넌트 사용법을 바꾸면 `lynx` frontmatter도 확인한다. 내부 서비스나 특정 앱의 지원 현황을 출처로 사용하지 않는다. 공개 저장소에 남아도 재현할 수 있도록 다음 공식 자료만 버전 근거로 사용한다.
+Lynx 컴포넌트 문서를 새로 쓰거나 기존 문서의 컴포넌트 사용법을 바꾸면 `compatibility.lynx` frontmatter도 확인한다. 내부 서비스나 특정 앱의 지원 현황을 출처로 사용하지 않는다. 공개 저장소에 남아도 재현할 수 있도록 다음 공식 자료만 버전 근거로 사용한다.
 
 - [Lynx API 인덱스](https://lynxjs.org/api/index.html)
 - [Lynx Compatibility Data](https://github.com/lynx-family/lynx-website/tree/main/packages/lynx-compat-data)
@@ -92,14 +92,15 @@ API 페이지의 Compatibility 표는 Lynx Compatibility Data를 렌더링한다
 2. 기본 경로뿐 아니라 prop에 따라 실행되는 조건부 경로와 전이 의존성도 포함한다. 예제 파일만 보고 판단하지 않는다.
 3. 목록의 각 항목을 공식 API 상세 페이지와 대응하는 호환성 JSON에서 찾는다. 대상 컴포넌트가 실제로 쓰는 attribute·method·event의 항목까지 확인한다.
 4. Android와 iOS의 `version_added`를 비교한다. 두 플랫폼에서 필요한 버전 중 높은 값을 그 기능의 최소 버전으로 삼는다.
-5. 모든 사용 기능의 최소 버전 중 가장 높은 값을 `lynx.engine`에 적는다. SEED의 최소 지원 버전보다 낮아도 조사한 값을 그대로 적는다. 문서 렌더러가 표시값을 보정한다.
+5. 모든 사용 기능의 최소 버전 중 가장 높은 값을 `compatibility.lynx.engine`에 적는다. SEED의 최소 지원 버전보다 낮아도 조사한 값을 그대로 적는다. 문서 렌더러가 표시값을 보정한다.
 6. 공식 엘레먼트 페이지 제목에 `XElement` 배지가 있으면 태그 이름을 `x-elements`에 추가한다. 해당 엘레먼트와 기능의 `version_added`는 Engine 최소 버전을 계산할 때만 사용한다.
 
 ```yaml
-lynx:
-  engine: "3.9"
-  x-elements:
-    - viewpager
+compatibility:
+  lynx:
+    engine: "3.9"
+    x-elements:
+      - viewpager
 ```
 
 `version_added: true`는 버전 번호 없이 지원됨을 뜻하므로 최소 버전을 올리지 않는다. `false`는 미지원이다. Android나 iOS 중 하나가 `false`이면 지원되는 것으로 문서화하지 말고 플랫폼 제한 또는 대체 구현을 확인한다. 값이 없거나 공식 자료끼리 충돌하면 버전을 추정하지 않는다. 핵심 경로의 최소 버전을 확정하지 못한 경우 `lynx`를 작성하지 않고 확인하지 못한 항목과 출처를 작업 결과에 남긴다.

--- a/skills/write-lynx-component-docs/references/authoring.md
+++ b/skills/write-lynx-component-docs/references/authoring.md
@@ -93,17 +93,18 @@ API 페이지의 Compatibility 표는 Lynx Compatibility Data를 렌더링한다
 3. 목록의 각 항목을 공식 API 상세 페이지와 대응하는 호환성 JSON에서 찾는다. 대상 컴포넌트가 실제로 쓰는 attribute·method·event의 항목까지 확인한다.
 4. Android와 iOS의 `version_added`를 비교한다. 두 플랫폼에서 필요한 버전 중 높은 값을 그 기능의 최소 버전으로 삼는다.
 5. 모든 사용 기능의 최소 버전 중 가장 높은 값을 `lynx.engine`에 적는다. SEED의 최소 지원 버전보다 낮아도 조사한 값을 그대로 적는다. 문서 렌더러가 표시값을 보정한다.
-6. 공식 엘레먼트 페이지 제목에 `XElement` 배지가 있으면 `x-elements`에 추가한다. `name`에는 태그 이름을 쓰고, `version`에는 그 엘레먼트에서 실제로 사용하는 항목의 Android·iOS `version_added` 중 가장 높은 값을 적는다.
+6. 공식 엘레먼트 페이지 제목에 `XElement` 배지가 있으면 태그 이름을 `x-elements`에 추가한다. 해당 엘레먼트와 기능의 `version_added`는 Engine 최소 버전을 계산할 때만 사용한다.
 
 ```yaml
 lynx:
   engine: "3.9"
   x-elements:
-    - name: viewpager
-      version: "3.9"
+    - viewpager
 ```
 
 `version_added: true`는 버전 번호 없이 지원됨을 뜻하므로 최소 버전을 올리지 않는다. `false`는 미지원이다. Android나 iOS 중 하나가 `false`이면 지원되는 것으로 문서화하지 말고 플랫폼 제한 또는 대체 구현을 확인한다. 값이 없거나 공식 자료끼리 충돌하면 버전을 추정하지 않는다. 핵심 경로의 최소 버전을 확정하지 못한 경우 `lynx`를 작성하지 않고 확인하지 못한 항목과 출처를 작업 결과에 남긴다.
+
+`x-elements`는 XElement의 사용 여부만 기록한다. 호환성 데이터의 `version_added`를 별도의 XElement 버전으로 옮겨 적지 않는다.
 
 일반 `<view>`, `<text>`처럼 내장 엘레먼트는 Engine 계산에는 포함하지만 `x-elements`에는 넣지 않는다. 직접 사용, 전이 사용, 조건부 사용으로 확인한 XElement는 모두 나열하며 이름이 같은 항목은 한 번만 적는다.
 


### PR DESCRIPTION
## 변경 사항

- Lynx 컴포넌트 문서 frontmatter에 Engine 및 XElement 최소 버전 메타데이터를 추가했습니다.
- 문서 헤더와 llms.txt에 호환성 정보를 표시합니다. 화면에 표시하는 Engine 버전은 SEED 최소 지원 버전인 3.6 이상으로 보정합니다.
- MDX Badge에 사용자 정의 className을 전달할 수 있도록 했습니다.
- Lynx 문서 작성 스킬이 공식 Lynx API와 Lynx Compatibility Data를 근거로 호환성 frontmatter를 작성하도록 보완했습니다.

## 검증

- `bun docs:test`
- `bun generate:all`
- `bun --filter @seed-design/docs build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - Lynx 문서에 엔진 및 사용 XElement 호환성 정보가 표시됩니다.
  - 호환성 배지가 지원 엔진과 XElement를 시각적으로 안내합니다.
  - 호환성 정보가 생성된 문서 텍스트에도 포함됩니다.

- **문서**
  - Lynx 컴포넌트 문서에 호환성 메타데이터가 추가되었습니다.
  - 호환성 정보 작성 및 검증 가이드가 보강되었습니다.

- **버그 수정**
  - 지원 기준보다 낮은 엔진 버전이 최소 지원 버전으로 일관되게 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->