### PR TITLE
feat(lynx-react): add segmented control

### DIFF
--- a/.changeset/steady-segments-slide.md
+++ b/.changeset/steady-segments-slide.md
@@ -1,0 +1,8 @@
+---
+"@seed-design/lynx-css": minor
+"@seed-design/lynx-react": minor
+---
+
+Lynx용 Segmented Control 컴포넌트를 추가합니다.
+
+- `npx @seed-design/cli@latest add ui:segmented-control`로 Registry 컴포넌트를 설치할 수 있습니다.

--- a/docs/content/lynx/components/segmented-control.mdx
+++ b/docs/content/lynx/components/segmented-control.mdx
@@ -1,0 +1,120 @@
+---
+title: Segmented Control
+description: 여러 옵션 중 하나를 선택하여 관련 콘텐츠를 즉시 필터링하거나 전환할 때 사용하는 컴포넌트입니다.
+compatibility:
+  lynx:
+    engine: "3.0"
+---
+
+<AvailableSince packages="@seed-design/lynx-react@0.6.0, @seed-design/lynx-css@0.10.0" />
+
+<LynxComponentExample name="lynx/segmented-control/preview">
+  ```json doc-gen:file
+  {"file":"examples/lynx/segmented-control/preview.tsx","codeblock":true}
+  ```
+</LynxComponentExample>
+
+## Installation
+
+```package-install
+npx @seed-design/cli add ui:segmented-control
+```
+
+<LynxManualInstallation name="segmented-control" />
+
+## Props
+
+### `SegmentedControl`
+
+<Callout type="info">
+`value`와 `defaultValue` 중 하나를 제공해야 선택된 항목과 Indicator를 표시할 수 있습니다.
+</Callout>
+
+<react-type-table
+  path="./registry/lynx/ui/segmented-control.tsx"
+  name="SegmentedControlProps"
+/>
+
+### `SegmentedControlItem`
+
+<react-type-table
+  path="./registry/lynx/ui/segmented-control.tsx"
+  name="SegmentedControlItemProps"
+/>
+
+## Usage
+
+```tsx
+import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from "@/components/ui/segmented-control";
+
+export function App() {
+  return (
+    <SegmentedControl defaultValue="hot" accessibility-label="정렬 기준">
+      <SegmentedControlItem value="hot">인기순</SegmentedControlItem>
+      <SegmentedControlItem value="new">최신순</SegmentedControlItem>
+    </SegmentedControl>
+  );
+}
+```
+
+Registry의 `SegmentedControl`은 선택 Indicator를 자동으로 추가합니다.
+
+## Examples
+
+### Disabled
+
+`SegmentedControl`의 `disabled`는 전체 항목을 비활성화합니다. 각 `SegmentedControlItem`도 따로 비활성화할 수 있습니다.
+
+<LynxComponentExample name="lynx/segmented-control/disabled">
+  ```json doc-gen:file
+  {"file":"examples/lynx/segmented-control/disabled.tsx","codeblock":true}
+  ```
+</LynxComponentExample>
+
+### Long Label
+
+<LynxComponentExample name="lynx/segmented-control/long-label">
+  ```json doc-gen:file
+  {"file":"examples/lynx/segmented-control/long-label.tsx","codeblock":true}
+  ```
+</LynxComponentExample>
+
+### Fixed Width
+
+`SegmentedControl`의 `style`이나 `className`으로 너비를 지정할 수 있습니다.
+
+<LynxComponentExample name="lynx/segmented-control/fixed-width">
+  ```json doc-gen:file
+  {"file":"examples/lynx/segmented-control/fixed-width.tsx","codeblock":true}
+  ```
+</LynxComponentExample>
+
+### Listening to Value Changes
+
+`onValueChange`로 선택 값 변경을 감지할 수 있습니다. Controlled 모드에서는 `value`와 함께 사용합니다.
+
+<LynxComponentExample name="lynx/segmented-control/value-changes">
+  ```json doc-gen:file
+  {"file":"examples/lynx/segmented-control/value-changes.tsx","codeblock":true}
+  ```
+</LynxComponentExample>
+
+## 웹 버전과의 차이
+
+| 항목 | React Web | Lynx |
+|---|---|---|
+| 렌더링 요소 | HTML `label`, `input` | 네이티브 `view`, `text` |
+| 선택 이벤트 | input change | `bindtap`, 공개 상태 이벤트는 `onValueChange` |
+| 접근성 | ARIA `radiogroup`, `radio` | Lynx `accessibility-*` 속성 |
+| Indicator | CSS grid와 custom property | Grid layout과 custom property |
+
+## Lynx 미지원 기능
+
+- HTML form 제출을 위한 `ItemHiddenInput`, `name`, `form`, `inputProps`
+- 키보드 focus와 focus-visible 상호작용
+- Registry `SegmentedControlItem`의 `notification` prop
+
+Lynx에는 대응하는 Notification Badge 컴포넌트가 없어 `notification` prop을 제공하지 않습니다. 항목 레이블은 문자열이나 숫자로 전달합니다.

--- a/docs/examples/lynx/segmented-control/disabled.tsx
+++ b/docs/examples/lynx/segmented-control/disabled.tsx
@@ -1,0 +1,28 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { useSeedClassName } from "@seed-design/lynx-react";
+import { SegmentedControl, SegmentedControlItem } from "@/components/ui/segmented-control";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <view className="segmented-control-example">
+        <SegmentedControl defaultValue="hot" disabled accessibility-label="전체 비활성화">
+          <SegmentedControlItem value="hot">인기순</SegmentedControlItem>
+          <SegmentedControlItem value="new">최신순</SegmentedControlItem>
+        </SegmentedControl>
+        <SegmentedControl defaultValue="hot" accessibility-label="일부 비활성화">
+          <SegmentedControlItem value="hot">인기순</SegmentedControlItem>
+          <SegmentedControlItem value="new" disabled>
+            최신순
+          </SegmentedControlItem>
+        </SegmentedControl>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/segmented-control/fixed-width.tsx
+++ b/docs/examples/lynx/segmented-control/fixed-width.tsx
@@ -1,0 +1,27 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { useSeedClassName } from "@seed-design/lynx-react";
+import { SegmentedControl, SegmentedControlItem } from "@/components/ui/segmented-control";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <view className="segmented-control-example">
+        <SegmentedControl
+          className="segmented-control-example__fixed"
+          defaultValue="oneway"
+          accessibility-label="Trip Type"
+        >
+          <SegmentedControlItem value="oneway">One Way Trip</SegmentedControlItem>
+          <SegmentedControlItem value="round">Round Trip</SegmentedControlItem>
+          <SegmentedControlItem value="multi">Multi-City Journey</SegmentedControlItem>
+        </SegmentedControl>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/segmented-control/long-label.tsx
+++ b/docs/examples/lynx/segmented-control/long-label.tsx
@@ -1,0 +1,23 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { useSeedClassName } from "@seed-design/lynx-react";
+import { SegmentedControl, SegmentedControlItem } from "@/components/ui/segmented-control";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <view className="segmented-control-example">
+        <SegmentedControl defaultValue="price" accessibility-label="정렬 기준">
+          <SegmentedControlItem value="price">가격 높은 순</SegmentedControlItem>
+          <SegmentedControlItem value="discount">할인율 높은 순</SegmentedControlItem>
+          <SegmentedControlItem value="popular">인기 많은 순</SegmentedControlItem>
+        </SegmentedControl>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/segmented-control/preview.css
+++ b/docs/examples/lynx/segmented-control/preview.css
@@ -1,0 +1,26 @@
+/* biome-ignore lint/correctness/noUnknownTypeSelector: Lynx의 page 요소입니다. */
+page {
+  height: 100%;
+  padding: 24px;
+  background-color: var(--seed-color-bg-layer-default);
+}
+
+.segmented-control-example {
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+}
+
+.segmented-control-example__control {
+  align-self: center;
+}
+
+.segmented-control-example__fixed {
+  width: 320px;
+}
+
+.segmented-control-example__status {
+  color: var(--seed-color-fg-neutral-muted);
+  font-size: 14px;
+}

