### PR TITLE
ci: add version peer dependency merge blocker

### DIFF
--- a/.github/scripts/check-version-peer-deps.test.ts
+++ b/.github/scripts/check-version-peer-deps.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { validateVersionPeerDependencies } from "./check-version-peer-deps";
+
+const repositoryRoot = join(import.meta.dir, "../..");
+const githubExpression = (expression: string): string => ["$", "{{ ", expression, " }}"].join("");
+
+function createManifest(
+  name: string,
+  version: string,
+  peerDependency?: { name: string; range: string },
+): string {
+  return `${JSON.stringify(
+    {
+      name,
+      version,
+      ...(peerDependency
+        ? {
+            peerDependencies: {
+              [peerDependency.name]: peerDependency.range,
+              react: ">=18.0.0",
+            },
+          }
+        : {}),
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+function createFixture(overrides?: {
+  baseCssVersion?: string;
+  basePeerRange?: string;
+  baseReactVersion?: string;
+  cssVersion?: string;
+  peerRange?: string;
+  reactVersion?: string;
+}) {
+  const values = {
+    baseCssVersion: "2.5.0",
+    basePeerRange: "^2.5.0",
+    baseReactVersion: "2.3.0",
+    cssVersion: "2.6.0",
+    peerRange: "^2.6.0",
+    reactVersion: "2.4.0",
+    ...overrides,
+  };
+
+  return {
+    baseCssManifest: createManifest("@seed-design/css", values.baseCssVersion),
+    baseReactManifest: createManifest("@seed-design/react", values.baseReactVersion, {
+      name: "@seed-design/css",
+      range: values.basePeerRange,
+    }),
+    baseLynxCssManifest: createManifest("@seed-design/lynx-css", "0.8.0"),
+    baseLynxReactManifest: createManifest("@seed-design/lynx-react", "0.4.0", {
+      name: "@seed-design/lynx-css",
+      range: "0.0.0 || >=0.8.0 <1.0.0",
+    }),
+    sourceCssManifest: createManifest("@seed-design/css", values.cssVersion),
+    sourceReactManifest: createManifest("@seed-design/react", values.reactVersion, {
+      name: "@seed-design/css",
+      range: values.peerRange,
+    }),
+    sourceLynxCssManifest: createManifest("@seed-design/lynx-css", "0.8.0"),
+    sourceLynxReactManifest: createManifest("@seed-design/lynx-react", "0.4.0", {
+      name: "@seed-design/lynx-css",
+      range: "0.0.0 || >=0.8.0 <1.0.0",
+    }),
+  };
+}
+
+function createLynxFixture(overrides?: {
+  baseLynxCssVersion?: string;
+  baseLynxReactVersion?: string;
+  basePeerRange?: string;
+  lynxCssVersion?: string;
+  lynxReactVersion?: string;
+  peerRange?: string;
+}) {
+  const values = {
+    baseLynxCssVersion: "0.8.1",
+    baseLynxReactVersion: "0.4.1",
+    basePeerRange: "0.0.0 || >=0.8.0 <1.0.0",
+    lynxCssVersion: "0.9.0",
+    lynxReactVersion: "0.5.0",
+    peerRange: "0.0.0 || >=0.9.0 <1.0.0",
+    ...overrides,
+  };
+
+  return {
+    ...createFixture({
+      cssVersion: "2.5.0",
+      peerRange: "^2.5.0",
+      reactVersion: "2.3.0",
+    }),
+    baseLynxCssManifest: createManifest("@seed-design/lynx-css", values.baseLynxCssVersion),
+    baseLynxReactManifest: createManifest("@seed-design/lynx-react", values.baseLynxReactVersion, {
+      name: "@seed-design/lynx-css",
+      range: values.basePeerRange,
+    }),
+    sourceLynxCssManifest: createManifest("@seed-design/lynx-css", values.lynxCssVersion),
+    sourceLynxReactManifest: createManifest("@seed-design/lynx-react", values.lynxReactVersion, {
+      name: "@seed-design/lynx-css",
+      range: values.peerRange,
+    }),
+  };
+}
+
+describe("Version Packages peer dependency 검사", () => {
+  test("CSS와 React 버전 및 peer 범위가 함께 오르면 통과한다", () => {
+    expect(validateVersionPeerDependencies(createFixture())).toEqual({
+      react: {
+        checked: true,
+        dependencyVersion: "2.6.0",
+        dependentVersion: "2.4.0",
+      },
+      lynxReact: {
+        checked: false,
+        dependencyVersion: "0.8.0",
+        dependentVersion: "0.4.0",
+      },
+    });
+  });
+
+  test("CSS와 React 버전이 올랐지만 peer 범위가 그대로면 실패한다", () => {
+    expect(() => validateVersionPeerDependencies(createFixture({ peerRange: "^2.5.0" }))).toThrow(
+      "peerDependency가 변경되지 않았습니다",
+    );
+  });
+
+  test("변경한 peer 범위가 새 CSS 버전과 다르면 실패한다", () => {
+    expect(() => validateVersionPeerDependencies(createFixture({ peerRange: "^2.5.1" }))).toThrow(
+      "peerDependency가 새 버전과 다릅니다",
+    );
+  });
+
+  test("CSS 또는 React 중 한 패키지만 버전이 바뀌면 건너뛴다", () => {
+    expect(
+      validateVersionPeerDependencies(
+        createFixture({ reactVersion: "2.3.0", peerRange: "^2.5.0" }),
+      ),
+    ).toMatchObject({
+      react: { checked: false, dependencyVersion: "2.6.0", dependentVersion: "2.3.0" },
+    });
+    expect(
+      validateVersionPeerDependencies(createFixture({ cssVersion: "2.5.0", peerRange: "^2.5.0" })),
+    ).toMatchObject({
+      react: { checked: false, dependencyVersion: "2.5.0", dependentVersion: "2.4.0" },
+    });
+  });
+
+  test("Lynx CSS와 Lynx React 버전 및 peer 범위가 함께 오르면 통과한다", () => {
+    expect(validateVersionPeerDependencies(createLynxFixture())).toMatchObject({
+      lynxReact: {
+        checked: true,
+        dependencyVersion: "0.9.0",
+        dependentVersion: "0.5.0",
+      },
+    });
+  });
+
+  test("Lynx 버전이 함께 올랐지만 peer 범위가 그대로면 실패한다", () => {
+    expect(() =>
+      validateVersionPeerDependencies(createLynxFixture({ peerRange: "0.0.0 || >=0.8.0 <1.0.0" })),
+    ).toThrow("peerDependency가 변경되지 않았습니다");
+  });
+
+  test("Lynx CSS patch만 올랐다면 같은 마이너 peer 범위를 허용한다", () => {
+    expect(
+      validateVersionPeerDependencies(
+        createLynxFixture({
+          baseLynxCssVersion: "0.9.0",
+          basePeerRange: "0.0.0 || >=0.9.0 <1.0.0",
+          lynxCssVersion: "0.9.1",
+          peerRange: "0.0.0 || >=0.9.0 <1.0.0",
+        }),
+      ),
+    ).toMatchObject({ lynxReact: { checked: true } });
+  });
+
+  test("Version Packages PR에서 신뢰된 검사 코드로 정확한 head를 검사한다", async () => {
+    const workflow = await Bun.file(
+      join(repositoryRoot, ".github/workflows/version-peer-deps-merge-blocker.yml"),
+    ).text();
+
+    expect(workflow).toContain("pull_request_target:");
+    expect(workflow).toContain("branches: [dev]");
+    expect(workflow).toContain("types: [opened, reopened, synchronize, edited]");
+    expect(workflow).toContain("contents: read");
+    expect(workflow).toContain("changeset-release/dev");
+    expect(workflow).toContain(
+      "github.event.pull_request.head.repo.full_name == github.repository",
+    );
+    expect(workflow).toContain(`ref: ${githubExpression("github.event.pull_request.base.sha")}`);
+    expect(workflow).toContain(`ref: ${githubExpression("github.event.pull_request.head.sha")}`);
+    expect(workflow).toContain("persist-credentials: false");
+    expect(workflow).toContain("bun ../control/.github/scripts/check-version-peer-deps.ts");
+    expect(workflow).toContain("Check React and Lynx peer dependency ranges");
+  });
+});

--- a/.github/scripts/check-version-peer-deps.test.ts
+++ b/.github/scripts/check-version-peer-deps.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
-import { validateVersionPeerDependencies } from "./check-version-peer-deps";
+import {
+  formatStatusDescription,
+  validateVersionPeerDependencies,
+} from "./check-version-peer-deps";
 
 const repositoryRoot = join(import.meta.dir, "../..");
 const githubExpression = (expression: string): string => ["$", "{{ ", expression, " }}"].join("");
@@ -108,6 +111,11 @@ function createLynxFixture(overrides?: {
 }
 
 describe("Version Packages peer dependency 검사", () => {
+  test("status description은 한 줄로 만들고 140자로 제한한다", () => {
+    expect(formatStatusDescription(new Error("  첫 줄\n둘째 줄  "))).toBe("첫 줄 둘째 줄");
+    expect(formatStatusDescription("가".repeat(141))).toBe("가".repeat(140));
+  });
+
   test("CSS와 React 버전 및 peer 범위가 함께 오르면 통과한다", () => {
     expect(validateVersionPeerDependencies(createFixture())).toEqual({
       react: {
@@ -188,6 +196,7 @@ describe("Version Packages peer dependency 검사", () => {
     expect(workflow).toContain("branches: [dev]");
     expect(workflow).toContain("types: [opened, reopened, synchronize, edited]");
     expect(workflow).toContain("contents: read");
+    expect(workflow).toContain("statuses: write");
     expect(workflow).toContain("changeset-release/dev");
     expect(workflow).toContain(
       "github.event.pull_request.head.repo.full_name == github.repository",
@@ -196,9 +205,14 @@ describe("Version Packages peer dependency 검사", () => {
     expect(workflow).toContain(`ref: ${githubExpression("github.event.pull_request.head.sha")}`);
     expect(workflow).toContain("persist-credentials: false");
     expect(workflow).toContain("working-directory: control");
+    expect(workflow).toContain("continue-on-error: true");
     expect(workflow).toContain("bun .github/scripts/check-version-peer-deps.ts");
     expect(workflow).toContain("--root ../source");
     expect(workflow).not.toContain("bun ../control/.github/scripts/check-version-peer-deps.ts");
     expect(workflow).toContain("Check React and Lynx peer dependency ranges");
+    expect(workflow).toContain("steps.check.outputs.error_message");
+    expect(workflow).toContain("github.rest.repos.createCommitStatus");
+    expect(workflow).toContain("context: 'Version Packages peer dependencies'");
+    expect(workflow).toContain("core.setFailed(description)");
   });
 });

--- a/.github/scripts/check-version-peer-deps.test.ts
+++ b/.github/scripts/check-version-peer-deps.test.ts
@@ -195,7 +195,10 @@ describe("Version Packages peer dependency 검사", () => {
     expect(workflow).toContain(`ref: ${githubExpression("github.event.pull_request.base.sha")}`);
     expect(workflow).toContain(`ref: ${githubExpression("github.event.pull_request.head.sha")}`);
     expect(workflow).toContain("persist-credentials: false");
-    expect(workflow).toContain("bun ../control/.github/scripts/check-version-peer-deps.ts");
+    expect(workflow).toContain("working-directory: control");
+    expect(workflow).toContain("bun .github/scripts/check-version-peer-deps.ts");
+    expect(workflow).toContain("--root ../source");
+    expect(workflow).not.toContain("bun ../control/.github/scripts/check-version-peer-deps.ts");
     expect(workflow).toContain("Check React and Lynx peer dependency ranges");
   });
 });

--- a/.github/scripts/check-version-peer-deps.ts
+++ b/.github/scripts/check-version-peer-deps.ts
@@ -1,3 +1,4 @@
+import { appendFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { parseArgs } from "node:util";
 import { compareStableVersions, parseStableVersion } from "./bump-peer-deps";
@@ -10,6 +11,7 @@ const LYNX_CSS_MANIFEST_PATH = "packages/lynx-css/package.json";
 const LYNX_REACT_PACKAGE = "@seed-design/lynx-react";
 const LYNX_REACT_MANIFEST_PATH = "packages/lynx-react/package.json";
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const STATUS_DESCRIPTION_MAX_LENGTH = 140;
 
 type JsonRecord = Record<string, unknown>;
 
@@ -354,6 +356,27 @@ async function main(): Promise<void> {
   reportValidation(result);
 }
 
+export function formatStatusDescription(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+
+  return message.replaceAll(/\s+/g, " ").trim().slice(0, STATUS_DESCRIPTION_MAX_LENGTH);
+}
+
+async function reportFailure(error: unknown): Promise<void> {
+  const description = formatStatusDescription(error);
+  const githubOutput = process.env.GITHUB_OUTPUT;
+
+  console.error(description);
+  if (githubOutput) {
+    await appendFile(githubOutput, `error_message=${description}\n`);
+  }
+  process.exitCode = 1;
+}
+
 if (import.meta.main) {
-  await main();
+  try {
+    await main();
+  } catch (error) {
+    await reportFailure(error);
+  }
 }

--- a/.github/scripts/check-version-peer-deps.ts
+++ b/.github/scripts/check-version-peer-deps.ts
@@ -1,0 +1,359 @@
+import { resolve } from "node:path";
+import { parseArgs } from "node:util";
+import { compareStableVersions, parseStableVersion } from "./bump-peer-deps";
+
+const CSS_PACKAGE = "@seed-design/css";
+const CSS_MANIFEST_PATH = "packages/css/package.json";
+const REACT_MANIFEST_PATH = "packages/react/package.json";
+const LYNX_CSS_PACKAGE = "@seed-design/lynx-css";
+const LYNX_CSS_MANIFEST_PATH = "packages/lynx-css/package.json";
+const LYNX_REACT_PACKAGE = "@seed-design/lynx-react";
+const LYNX_REACT_MANIFEST_PATH = "packages/lynx-react/package.json";
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+type JsonRecord = Record<string, unknown>;
+
+interface PairValidationResult {
+  checked: boolean;
+  dependencyVersion: string;
+  dependentVersion: string;
+}
+
+interface ValidationResult {
+  react: PairValidationResult;
+  lynxReact: PairValidationResult;
+}
+
+interface CliInput {
+  root: string;
+  baseSha: string;
+  sourceSha: string;
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readManifest(text: string, path: string): JsonRecord {
+  const value: unknown = JSON.parse(text);
+
+  if (!isRecord(value)) {
+    throw new Error(`${path}가 JSON 객체가 아닙니다.`);
+  }
+
+  return value;
+}
+
+function readVersion(manifest: JsonRecord, path: string): string {
+  const version = manifest.version;
+
+  if (typeof version !== "string") {
+    throw new Error(`${path}에 문자열 version이 없습니다.`);
+  }
+
+  return version;
+}
+
+function readPeerRange(manifest: JsonRecord, path: string, dependencyName: string): string {
+  if (!isRecord(manifest.peerDependencies)) {
+    throw new Error(`${path}에 peerDependencies가 없습니다.`);
+  }
+
+  const range = manifest.peerDependencies[dependencyName];
+
+  if (typeof range !== "string") {
+    throw new Error(`${path}에 ${dependencyName} peerDependency가 없습니다.`);
+  }
+
+  return range;
+}
+
+function didBothVersionsChange(input: {
+  baseDependencyVersion: string;
+  baseDependentVersion: string;
+  dependencyVersion: string;
+  dependentVersion: string;
+}): boolean {
+  return (
+    input.baseDependencyVersion !== input.dependencyVersion &&
+    input.baseDependentVersion !== input.dependentVersion
+  );
+}
+
+function assertVersionIncreased(input: {
+  baseVersion: string;
+  packageName: string;
+  version: string;
+}): void {
+  if (compareStableVersions(input.version, input.baseVersion) <= 0) {
+    throw new Error(
+      `${input.packageName} 버전이 올라가지 않았습니다: ${input.baseVersion} -> ${input.version}`,
+    );
+  }
+}
+
+function assertPeerRange(input: {
+  baseRange: string;
+  dependencyName: string;
+  dependentManifestPath: string;
+  desiredRange: string;
+  sourceRange: string;
+}): void {
+  if (input.sourceRange === input.baseRange && input.sourceRange !== input.desiredRange) {
+    throw new Error(
+      `${input.dependentManifestPath}의 ${input.dependencyName} peerDependency가 변경되지 않았습니다. 최신 Version Packages PR에서 /bump-peer-deps를 다시 실행해 주세요.`,
+    );
+  }
+
+  if (input.sourceRange !== input.desiredRange) {
+    throw new Error(
+      `${input.dependentManifestPath}의 ${input.dependencyName} peerDependency가 새 버전과 다릅니다: ${input.sourceRange} (예상: ${input.desiredRange})`,
+    );
+  }
+}
+
+function validatePair(input: {
+  baseDependencyManifest: string;
+  baseDependentManifest: string;
+  dependencyManifestPath: string;
+  dependencyName: string;
+  dependentManifestPath: string;
+  dependentName: string;
+  desiredRange: (dependencyVersion: string) => string;
+  sourceDependencyManifest: string;
+  sourceDependentManifest: string;
+}): PairValidationResult {
+  const baseDependency = readManifest(
+    input.baseDependencyManifest,
+    `base:${input.dependencyManifestPath}`,
+  );
+  const baseDependent = readManifest(
+    input.baseDependentManifest,
+    `base:${input.dependentManifestPath}`,
+  );
+  const sourceDependency = readManifest(
+    input.sourceDependencyManifest,
+    input.dependencyManifestPath,
+  );
+  const sourceDependent = readManifest(input.sourceDependentManifest, input.dependentManifestPath);
+  const baseDependencyVersion = readVersion(baseDependency, `base:${input.dependencyManifestPath}`);
+  const baseDependentVersion = readVersion(baseDependent, `base:${input.dependentManifestPath}`);
+  const dependencyVersion = readVersion(sourceDependency, input.dependencyManifestPath);
+  const dependentVersion = readVersion(sourceDependent, input.dependentManifestPath);
+  if (
+    !didBothVersionsChange({
+      baseDependencyVersion,
+      baseDependentVersion,
+      dependencyVersion,
+      dependentVersion,
+    })
+  ) {
+    return { checked: false, dependencyVersion, dependentVersion };
+  }
+
+  assertVersionIncreased({
+    baseVersion: baseDependencyVersion,
+    packageName: input.dependencyName,
+    version: dependencyVersion,
+  });
+  assertVersionIncreased({
+    baseVersion: baseDependentVersion,
+    packageName: input.dependentName,
+    version: dependentVersion,
+  });
+
+  const basePeerRange = readPeerRange(
+    baseDependent,
+    `base:${input.dependentManifestPath}`,
+    input.dependencyName,
+  );
+  const sourcePeerRange = readPeerRange(
+    sourceDependent,
+    input.dependentManifestPath,
+    input.dependencyName,
+  );
+  const desiredPeerRange = input.desiredRange(dependencyVersion);
+
+  assertPeerRange({
+    baseRange: basePeerRange,
+    dependencyName: input.dependencyName,
+    dependentManifestPath: input.dependentManifestPath,
+    desiredRange: desiredPeerRange,
+    sourceRange: sourcePeerRange,
+  });
+
+  return { checked: true, dependencyVersion, dependentVersion };
+}
+
+function createLynxCssPeerRange(version: string): string {
+  const [major, minor] = parseStableVersion(version);
+
+  if (major !== 0) {
+    throw new Error(`${LYNX_CSS_PACKAGE} 버전의 major가 0이 아닙니다: ${version}`);
+  }
+
+  return `0.0.0 || >=0.${minor}.0 <1.0.0`;
+}
+
+export function validateVersionPeerDependencies(input: {
+  baseCssManifest: string;
+  baseLynxCssManifest: string;
+  baseLynxReactManifest: string;
+  baseReactManifest: string;
+  sourceCssManifest: string;
+  sourceLynxCssManifest: string;
+  sourceLynxReactManifest: string;
+  sourceReactManifest: string;
+}): ValidationResult {
+  return {
+    react: validatePair({
+      baseDependencyManifest: input.baseCssManifest,
+      baseDependentManifest: input.baseReactManifest,
+      dependencyManifestPath: CSS_MANIFEST_PATH,
+      dependencyName: CSS_PACKAGE,
+      dependentManifestPath: REACT_MANIFEST_PATH,
+      dependentName: "@seed-design/react",
+      desiredRange: (version) => `^${version}`,
+      sourceDependencyManifest: input.sourceCssManifest,
+      sourceDependentManifest: input.sourceReactManifest,
+    }),
+    lynxReact: validatePair({
+      baseDependencyManifest: input.baseLynxCssManifest,
+      baseDependentManifest: input.baseLynxReactManifest,
+      dependencyManifestPath: LYNX_CSS_MANIFEST_PATH,
+      dependencyName: LYNX_CSS_PACKAGE,
+      dependentManifestPath: LYNX_REACT_MANIFEST_PATH,
+      dependentName: LYNX_REACT_PACKAGE,
+      desiredRange: createLynxCssPeerRange,
+      sourceDependencyManifest: input.sourceLynxCssManifest,
+      sourceDependentManifest: input.sourceLynxReactManifest,
+    }),
+  };
+}
+
+async function runGit(root: string, args: string[]): Promise<string> {
+  const process = Bun.spawn(["git", "-C", root, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+
+  if (exitCode !== 0) {
+    throw new Error(`git ${args.join(" ")} 실패: ${stderr.trim()}`);
+  }
+
+  return stdout;
+}
+
+function requireOption(value: string | undefined, name: string): string {
+  if (!value) {
+    throw new Error(`${name}이 필요합니다.`);
+  }
+
+  return value;
+}
+
+function assertSha(value: string, name: string): void {
+  if (!SHA_PATTERN.test(value)) {
+    throw new Error(`${name} SHA 형식이 올바르지 않습니다.`);
+  }
+}
+
+function readCliInput(): CliInput {
+  const { values } = parseArgs({
+    options: {
+      root: { type: "string" },
+      "base-sha": { type: "string" },
+      "source-sha": { type: "string" },
+    },
+    strict: true,
+  });
+  const root = resolve(requireOption(values.root, "--root"));
+  const baseSha = requireOption(values["base-sha"], "--base-sha");
+  const sourceSha = requireOption(values["source-sha"], "--source-sha");
+
+  assertSha(baseSha, "base");
+  assertSha(sourceSha, "source");
+
+  return { root, baseSha, sourceSha };
+}
+
+async function assertCheckedOutSource(root: string, sourceSha: string): Promise<void> {
+  const checkedOutSha = (await runGit(root, ["rev-parse", "HEAD"])).trim();
+  if (checkedOutSha !== sourceSha) {
+    throw new Error(`체크아웃한 SHA가 PR head와 다릅니다: ${checkedOutSha}`);
+  }
+}
+
+async function findMergeBase(root: string, baseSha: string, sourceSha: string): Promise<string> {
+  const mergeBaseSha = (await runGit(root, ["merge-base", baseSha, sourceSha])).trim();
+  if (!SHA_PATTERN.test(mergeBaseSha)) {
+    throw new Error("PR base와 head의 공통 조상을 찾지 못했습니다.");
+  }
+
+  return mergeBaseSha;
+}
+
+async function loadValidationInput(
+  root: string,
+  mergeBaseSha: string,
+): Promise<Parameters<typeof validateVersionPeerDependencies>[0]> {
+  return {
+    baseCssManifest: await runGit(root, ["show", `${mergeBaseSha}:${CSS_MANIFEST_PATH}`]),
+    baseLynxCssManifest: await runGit(root, ["show", `${mergeBaseSha}:${LYNX_CSS_MANIFEST_PATH}`]),
+    baseLynxReactManifest: await runGit(root, [
+      "show",
+      `${mergeBaseSha}:${LYNX_REACT_MANIFEST_PATH}`,
+    ]),
+    baseReactManifest: await runGit(root, ["show", `${mergeBaseSha}:${REACT_MANIFEST_PATH}`]),
+    sourceCssManifest: await Bun.file(resolve(root, CSS_MANIFEST_PATH)).text(),
+    sourceLynxCssManifest: await Bun.file(resolve(root, LYNX_CSS_MANIFEST_PATH)).text(),
+    sourceLynxReactManifest: await Bun.file(resolve(root, LYNX_REACT_MANIFEST_PATH)).text(),
+    sourceReactManifest: await Bun.file(resolve(root, REACT_MANIFEST_PATH)).text(),
+  };
+}
+
+function reportPair(input: {
+  result: PairValidationResult;
+  successMessage: (result: PairValidationResult) => string;
+  skippedMessage: string;
+}): void {
+  if (input.result.checked) {
+    console.log(input.successMessage(input.result));
+    return;
+  }
+
+  console.log(input.skippedMessage);
+}
+
+function reportValidation(result: ValidationResult): void {
+  reportPair({
+    result: result.react,
+    successMessage: (react) =>
+      `React ${react.dependentVersion}의 CSS peerDependency가 CSS ${react.dependencyVersion}과 일치합니다.`,
+    skippedMessage: "CSS와 React 버전이 함께 바뀐 PR이 아니므로 검사를 건너뜁니다.",
+  });
+  reportPair({
+    result: result.lynxReact,
+    successMessage: (lynxReact) =>
+      `Lynx React ${lynxReact.dependentVersion}의 Lynx CSS peerDependency가 Lynx CSS ${lynxReact.dependencyVersion}과 일치합니다.`,
+    skippedMessage: "Lynx CSS와 Lynx React 버전이 함께 바뀐 PR이 아니므로 검사를 건너뜁니다.",
+  });
+}
+
+async function main(): Promise<void> {
+  const { root, baseSha, sourceSha } = readCliInput();
+  await assertCheckedOutSource(root, sourceSha);
+  const mergeBaseSha = await findMergeBase(root, baseSha, sourceSha);
+  const result = validateVersionPeerDependencies(await loadValidationInput(root, mergeBaseSha));
+
+  reportValidation(result);
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/.github/workflows/version-peer-deps-merge-blocker.yml
+++ b/.github/workflows/version-peer-deps-merge-blocker.yml
@@ -42,12 +42,12 @@ jobs:
           bun-version: "1.3.13"
 
       - name: Check React and Lynx peer dependency ranges
-        working-directory: source
+        working-directory: control
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
         run: >-
-          bun ../control/.github/scripts/check-version-peer-deps.ts
-          --root .
+          bun .github/scripts/check-version-peer-deps.ts
+          --root ../source
           --base-sha "$BASE_SHA"
           --source-sha "$SOURCE_SHA"

--- a/.github/workflows/version-peer-deps-merge-blocker.yml
+++ b/.github/workflows/version-peer-deps-merge-blocker.yml
@@ -1,0 +1,53 @@
+name: Version Packages peer dependency merge blocker
+
+on:
+  pull_request_target:
+    branches: [dev]
+    types: [opened, reopened, synchronize, edited]
+
+concurrency:
+  group: version-peer-deps-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check Version Packages peer dependencies
+    if: >-
+      github.event.pull_request.head.ref == 'changeset-release/dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout trusted checker
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: control
+          persist-credentials: false
+
+      - name: Checkout exact Version Packages PR head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: source
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+
+      - name: Check React and Lynx peer dependency ranges
+        working-directory: source
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
+        run: >-
+          bun ../control/.github/scripts/check-version-peer-deps.ts
+          --root .
+          --base-sha "$BASE_SHA"
+          --source-sha "$SOURCE_SHA"

--- a/.github/workflows/version-peer-deps-merge-blocker.yml
+++ b/.github/workflows/version-peer-deps-merge-blocker.yml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   contents: read
+  statuses: write
 
 jobs:
   check:
@@ -42,6 +43,8 @@ jobs:
           bun-version: "1.3.13"
 
       - name: Check React and Lynx peer dependency ranges
+        id: check
+        continue-on-error: true
         working-directory: control
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -51,3 +54,30 @@ jobs:
           --root ../source
           --base-sha "$BASE_SHA"
           --source-sha "$SOURCE_SHA"
+
+      - name: Publish peer dependency status
+        if: always() && steps.check.outcome != 'skipped'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CHECK_OUTCOME: ${{ steps.check.outcome }}
+          ERROR_MESSAGE: ${{ steps.check.outputs.error_message }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const failed = process.env.CHECK_OUTCOME === 'failure';
+            const description = failed
+              ? process.env.ERROR_MESSAGE || 'Peer dependency 검사에 실패했습니다.'
+              : 'Peer dependency 범위가 새 패키지 버전과 일치합니다.';
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.SOURCE_SHA,
+              state: failed ? 'failure' : 'success',
+              target_url: process.env.RUN_URL,
+              description,
+              context: 'Version Packages peer dependencies',
+            });
+
+            if (failed) core.setFailed(description);


### PR DESCRIPTION
## 변경 내용

- Version Packages PR에서 React/CSS와 Lynx React/Lynx CSS의 버전 및 peer dependency 범위를 검사합니다.
- peer dependency 갱신이 빠졌거나 새 CSS 버전과 맞지 않으면 병합 검사를 실패시킵니다.
- PR 브랜치의 코드를 실행하지 않고 dev의 신뢰된 검사 코드로 정확한 PR head를 읽습니다.
- 검사 로직과 워크플로 계약에 대한 회귀 테스트를 추가합니다.

## 검증

- `bun generate:all`
- `bun test ./.github/scripts/check-version-peer-deps.test.ts ./.github/scripts/bump-peer-deps.test.ts`
- `bun test:all`
- OXLint 순환 복잡도 측정: `main` 1, `validatePair` 2, 전체 함수 4 이하
- 실제 사고 커밋 검증: bump 반영 head 통과, force-push 뒤 head 차단

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
  - 패키지 버전과 peer dependency 범위가 올바르게 함께 변경되는지 자동 검증합니다.
  - React 및 Lynx 패키지의 버전 불일치, 잘못된 범위 설정, 예외적인 변경 사례를 확인합니다.

- **개선**
  - Version Packages 변경 사항에 대한 검증 절차를 추가해 호환되지 않는 버전 조합이 병합되지 않도록 지원합니다.
  - 관련 검사는 변경된 항목에 따라 자동으로 실행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->