### PR TITLE
docs(typography): note the medium weight difference across platforms

### DIFF
--- a/docs/content/foundations/typography.mdx
+++ b/docs/content/foundations/typography.mdx
@@ -50,9 +50,10 @@ font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo",
 <TokenReference groups={["font-weight"]} />
 
 <Callout type="warn" title="medium은 플랫폼에 따라 두께가 조금 다르게 보여요">
-  시스템 폰트를 사용하기 때문에, 같은 medium(500)이라도 iOS와 Android의 글꼴 자체가
-  다릅니다. 한글에서는 Android(Noto Sans KR)가 iOS(Apple SD Gothic Neo)보다 획이 조금 더
-  두껍게 보입니다.
+  시스템 폰트를 사용하기 때문에, 같은 medium(500)이라도 플랫폼마다 실제로 그려지는 글꼴이
+  다릅니다. 한글에서는 iOS(Apple SD Gothic Neo)보다 Android 쪽 획이 조금 더 두껍게 보일 수
+  있습니다. Android는 기기·OS 버전·제조사 설정에 따라 기본 글꼴과 대체 순서가 달라서(예: Noto
+  Sans KR 계열), 차이의 정도도 기기마다 다릅니다.
 </Callout>
 
 Android에서는 medium이 bold에 가깝게 느껴질 수 있어, 두께 차이에만 기대어 만든 위계는 두

--- a/docs/content/foundations/typography.mdx
+++ b/docs/content/foundations/typography.mdx
@@ -49,6 +49,16 @@ font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo",
 
 <TokenReference groups={["font-weight"]} />
 
+<Callout type="warn" title="medium은 플랫폼에 따라 두께가 조금 다르게 보여요">
+  시스템 폰트를 사용하기 때문에, 같은 medium(500)이라도 iOS와 Android의 글꼴 자체가
+  다릅니다. 한글에서는 Android(Noto Sans KR)가 iOS(Apple SD Gothic Neo)보다 획이 조금 더
+  두껍게 보입니다.
+</Callout>
+
+Android에서는 medium이 bold에 가깝게 느껴질 수 있어, 두께 차이에만 기대어 만든 위계는 두
+플랫폼에서 다르게 읽힙니다. medium과 bold를 나란히 써서 강조를 구분할 때는 폰트 크기나 색상
+등 다른 요소를 함께 사용하고, 두 플랫폼 실기기에서 위계가 그대로 유지되는지 확인해 주세요.
+
 ## 타이포그래피 컴포넌트
 
 텍스트 스타일은 토큰들을 조합하여 사용 가능한 컴포넌트로 취급되며, 두 가지 주요 범주로 나뉩니다:

--- a/docs/content/foundations/typography.mdx
+++ b/docs/content/foundations/typography.mdx
@@ -56,10 +56,6 @@ font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo",
   Sans KR 계열), 차이의 정도도 기기마다 다릅니다.
 </Callout>
 
-Android에서는 medium이 bold에 가깝게 느껴질 수 있어, 두께 차이에만 기대어 만든 위계는 두
-플랫폼에서 다르게 읽힙니다. medium과 bold를 나란히 써서 강조를 구분할 때는 폰트 크기나 색상
-등 다른 요소를 함께 사용하고, 두 플랫폼 실기기에서 위계가 그대로 유지되는지 확인해 주세요.
-
 ## 타이포그래피 컴포넌트
 
 텍스트 스타일은 토큰들을 조합하여 사용 가능한 컴포넌트로 취급되며, 두 가지 주요 범주로 나뉩니다:


### PR DESCRIPTION
## 배경

SEED는 시스템 폰트를 사용합니다. 그래서 같은 `$font-weight.medium`(500)이라도 플랫폼마다 실제로 그려지는 글꼴이 달라, 한글에서는 iOS(Apple SD Gothic Neo)보다 Android 쪽 획이 조금 더 두껍게 보일 수 있습니다. Foundation 문서에 이 내용이 없어 medium을 쓸 때마다 각자 발견하게 되는 상태였어요.

## 변경사항

`foundations/typography.mdx`의 **폰트 두께 토큰** 섹션에 Callout을 하나 추가했습니다.

- 두께 매핑 문제가 아니라 플랫폼별 **글꼴이 다른 것**이 원인
- Android의 기본 글꼴과 대체 순서는 기기·OS 버전·제조사 설정에 따라 달라져, 차이의 정도도 기기마다 다름

문서 문구만 바뀌었고 토큰·컴포넌트 변경은 없어 changeset은 넣지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
  - 시스템 글꼴이 플랫폼별로 다르게 렌더링될 수 있음을 안내합니다.
  - Android의 시스템 글꼴 및 대체 순서가 기기, OS 버전, 제조사 설정에 따라 달라질 수 있음을 명시했습니다.
  - Android의 `medium` 글꼴 두께가 iOS보다 두껍게 보이는 정도도 기기마다 다를 수 있음을 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->