--- a/docs/examples/lynx/segmented-control/preview.tsx
+++ b/docs/examples/lynx/segmented-control/preview.tsx
@@ -1,0 +1,26 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { useSeedClassName } from "@seed-design/lynx-react";
+import { SegmentedControl, SegmentedControlItem } from "@/components/ui/segmented-control";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <view className="segmented-control-example">
+        <SegmentedControl
+          className="segmented-control-example__control"
+          defaultValue="hot"
+          accessibility-label="정렬 기준"
+        >
+          <SegmentedControlItem value="hot">인기순</SegmentedControlItem>
+          <SegmentedControlItem value="new">최신순</SegmentedControlItem>
+        </SegmentedControl>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/segmented-control/styles.ts
+++ b/docs/examples/lynx/segmented-control/styles.ts
@@ -1,0 +1,2 @@
+import "@seed-design/lynx-css/base.css";
+import "./preview.css";

--- a/docs/examples/lynx/segmented-control/value-changes.tsx
+++ b/docs/examples/lynx/segmented-control/value-changes.tsx
@@ -1,0 +1,33 @@
+import "./styles";
+
+import { root, useState } from "@lynx-js/react";
+import { useSeedClassName } from "@seed-design/lynx-react";
+import { SegmentedControl, SegmentedControlItem } from "@/components/ui/segmented-control";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+  const [value, setValue] = useState("hot");
+
+  function handleValueChange(nextValue: string) {
+    "background only";
+    setValue(nextValue);
+  }
+
+  return (
+    <page className={seedClassName}>
+      <view className="segmented-control-example">
+        <SegmentedControl
+          value={value}
+          onValueChange={handleValueChange}
+          accessibility-label="정렬 기준"
+        >
+          <SegmentedControlItem value="hot">인기순</SegmentedControlItem>
+          <SegmentedControlItem value="new">최신순</SegmentedControlItem>
+        </SegmentedControl>
+        <text className="segmented-control-example__status">선택값: {value}</text>
+      </view>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/public/__docs__/index.json
+++ b/docs/public/__docs__/index.json
@@ -685,6 +685,12 @@
               "docUrl": "/foundations/color"
             },
             {
+              "id": "color",
+              "title": "Color",
+              "description": "누를 수 있는 요소는 눌린 동안 표면 색이 바뀝니다. SEED는 눌린 상태의 색을 역할 색상 체계 안의 pressed 토큰으로 정의합니다.",
+              "docUrl": "/foundations/feedback/color"
+            },
+            {
               "id": "color-role",
               "title": "Roles",
               "description": "역할이 부여된 색상은 색상에 특정 기능적 역할(주요 액션, 오류, 정보 등)을 할당하여 사용자 인터페이스 전반에 걸쳐 일관성, 명확성, 접근성을 보장합니다.",
@@ -701,6 +707,12 @@
               "title": "Elevation",
               "description": "UI 요소 간의 상대적인 깊이와 계층 구조를 시각적으로 표현하는 디자인 원칙입니다.",
               "docUrl": "/foundations/elevation"
+            },
+            {
+              "id": "feedback",
+              "title": "Overview",
+              "description": "피드백은 사용자의 입력에 대한 즉각적인 반응입니다. 요소가 조작 가능하다는 사실과 입력이 전달되었다는 사실을 알려줍니다.",
+              "docUrl": "/foundations/feedback"
             },
             {
               "id": "gradient",
@@ -759,6 +771,12 @@
               "title": "Reference",
               "description": "SEED 디자인 토큰의 전체 목록을 제공합니다.",
               "docUrl": "/foundations/design-token/reference"
+            },
+            {
+              "id": "scale",
+              "title": "Scale",
+              "description": "누를 수 있는 요소는 눌린 동안 살짝 작아집니다. SEED는 모든 요소에서 눌린 느낌의 양이 같도록 축소량을 배율이 아닌 거리로 정의합니다.",
+              "docUrl": "/foundations/feedback/scale"
             },
             {
               "id": "spacing",
@@ -2174,6 +2192,19 @@
                 {
                   "label": "react",
                   "path": "radio-group.tsx"
+                }
+              ]
+            },
+            {
+              "id": "segmented-control",
+              "title": "Segmented Control",
+              "description": "여러 옵션 중 하나를 선택하여 관련 콘텐츠를 즉시 필터링하거나 전환할 때 사용하는 컴포넌트입니다.",
+              "docUrl": "/lynx/components/segmented-control",
+              "snippetKey": "lynx/ui:segmented-control",
+              "snippets": [
+                {
+                  "label": "react",
+                  "path": "segmented-control.tsx"
                 }
               ]
             },

