### PR TITLE
fix(field, attachment-input): anchor hidden form elements to the component root

### DIFF
--- a/.changeset/tidy-forks-invent.md
+++ b/.changeset/tidy-forks-invent.md
@@ -1,0 +1,7 @@
+---
+"@seed-design/css": patch
+---
+
+숨겨진 폼 요소가 컴포넌트 밖으로 빠져나가 스크롤을 만드는 문제를 수정합니다.
+
+`field`와 `attachment-input`의 root에 `position: relative`를 지정합니다. 이전에는 Select의 native `<select>`와 AttachmentField의 `<input type="file">`이 컴포넌트 바깥의 positioned 조상을 기준으로 배치되어, 자체 스크롤 영역을 가진 페이지에서 바깥 컨테이너에 불필요한 스크롤이 생겼습니다.

--- a/packages/css/all.css
+++ b/packages/css/all.css
@@ -5530,6 +5530,7 @@
   flex-direction: column;
   width: 100%;
   display: flex;
+  position: relative;
 }
 
 .seed-field__header {
@@ -5642,6 +5643,7 @@
   margin-inline: calc(var(--seed-attachment-input-extend-x) * -1);
   flex-direction: column;
   display: flex;
+  position: relative;
 }
 
 .seed-attachment-input__dropzone {

--- a/packages/css/all.layered.css
+++ b/packages/css/all.layered.css
@@ -5779,6 +5779,7 @@
     flex-direction: column;
     width: 100%;
     display: flex;
+    position: relative;
   }
 
   .seed-field__header {
@@ -5891,6 +5892,7 @@
     margin-inline: calc(var(--seed-attachment-input-extend-x) * -1);
     flex-direction: column;
     display: flex;
+    position: relative;
   }
 
   .seed-attachment-input__dropzone {

--- a/packages/css/recipes/attachment-input.css
+++ b/packages/css/recipes/attachment-input.css
@@ -1,6 +1,7 @@
 .seed-attachment-input__root {
     display: flex;
     flex-direction: column;
+    position: relative;
     gap: var(--seed-dimension-x2);
     margin-inline: calc(var(--seed-attachment-input-extend-x) * -1);
 }

--- a/packages/css/recipes/attachment-input.layered.css
+++ b/packages/css/recipes/attachment-input.layered.css
@@ -4,6 +4,7 @@
     margin-inline: calc(var(--seed-attachment-input-extend-x) * -1);
     flex-direction: column;
     display: flex;
+    position: relative;
   }
 
   .seed-attachment-input__dropzone {

--- a/packages/css/recipes/field.css
+++ b/packages/css/recipes/field.css
@@ -2,6 +2,7 @@
     display: flex;
     flex-direction: column;
     width: 100%;
+    position: relative;
     gap: var(--seed-dimension-x2);
 }
 .seed-field__header {

--- a/packages/css/recipes/field.layered.css
+++ b/packages/css/recipes/field.layered.css
@@ -4,6 +4,7 @@
     flex-direction: column;
     width: 100%;
     display: flex;
+    position: relative;
   }
 
   .seed-field__header {

--- a/packages/qvism-preset/src/recipes/attachment-input.ts
+++ b/packages/qvism-preset/src/recipes/attachment-input.ts
@@ -491,6 +491,8 @@ const attachmentInput = defineSlotRecipe({
       display: "flex",
       flexDirection: "column",
 
+      position: "relative",
+
       gap: vars.base.enabled.root.gap,
 
       marginInline: "calc(var(--seed-attachment-input-extend-x) * -1)",

--- a/packages/qvism-preset/src/recipes/field.ts
+++ b/packages/qvism-preset/src/recipes/field.ts
@@ -22,6 +22,10 @@ export const field = defineSlotRecipe({
 
       width: "100%",
 
+      // Select has no root of its own to wrap its hidden native `<select>` with, so the field
+      // takes that role and keeps it from escaping into an outer scroll container.
+      position: "relative",
+
       gap: vars.base.enabled.root.gap,
     },
     header: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 자체 스크롤 영역을 사용하는 페이지에서 Select와 파일 첨부 입력이 바깥 컨테이너에 불필요한 스크롤을 생성하던 문제를 수정했습니다.
  * 필드 및 파일 첨부 영역 내부에 숨겨진 입력 요소가 올바른 위치를 기준으로 배치되도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->