--- a/docs/public/__registry__/lynx/ui/index.json
+++ b/docs/public/__registry__/lynx/ui/index.json
@@ -114,6 +114,21 @@
     {
       "snippets": [
         {
+          "path": "segmented-control.tsx",
+          "dependencies": {
+            "@seed-design/lynx-react": ">=0.6.0 <1.0.0",
+            "@seed-design/lynx-css": ">=0.10.0 <1.0.0"
+          }
+        }
+      ],
+      "id": "segmented-control",
+      "dependencies": [
+        "@seed-design/lynx-react"
+      ]
+    },
+    {
+      "snippets": [
+        {
           "path": "switch.tsx",
           "dependencies": {
             "@seed-design/lynx-react": ">=0.1.0 <1.0.0",

--- a/docs/public/__registry__/lynx/ui/segmented-control.json
+++ b/docs/public/__registry__/lynx/ui/segmented-control.json
@@ -1,0 +1,16 @@
+{
+  "id": "segmented-control",
+  "dependencies": [
+    "@seed-design/lynx-react"
+  ],
+  "snippets": [
+    {
+      "path": "segmented-control.tsx",
+      "content": "/**\n * @file ui:segmented-control\n * @requires @seed-design/lynx-react@>=0.6.0 <1.0.0\n * @requires @seed-design/lynx-css@>=0.10.0 <1.0.0\n **/\n\nimport * as React from \"@lynx-js/react\";\nimport { SegmentedControl as SeedSegmentedControl } from \"@seed-design/lynx-react\";\n\nexport interface SegmentedControlProps extends SeedSegmentedControl.RootProps {}\n\n/**\n * @see https://seed-design.io/lynx/components/segmented-control\n */\nexport const SegmentedControl = React.forwardRef<unknown, SegmentedControlProps>(\n  ({ children, ...otherProps }, ref) => {\n    return (\n      <SeedSegmentedControl.Root ref={ref} {...otherProps}>\n        {children}\n        <SeedSegmentedControl.Indicator />\n      </SeedSegmentedControl.Root>\n    );\n  },\n);\nSegmentedControl.displayName = \"SegmentedControl\";\n\nexport interface SegmentedControlItemProps extends SeedSegmentedControl.ItemProps {}\n\n/**\n * @see https://seed-design.io/lynx/components/segmented-control#segmentedcontrolitem\n */\nexport const SegmentedControlItem = SeedSegmentedControl.Item;\n\n/**\n * This file is a snippet from SEED Design, helping you get started quickly with @seed-design/* packages.\n * You can extend this snippet however you want.\n */\n",
+      "dependencies": {
+        "@seed-design/lynx-react": ">=0.6.0 <1.0.0",
+        "@seed-design/lynx-css": ">=0.10.0 <1.0.0"
+      }
+    }
+  ]
+}

--- a/docs/registry/lynx/registry-ui.ts
+++ b/docs/registry/lynx/registry-ui.ts
@@ -85,6 +85,18 @@ export const registryUI: Registry = {
       ],
     },
     {
+      id: "segmented-control",
+      snippets: [
+        {
+          path: "segmented-control.tsx",
+          dependencies: {
+            "@seed-design/lynx-react": ">=0.6.0 <1.0.0",
+            "@seed-design/lynx-css": ">=0.10.0 <1.0.0",
+          },
+        },
+      ],
+    },
+    {
       id: "switch",
       snippets: [
         {

--- a/docs/registry/lynx/ui/segmented-control.tsx
+++ b/docs/registry/lynx/ui/segmented-control.tsx
@@ -1,0 +1,26 @@
+import * as React from "@lynx-js/react";
+import { SegmentedControl as SeedSegmentedControl } from "@seed-design/lynx-react";
+
+export interface SegmentedControlProps extends SeedSegmentedControl.RootProps {}
+
+/**
+ * @see https://seed-design.io/lynx/components/segmented-control
+ */
+export const SegmentedControl = React.forwardRef<unknown, SegmentedControlProps>(
+  ({ children, ...otherProps }, ref) => {
+    return (
+      <SeedSegmentedControl.Root ref={ref} {...otherProps}>
+        {children}
+        <SeedSegmentedControl.Indicator />
+      </SeedSegmentedControl.Root>
+    );
+  },
+);
+SegmentedControl.displayName = "SegmentedControl";
+
+export interface SegmentedControlItemProps extends SeedSegmentedControl.ItemProps {}
+
+/**
+ * @see https://seed-design.io/lynx/components/segmented-control#segmentedcontrolitem
+ */
+export const SegmentedControlItem = SeedSegmentedControl.Item;

--- a/packages/lynx-css/all.css
+++ b/packages/lynx-css/all.css
@@ -2600,6 +2600,109 @@ text {
   background-color: var(--seed-color-bg-neutral-inverted-pressed);
 }
 
+.seed-segmented-control__root {
+  width: max-content;
+  max-width: 100%;
+  padding: var(--seed-dimension-x1);
+  border-radius: var(--seed-radius-full);
+  background-color: var(--seed-color-bg-neutral-weak-alpha);
+  grid-auto-rows: 1fr;
+  grid-auto-columns: 1fr;
+  grid-auto-flow: column;
+  align-items: stretch;
+  display: grid;
+  position: relative;
+}
+
+.seed-segmented-control__indicator {
+  top: var(--seed-dimension-x1);
+  bottom: var(--seed-dimension-x1);
+  left: var(--seed-dimension-x1);
+  z-index: 0;
+  width: calc((100% - var(--seed-dimension-x1) * 2) / var(--segment-count, 1));
+  border-radius: var(--seed-radius-full);
+  background-color: var(--seed-color-palette-gray-00);
+  box-shadow: inset 0 0 0 1px var(--seed-color-stroke-neutral-muted);
+  transform: translateX(calc(var(--segment-index, 0) * 100%));
+  transition-property: transform, opacity;
+  transition-duration: var(--seed-duration-d4);
+  transition-timing-function: var(--seed-timing-function-easing);
+  position: absolute;
+}
+
+.seed-segmented-control__item {
+  z-index: 1;
+  justify-content: center;
+  align-items: center;
+  gap: var(--seed-dimension-x1_5);
+  min-width: 86px;
+  height: 100%;
+  min-height: 34px;
+  padding-left: var(--seed-dimension-x6);
+  padding-right: var(--seed-dimension-x6);
+  padding-top: var(--seed-dimension-x1_5);
+  padding-bottom: var(--seed-dimension-x1_5);
+  border-radius: var(--seed-radius-full);
+  flex-direction: row;
+  display: flex;
+  position: relative;
+}
+
+.seed-segmented-control__itemBackground {
+  border-radius: var(--seed-radius-full);
+  opacity: 0;
+  transition-property: opacity;
+  transition-duration: var(--seed-duration-color-transition);
+  transition-timing-function: var(--seed-timing-function-easing);
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.seed-segmented-control__label {
+  color: var(--seed-color-fg-neutral-subtle);
+  font-weight: var(--seed-font-weight-bold);
+  font-size: var(--seed-font-size-t5);
+  line-height: var(--seed-line-height-t5);
+  text-align: center;
+  transition-property: color;
+  transition-duration: var(--seed-duration-color-transition);
+  transition-timing-function: var(--seed-timing-function-easing);
+}
+
+.seed-segmented-control__itemBackground--selected_true {
+  background-color: var(--seed-color-palette-gray-100);
+  box-shadow: inset 0 0 0 1px var(--seed-color-stroke-neutral-muted);
+}
+
+.seed-segmented-control__label--selected_true {
+  color: var(--seed-color-fg-neutral);
+}
+
+.seed-segmented-control__itemBackground--selected_false {
+  background-color: var(--seed-color-bg-neutral-weak-pressed);
+  box-shadow: inset 0 0 0 1px var(--seed-color-stroke-neutral-muted);
+}
+
+.seed-segmented-control__label--disabled_true {
+  color: var(--seed-color-fg-disabled);
+}
+
+.seed-segmented-control__itemBackground--pressed_true {
+  opacity: 1;
+}
+
+.seed-segmented-control__indicator--hasSelection_false {
+  opacity: 0;
+}
+
+.seed-segmented-control__item--selected_true-disabled_true {
+  background-color: var(--seed-color-bg-disabled);
+  box-shadow: inset 0 0 0 1px var(--seed-color-stroke-neutral-muted);
+}
+
 .seed-switch__root {
   align-items: flex-start;
   display: flex;

--- a/packages/lynx-css/recipes/segmented-control.css
+++ b/packages/lynx-css/recipes/segmented-control.css
@@ -1,0 +1,91 @@
+.seed-segmented-control__root {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: 1fr;
+    grid-auto-rows: 1fr;
+    position: relative;
+    align-items: stretch;
+    width: max-content;
+    max-width: 100%;
+    padding: var(--seed-dimension-x1);
+    border-radius: var(--seed-radius-full);
+    background-color: var(--seed-color-bg-neutral-weak-alpha)
+}
+.seed-segmented-control__indicator {
+    position: absolute;
+    top: var(--seed-dimension-x1);
+    bottom: var(--seed-dimension-x1);
+    left: var(--seed-dimension-x1);
+    z-index: 0;
+    width: calc((100% - var(--seed-dimension-x1) * 2) / var(--segment-count, 1));
+    border-radius: var(--seed-radius-full);
+    background-color: var(--seed-color-palette-gray-00);
+    box-shadow: inset 0 0 0 1px var(--seed-color-stroke-neutral-muted);
+    transform: translateX(calc(var(--segment-index, 0) * 100%));
+    transition-property: transform, opacity;
+    transition-duration: var(--seed-duration-d4);
+    transition-timing-function: var(--seed-timing-function-easing)
+}
+.seed-segmented-control__item {
+    display: flex;
+    flex-direction: row;
+    position: relative;
+    z-index: 1;
+    align-items: center;
+    justify-content: center;
+    min-width: 86px;
+    min-height: 34px;
+    height: 100%;
+    gap: var(--seed-dimension-x1_5);
+    padding-left: var(--seed-dimension-x6);
+    padding-right: var(--seed-dimension-x6);
+    padding-top: var(--seed-dimension-x1_5);
+    padding-bottom: var(--seed-dimension-x1_5);
+    border-radius: var(--seed-radius-full)
+}
+.seed-segmented-control__itemBackground {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    border-radius: var(--seed-radius-full);
+    opacity: 0;
+    transition-property: opacity;
+    transition-duration: var(--seed-duration-color-transition);
+    transition-timing-function: var(--seed-timing-function-easing)
+}
+.seed-segmented-control__label {
+    color: var(--seed-color-fg-neutral-subtle);
+    font-weight: var(--seed-font-weight-bold);
+    font-size: var(--seed-font-size-t5);
+    line-height: var(--seed-line-height-t5);
+    text-align: center;
+    transition-property: color;
+    transition-duration: var(--seed-duration-color-transition);
+    transition-timing-function: var(--seed-timing-function-easing)
+}
+.seed-segmented-control__itemBackground--selected_true {
+    background-color: var(--seed-color-palette-gray-100);
+    box-shadow: inset 0 0 0 1px var(--seed-color-stroke-neutral-muted)
+}
+.seed-segmented-control__label--selected_true {
+    color: var(--seed-color-fg-neutral)
+}
+.seed-segmented-control__itemBackground--selected_false {
+    background-color: var(--seed-color-bg-neutral-weak-pressed);
+    box-shadow: inset 0 0 0 1px var(--seed-color-stroke-neutral-muted)
+}
+.seed-segmented-control__label--disabled_true {
+    color: var(--seed-color-fg-disabled)
+}
+.seed-segmented-control__itemBackground--pressed_true {
+    opacity: 1
+}
+.seed-segmented-control__indicator--hasSelection_false {
+    opacity: 0
+}
+.seed-segmented-control__item--selected_true-disabled_true {
+    background-color: var(--seed-color-bg-disabled);
+    box-shadow: inset 0 0 0 1px var(--seed-color-stroke-neutral-muted)
+}

--- a/packages/lynx-css/recipes/segmented-control.d.ts
+++ b/packages/lynx-css/recipes/segmented-control.d.ts
@@ -1,0 +1,36 @@
+declare interface SegmentedControlVariant {
+  /**
+  * @default false
+  */
+  selected: boolean;
+/**
+  * @default false
+  */
+  disabled: boolean;
+/**
+  * @default false
+  */
+  pressed: boolean;
+/**
+  * @default true
+  */
+  hasSelection: boolean;
+}
+
+declare type SegmentedControlVariantMap = {
+  [key in keyof SegmentedControlVariant]: Array<SegmentedControlVariant[key]>;
+};
+
+export declare type SegmentedControlVariantProps = Partial<SegmentedControlVariant>;
+
+export declare type SegmentedControlSlotName = "root" | "indicator" | "item" | "itemBackground" | "label";
+
+export declare const segmentedControlVariantMap: SegmentedControlVariantMap;
+
+export declare const segmentedControl: ((
+  props?: SegmentedControlVariantProps,
+) => Record<SegmentedControlSlotName, string>) & {
+  splitVariantProps: <T extends SegmentedControlVariantProps>(
+    props: T,
+  ) => [SegmentedControlVariantProps, Omit<T, keyof SegmentedControlVariantProps>];
+}

--- a/packages/lynx-css/recipes/segmented-control.mjs
+++ b/packages/lynx-css/recipes/segmented-control.mjs
@@ -1,0 +1,75 @@
+import './segmented-control.css';
+import { createClassName, mergeVariants, splitVariantProps } from "./shared.mjs";
+
+const segmentedControlSlotNames = [
+  [
+    "root",
+    "seed-segmented-control__root"
+  ],
+  [
+    "indicator",
+    "seed-segmented-control__indicator"
+  ],
+  [
+    "item",
+    "seed-segmented-control__item"
+  ],
+  [
+    "itemBackground",
+    "seed-segmented-control__itemBackground"
+  ],
+  [
+    "label",
+    "seed-segmented-control__label"
+  ]
+];
+
+const defaultVariant = {
+  "selected": false,
+  "disabled": false,
+  "pressed": false,
+  "hasSelection": true
+};
+
+const compoundVariants = [
+  {
+    "selected": true,
+    "disabled": true
+  }
+];
+
+export const segmentedControlVariantMap = {
+  "selected": [
+    true,
+    false
+  ],
+  "disabled": [
+    true,
+    false
+  ],
+  "pressed": [
+    true,
+    false
+  ],
+  "hasSelection": [
+    true,
+    false
+  ]
+};
+
+export const segmentedControlVariantKeys = Object.keys(segmentedControlVariantMap);
+
+export function segmentedControl(props) {
+  return Object.fromEntries(
+    segmentedControlSlotNames.map(([slot, className]) => {
+      return [
+        slot,
+        createClassName(className, mergeVariants(defaultVariant, props), compoundVariants),
+      ];
+    }),
+  );
+}
+
+Object.assign(segmentedControl, { splitVariantProps: (props) => splitVariantProps(props, segmentedControlVariantMap) });
+
+// @recipe(seed): segmented-control

--- a/packages/lynx-qvism-preset/segmented-control.test.ts
+++ b/packages/lynx-qvism-preset/segmented-control.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+
+import segmentedControl from "./src/recipes/segmented-control";
+
+describe("Lynx segmented control recipe", () => {
+  it("uses intrinsic root width without forcing labels onto one line", () => {
+    expect(segmentedControl.base.root).toMatchObject({
+      display: "grid",
+      gridAutoFlow: "column",
+      gridAutoColumns: "1fr",
+      width: "max-content",
+      maxWidth: "100%",
+    });
+    expect(segmentedControl.base.label).toMatchObject({ textAlign: "center" });
+    expect(segmentedControl.base.label).not.toHaveProperty("whiteSpace");
+  });
+
+  it("transitions press feedback with an opacity background", () => {
+    expect(segmentedControl.slots).toContain("itemBackground");
+    expect(segmentedControl.base.item).not.toHaveProperty("transitionProperty");
+    expect(segmentedControl.base.itemBackground).toMatchObject({
+      opacity: 0,
+      transitionProperty: "opacity",
+    });
+    expect(segmentedControl.variants.pressed.true.itemBackground).toEqual({ opacity: 1 });
+  });
+});

--- a/packages/lynx-qvism-preset/src/recipes.ts
+++ b/packages/lynx-qvism-preset/src/recipes.ts
@@ -14,6 +14,7 @@ import fieldLabel from "./recipes/field-label";
 import radio from "./recipes/radio";
 import radioGroup from "./recipes/radio-group";
 import radiomark from "./recipes/radiomark";
+import segmentedControl from "./recipes/segmented-control";
 import switchRecipe from "./recipes/switch";
 import switchmarkRecipe from "./recipes/switchmark";
 import { tagGroup as lynxTagGroup, tagGroupItem as lynxTagGroupItem } from "./recipes/tag-group";
@@ -41,6 +42,7 @@ export const recipes = {
   radio,
   radioGroup,
   radiomark,
+  segmentedControl,
   switch: switchRecipe,
   switchmark: switchmarkRecipe,
   tagGroup: lynxTagGroup,

--- a/packages/lynx-qvism-preset/src/recipes/segmented-control.ts
+++ b/packages/lynx-qvism-preset/src/recipes/segmented-control.ts
@@ -1,0 +1,143 @@
+import {
+  segmentedControlItem as itemVars,
+  segmentedControl as vars,
+  segmentedControlIndicator as indicatorVars,
+} from "../vars/component";
+import { defineSlotRecipe } from "../utils/define";
+
+const segmentedControl = defineSlotRecipe({
+  name: "segmented-control",
+  slots: ["root", "indicator", "item", "itemBackground", "label"],
+  base: {
+    root: {
+      display: "grid",
+      gridAutoFlow: "column",
+      gridAutoColumns: "1fr",
+      gridAutoRows: "1fr",
+      position: "relative",
+      alignItems: "stretch",
+      width: "max-content",
+      maxWidth: "100%",
+      padding: vars.base.enabled.root.padding,
+      borderRadius: vars.base.enabled.root.cornerRadius,
+      backgroundColor: vars.base.enabled.root.color,
+    },
+    indicator: {
+      position: "absolute",
+      top: vars.base.enabled.root.padding,
+      bottom: vars.base.enabled.root.padding,
+      left: vars.base.enabled.root.padding,
+      zIndex: 0,
+      width: `calc((100% - ${vars.base.enabled.root.padding} * 2) / var(--segment-count, 1))`,
+      borderRadius: indicatorVars.base.enabled.root.cornerRadius,
+      backgroundColor: indicatorVars.base.enabled.root.color,
+      boxShadow: `inset 0 0 0 ${indicatorVars.base.enabled.root.strokeWidth} ${indicatorVars.base.enabled.root.strokeColor}`,
+      transform: "translateX(calc(var(--segment-index, 0) * 100%))",
+      transitionProperty: "transform, opacity",
+      transitionDuration: indicatorVars.base.enabled.root.transformDuration,
+      transitionTimingFunction: indicatorVars.base.enabled.root.transformTimingFunction,
+    },
+    item: {
+      display: "flex",
+      flexDirection: "row",
+      position: "relative",
+      zIndex: 1,
+      alignItems: "center",
+      justifyContent: "center",
+      minWidth: itemVars.base.enabled.root.minWidth,
+      minHeight: itemVars.base.enabled.root.minHeight,
+      height: "100%",
+      gap: itemVars.base.enabled.root.gap,
+      paddingLeft: itemVars.base.enabled.root.paddingX,
+      paddingRight: itemVars.base.enabled.root.paddingX,
+      paddingTop: itemVars.base.enabled.root.paddingY,
+      paddingBottom: itemVars.base.enabled.root.paddingY,
+      borderRadius: itemVars.base.enabled.root.cornerRadius,
+    },
+    itemBackground: {
+      position: "absolute",
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      borderRadius: itemVars.base.enabled.root.cornerRadius,
+      opacity: 0,
+      transitionProperty: "opacity",
+      transitionDuration: itemVars.base.enabled.root.colorDuration,
+      transitionTimingFunction: itemVars.base.enabled.root.colorTimingFunction,
+    },
+    label: {
+      color: itemVars.base.enabled.label.color,
+      fontWeight: itemVars.base.enabled.label.fontWeight,
+      fontSize: itemVars.base.enabled.label.fontSize,
+      lineHeight: itemVars.base.enabled.label.lineHeight,
+      textAlign: "center",
+      transitionProperty: "color",
+      transitionDuration: itemVars.base.enabled.label.colorDuration,
+      transitionTimingFunction: itemVars.base.enabled.label.colorTimingFunction,
+    },
+  },
+  variants: {
+    selected: {
+      true: {
+        itemBackground: {
+          backgroundColor: indicatorVars.base.pressed.root.color,
+          boxShadow: `inset 0 0 0 ${indicatorVars.base.enabled.root.strokeWidth} ${indicatorVars.base.enabled.root.strokeColor}`,
+        },
+        label: {
+          color: itemVars.base.selected.label.color,
+        },
+      },
+      false: {
+        itemBackground: {
+          backgroundColor: itemVars.base.pressed.root.color,
+          boxShadow: `inset 0 0 0 ${itemVars.base.pressed.root.strokeWidth} ${itemVars.base.pressed.root.strokeColor}`,
+        },
+      },
+    },
+    disabled: {
+      true: {
+        label: {
+          color: itemVars.base.disabled.label.color,
+        },
+      },
+      false: {},
+    },
+    pressed: {
+      true: {
+        itemBackground: {
+          opacity: 1,
+        },
+      },
+      false: {},
+    },
+    hasSelection: {
+      true: {},
+      false: {
+        indicator: {
+          opacity: 0,
+        },
+      },
+    },
+  },
+  compoundVariants: [
+    {
+      selected: true,
+      disabled: true,
+      css: {
+        item: {
+          backgroundColor: indicatorVars.base.disabled.root.color,
+          boxShadow: `inset 0 0 0 ${indicatorVars.base.enabled.root.strokeWidth} ${indicatorVars.base.enabled.root.strokeColor}`,
+        },
+      },
+    },
+  ],
+  defaultVariants: {
+    selected: false,
+    disabled: false,
+    pressed: false,
+    hasSelection: true,
+  },
+});
+
+export default segmentedControl;

--- a/packages/lynx-react/src/components/SegmentedControl/SegmentedControl.namespace.ts
+++ b/packages/lynx-react/src/components/SegmentedControl/SegmentedControl.namespace.ts
@@ -1,0 +1,8 @@
+export {
+  SegmentedControlIndicator as Indicator,
+  SegmentedControlItem as Item,
+  SegmentedControlRoot as Root,
+  type SegmentedControlIndicatorProps as IndicatorProps,
+  type SegmentedControlItemProps as ItemProps,
+  type SegmentedControlRootProps as RootProps,
+} from "./SegmentedControl";

--- a/packages/lynx-react/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/lynx-react/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -1,0 +1,81 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render } from "@lynx-js/react/testing-library";
+import { describe, expect, it, vi } from "vitest";
+
+import * as SegmentedControl from "./SegmentedControl.namespace";
+
+function BasicSegmentedControl(props: {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+}) {
+  return (
+    <SegmentedControl.Root {...props} accessibility-label="정렬 기준">
+      <SegmentedControl.Item value="hot">인기순</SegmentedControl.Item>
+      <SegmentedControl.Item value="new">최신순</SegmentedControl.Item>
+      <SegmentedControl.Indicator />
+    </SegmentedControl.Root>
+  );
+}
+
+function getItem(container: HTMLElement, label: string) {
+  const item = Array.from(
+    container.querySelectorAll<HTMLElement>(".seed-segmented-control__item"),
+  ).find((element) => element.textContent === label);
+  if (!item) throw new Error(`Expected item for ${label} to exist.`);
+  return item;
+}
+
+describe("SegmentedControl", () => {
+  it("changes an uncontrolled value when an item is tapped", () => {
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <BasicSegmentedControl defaultValue="hot" onValueChange={onValueChange} />,
+    );
+    const hot = getItem(container, "인기순");
+    const latest = getItem(container, "최신순");
+
+    expect(hot).toHaveAttribute("accessibility-value", "selected");
+    expect(latest).toHaveAttribute("accessibility-value", "not selected");
+
+    fireEvent.tap(latest);
+
+    expect(onValueChange).toHaveBeenCalledWith("new");
+    expect(latest).toHaveAttribute("accessibility-value", "selected");
+  });
+
+  it("does not select a disabled item", () => {
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <SegmentedControl.Root defaultValue="hot" onValueChange={onValueChange}>
+        <SegmentedControl.Item value="hot">인기순</SegmentedControl.Item>
+        <SegmentedControl.Item value="new" disabled>
+          최신순
+        </SegmentedControl.Item>
+      </SegmentedControl.Root>,
+    );
+    const disabledItem = getItem(container, "최신순");
+
+    fireEvent.tap(disabledItem);
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(disabledItem).toHaveAttribute("accessibility-traits", "disabled");
+  });
+
+  it("keeps the press-start selection on the fading item background", () => {
+    const { container } = render(<BasicSegmentedControl defaultValue="hot" />);
+    const latest = getItem(container, "최신순");
+    const getBackground = () =>
+      latest.querySelector<HTMLElement>(".seed-segmented-control__itemBackground");
+
+    fireEvent.touchstart(latest, {});
+    expect(getBackground()).toHaveClass("seed-segmented-control__itemBackground--pressed_true");
+    expect(getBackground()).toHaveClass("seed-segmented-control__itemBackground--selected_false");
+
+    fireEvent.touchend(latest, {});
+    fireEvent.tap(latest);
+
+    expect(getBackground()).toHaveClass("seed-segmented-control__itemBackground--pressed_false");
+    expect(getBackground()).toHaveClass("seed-segmented-control__itemBackground--selected_false");
+  });
+});

--- a/packages/lynx-react/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/lynx-react/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,0 +1,236 @@
+import { segmentedControl } from "@seed-design/lynx-css/recipes/segmented-control";
+import * as React from "@lynx-js/react";
+import clsx from "clsx";
+
+import { useControllableState } from "../../hooks/useControllableState";
+import { usePressTap } from "../../hooks/usePressTap";
+import type {
+  LynxAccessibilityProps,
+  LynxPressableProps,
+  LynxStyledElementProps,
+  LynxViewProps,
+  LynxViewRef,
+} from "../../types";
+import { createSlotRecipeContext } from "../../utils/create-slot-recipe-context";
+
+interface SegmentedControlContextValue {
+  value: string | undefined;
+  disabled: boolean;
+  items: string[];
+  selectValue: (value: string) => void;
+  registerItem: (value: string) => () => void;
+}
+
+const SegmentedControlContext = React.createContext<SegmentedControlContextValue | null>(null);
+const { ClassNamesProvider, useClassNames } = createSlotRecipeContext(segmentedControl);
+
+function useSegmentedControlContext(consumer: string) {
+  const context = React.useContext(SegmentedControlContext);
+  if (!context) {
+    throw new Error(`<${consumer}/> must be rendered inside <SegmentedControlRoot/>.`);
+  }
+  return context;
+}
+
+/**
+ * @platform Lynx
+ *
+ * 웹 대비 미지원 기능:
+ * - HiddenInput, name, form: Lynx에 HTML form 제출 모델이 없음
+ * - focus, focusVisible: Lynx에 키보드 포커스 모델이 없음
+ * - raw DOM change event: 선택 변경은 onValueChange로 노출
+ */
+export interface SegmentedControlRootProps extends LynxStyledElementProps, LynxAccessibilityProps {
+  value?: string;
+  defaultValue?: string;
+  disabled?: boolean;
+  onValueChange?: (value: string) => void;
+}
+
+export const SegmentedControlRoot = React.forwardRef<unknown, SegmentedControlRootProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      style,
+      value: valueProp,
+      defaultValue,
+      disabled = false,
+      onValueChange,
+      "accessibility-element": accessibilityElement = true,
+      "accessibility-role-description": accessibilityRoleDescription = "radiogroup",
+      ...nativeProps
+    } = props;
+    const [value, setValue] = useControllableState<string | undefined>({
+      value: valueProp,
+      defaultValue,
+      onChange(nextValue) {
+        "background only";
+        if (nextValue !== undefined) onValueChange?.(nextValue);
+      },
+    });
+    const [items, setItems] = React.useState<string[]>([]);
+
+    const registerItem = React.useCallback((itemValue: string) => {
+      setItems((current) => {
+        if (current.includes(itemValue)) return current;
+        return [...current, itemValue];
+      });
+      return () => {
+        "background only";
+        setItems((current) => current.filter((item) => item !== itemValue));
+      };
+    }, []);
+
+    const selectValue = React.useCallback(
+      (nextValue: string) => {
+        if (!disabled) setValue(nextValue);
+      },
+      [disabled, setValue],
+    );
+    const selectedIndex = items.indexOf(value ?? "");
+    const classNames = segmentedControl({ hasSelection: selectedIndex >= 0 });
+    const contextValue = React.useMemo<SegmentedControlContextValue>(
+      () => ({
+        value,
+        disabled,
+        items,
+        selectValue,
+        registerItem,
+      }),
+      [value, disabled, items, selectValue, registerItem],
+    );
+
+    return (
+      <SegmentedControlContext.Provider value={contextValue}>
+        <ClassNamesProvider value={classNames}>
+          <view
+            {...(ref ? { ref: ref as LynxViewRef } : {})}
+            {...nativeProps}
+            accessibility-element={accessibilityElement}
+            accessibility-role-description={accessibilityRoleDescription}
+            className={clsx(classNames.root, className)}
+            style={
+              {
+                "--segment-count": Math.max(items.length, 1).toString(),
+                "--segment-index": Math.max(selectedIndex, 0).toString(),
+                ...style,
+              } as LynxViewProps["style"]
+            }
+          >
+            {children}
+          </view>
+        </ClassNamesProvider>
+      </SegmentedControlContext.Provider>
+    );
+  },
+);
+SegmentedControlRoot.displayName = "SegmentedControlRoot";
+
+export interface SegmentedControlItemProps
+  extends Omit<LynxStyledElementProps, "children">,
+    LynxAccessibilityProps,
+    LynxPressableProps {
+  children: string | number;
+  value: string;
+  disabled?: boolean;
+}
+
+export const SegmentedControlItem = React.forwardRef<unknown, SegmentedControlItemProps>(
+  (props, ref) => {
+    const {
+      children,
+      className,
+      style,
+      value: itemValue,
+      disabled: itemDisabled = false,
+      bindtap,
+      "main-thread:bindtap": mainThreadBindtap,
+      "accessibility-element": accessibilityElement = true,
+      "accessibility-label": accessibilityLabel,
+      "accessibility-role-description": accessibilityRoleDescription = "radio",
+      "accessibility-traits": accessibilityTraits,
+      ...nativeProps
+    } = props;
+    const context = useSegmentedControlContext("SegmentedControlItem");
+    const disabled = context.disabled || itemDisabled;
+    const selected = context.value === itemValue;
+
+    React.useEffect(() => {
+      "background only";
+      return context.registerItem(itemValue);
+    }, [context.registerItem, itemValue]);
+
+    const handleTap = React.useCallback(
+      (...args: Parameters<NonNullable<LynxPressableProps["bindtap"]>>) => {
+        "background only";
+        if (!selected) context.selectValue(itemValue);
+        bindtap?.(...args);
+      },
+      [bindtap, context.selectValue, itemValue, selected],
+    );
+    const pressSelectionRef = React.useRef(selected);
+    const { pressed, bindtouchstart, ...pressHandlers } = usePressTap({
+      disabled,
+      onTap: handleTap,
+      mainThreadOnTap: mainThreadBindtap,
+    });
+    const handleTouchStart = React.useCallback(
+      (...args: Parameters<typeof bindtouchstart>) => {
+        pressSelectionRef.current = selected;
+        bindtouchstart(...args);
+      },
+      [bindtouchstart, selected],
+    );
+    const classes = segmentedControl({ selected, disabled, pressed });
+    const pressStartClasses = segmentedControl({
+      selected: pressSelectionRef.current,
+      disabled,
+      pressed,
+    });
+    const label =
+      typeof children === "string" || typeof children === "number" ? String(children) : undefined;
+
+    return (
+      <view
+        {...(ref ? { ref: ref as LynxViewRef } : {})}
+        {...nativeProps}
+        bindtouchstart={handleTouchStart}
+        {...pressHandlers}
+        accessibility-element={accessibilityElement}
+        accessibility-label={accessibilityLabel ?? label}
+        accessibility-role-description={accessibilityRoleDescription}
+        accessibility-value={selected ? "selected" : "not selected"}
+        accessibility-traits={
+          disabled ? "disabled" : selected ? "selected" : (accessibilityTraits ?? "button")
+        }
+        className={clsx(classes.item, className)}
+        style={style}
+      >
+        <view accessibility-elements-hidden={true} className={pressStartClasses.itemBackground} />
+        <text className={classes.label}>{children}</text>
+      </view>
+    );
+  },
+);
+SegmentedControlItem.displayName = "SegmentedControlItem";
+
+export interface SegmentedControlIndicatorProps extends LynxStyledElementProps {}
+
+export const SegmentedControlIndicator = React.forwardRef<unknown, SegmentedControlIndicatorProps>(
+  (props, ref) => {
+    const { className, style, ...nativeProps } = props;
+    const classNames = useClassNames();
+
+    return (
+      <view
+        {...(ref ? { ref: ref as LynxViewRef } : {})}
+        {...nativeProps}
+        accessibility-elements-hidden={true}
+        className={clsx(classNames.indicator, className)}
+        style={style}
+      />
+    );
+  },
+);
+SegmentedControlIndicator.displayName = "SegmentedControlIndicator";

--- a/packages/lynx-react/src/components/SegmentedControl/index.ts
+++ b/packages/lynx-react/src/components/SegmentedControl/index.ts
@@ -1,0 +1,10 @@
+export {
+  SegmentedControlIndicator,
+  SegmentedControlItem,
+  SegmentedControlRoot,
+  type SegmentedControlIndicatorProps,
+  type SegmentedControlItemProps,
+  type SegmentedControlRootProps,
+} from "./SegmentedControl";
+
+export * as SegmentedControl from "./SegmentedControl.namespace";

--- a/packages/lynx-react/src/components/index.ts
+++ b/packages/lynx-react/src/components/index.ts
@@ -13,6 +13,7 @@ export * from "./Icon";
 export * from "./KeyboardAvoidingScrollView";
 export * from "./ProgressCircle";
 export * from "./RadioGroup";
+export * from "./SegmentedControl";
 export * from "./Stack";
 export * from "./Switch";
 export * from "./Tabs";

--- a/skills/seed-create-component/SKILL.md
+++ b/skills/seed-create-component/SKILL.md
@@ -84,7 +84,7 @@ bun skills/seed-create-component/scripts/scaffold-plan.ts <component> \
 | 요구사항에 중요한 빈칸이 있음 | [brainstorming.md](references/brainstorming.md) |
 | 새 컴포넌트 또는 레이어 구조 변경 | [architecture-decisions.md](references/architecture-decisions.md), [pattern-catalog.md](references/pattern-catalog.md) |
 | React Styled UI 구현 | [react-patterns.md](references/react-patterns.md) |
-| Lynx 구현 | [lynx-patterns.md](references/lynx-patterns.md) |
+| Lynx 구현, native 텍스트 배치나 상태 전환 | [lynx-patterns.md](references/lynx-patterns.md) |
 | Recipe 구현 | [recipe-patterns.md](references/recipe-patterns.md) |
 | 레이어별 경로와 생성 관계만 확인 | [guide.md](references/guide.md) |
 | Registry·문서·예제를 포함한 구현 순서 | [implementation-steps.md](references/implementation-steps.md) |

--- a/skills/seed-create-component/references/lynx-patterns.md
+++ b/skills/seed-create-component/references/lynx-patterns.md
@@ -48,6 +48,94 @@ Lynx compound 컴포넌트라고 해서 `createSlotRecipeContext`를 무조건 �
 - `inherit`, CSS-wide keyword, Web-only SVG stroke/fill CSS, `content`, unsupported shorthand에 의존하지 않는다.
 - style 변경은 `packages/lynx-qvism-preset/src/recipes/*` 또는 Rootage 원천에서 하고, generated `packages/lynx-css/*`는 직접 수정하지 않는다.
 
+## 텍스트 줄바꿈과 intrinsic size
+
+자동 너비에서는 라벨을 한 줄로 유지하고, 부모가 너비를 제한했을 때만 줄바꿈해야 하는 컴포넌트가 있다. 이 요구를 `white-space`로 해결하지 않는다. Lynx Android에서 CJK 라벨에 `white-space: nowrap` 또는 `pre`를 적용하면 수직 정렬이 어긋날 수 있다. Chip도 같은 이유로 `whiteSpace: "nowrap"`을 제거했다.
+
+먼저 컨테이너와 항목의 크기 계산을 확인한다. Lynx의 `flex: 1` 항목은 Web의 Grid와 달리 라벨의 max-content 너비보다 작게 줄어들 수 있다. 같은 너비의 여러 항목이 필요한 경우에는 다음 조합을 우선 검토한다.
+
+```ts
+root: {
+  display: "grid",
+  gridAutoFlow: "column",
+  gridAutoColumns: "1fr",
+  gridAutoRows: "1fr",
+  width: "max-content",
+  maxWidth: "100%",
+},
+label: {
+  textAlign: "center",
+},
+```
+
+- `width: max-content`는 자동 너비에서 가장 긴 라벨을 기준으로 각 Grid track을 계산한다.
+- `max-width: 100%`는 사용 가능한 부모 너비를 넘지 않게 한다.
+- 명시한 `width`나 좁은 부모가 컨테이너를 제한하면 라벨은 줄바꿈한다. `text-align: center`가 여러 줄에도 적용되는지 확인한다.
+- Grid가 필요하지 않거나 항목 너비가 달라도 되는 컴포넌트에는 이 구조를 그대로 복사하지 않는다. 핵심은 `white-space`로 줄바꿈을 막지 않고 컨테이너의 intrinsic sizing을 고치는 것이다.
+
+`display: grid`, `grid-auto-columns: 1fr`, `width: max-content`를 사용하기 전에 `lynx-check-css-support`로 Android와 iOS의 최소 Engine 버전을 확인한다. 문서의 compatibility도 가장 높은 요구 버전에 맞춘다.
+
+시각 검증은 두 경우를 분리한다.
+
+1. 자동 너비와 긴 라벨: 모든 라벨이 한 줄이고 항목 너비가 같다.
+2. 고정 너비와 더 긴 라벨: 필요한 라벨만 줄바꿈하고, 텍스트와 항목 높이가 가운데 정렬된다.
+
+브라우저용 Lynx 미리보기만으로 native 결과를 확정하지 않는다. Android와 iOS 중 실행 가능한 호스트 앱에서도 확인한다.
+
+현재 저장소에서는 `packages/lynx-qvism-preset/src/recipes/chip.ts`의 CJK 라벨 처리와 `packages/lynx-qvism-preset/src/recipes/segmented-control.ts`의 Grid 배치를 참고할 수 있다.
+
+## 투명 배경의 색상 전환
+
+눌림 배경처럼 평소에는 투명하고 누르는 동안만 나타나는 면에 `background-color` transition을 직접 걸지 않는다. Lynx는 불투명한 상태 색과 transparent black 사이를 보간할 때 중간 RGB가 검게 탁해질 수 있다. 선택 상태나 checked 상태까지 같은 제스처에서 바뀌면 Indicator 아래에 어두운 잔상이 보이기도 한다.
+
+이 경우 배경색과 가시성 전환을 분리한다.
+
+```ts
+background: {
+  position: "absolute",
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+  opacity: 0,
+  transitionProperty: "opacity",
+  backgroundColor: pressedColor,
+},
+pressed: {
+  true: { background: { opacity: 1 } },
+},
+```
+
+- root는 투명 상태로 고정한다.
+- 별도 native `<view>`와 recipe slot에 최종 pressed 색을 칠한다.
+- 배경색 자체는 보간하지 않고 overlay의 `opacity`만 전환한다.
+- 상시 배경이나 실제로 두 불투명 색 사이를 전환하는 경우에는 이 레이어를 추가하지 않는다.
+
+선택 상태가 tap에서 바뀌는 컴포넌트는 touch start 시점의 의미 상태도 고정해야 한다. `useRef`에 `checked`, `selected`, `indeterminate`처럼 pressed 색을 결정하는 값을 저장하고, overlay className은 그 값과 현재 `pressed`를 조합한다. 본문과 Indicator는 최신 상태로 갱신해도 된다. 이렇게 해야 release fade 도중 overlay 색이 새 선택 상태의 색으로 바뀌지 않는다.
+
+```tsx
+const pressSelectionRef = React.useRef(selected);
+const { pressed, bindtouchstart, ...pressHandlers } = usePressTap({ onTap });
+
+const handleTouchStart = (...args: Parameters<typeof bindtouchstart>) => {
+  pressSelectionRef.current = selected;
+  bindtouchstart(...args);
+};
+
+const pressStartClasses = recipe({
+  selected: pressSelectionRef.current,
+  pressed,
+});
+```
+
+이 패턴에는 작은 회귀 테스트를 둔다.
+
+- recipe 테스트는 root가 `background-color` transition을 하지 않고 overlay가 `opacity`만 전환하는지 확인한다.
+- 컴포넌트 테스트는 `touchstart` 뒤 선택 값이 바뀌어도 overlay가 touch start 상태의 variant를 release까지 유지하는지 확인한다.
+- 실제 전환 영상이 있으면 눌림 시작, Indicator 이동 중간, release fade 종료 프레임을 나눠 탁한 중간색과 잔상을 확인한다.
+
+현재 저장소에서는 `packages/lynx-qvism-preset/src/recipes/checkmark.ts`와 `packages/lynx-react/src/components/Checkbox/Checkbox.tsx`를 기준 구현으로 본다. 선택 Indicator가 움직이는 경우에는 Segmented Control의 recipe와 컴포넌트 구현도 함께 확인한다.
+
 ## Unsupported Web API 문서화
 
 Web과 Lynx의 차이는 타입과 문서가 같은 말을 해야 한다.


### PR DESCRIPTION
## 변경 사항

- Lynx용 Segmented Control 컴포넌트와 Recipe, 공개 export를 추가합니다.
- Registry, 문서, 실행 예제와 changeset을 추가합니다.
- 자동 너비에서는 긴 라벨이 줄바꿈되지 않도록 Grid의 intrinsic sizing을 사용합니다. 제한된 너비에서는 여러 줄 라벨을 가운데 정렬합니다.
- 눌림 배경을 별도 opacity 레이어로 분리하고 터치 시작 시 선택 상태를 유지해 전환 중 탁한 색과 잔상을 방지합니다.
- `seed-create-component`의 Lynx reference에 텍스트 배치와 투명 배경 전환 패턴을 기록합니다.

## 검증

- `bun generate:all`
- `bun packages:build`
- `bun docs:test`
- `bun test skills/seed-create-component/scripts/scaffold-plan.test.ts`
- `bun test:all`
- Lynx Web 문서 미리보기에서 자동 너비 한 줄 표시와 제한 너비 가운데 정렬 확인

## 참고

- 리베이스 과정에서 `minor`의 생성 정책에 맞춰 `packages/lynx-css/all.min.css`는 삭제 상태를 유지했습니다.
- PlayLynx native 환경의 최종 재확인은 별도로 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Lynx용 `SegmentedControl` 컴포넌트를 추가했습니다.
  * 선택, 비활성화, 고정 너비, 긴 레이블 및 값 변경 이벤트를 지원합니다.
  * Registry를 통해 컴포넌트를 설치할 수 있습니다.

* **문서**
  * 설치 방법과 주요 속성, 사용 예제를 추가했습니다.
  * 접근성, 색상 모드 및 웹 버전과의 차이점을 안내합니다.

* **테스트**
  * 선택 변경, 비활성화 상태, 접근성 속성 및 눌림 상태를 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->