### PR TITLE
feat(lynx): run pressed feedback on main thread

### DIFF
--- a/.changeset/calm-tigers-press.md
+++ b/.changeset/calm-tigers-press.md
@@ -1,0 +1,18 @@
+---
+"@seed-design/lynx-css": minor
+"@seed-design/lynx-react": minor
+---
+
+Lynx 컴포넌트에 pressed 색상 피드백을 추가합니다.
+
+- Action Button
+- Chip
+- Callout
+- Accordion
+- Checkbox
+- Radio Group
+- Page Banner의 actionable Root·Close Button
+- Select Box
+- Segmented Control
+
+pressed 색상 피드백을 Background Thread의 상태 갱신을 기다리지 않고 Main Thread에서 시작합니다.

--- a/.changeset/calm-tigers-press.md
+++ b/.changeset/calm-tigers-press.md
@@ -3,16 +3,10 @@
 "@seed-design/lynx-react": minor
 ---
 
-Lynx 컴포넌트에 pressed 색상 피드백을 추가합니다.
+Lynx 컴포넌트의 pressed 색상 피드백을 개선합니다.
 
-- Action Button
-- Chip
-- Callout
-- Accordion
-- Checkbox
-- Radio Group
-- Page Banner의 actionable Root·Close Button
-- Select Box
-- Segmented Control
+기존 Background Thread의 상태 갱신에 의존하던 pressed 색상 반응을
+Main Thread의 `:active` 기반으로 개선하고, React와 동일한 색상 transition을 적용합니다.
+짧은 탭에서도 색상 피드백이 빠르게 시작됩니다.
 
-pressed 색상 피드백을 Background Thread의 상태 갱신을 기다리지 않고 Main Thread에서 시작합니다.
+disabled·loading 상태의 입력 제한과 기존 pressed 상태 처리는 유지합니다.

--- a/docs/content/lynx/components/concepts/scale-feedback.mdx
+++ b/docs/content/lynx/components/concepts/scale-feedback.mdx
@@ -127,6 +127,14 @@ Main Thread 핸들러가 scale을 즉시 시작한 뒤 필요한 callback만 `ru
 
 `usePressTap`과 직접 조합할 때는 `bindtouchstart`, `bindtouchend`, `bindtouchcancel`을 `onTouchStart`, `onTouchEnd`, `onTouchCancel`로 전달합니다. 동일 touch 이벤트에 Main/Background 핸들러를 따로 등록하지 않습니다.
 
+### pressed 색상 피드백
+
+Scale과 함께 바뀌는 pressed 색상은 Lynx CSS의 `:active`에서 시작합니다. Background Thread의 `usePressTap()`이 className을 갱신할 때까지 기다리지 않으므로 짧은 탭에서도 색상 transition이 Main Thread 입력과 함께 시작됩니다.
+
+Action Button, Chip, Callout처럼 trigger와 color target이 같은 컴포넌트는 Self selector를 사용합니다. Accordion, Checkbox, Radio처럼 target이 내부 slot인 컴포넌트는 enabled trigger의 `:active` selector가 해당 content class를 대상으로 합니다. disabled 또는 loading variant에는 active selector class가 생성되지 않습니다.
+
+Background Thread의 `pressed` variant는 상태 기반 렌더링과 기존 fallback을 위해 유지합니다. 즉각적인 시각 반응은 `:active`, tap 처리와 React state는 `usePressTap()`이 담당합니다.
+
 ## 애니메이션과 Rootage 값
 
 Scale은 CSS `transition` 문자열을 inline style에 쓰지 않고 `Element.animate()`로 실행합니다. 따라서 target에 이미 선언된 background-color, color, border-color transition을 덮어쓰지 않습니다.

--- a/docs/content/lynx/components/page-banner.mdx
+++ b/docs/content/lynx/components/page-banner.mdx
@@ -185,7 +185,7 @@ export function App() {
 | Polymorphism | `asChild` 지원 | 미지원 |
 | Interaction feedback | focus ring, scale feedback | pressed 배경색, Button·CloseButton Scale Feedback |
 
-Lynx의 actionable Root와 CloseButton은 터치되는 동안 `pressed` Recipe 상태를 적용합니다. `PageBannerButton`과 CloseButton은 Scale Feedback도 적용하며, child의 기존 Main Thread 이벤트와 ref를 보존합니다. `PageBannerButton`, actionable Root, CloseButton은 기본적으로 button trait를 사용합니다.
+Lynx의 actionable Root와 CloseButton은 Main Thread의 `:active` 상태에서 pressed 배경색을 즉시 적용합니다. `PageBannerButton`과 CloseButton은 Scale Feedback도 적용하며, child의 기존 Main Thread 이벤트와 ref를 보존합니다. `PageBannerButton`, actionable Root, CloseButton은 기본적으로 button trait를 사용합니다.
 
 ## Unsupported Lynx Features
 

--- a/packages/lynx-css/all.css
+++ b/packages/lynx-css/all.css
@@ -772,6 +772,10 @@ text {
   color: var(--seed-color-fg-disabled);
 }
 
+.seed-accordion__trigger--disabled_false:active .seed-accordion__pressedOverlay {
+  background-color: var(--seed-color-bg-transparent-pressed);
+}
+
 .seed-accordion__root--variant_separated-size_medium {
   gap: var(--seed-dimension-x3);
 }
@@ -1082,23 +1086,23 @@ text {
   height: 22px;
 }
 
-.seed-action-button__root--variant_brandSolid-pressed_true {
+.seed-action-button__root--variant_brandSolid-pressed_true, .seed-action-button__root--variant_brandSolid-disabled_false-loading_false:active {
   background: var(--seed-color-bg-brand-solid-pressed);
 }
 
-.seed-action-button__root--variant_neutralSolid-pressed_true {
+.seed-action-button__root--variant_neutralSolid-pressed_true, .seed-action-button__root--variant_neutralSolid-disabled_false-loading_false:active {
   background: var(--seed-color-bg-neutral-inverted-pressed);
 }
 
-.seed-action-button__root--variant_neutralWeak-pressed_true {
+.seed-action-button__root--variant_neutralWeak-pressed_true, .seed-action-button__root--variant_neutralWeak-disabled_false-loading_false:active {
   background: var(--seed-color-bg-neutral-weak-pressed);
 }
 
-.seed-action-button__root--variant_criticalSolid-pressed_true {
+.seed-action-button__root--variant_criticalSolid-pressed_true, .seed-action-button__root--variant_criticalSolid-disabled_false-loading_false:active {
   background: var(--seed-color-bg-critical-solid-pressed);
 }
 
-.seed-action-button__root--variant_brandOutline-pressed_true, .seed-action-button__root--variant_neutralOutline-pressed_true, .seed-action-button__root--variant_ghost-pressed_true {
+.seed-action-button__root--variant_brandOutline-pressed_true, .seed-action-button__root--variant_brandOutline-disabled_false-loading_false:active, .seed-action-button__root--variant_neutralOutline-pressed_true, .seed-action-button__root--variant_neutralOutline-disabled_false-loading_false:active, .seed-action-button__root--variant_ghost-pressed_true, .seed-action-button__root--variant_ghost-disabled_false-loading_false:active {
   background: var(--seed-color-bg-transparent-pressed);
 }
 
@@ -1862,27 +1866,27 @@ text {
   color: var(--seed-color-fg-neutral);
 }
 
-.seed-callout__root--tone_neutral-pressed_true {
+.seed-callout__root--tone_neutral-pressed_true, .seed-callout__root--tone_neutral-interactive_true:active {
   background-color: var(--seed-color-bg-neutral-weak-pressed);
 }
 
-.seed-callout__root--tone_informative-pressed_true {
+.seed-callout__root--tone_informative-pressed_true, .seed-callout__root--tone_informative-interactive_true:active {
   background-color: var(--seed-color-bg-informative-weak-pressed);
 }
 
-.seed-callout__root--tone_positive-pressed_true {
+.seed-callout__root--tone_positive-pressed_true, .seed-callout__root--tone_positive-interactive_true:active {
   background-color: var(--seed-color-bg-positive-weak-pressed);
 }
 
-.seed-callout__root--tone_warning-pressed_true {
+.seed-callout__root--tone_warning-pressed_true, .seed-callout__root--tone_warning-interactive_true:active {
   background-color: var(--seed-color-bg-warning-weak-pressed);
 }
 
-.seed-callout__root--tone_critical-pressed_true {
+.seed-callout__root--tone_critical-pressed_true, .seed-callout__root--tone_critical-interactive_true:active {
   background-color: var(--seed-color-bg-critical-weak-pressed);
 }
 
-.seed-callout__root--tone_magic-pressed_true {
+.seed-callout__root--tone_magic-pressed_true, .seed-callout__root--tone_magic-interactive_true:active {
   background-image: linear-gradient(88deg, var(--seed-gradient-glow-magic-pressed));
 }
 
@@ -1937,6 +1941,14 @@ text {
   color: var(--seed-color-fg-disabled);
 }
 
+.seed-checkbox__root--disabled_false:active .seed-checkmark__root {
+  background-color: var(--seed-checkmark-pressed-color);
+}
+
+.seed-checkbox__root--disabled_false:active .seed-checkmark__background {
+  opacity: 1;
+}
+
 .seed-checkbox-group__root {
   gap: var(--seed-dimension-x1);
   flex-direction: column;
@@ -1966,6 +1978,7 @@ text {
 }
 
 .seed-checkmark__root--variant_square {
+  --seed-checkmark-pressed-color: var(--seed-color-bg-transparent-pressed);
   border-style: solid;
   border-width: 1px;
   border-color: var(--seed-color-stroke-neutral-weak);
@@ -2026,6 +2039,7 @@ text {
 
 .seed-checkmark__root--variant_square-tone_brand-checked_true-disabled_false {
   background-color: var(--seed-color-bg-brand-solid);
+  --seed-checkmark-pressed-color: var(--seed-color-bg-brand-solid-pressed);
 }
 
 .seed-checkmark__icon--variant_square-tone_brand-checked_true-disabled_false {
@@ -2034,6 +2048,7 @@ text {
 
 .seed-checkmark__root--variant_square-tone_neutral-checked_true-disabled_false {
   background-color: var(--seed-color-bg-neutral-inverted);
+  --seed-checkmark-pressed-color: var(--seed-color-bg-neutral-inverted-pressed);
 }
 
 .seed-checkmark__icon--variant_square-tone_neutral-checked_true-disabled_false {
@@ -2042,6 +2057,7 @@ text {
 
 .seed-checkmark__root--variant_square-tone_brand-indeterminate_true-disabled_false {
   background-color: var(--seed-color-bg-brand-solid);
+  --seed-checkmark-pressed-color: var(--seed-color-bg-brand-solid-pressed);
 }
 
 .seed-checkmark__icon--variant_square-tone_brand-indeterminate_true-disabled_false {
@@ -2050,6 +2066,7 @@ text {
 
 .seed-checkmark__root--variant_square-tone_neutral-indeterminate_true-disabled_false {
   background-color: var(--seed-color-bg-neutral-inverted);
+  --seed-checkmark-pressed-color: var(--seed-color-bg-neutral-inverted-pressed);
 }
 
 .seed-checkmark__icon--variant_square-tone_neutral-indeterminate_true-disabled_false {
@@ -2332,19 +2349,19 @@ text {
   box-shadow: inset 0 0 0 1px var(--seed-color-stroke-neutral-contrast);
 }
 
-.seed-chip__root--variant_solid-pressed_true-selected_false {
+.seed-chip__root--variant_solid-pressed_true-selected_false, .seed-chip__root--variant_solid-selected_false-disabled_false:active {
   background: var(--seed-color-bg-neutral-weak-alpha-pressed);
 }
 
-.seed-chip__root--variant_outlineStrong-pressed_true-selected_false, .seed-chip__root--variant_outlineWeak-pressed_true-selected_false {
+.seed-chip__root--variant_outlineStrong-pressed_true-selected_false, .seed-chip__root--variant_outlineStrong-selected_false-disabled_false:active, .seed-chip__root--variant_outlineWeak-pressed_true-selected_false, .seed-chip__root--variant_outlineWeak-selected_false-disabled_false:active {
   background: var(--seed-color-bg-transparent-pressed);
 }
 
-.seed-chip__root--variant_solid-selected_true-pressed_true, .seed-chip__root--variant_outlineStrong-selected_true-pressed_true {
+.seed-chip__root--variant_solid-selected_true-pressed_true, .seed-chip__root--variant_solid-selected_true-disabled_false:active, .seed-chip__root--variant_outlineStrong-selected_true-pressed_true, .seed-chip__root--variant_outlineStrong-selected_true-disabled_false:active {
   background: var(--seed-color-bg-neutral-inverted-pressed);
 }
 
-.seed-chip__root--variant_outlineWeak-selected_true-pressed_true {
+.seed-chip__root--variant_outlineWeak-selected_true-pressed_true, .seed-chip__root--variant_outlineWeak-selected_true-disabled_false:active {
   background: var(--seed-color-bg-neutral-weak-pressed);
 }
 
@@ -2676,6 +2693,7 @@ text {
   margin-left: calc((var(--seed-dimension-x10) - var(--seed-dimension-x4)) * -.5 + var(--seed-dimension-x2));
   border-radius: var(--seed-radius-r2);
   background-color: var(--seed-color-bg-transparent);
+  transition: background-color var(--seed-duration-color-transition) var(--seed-timing-function-easing);
   flex-direction: row;
   flex-grow: 0;
   flex-shrink: 0;
@@ -2683,6 +2701,10 @@ text {
   align-self: center;
   align-items: center;
   display: flex;
+}
+
+.seed-page-banner__closeButton:active {
+  background-color: var(--seed-color-bg-transparent-pressed);
 }
 
 .seed-page-banner__prefixIcon {
@@ -2707,12 +2729,18 @@ text {
   flex-shrink: 0;
 }
 
+.seed-page-banner__root--interactive_true:active {
+  background-color: var(--seed-page-banner-pressed-background-color);
+  background-image: var(--seed-page-banner-pressed-background-image);
+}
+
 .seed-page-banner__closeButton--closeButtonPressed_true {
   background-color: var(--seed-color-bg-transparent-pressed);
 }
 
 .seed-page-banner__root--tone_neutral-variant_weak {
   background-color: var(--seed-color-bg-neutral-weak);
+  --seed-page-banner-pressed-background-color: var(--seed-color-bg-neutral-weak-pressed);
 }
 
 .seed-page-banner__title--tone_neutral-variant_weak, .seed-page-banner__description--tone_neutral-variant_weak, .seed-page-banner__button--tone_neutral-variant_weak, .seed-page-banner__prefixIcon--tone_neutral-variant_weak, .seed-page-banner__suffixIcon--tone_neutral-variant_weak, .seed-page-banner__closeButtonIcon--tone_neutral-variant_weak {
@@ -2721,6 +2749,7 @@ text {
 
 .seed-page-banner__root--tone_neutral-variant_solid {
   background-color: var(--seed-color-bg-neutral-inverted);
+  --seed-page-banner-pressed-background-color: var(--seed-color-bg-neutral-inverted-pressed);
 }
 
 .seed-page-banner__title--tone_neutral-variant_solid, .seed-page-banner__description--tone_neutral-variant_solid, .seed-page-banner__button--tone_neutral-variant_solid, .seed-page-banner__prefixIcon--tone_neutral-variant_solid, .seed-page-banner__suffixIcon--tone_neutral-variant_solid, .seed-page-banner__closeButtonIcon--tone_neutral-variant_solid {
@@ -2729,6 +2758,7 @@ text {
 
 .seed-page-banner__root--tone_informative-variant_weak {
   background-color: var(--seed-color-bg-informative-weak);
+  --seed-page-banner-pressed-background-color: var(--seed-color-bg-informative-weak-pressed);
 }
 
 .seed-page-banner__title--tone_informative-variant_weak, .seed-page-banner__description--tone_informative-variant_weak, .seed-page-banner__button--tone_informative-variant_weak, .seed-page-banner__prefixIcon--tone_informative-variant_weak, .seed-page-banner__suffixIcon--tone_informative-variant_weak, .seed-page-banner__closeButtonIcon--tone_informative-variant_weak {
@@ -2737,6 +2767,7 @@ text {
 
 .seed-page-banner__root--tone_informative-variant_solid {
   background-color: var(--seed-color-bg-informative-solid);
+  --seed-page-banner-pressed-background-color: var(--seed-color-bg-informative-solid-pressed);
 }
 
 .seed-page-banner__title--tone_informative-variant_solid, .seed-page-banner__description--tone_informative-variant_solid, .seed-page-banner__button--tone_informative-variant_solid, .seed-page-banner__prefixIcon--tone_informative-variant_solid, .seed-page-banner__suffixIcon--tone_informative-variant_solid, .seed-page-banner__closeButtonIcon--tone_informative-variant_solid {
@@ -2745,6 +2776,7 @@ text {
 
 .seed-page-banner__root--tone_positive-variant_weak {
   background-color: var(--seed-color-bg-positive-weak);
+  --seed-page-banner-pressed-background-color: var(--seed-color-bg-positive-weak-pressed);
 }
 
 .seed-page-banner__title--tone_positive-variant_weak, .seed-page-banner__description--tone_positive-variant_weak, .seed-page-banner__button--tone_positive-variant_weak, .seed-page-banner__prefixIcon--tone_positive-variant_weak, .seed-page-banner__suffixIcon--tone_positive-variant_weak, .seed-page-banner__closeButtonIcon--tone_positive-variant_weak {
@@ -2753,6 +2785,7 @@ text {
 
 .seed-page-banner__root--tone_positive-variant_solid {
   background-color: var(--seed-color-bg-positive-solid);
+  --seed-page-banner-pressed-background-color: var(--seed-color-bg-positive-solid-pressed);
 }
 
 .seed-page-banner__title--tone_positive-variant_solid, .seed-page-banner__description--tone_positive-variant_solid, .seed-page-banner__button--tone_positive-variant_solid, .seed-page-banner__prefixIcon--tone_positive-variant_solid, .seed-page-banner__suffixIcon--tone_positive-variant_solid, .seed-page-banner__closeButtonIcon--tone_positive-variant_solid {
@@ -2761,6 +2794,7 @@ text {
 
 .seed-page-banner__root--tone_warning-variant_weak {
   background-color: var(--seed-color-bg-warning-weak);
+  --seed-page-banner-pressed-background-color: var(--seed-color-bg-warning-weak-pressed);
 }
 
 .seed-page-banner__title--tone_warning-variant_weak, .seed-page-banner__description--tone_warning-variant_weak, .seed-page-banner__button--tone_warning-variant_weak, .seed-page-banner__prefixIcon--tone_warning-variant_weak, .seed-page-banner__suffixIcon--tone_warning-variant_weak, .seed-page-banner__closeButtonIcon--tone_warning-variant_weak {
@@ -2769,6 +2803,7 @@ text {
 
 .seed-page-banner__root--tone_warning-variant_solid {
   background-color: var(--seed-color-bg-warning-solid);
+  --seed-page-banner-pressed-background-color: var(--seed-color-bg-warning-solid-pressed);
 }
 
 .seed-page-banner__title--tone_warning-variant_solid, .seed-page-banner__description--tone_warning-variant_solid, .seed-page-banner__button--tone_warning-variant_solid, .seed-page-banner__prefixIcon--tone_warning-variant_solid, .seed-page-banner__suffixIcon--tone_warning-variant_solid, .seed-page-banner__closeButtonIcon--tone_warning-variant_solid {
@@ -2777,6 +2812,7 @@ text {
 
 .seed-page-banner__root--tone_critical-variant_weak {
   background-color: var(--seed-color-bg-critical-weak);
+  --seed-page-banner-pressed-background-color: var(--seed-color-bg-critical-weak-pressed);
 }
 
 .seed-page-banner__title--tone_critical-variant_weak, .seed-page-banner__description--tone_critical-variant_weak, .seed-page-banner__button--tone_critical-variant_weak, .seed-page-banner__prefixIcon--tone_critical-variant_weak, .seed-page-banner__suffixIcon--tone_critical-variant_weak, .seed-page-banner__closeButtonIcon--tone_critical-variant_weak {
@@ -2785,6 +2821,7 @@ text {
 
 .seed-page-banner__root--tone_critical-variant_solid {
   background-color: var(--seed-color-bg-critical-solid);
+  --seed-page-banner-pressed-background-color: var(--seed-color-bg-critical-solid-pressed);
 }
 
 .seed-page-banner__title--tone_critical-variant_solid, .seed-page-banner__description--tone_critical-variant_solid, .seed-page-banner__button--tone_critical-variant_solid, .seed-page-banner__prefixIcon--tone_critical-variant_solid, .seed-page-banner__suffixIcon--tone_critical-variant_solid, .seed-page-banner__closeButtonIcon--tone_critical-variant_solid {
@@ -2793,6 +2830,7 @@ text {
 
 .seed-page-banner__root--tone_magic-variant_weak {
   background-image: linear-gradient(88deg, var(--seed-gradient-glow-magic));
+  --seed-page-banner-pressed-background-image: linear-gradient(88deg, var(--seed-gradient-glow-magic-pressed));
 }
 
 .seed-page-banner__title--tone_magic-variant_weak, .seed-page-banner__description--tone_magic-variant_weak, .seed-page-banner__button--tone_magic-variant_weak, .seed-page-banner__prefixIcon--tone_magic-variant_weak, .seed-page-banner__suffixIcon--tone_magic-variant_weak, .seed-page-banner__closeButtonIcon--tone_magic-variant_weak {
@@ -3249,6 +3287,10 @@ text {
   color: var(--seed-color-fg-disabled);
 }
 
+.seed-radio__root--disabled_false:active .seed-radiomark__root {
+  background-color: var(--seed-radiomark-pressed-color);
+}
+
 .seed-radio-group__root {
   gap: var(--seed-dimension-x1);
   flex-direction: column;
@@ -3261,6 +3303,7 @@ text {
   border-color: var(--seed-color-stroke-neutral-weak);
   border-radius: var(--seed-radius-full);
   transition: background-color var(--seed-duration-color-transition) var(--seed-timing-function-easing);
+  --seed-radiomark-pressed-color: var(--seed-color-bg-transparent-pressed);
   flex: none;
   justify-content: center;
   align-items: center;
@@ -3298,6 +3341,7 @@ text {
 
 .seed-radiomark__root--tone_brand-checked_true-disabled_false {
   background-color: var(--seed-color-bg-brand-solid);
+  --seed-radiomark-pressed-color: var(--seed-color-bg-brand-solid-pressed);
   border-width: 0;
   border-color: #0000;
 }
@@ -3309,6 +3353,7 @@ text {
 
 .seed-radiomark__root--tone_neutral-checked_true-disabled_false {
   background-color: var(--seed-color-bg-neutral-inverted);
+  --seed-radiomark-pressed-color: var(--seed-color-bg-neutral-inverted-pressed);
   border-width: 0;
   border-color: #0000;
 }
@@ -3684,11 +3729,11 @@ text {
   color: var(--seed-color-fg-disabled);
 }
 
-.seed-segmented-control__itemBackground--pressed_true {
+.seed-segmented-control__item--disabled_false:active .seed-segmented-control__itemBackground, .seed-segmented-control__itemBackground--pressed_true {
   opacity: 1;
 }
 
-.seed-segmented-control__indicator--hasSelection_false {
+.seed-segmented-control__indicator--hasSelection_false, .seed-segmented-control__itemBackground--disabled_true-pressed_true {
   opacity: 0;
 }
 
@@ -3851,6 +3896,10 @@ text {
 
 .seed-select-box__prefixIcon--disabled_true, .seed-select-box__label--disabled_true, .seed-select-box__description--disabled_true {
   color: var(--seed-color-fg-disabled);
+}
+
+.seed-select-box__root--disabled_false:active {
+  background-color: var(--seed-color-bg-transparent-pressed);
 }
 
 .seed-select-box__footer--footerOpen_true {

--- a/packages/lynx-css/all.css
+++ b/packages/lynx-css/all.css
@@ -2729,18 +2729,56 @@ text {
   flex-shrink: 0;
 }
 
-.seed-page-banner__root--interactive_true:active {
-  background-color: var(--seed-page-banner-pressed-background-color);
-  background-image: var(--seed-page-banner-pressed-background-image);
-}
-
 .seed-page-banner__closeButton--closeButtonPressed_true {
   background-color: var(--seed-color-bg-transparent-pressed);
 }
 
+.seed-page-banner__root--tone_neutral-variant_weak-interactive_true:active {
+  background-color: var(--seed-color-bg-neutral-weak-pressed);
+}
+
+.seed-page-banner__root--tone_neutral-variant_solid-interactive_true:active {
+  background-color: var(--seed-color-bg-neutral-inverted-pressed);
+}
+
+.seed-page-banner__root--tone_informative-variant_weak-interactive_true:active {
+  background-color: var(--seed-color-bg-informative-weak-pressed);
+}
+
+.seed-page-banner__root--tone_informative-variant_solid-interactive_true:active {
+  background-color: var(--seed-color-bg-informative-solid-pressed);
+}
+
+.seed-page-banner__root--tone_positive-variant_weak-interactive_true:active {
+  background-color: var(--seed-color-bg-positive-weak-pressed);
+}
+
+.seed-page-banner__root--tone_positive-variant_solid-interactive_true:active {
+  background-color: var(--seed-color-bg-positive-solid-pressed);
+}
+
+.seed-page-banner__root--tone_warning-variant_weak-interactive_true:active {
+  background-color: var(--seed-color-bg-warning-weak-pressed);
+}
+
+.seed-page-banner__root--tone_warning-variant_solid-interactive_true:active {
+  background-color: var(--seed-color-bg-warning-solid-pressed);
+}
+
+.seed-page-banner__root--tone_critical-variant_weak-interactive_true:active {
+  background-color: var(--seed-color-bg-critical-weak-pressed);
+}
+
+.seed-page-banner__root--tone_critical-variant_solid-interactive_true:active {
+  background-color: var(--seed-color-bg-critical-solid-pressed);
+}
+
+.seed-page-banner__root--tone_magic-variant_weak-interactive_true:active {
+  background-image: linear-gradient(88deg, var(--seed-gradient-glow-magic-pressed));
+}
+
 .seed-page-banner__root--tone_neutral-variant_weak {
   background-color: var(--seed-color-bg-neutral-weak);
-  --seed-page-banner-pressed-background-color: var(--seed-color-bg-neutral-weak-pressed);
 }
 
 .seed-page-banner__title--tone_neutral-variant_weak, .seed-page-banner__description--tone_neutral-variant_weak, .seed-page-banner__button--tone_neutral-variant_weak, .seed-page-banner__prefixIcon--tone_neutral-variant_weak, .seed-page-banner__suffixIcon--tone_neutral-variant_weak, .seed-page-banner__closeButtonIcon--tone_neutral-variant_weak {
@@ -2749,7 +2787,6 @@ text {
 
 .seed-page-banner__root--tone_neutral-variant_solid {
   background-color: var(--seed-color-bg-neutral-inverted);
-  --seed-page-banner-pressed-background-color: var(--seed-color-bg-neutral-inverted-pressed);
 }
 
 .seed-page-banner__title--tone_neutral-variant_solid, .seed-page-banner__description--tone_neutral-variant_solid, .seed-page-banner__button--tone_neutral-variant_solid, .seed-page-banner__prefixIcon--tone_neutral-variant_solid, .seed-page-banner__suffixIcon--tone_neutral-variant_solid, .seed-page-banner__closeButtonIcon--tone_neutral-variant_solid {
@@ -2758,7 +2795,6 @@ text {
 
 .seed-page-banner__root--tone_informative-variant_weak {
   background-color: var(--seed-color-bg-informative-weak);
-  --seed-page-banner-pressed-background-color: var(--seed-color-bg-informative-weak-pressed);
 }
 
 .seed-page-banner__title--tone_informative-variant_weak, .seed-page-banner__description--tone_informative-variant_weak, .seed-page-banner__button--tone_informative-variant_weak, .seed-page-banner__prefixIcon--tone_informative-variant_weak, .seed-page-banner__suffixIcon--tone_informative-variant_weak, .seed-page-banner__closeButtonIcon--tone_informative-variant_weak {
@@ -2767,7 +2803,6 @@ text {
 
 .seed-page-banner__root--tone_informative-variant_solid {
   background-color: var(--seed-color-bg-informative-solid);
-  --seed-page-banner-pressed-background-color: var(--seed-color-bg-informative-solid-pressed);
 }
 
 .seed-page-banner__title--tone_informative-variant_solid, .seed-page-banner__description--tone_informative-variant_solid, .seed-page-banner__button--tone_informative-variant_solid, .seed-page-banner__prefixIcon--tone_informative-variant_solid, .seed-page-banner__suffixIcon--tone_informative-variant_solid, .seed-page-banner__closeButtonIcon--tone_informative-variant_solid {
@@ -2776,7 +2811,6 @@ text {
 
 .seed-page-banner__root--tone_positive-variant_weak {
   background-color: var(--seed-color-bg-positive-weak);
-  --seed-page-banner-pressed-background-color: var(--seed-color-bg-positive-weak-pressed);
 }
 
 .seed-page-banner__title--tone_positive-variant_weak, .seed-page-banner__description--tone_positive-variant_weak, .seed-page-banner__button--tone_positive-variant_weak, .seed-page-banner__prefixIcon--tone_positive-variant_weak, .seed-page-banner__suffixIcon--tone_positive-variant_weak, .seed-page-banner__closeButtonIcon--tone_positive-variant_weak {
@@ -2785,7 +2819,6 @@ text {
 
 .seed-page-banner__root--tone_positive-variant_solid {
   background-color: var(--seed-color-bg-positive-solid);
-  --seed-page-banner-pressed-background-color: var(--seed-color-bg-positive-solid-pressed);
 }
 
 .seed-page-banner__title--tone_positive-variant_solid, .seed-page-banner__description--tone_positive-variant_solid, .seed-page-banner__button--tone_positive-variant_solid, .seed-page-banner__prefixIcon--tone_positive-variant_solid, .seed-page-banner__suffixIcon--tone_positive-variant_solid, .seed-page-banner__closeButtonIcon--tone_positive-variant_solid {
@@ -2794,7 +2827,6 @@ text {
 
 .seed-page-banner__root--tone_warning-variant_weak {
   background-color: var(--seed-color-bg-warning-weak);
-  --seed-page-banner-pressed-background-color: var(--seed-color-bg-warning-weak-pressed);
 }
 
 .seed-page-banner__title--tone_warning-variant_weak, .seed-page-banner__description--tone_warning-variant_weak, .seed-page-banner__button--tone_warning-variant_weak, .seed-page-banner__prefixIcon--tone_warning-variant_weak, .seed-page-banner__suffixIcon--tone_warning-variant_weak, .seed-page-banner__closeButtonIcon--tone_warning-variant_weak {
@@ -2803,7 +2835,6 @@ text {
 
 .seed-page-banner__root--tone_warning-variant_solid {
   background-color: var(--seed-color-bg-warning-solid);
-  --seed-page-banner-pressed-background-color: var(--seed-color-bg-warning-solid-pressed);
 }
 
 .seed-page-banner__title--tone_warning-variant_solid, .seed-page-banner__description--tone_warning-variant_solid, .seed-page-banner__button--tone_warning-variant_solid, .seed-page-banner__prefixIcon--tone_warning-variant_solid, .seed-page-banner__suffixIcon--tone_warning-variant_solid, .seed-page-banner__closeButtonIcon--tone_warning-variant_solid {
@@ -2812,7 +2843,6 @@ text {
 
 .seed-page-banner__root--tone_critical-variant_weak {
   background-color: var(--seed-color-bg-critical-weak);
-  --seed-page-banner-pressed-background-color: var(--seed-color-bg-critical-weak-pressed);
 }
 
 .seed-page-banner__title--tone_critical-variant_weak, .seed-page-banner__description--tone_critical-variant_weak, .seed-page-banner__button--tone_critical-variant_weak, .seed-page-banner__prefixIcon--tone_critical-variant_weak, .seed-page-banner__suffixIcon--tone_critical-variant_weak, .seed-page-banner__closeButtonIcon--tone_critical-variant_weak {
@@ -2821,7 +2851,6 @@ text {
 
 .seed-page-banner__root--tone_critical-variant_solid {
   background-color: var(--seed-color-bg-critical-solid);
-  --seed-page-banner-pressed-background-color: var(--seed-color-bg-critical-solid-pressed);
 }
 
 .seed-page-banner__title--tone_critical-variant_solid, .seed-page-banner__description--tone_critical-variant_solid, .seed-page-banner__button--tone_critical-variant_solid, .seed-page-banner__prefixIcon--tone_critical-variant_solid, .seed-page-banner__suffixIcon--tone_critical-variant_solid, .seed-page-banner__closeButtonIcon--tone_critical-variant_solid {
@@ -2830,7 +2859,6 @@ text {
 
 .seed-page-banner__root--tone_magic-variant_weak {
   background-image: linear-gradient(88deg, var(--seed-gradient-glow-magic));
-  --seed-page-banner-pressed-background-image: linear-gradient(88deg, var(--seed-gradient-glow-magic-pressed));
 }
 
 .seed-page-banner__title--tone_magic-variant_weak, .seed-page-banner__description--tone_magic-variant_weak, .seed-page-banner__button--tone_magic-variant_weak, .seed-page-banner__prefixIcon--tone_magic-variant_weak, .seed-page-banner__suffixIcon--tone_magic-variant_weak, .seed-page-banner__closeButtonIcon--tone_magic-variant_weak {

--- a/packages/lynx-css/recipes/accordion.css
+++ b/packages/lynx-css/recipes/accordion.css
@@ -173,6 +173,9 @@
 .seed-accordion__suffixIcon--disabled_true {
     color: var(--seed-color-fg-disabled)
 }
+.seed-accordion__trigger--disabled_false:active .seed-accordion__pressedOverlay {
+    background-color: var(--seed-color-bg-transparent-pressed)
+}
 .seed-accordion__root--variant_separated-size_medium {
     gap: var(--seed-dimension-x3)
 }

--- a/packages/lynx-css/recipes/action-button.css
+++ b/packages/lynx-css/recipes/action-button.css
@@ -341,22 +341,43 @@
 .seed-action-button__root--variant_brandSolid-pressed_true {
     background: var(--seed-color-bg-brand-solid-pressed)
 }
+.seed-action-button__root--variant_brandSolid-disabled_false-loading_false:active {
+    background: var(--seed-color-bg-brand-solid-pressed)
+}
 .seed-action-button__root--variant_neutralSolid-pressed_true {
+    background: var(--seed-color-bg-neutral-inverted-pressed)
+}
+.seed-action-button__root--variant_neutralSolid-disabled_false-loading_false:active {
     background: var(--seed-color-bg-neutral-inverted-pressed)
 }
 .seed-action-button__root--variant_neutralWeak-pressed_true {
     background: var(--seed-color-bg-neutral-weak-pressed)
 }
+.seed-action-button__root--variant_neutralWeak-disabled_false-loading_false:active {
+    background: var(--seed-color-bg-neutral-weak-pressed)
+}
 .seed-action-button__root--variant_criticalSolid-pressed_true {
+    background: var(--seed-color-bg-critical-solid-pressed)
+}
+.seed-action-button__root--variant_criticalSolid-disabled_false-loading_false:active {
     background: var(--seed-color-bg-critical-solid-pressed)
 }
 .seed-action-button__root--variant_brandOutline-pressed_true {
     background: var(--seed-color-bg-transparent-pressed)
 }
+.seed-action-button__root--variant_brandOutline-disabled_false-loading_false:active {
+    background: var(--seed-color-bg-transparent-pressed)
+}
 .seed-action-button__root--variant_neutralOutline-pressed_true {
     background: var(--seed-color-bg-transparent-pressed)
 }
+.seed-action-button__root--variant_neutralOutline-disabled_false-loading_false:active {
+    background: var(--seed-color-bg-transparent-pressed)
+}
 .seed-action-button__root--variant_ghost-pressed_true {
+    background: var(--seed-color-bg-transparent-pressed)
+}
+.seed-action-button__root--variant_ghost-disabled_false-loading_false:active {
     background: var(--seed-color-bg-transparent-pressed)
 }
 .seed-action-button__root--variant_brandSolid-disabled_true {

--- a/packages/lynx-css/recipes/action-button.mjs
+++ b/packages/lynx-css/recipes/action-button.mjs
@@ -79,28 +79,63 @@ const compoundVariants = [
     "pressed": true
   },
   {
+    "variant": "brandSolid",
+    "disabled": false,
+    "loading": false
+  },
+  {
     "variant": "neutralSolid",
     "pressed": true
+  },
+  {
+    "variant": "neutralSolid",
+    "disabled": false,
+    "loading": false
   },
   {
     "variant": "neutralWeak",
     "pressed": true
   },
   {
+    "variant": "neutralWeak",
+    "disabled": false,
+    "loading": false
+  },
+  {
     "variant": "criticalSolid",
     "pressed": true
+  },
+  {
+    "variant": "criticalSolid",
+    "disabled": false,
+    "loading": false
   },
   {
     "variant": "brandOutline",
     "pressed": true
   },
   {
+    "variant": "brandOutline",
+    "disabled": false,
+    "loading": false
+  },
+  {
     "variant": "neutralOutline",
     "pressed": true
   },
   {
+    "variant": "neutralOutline",
+    "disabled": false,
+    "loading": false
+  },
+  {
     "variant": "ghost",
     "pressed": true
+  },
+  {
+    "variant": "ghost",
+    "disabled": false,
+    "loading": false
   },
   {
     "variant": "brandSolid",

--- a/packages/lynx-css/recipes/callout.css
+++ b/packages/lynx-css/recipes/callout.css
@@ -175,18 +175,36 @@
 .seed-callout__root--tone_neutral-pressed_true {
     background-color: var(--seed-color-bg-neutral-weak-pressed)
 }
+.seed-callout__root--tone_neutral-interactive_true:active {
+    background-color: var(--seed-color-bg-neutral-weak-pressed)
+}
 .seed-callout__root--tone_informative-pressed_true {
+    background-color: var(--seed-color-bg-informative-weak-pressed)
+}
+.seed-callout__root--tone_informative-interactive_true:active {
     background-color: var(--seed-color-bg-informative-weak-pressed)
 }
 .seed-callout__root--tone_positive-pressed_true {
     background-color: var(--seed-color-bg-positive-weak-pressed)
 }
+.seed-callout__root--tone_positive-interactive_true:active {
+    background-color: var(--seed-color-bg-positive-weak-pressed)
+}
 .seed-callout__root--tone_warning-pressed_true {
+    background-color: var(--seed-color-bg-warning-weak-pressed)
+}
+.seed-callout__root--tone_warning-interactive_true:active {
     background-color: var(--seed-color-bg-warning-weak-pressed)
 }
 .seed-callout__root--tone_critical-pressed_true {
     background-color: var(--seed-color-bg-critical-weak-pressed)
 }
+.seed-callout__root--tone_critical-interactive_true:active {
+    background-color: var(--seed-color-bg-critical-weak-pressed)
+}
 .seed-callout__root--tone_magic-pressed_true {
+    background-image: linear-gradient(88deg, var(--seed-gradient-glow-magic-pressed))
+}
+.seed-callout__root--tone_magic-interactive_true:active {
     background-image: linear-gradient(88deg, var(--seed-gradient-glow-magic-pressed))
 }

--- a/packages/lynx-css/recipes/callout.d.ts
+++ b/packages/lynx-css/recipes/callout.d.ts
@@ -7,6 +7,10 @@ declare interface CalloutVariant {
   * @default false
   */
   pressed: boolean;
+/**
+  * @default false
+  */
+  interactive: boolean;
 }
 
 declare type CalloutVariantMap = {

--- a/packages/lynx-css/recipes/callout.mjs
+++ b/packages/lynx-css/recipes/callout.mjs
@@ -38,7 +38,8 @@ const calloutSlotNames = [
 
 const defaultVariant = {
   "tone": "neutral",
-  "pressed": false
+  "pressed": false,
+  "interactive": false
 };
 
 const compoundVariants = [
@@ -47,24 +48,48 @@ const compoundVariants = [
     "pressed": true
   },
   {
+    "tone": "neutral",
+    "interactive": true
+  },
+  {
     "tone": "informative",
     "pressed": true
+  },
+  {
+    "tone": "informative",
+    "interactive": true
   },
   {
     "tone": "positive",
     "pressed": true
   },
   {
+    "tone": "positive",
+    "interactive": true
+  },
+  {
     "tone": "warning",
     "pressed": true
+  },
+  {
+    "tone": "warning",
+    "interactive": true
   },
   {
     "tone": "critical",
     "pressed": true
   },
   {
+    "tone": "critical",
+    "interactive": true
+  },
+  {
     "tone": "magic",
     "pressed": true
+  },
+  {
+    "tone": "magic",
+    "interactive": true
   }
 ];
 
@@ -78,6 +103,10 @@ export const calloutVariantMap = {
     "magic"
   ],
   "pressed": [
+    true,
+    false
+  ],
+  "interactive": [
     true,
     false
   ]

--- a/packages/lynx-css/recipes/checkbox.css
+++ b/packages/lynx-css/recipes/checkbox.css
@@ -38,3 +38,9 @@
 .seed-checkbox__label--disabled_true {
     color: var(--seed-color-fg-disabled)
 }
+.seed-checkbox__root--disabled_false:active .seed-checkmark__root {
+    background-color: var(--seed-checkmark-pressed-color)
+}
+.seed-checkbox__root--disabled_false:active .seed-checkmark__background {
+    opacity: 1
+}

--- a/packages/lynx-css/recipes/checkmark.css
+++ b/packages/lynx-css/recipes/checkmark.css
@@ -18,6 +18,7 @@
     position: absolute
 }
 .seed-checkmark__root--variant_square {
+    --seed-checkmark-pressed-color: var(--seed-color-bg-transparent-pressed);
     border-width: 1px;
     border-style: solid;
     border-color: var(--seed-color-stroke-neutral-weak);
@@ -73,25 +74,29 @@
     border-color: #00000000
 }
 .seed-checkmark__root--variant_square-tone_brand-checked_true-disabled_false {
-    background-color: var(--seed-color-bg-brand-solid)
+    background-color: var(--seed-color-bg-brand-solid);
+    --seed-checkmark-pressed-color: var(--seed-color-bg-brand-solid-pressed)
 }
 .seed-checkmark__icon--variant_square-tone_brand-checked_true-disabled_false {
     color: var(--seed-color-palette-static-white)
 }
 .seed-checkmark__root--variant_square-tone_neutral-checked_true-disabled_false {
-    background-color: var(--seed-color-bg-neutral-inverted)
+    background-color: var(--seed-color-bg-neutral-inverted);
+    --seed-checkmark-pressed-color: var(--seed-color-bg-neutral-inverted-pressed)
 }
 .seed-checkmark__icon--variant_square-tone_neutral-checked_true-disabled_false {
     color: var(--seed-color-fg-neutral-inverted)
 }
 .seed-checkmark__root--variant_square-tone_brand-indeterminate_true-disabled_false {
-    background-color: var(--seed-color-bg-brand-solid)
+    background-color: var(--seed-color-bg-brand-solid);
+    --seed-checkmark-pressed-color: var(--seed-color-bg-brand-solid-pressed)
 }
 .seed-checkmark__icon--variant_square-tone_brand-indeterminate_true-disabled_false {
     color: var(--seed-color-palette-static-white)
 }
 .seed-checkmark__root--variant_square-tone_neutral-indeterminate_true-disabled_false {
-    background-color: var(--seed-color-bg-neutral-inverted)
+    background-color: var(--seed-color-bg-neutral-inverted);
+    --seed-checkmark-pressed-color: var(--seed-color-bg-neutral-inverted-pressed)
 }
 .seed-checkmark__icon--variant_square-tone_neutral-indeterminate_true-disabled_false {
     color: var(--seed-color-fg-neutral-inverted)

--- a/packages/lynx-css/recipes/chip.css
+++ b/packages/lynx-css/recipes/chip.css
@@ -221,18 +221,36 @@
 .seed-chip__root--variant_solid-pressed_true-selected_false {
     background: var(--seed-color-bg-neutral-weak-alpha-pressed)
 }
+.seed-chip__root--variant_solid-selected_false-disabled_false:active {
+    background: var(--seed-color-bg-neutral-weak-alpha-pressed)
+}
 .seed-chip__root--variant_outlineStrong-pressed_true-selected_false {
+    background: var(--seed-color-bg-transparent-pressed)
+}
+.seed-chip__root--variant_outlineStrong-selected_false-disabled_false:active {
     background: var(--seed-color-bg-transparent-pressed)
 }
 .seed-chip__root--variant_outlineWeak-pressed_true-selected_false {
     background: var(--seed-color-bg-transparent-pressed)
 }
+.seed-chip__root--variant_outlineWeak-selected_false-disabled_false:active {
+    background: var(--seed-color-bg-transparent-pressed)
+}
 .seed-chip__root--variant_solid-selected_true-pressed_true {
+    background: var(--seed-color-bg-neutral-inverted-pressed)
+}
+.seed-chip__root--variant_solid-selected_true-disabled_false:active {
     background: var(--seed-color-bg-neutral-inverted-pressed)
 }
 .seed-chip__root--variant_outlineStrong-selected_true-pressed_true {
     background: var(--seed-color-bg-neutral-inverted-pressed)
 }
+.seed-chip__root--variant_outlineStrong-selected_true-disabled_false:active {
+    background: var(--seed-color-bg-neutral-inverted-pressed)
+}
 .seed-chip__root--variant_outlineWeak-selected_true-pressed_true {
+    background: var(--seed-color-bg-neutral-weak-pressed)
+}
+.seed-chip__root--variant_outlineWeak-selected_true-disabled_false:active {
     background: var(--seed-color-bg-neutral-weak-pressed)
 }

--- a/packages/lynx-css/recipes/chip.mjs
+++ b/packages/lynx-css/recipes/chip.mjs
@@ -80,14 +80,29 @@ const compoundVariants = [
     "selected": false
   },
   {
+    "variant": "solid",
+    "selected": false,
+    "disabled": false
+  },
+  {
     "variant": "outlineStrong",
     "pressed": true,
     "selected": false
   },
   {
+    "variant": "outlineStrong",
+    "selected": false,
+    "disabled": false
+  },
+  {
     "variant": "outlineWeak",
     "pressed": true,
     "selected": false
+  },
+  {
+    "variant": "outlineWeak",
+    "selected": false,
+    "disabled": false
   },
   {
     "variant": "solid",
@@ -95,14 +110,29 @@ const compoundVariants = [
     "pressed": true
   },
   {
+    "variant": "solid",
+    "selected": true,
+    "disabled": false
+  },
+  {
     "variant": "outlineStrong",
+    "selected": true,
+    "pressed": true
+  },
+  {
+    "variant": "outlineStrong",
+    "selected": true,
+    "disabled": false
+  },
+  {
+    "variant": "outlineWeak",
     "selected": true,
     "pressed": true
   },
   {
     "variant": "outlineWeak",
     "selected": true,
-    "pressed": true
+    "disabled": false
   }
 ];
 

--- a/packages/lynx-css/recipes/page-banner.css
+++ b/packages/lynx-css/recipes/page-banner.css
@@ -7,7 +7,7 @@
     padding-left: var(--seed-dimension-x4);
     padding-right: var(--seed-dimension-x4);
     padding-top: var(--seed-dimension-x2_5);
-    padding-bottom: var(--seed-dimension-x2_5)
+    padding-bottom: var(--seed-dimension-x2_5);
 }
 .seed-page-banner__content {
     display: flex;
@@ -17,23 +17,23 @@
     justify-content: space-between;
     flex-grow: 1;
     flex-shrink: 1;
-    gap: var(--seed-dimension-x1_5)
+    gap: var(--seed-dimension-x1_5);
 }
 .seed-page-banner__body {
     flex-grow: 1;
     flex-shrink: 1;
-    line-height: var(--seed-line-height-t4)
+    line-height: var(--seed-line-height-t4);
 }
 .seed-page-banner__title {
     flex-shrink: 0;
     font-size: var(--seed-font-size-t4);
     line-height: var(--seed-line-height-t4);
-    font-weight: var(--seed-font-weight-bold)
+    font-weight: var(--seed-font-weight-bold);
 }
 .seed-page-banner__description {
     font-size: var(--seed-font-size-t4);
     line-height: var(--seed-line-height-t4);
-    font-weight: var(--seed-font-weight-medium)
+    font-weight: var(--seed-font-weight-medium);
 }
 .seed-page-banner__button {
     display: flex;
@@ -50,7 +50,7 @@
     font-size: var(--seed-font-size-t3);
     line-height: var(--seed-line-height-t3);
     font-weight: var(--seed-font-weight-bold);
-    border-radius: var(--seed-radius-r1)
+    border-radius: var(--seed-radius-r1);
 }
 .seed-page-banner__closeButton {
     flex-grow: 0;
@@ -67,291 +67,310 @@
     margin-bottom: calc((var(--seed-dimension-x10) - var(--seed-dimension-x4)) * -0.5);
     margin-left: calc((var(--seed-dimension-x10) - var(--seed-dimension-x4)) * -0.5 + var(--seed-dimension-x2));
     border-radius: var(--seed-radius-r2);
-    background-color: var(--seed-color-bg-transparent)
+    background-color: var(--seed-color-bg-transparent);
+    transition: background-color var(--seed-duration-color-transition) var(--seed-timing-function-easing);
+}
+.seed-page-banner__closeButton:active {
+    background-color: var(--seed-color-bg-transparent-pressed);
 }
 .seed-page-banner__prefixIcon {
     flex-shrink: 0;
     width: var(--seed-dimension-x4);
     height: var(--seed-dimension-x4);
     margin-top: calc((var(--seed-dimension-x10) - var(--seed-dimension-x4)) * 0.5 - var(--seed-dimension-x2_5));
-    margin-right: var(--seed-dimension-x2)
+    margin-right: var(--seed-dimension-x2);
 }
 .seed-page-banner__suffixIcon {
     flex-shrink: 0;
     align-self: center;
     width: var(--seed-dimension-x4);
     height: var(--seed-dimension-x4);
-    margin-left: var(--seed-dimension-x2)
+    margin-left: var(--seed-dimension-x2);
 }
 .seed-page-banner__closeButtonIcon {
     flex-shrink: 0;
     width: var(--seed-dimension-x4);
-    height: var(--seed-dimension-x4)
+    height: var(--seed-dimension-x4);
+}
+.seed-page-banner__root--interactive_true:active {
+    background-color: var(--seed-page-banner-pressed-background-color);
+    background-image: var(--seed-page-banner-pressed-background-image);
 }
 .seed-page-banner__closeButton--closeButtonPressed_true {
-    background-color: var(--seed-color-bg-transparent-pressed)
+    background-color: var(--seed-color-bg-transparent-pressed);
 }
 .seed-page-banner__root--tone_neutral-variant_weak {
-    background-color: var(--seed-color-bg-neutral-weak)
+    background-color: var(--seed-color-bg-neutral-weak);
+    --seed-page-banner-pressed-background-color: var(--seed-color-bg-neutral-weak-pressed);
 }
 .seed-page-banner__title--tone_neutral-variant_weak {
-    color: var(--seed-color-fg-neutral)
+    color: var(--seed-color-fg-neutral);
 }
 .seed-page-banner__description--tone_neutral-variant_weak {
-    color: var(--seed-color-fg-neutral)
+    color: var(--seed-color-fg-neutral);
 }
 .seed-page-banner__button--tone_neutral-variant_weak {
-    color: var(--seed-color-fg-neutral)
+    color: var(--seed-color-fg-neutral);
 }
 .seed-page-banner__prefixIcon--tone_neutral-variant_weak {
-    color: var(--seed-color-fg-neutral)
+    color: var(--seed-color-fg-neutral);
 }
 .seed-page-banner__suffixIcon--tone_neutral-variant_weak {
-    color: var(--seed-color-fg-neutral)
+    color: var(--seed-color-fg-neutral);
 }
 .seed-page-banner__closeButtonIcon--tone_neutral-variant_weak {
-    color: var(--seed-color-fg-neutral)
+    color: var(--seed-color-fg-neutral);
 }
 .seed-page-banner__root--tone_neutral-variant_solid {
-    background-color: var(--seed-color-bg-neutral-inverted)
+    background-color: var(--seed-color-bg-neutral-inverted);
+    --seed-page-banner-pressed-background-color: var(--seed-color-bg-neutral-inverted-pressed);
 }
 .seed-page-banner__title--tone_neutral-variant_solid {
-    color: var(--seed-color-fg-neutral-inverted)
+    color: var(--seed-color-fg-neutral-inverted);
 }
 .seed-page-banner__description--tone_neutral-variant_solid {
-    color: var(--seed-color-fg-neutral-inverted)
+    color: var(--seed-color-fg-neutral-inverted);
 }
 .seed-page-banner__button--tone_neutral-variant_solid {
-    color: var(--seed-color-fg-neutral-inverted)
+    color: var(--seed-color-fg-neutral-inverted);
 }
 .seed-page-banner__prefixIcon--tone_neutral-variant_solid {
-    color: var(--seed-color-fg-neutral-inverted)
+    color: var(--seed-color-fg-neutral-inverted);
 }
 .seed-page-banner__suffixIcon--tone_neutral-variant_solid {
-    color: var(--seed-color-fg-neutral-inverted)
+    color: var(--seed-color-fg-neutral-inverted);
 }
 .seed-page-banner__closeButtonIcon--tone_neutral-variant_solid {
-    color: var(--seed-color-fg-neutral-inverted)
+    color: var(--seed-color-fg-neutral-inverted);
 }
 .seed-page-banner__root--tone_informative-variant_weak {
-    background-color: var(--seed-color-bg-informative-weak)
+    background-color: var(--seed-color-bg-informative-weak);
+    --seed-page-banner-pressed-background-color: var(--seed-color-bg-informative-weak-pressed);
 }
 .seed-page-banner__title--tone_informative-variant_weak {
-    color: var(--seed-color-fg-informative-contrast)
+    color: var(--seed-color-fg-informative-contrast);
 }
 .seed-page-banner__description--tone_informative-variant_weak {
-    color: var(--seed-color-fg-informative-contrast)
+    color: var(--seed-color-fg-informative-contrast);
 }
 .seed-page-banner__button--tone_informative-variant_weak {
-    color: var(--seed-color-fg-informative-contrast)
+    color: var(--seed-color-fg-informative-contrast);
 }
 .seed-page-banner__prefixIcon--tone_informative-variant_weak {
-    color: var(--seed-color-fg-informative-contrast)
+    color: var(--seed-color-fg-informative-contrast);
 }
 .seed-page-banner__suffixIcon--tone_informative-variant_weak {
-    color: var(--seed-color-fg-informative-contrast)
+    color: var(--seed-color-fg-informative-contrast);
 }
 .seed-page-banner__closeButtonIcon--tone_informative-variant_weak {
-    color: var(--seed-color-fg-informative-contrast)
+    color: var(--seed-color-fg-informative-contrast);
 }
 .seed-page-banner__root--tone_informative-variant_solid {
-    background-color: var(--seed-color-bg-informative-solid)
+    background-color: var(--seed-color-bg-informative-solid);
+    --seed-page-banner-pressed-background-color: var(--seed-color-bg-informative-solid-pressed);
 }
 .seed-page-banner__title--tone_informative-variant_solid {
-    color: var(--seed-color-palette-static-white)
+    color: var(--seed-color-palette-static-white);
 }
 .seed-page-banner__description--tone_informative-variant_solid {
-    color: var(--seed-color-palette-static-white)
+    color: var(--seed-color-palette-static-white);
 }
 .seed-page-banner__button--tone_informative-variant_solid {
-    color: var(--seed-color-palette-static-white)
+    color: var(--seed-color-palette-static-white);
 }
 .seed-page-banner__prefixIcon--tone_informative-variant_solid {
-    color: var(--seed-color-palette-static-white)
+    color: var(--seed-color-palette-static-white);
 }
 .seed-page-banner__suffixIcon--tone_informative-variant_solid {
-    color: var(--seed-color-palette-static-white)
+    color: var(--seed-color-palette-static-white);
 }
 .seed-page-banner__closeButtonIcon--tone_informative-variant_solid {
-    color: var(--seed-color-palette-static-white)
+    color: var(--seed-color-palette-static-white);
 }
 .seed-page-banner__root--tone_positive-variant_weak {
-    background-color: var(--seed-color-bg-positive-weak)
+    background-color: var(--seed-color-bg-positive-weak);
+    --seed-page-banner-pressed-background-color: var(--seed-color-bg-positive-weak-pressed);
 }
 .seed-page-banner__title--tone_positive-variant_weak {
-    color: var(--seed-color-fg-positive-contrast)
+    color: var(--seed-color-fg-positive-contrast);
 }
 .seed-page-banner__description--tone_positive-variant_weak {
-    color: var(--seed-color-fg-positive-contrast)
+    color: var(--seed-color-fg-positive-contrast);
 }
 .seed-page-banner__button--tone_positive-variant_weak {
-    color: var(--seed-color-fg-positive-contrast)
+    color: var(--seed-color-fg-positive-contrast);
 }
 .seed-page-banner__prefixIcon--tone_positive-variant_weak {
-    color: var(--seed-color-fg-positive-contrast)
+    color: var(--seed-color-fg-positive-contrast);
 }
 .seed-page-banner__suffixIcon--tone_positive-variant_weak {
-    color: var(--seed-color-fg-positive-contrast)
+    color: var(--seed-color-fg-positive-contrast);
 }
 .seed-page-banner__closeButtonIcon--tone_positive-variant_weak {
-    color: var(--seed-color-fg-positive-contrast)
+    color: var(--seed-color-fg-positive-contrast);
 }
 .seed-page-banner__root--tone_positive-variant_solid {
-    background-color: var(--seed-color-bg-positive-solid)
+    background-color: var(--seed-color-bg-positive-solid);
+    --seed-page-banner-pressed-background-color: var(--seed-color-bg-positive-solid-pressed);
 }
 .seed-page-banner__title--tone_positive-variant_solid {
-    color: var(--seed-color-palette-static-white)
+    color: var(--seed-color-palette-static-white);
 }
 .seed-page-banner__description--tone_positive-variant_solid {
-    color: var(--seed-color-palette-static-white)
+    color: var(--seed-color-palette-static-white);
 }
 .seed-page-banner__button--tone_positive-variant_solid {
-    color: var(--seed-color-palette-static-white)
+    color: var(--seed-color-palette-static-white);
 }
 .seed-page-banner__prefixIcon--tone_positive-variant_solid {
-    color: var(--seed-color-palette-static-white)
+    color: var(--seed-color-palette-static-white);
 }
 .seed-page-banner__suffixIcon--tone_positive-variant_solid {
-    color: var(--seed-color-palette-static-white)
+    color: var(--seed-color-palette-static-white);
 }
 .seed-page-banner__closeButtonIcon--tone_positive-variant_solid {
-    color: var(--seed-color-palette-static-white)
+    color: var(--seed-color-palette-static-white);
 }
 .seed-page-banner__root--tone_warning-variant_weak {
-    background-color: var(--seed-color-bg-warning-weak)
+    background-color: var(--seed-color-bg-warning-weak);
+    --seed-page-banner-pressed-background-color: var(--seed-color-bg-warning-weak-pressed);
 }
 .seed-page-banner__title--tone_warning-variant_weak {
-    color: var(--seed-color-fg-warning-contrast)
+    color: var(--seed-color-fg-warning-contrast);
 }
 .seed-page-banner__description--tone_warning-variant_weak {
-    color: var(--seed-color-fg-warning-contrast)
+    color: var(--seed-color-fg-warning-contrast);
 }
 .seed-page-banner__button--tone_warning-variant_weak {
-    color: var(--seed-color-fg-warning-contrast)
+    color: var(--seed-color-fg-warning-contrast);
 }
 .seed-page-banner__prefixIcon--tone_warning-variant_weak {
-    color: var(--seed-color-fg-warning-contrast)
+    color: var(--seed-color-fg-warning-contrast);
 }
 .seed-page-banner__suffixIcon--tone_warning-variant_weak {
-    color: var(--seed-color-fg-warning-contrast)
+    color: var(--seed-color-fg-warning-contrast);
 }
 .seed-page-banner__closeButtonIcon--tone_warning-variant_weak {
-    color: var(--seed-color-fg-warning-contrast)
+    color: var(--seed-color-fg-warning-contrast);
 }
 .seed-page-banner__root--tone_warning-variant_solid {
-    background-color: var(--seed-color-bg-warning-solid)
+    background-color: var(--seed-color-bg-warning-solid);
+    --seed-page-banner-pressed-background-color: var(--seed-color-bg-warning-solid-pressed);
 }
 .seed-page-banner__title--tone_warning-variant_solid {
-    color: var(--seed-color-palette-static-black-alpha-900)
+    color: var(--seed-color-palette-static-black-alpha-900);
 }
 .seed-page-banner__description--tone_warning-variant_solid {
-    color: var(--seed-color-palette-static-black-alpha-900)
+    color: var(--seed-color-palette-static-black-alpha-900);
 }
 .seed-page-banner__button--tone_warning-variant_solid {
-    color: var(--seed-color-palette-static-black-alpha-900)
+    color: var(--seed-color-palette-static-black-alpha-900);
 }
 .seed-page-banner__prefixIcon--tone_warning-variant_solid {
-    color: var(--seed-color-palette-static-black-alpha-900)
+    color: var(--seed-color-palette-static-black-alpha-900);
 }
 .seed-page-banner__suffixIcon--tone_warning-variant_solid {
-    color: var(--seed-color-palette-static-black-alpha-900)
+    color: var(--seed-color-palette-static-black-alpha-900);
 }
 .seed-page-banner__closeButtonIcon--tone_warning-variant_solid {
-    color: var(--seed-color-palette-static-black-alpha-900)
+    color: var(--seed-color-palette-static-black-alpha-900);
 }
 .seed-page-banner__root--tone_critical-variant_weak {
-    background-color: var(--seed-color-bg-critical-weak)
+    background-color: var(--seed-color-bg-critical-weak);
+    --seed-page-banner-pressed-background-color: var(--seed-color-bg-critical-weak-pressed);
 }
 .seed-page-banner__title--tone_critical-variant_weak {
-    color: var(--seed-color-fg-critical-contrast)
+    color: var(--seed-color-fg-critical-contrast);
 }
 .seed-page-banner__description--tone_critical-variant_weak {
-    color: var(--seed-color-fg-critical-contrast)
+    color: var(--seed-color-fg-critical-contrast);
 }
 .seed-page-banner__button--tone_critical-variant_weak {
-    color: var(--seed-color-fg-critical-contrast)
+    color: var(--seed-color-fg-critical-contrast);
 }
 .seed-page-banner__prefixIcon--tone_critical-variant_weak {
-    color: var(--seed-color-fg-critical-contrast)
+    color: var(--seed-color-fg-critical-contrast);
 }
 .seed-page-banner__suffixIcon--tone_critical-variant_weak {
-    color: var(--seed-color-fg-critical-contrast)
+    color: var(--seed-color-fg-critical-contrast);
 }
 .seed-page-banner__closeButtonIcon--tone_critical-variant_weak {
-    color: var(--seed-color-fg-critical-contrast)
+    color: var(--seed-color-fg-critical-contrast);
 }
 .seed-page-banner__root--tone_critical-variant_solid {
-    background-color: var(--seed-color-bg-critical-solid)
+    background-color: var(--seed-color-bg-critical-solid);
+    --seed-page-banner-pressed-background-color: var(--seed-color-bg-critical-solid-pressed);
 }
 .seed-page-banner__title--tone_critical-variant_solid {
-    color: var(--seed-color-palette-static-white)
+    color: var(--seed-color-palette-static-white);
 }
 .seed-page-banner__description--tone_critical-variant_solid {
-    color: var(--seed-color-palette-static-white)
+    color: var(--seed-color-palette-static-white);
 }
 .seed-page-banner__button--tone_critical-variant_solid {
-    color: var(--seed-color-palette-static-white)
+    color: var(--seed-color-palette-static-white);
 }
 .seed-page-banner__prefixIcon--tone_critical-variant_solid {
-    color: var(--seed-color-palette-static-white)
+    color: var(--seed-color-palette-static-white);
 }
 .seed-page-banner__suffixIcon--tone_critical-variant_solid {
-    color: var(--seed-color-palette-static-white)
+    color: var(--seed-color-palette-static-white);
 }
 .seed-page-banner__closeButtonIcon--tone_critical-variant_solid {
-    color: var(--seed-color-palette-static-white)
+    color: var(--seed-color-palette-static-white);
 }
 .seed-page-banner__root--tone_magic-variant_weak {
-    background-image: linear-gradient(88deg, var(--seed-gradient-glow-magic))
+    background-image: linear-gradient(88deg, var(--seed-gradient-glow-magic));
+    --seed-page-banner-pressed-background-image: linear-gradient(88deg, var(--seed-gradient-glow-magic-pressed));
 }
 .seed-page-banner__title--tone_magic-variant_weak {
-    color: var(--seed-color-fg-neutral)
+    color: var(--seed-color-fg-neutral);
 }
 .seed-page-banner__description--tone_magic-variant_weak {
-    color: var(--seed-color-fg-neutral)
+    color: var(--seed-color-fg-neutral);
 }
 .seed-page-banner__button--tone_magic-variant_weak {
-    color: var(--seed-color-fg-neutral)
+    color: var(--seed-color-fg-neutral);
 }
 .seed-page-banner__prefixIcon--tone_magic-variant_weak {
-    color: var(--seed-color-fg-neutral)
+    color: var(--seed-color-fg-neutral);
 }
 .seed-page-banner__suffixIcon--tone_magic-variant_weak {
-    color: var(--seed-color-fg-neutral)
+    color: var(--seed-color-fg-neutral);
 }
 .seed-page-banner__closeButtonIcon--tone_magic-variant_weak {
-    color: var(--seed-color-fg-neutral)
+    color: var(--seed-color-fg-neutral);
 }
 .seed-page-banner__root--tone_neutral-variant_weak-pressed_true {
-    background-color: var(--seed-color-bg-neutral-weak-pressed)
+    background-color: var(--seed-color-bg-neutral-weak-pressed);
 }
 .seed-page-banner__root--tone_neutral-variant_solid-pressed_true {
-    background-color: var(--seed-color-bg-neutral-inverted-pressed)
+    background-color: var(--seed-color-bg-neutral-inverted-pressed);
 }
 .seed-page-banner__root--tone_informative-variant_weak-pressed_true {
-    background-color: var(--seed-color-bg-informative-weak-pressed)
+    background-color: var(--seed-color-bg-informative-weak-pressed);
 }
 .seed-page-banner__root--tone_informative-variant_solid-pressed_true {
-    background-color: var(--seed-color-bg-informative-solid-pressed)
+    background-color: var(--seed-color-bg-informative-solid-pressed);
 }
 .seed-page-banner__root--tone_positive-variant_weak-pressed_true {
-    background-color: var(--seed-color-bg-positive-weak-pressed)
+    background-color: var(--seed-color-bg-positive-weak-pressed);
 }
 .seed-page-banner__root--tone_positive-variant_solid-pressed_true {
-    background-color: var(--seed-color-bg-positive-solid-pressed)
+    background-color: var(--seed-color-bg-positive-solid-pressed);
 }
 .seed-page-banner__root--tone_warning-variant_weak-pressed_true {
-    background-color: var(--seed-color-bg-warning-weak-pressed)
+    background-color: var(--seed-color-bg-warning-weak-pressed);
 }
 .seed-page-banner__root--tone_warning-variant_solid-pressed_true {
-    background-color: var(--seed-color-bg-warning-solid-pressed)
+    background-color: var(--seed-color-bg-warning-solid-pressed);
 }
 .seed-page-banner__root--tone_critical-variant_weak-pressed_true {
-    background-color: var(--seed-color-bg-critical-weak-pressed)
+    background-color: var(--seed-color-bg-critical-weak-pressed);
 }
 .seed-page-banner__root--tone_critical-variant_solid-pressed_true {
-    background-color: var(--seed-color-bg-critical-solid-pressed)
+    background-color: var(--seed-color-bg-critical-solid-pressed);
 }
 .seed-page-banner__root--tone_magic-variant_weak-pressed_true {
-    background-image: linear-gradient(88deg, var(--seed-gradient-glow-magic-pressed))
+    background-image: linear-gradient(88deg, var(--seed-gradient-glow-magic-pressed));
 }

--- a/packages/lynx-css/recipes/page-banner.css
+++ b/packages/lynx-css/recipes/page-banner.css
@@ -92,16 +92,44 @@
     width: var(--seed-dimension-x4);
     height: var(--seed-dimension-x4);
 }
-.seed-page-banner__root--interactive_true:active {
-    background-color: var(--seed-page-banner-pressed-background-color);
-    background-image: var(--seed-page-banner-pressed-background-image);
-}
 .seed-page-banner__closeButton--closeButtonPressed_true {
     background-color: var(--seed-color-bg-transparent-pressed);
 }
+.seed-page-banner__root--tone_neutral-variant_weak-interactive_true:active {
+    background-color: var(--seed-color-bg-neutral-weak-pressed);
+}
+.seed-page-banner__root--tone_neutral-variant_solid-interactive_true:active {
+    background-color: var(--seed-color-bg-neutral-inverted-pressed);
+}
+.seed-page-banner__root--tone_informative-variant_weak-interactive_true:active {
+    background-color: var(--seed-color-bg-informative-weak-pressed);
+}
+.seed-page-banner__root--tone_informative-variant_solid-interactive_true:active {
+    background-color: var(--seed-color-bg-informative-solid-pressed);
+}
+.seed-page-banner__root--tone_positive-variant_weak-interactive_true:active {
+    background-color: var(--seed-color-bg-positive-weak-pressed);
+}
+.seed-page-banner__root--tone_positive-variant_solid-interactive_true:active {
+    background-color: var(--seed-color-bg-positive-solid-pressed);
+}
+.seed-page-banner__root--tone_warning-variant_weak-interactive_true:active {
+    background-color: var(--seed-color-bg-warning-weak-pressed);
+}
+.seed-page-banner__root--tone_warning-variant_solid-interactive_true:active {
+    background-color: var(--seed-color-bg-warning-solid-pressed);
+}
+.seed-page-banner__root--tone_critical-variant_weak-interactive_true:active {
+    background-color: var(--seed-color-bg-critical-weak-pressed);
+}
+.seed-page-banner__root--tone_critical-variant_solid-interactive_true:active {
+    background-color: var(--seed-color-bg-critical-solid-pressed);
+}
+.seed-page-banner__root--tone_magic-variant_weak-interactive_true:active {
+    background-image: linear-gradient(88deg, var(--seed-gradient-glow-magic-pressed));
+}
 .seed-page-banner__root--tone_neutral-variant_weak {
     background-color: var(--seed-color-bg-neutral-weak);
-    --seed-page-banner-pressed-background-color: var(--seed-color-bg-neutral-weak-pressed);
 }
 .seed-page-banner__title--tone_neutral-variant_weak {
     color: var(--seed-color-fg-neutral);
@@ -123,7 +151,6 @@
 }
 .seed-page-banner__root--tone_neutral-variant_solid {
     background-color: var(--seed-color-bg-neutral-inverted);
-    --seed-page-banner-pressed-background-color: var(--seed-color-bg-neutral-inverted-pressed);
 }
 .seed-page-banner__title--tone_neutral-variant_solid {
     color: var(--seed-color-fg-neutral-inverted);
@@ -145,7 +172,6 @@
 }
 .seed-page-banner__root--tone_informative-variant_weak {
     background-color: var(--seed-color-bg-informative-weak);
-    --seed-page-banner-pressed-background-color: var(--seed-color-bg-informative-weak-pressed);
 }
 .seed-page-banner__title--tone_informative-variant_weak {
     color: var(--seed-color-fg-informative-contrast);
@@ -167,7 +193,6 @@
 }
 .seed-page-banner__root--tone_informative-variant_solid {
     background-color: var(--seed-color-bg-informative-solid);
-    --seed-page-banner-pressed-background-color: var(--seed-color-bg-informative-solid-pressed);
 }
 .seed-page-banner__title--tone_informative-variant_solid {
     color: var(--seed-color-palette-static-white);
@@ -189,7 +214,6 @@
 }
 .seed-page-banner__root--tone_positive-variant_weak {
     background-color: var(--seed-color-bg-positive-weak);
-    --seed-page-banner-pressed-background-color: var(--seed-color-bg-positive-weak-pressed);
 }
 .seed-page-banner__title--tone_positive-variant_weak {
     color: var(--seed-color-fg-positive-contrast);
@@ -211,7 +235,6 @@
 }
 .seed-page-banner__root--tone_positive-variant_solid {
     background-color: var(--seed-color-bg-positive-solid);
-    --seed-page-banner-pressed-background-color: var(--seed-color-bg-positive-solid-pressed);
 }
 .seed-page-banner__title--tone_positive-variant_solid {
     color: var(--seed-color-palette-static-white);
@@ -233,7 +256,6 @@
 }
 .seed-page-banner__root--tone_warning-variant_weak {
     background-color: var(--seed-color-bg-warning-weak);
-    --seed-page-banner-pressed-background-color: var(--seed-color-bg-warning-weak-pressed);
 }
 .seed-page-banner__title--tone_warning-variant_weak {
     color: var(--seed-color-fg-warning-contrast);
@@ -255,7 +277,6 @@
 }
 .seed-page-banner__root--tone_warning-variant_solid {
     background-color: var(--seed-color-bg-warning-solid);
-    --seed-page-banner-pressed-background-color: var(--seed-color-bg-warning-solid-pressed);
 }
 .seed-page-banner__title--tone_warning-variant_solid {
     color: var(--seed-color-palette-static-black-alpha-900);
@@ -277,7 +298,6 @@
 }
 .seed-page-banner__root--tone_critical-variant_weak {
     background-color: var(--seed-color-bg-critical-weak);
-    --seed-page-banner-pressed-background-color: var(--seed-color-bg-critical-weak-pressed);
 }
 .seed-page-banner__title--tone_critical-variant_weak {
     color: var(--seed-color-fg-critical-contrast);
@@ -299,7 +319,6 @@
 }
 .seed-page-banner__root--tone_critical-variant_solid {
     background-color: var(--seed-color-bg-critical-solid);
-    --seed-page-banner-pressed-background-color: var(--seed-color-bg-critical-solid-pressed);
 }
 .seed-page-banner__title--tone_critical-variant_solid {
     color: var(--seed-color-palette-static-white);
@@ -321,7 +340,6 @@
 }
 .seed-page-banner__root--tone_magic-variant_weak {
     background-image: linear-gradient(88deg, var(--seed-gradient-glow-magic));
-    --seed-page-banner-pressed-background-image: linear-gradient(88deg, var(--seed-gradient-glow-magic-pressed));
 }
 .seed-page-banner__title--tone_magic-variant_weak {
     color: var(--seed-color-fg-neutral);

--- a/packages/lynx-css/recipes/page-banner.d.ts
+++ b/packages/lynx-css/recipes/page-banner.d.ts
@@ -14,6 +14,10 @@ declare interface PageBannerVariant {
 /**
   * @default false
   */
+  interactive: boolean;
+/**
+  * @default false
+  */
   closeButtonPressed: boolean;
 }
 

--- a/packages/lynx-css/recipes/page-banner.mjs
+++ b/packages/lynx-css/recipes/page-banner.mjs
@@ -48,7 +48,8 @@ const defaultVariant = {
   "tone": "neutral",
   "variant": "weak",
   "pressed": false,
-  "closeButtonPressed": false
+  "closeButtonPressed": false,
+  "interactive": false
 };
 
 const compoundVariants = [
@@ -167,6 +168,10 @@ export const pageBannerVariantMap = {
     "solid"
   ],
   "pressed": [
+    true,
+    false
+  ],
+  "interactive": [
     true,
     false
   ],

--- a/packages/lynx-css/recipes/page-banner.mjs
+++ b/packages/lynx-css/recipes/page-banner.mjs
@@ -55,6 +55,61 @@ const defaultVariant = {
 const compoundVariants = [
   {
     "tone": "neutral",
+    "variant": "weak",
+    "interactive": true
+  },
+  {
+    "tone": "neutral",
+    "variant": "solid",
+    "interactive": true
+  },
+  {
+    "tone": "informative",
+    "variant": "weak",
+    "interactive": true
+  },
+  {
+    "tone": "informative",
+    "variant": "solid",
+    "interactive": true
+  },
+  {
+    "tone": "positive",
+    "variant": "weak",
+    "interactive": true
+  },
+  {
+    "tone": "positive",
+    "variant": "solid",
+    "interactive": true
+  },
+  {
+    "tone": "warning",
+    "variant": "weak",
+    "interactive": true
+  },
+  {
+    "tone": "warning",
+    "variant": "solid",
+    "interactive": true
+  },
+  {
+    "tone": "critical",
+    "variant": "weak",
+    "interactive": true
+  },
+  {
+    "tone": "critical",
+    "variant": "solid",
+    "interactive": true
+  },
+  {
+    "tone": "magic",
+    "variant": "weak",
+    "interactive": true
+  },
+  {
+    "tone": "neutral",
     "variant": "weak"
   },
   {

--- a/packages/lynx-css/recipes/radio.css
+++ b/packages/lynx-css/recipes/radio.css
@@ -38,3 +38,6 @@
 .seed-radio__label--disabled_true {
     color: var(--seed-color-fg-disabled)
 }
+.seed-radio__root--disabled_false:active .seed-radiomark__root {
+    background-color: var(--seed-radiomark-pressed-color)
+}

--- a/packages/lynx-css/recipes/radiomark.css
+++ b/packages/lynx-css/recipes/radiomark.css
@@ -8,7 +8,8 @@
     border-style: solid;
     border-color: var(--seed-color-stroke-neutral-weak);
     border-radius: var(--seed-radius-full);
-    transition: background-color var(--seed-duration-color-transition) var(--seed-timing-function-easing)
+    transition: background-color var(--seed-duration-color-transition) var(--seed-timing-function-easing);
+    --seed-radiomark-pressed-color: var(--seed-color-bg-transparent-pressed)
 }
 .seed-radiomark__icon {
     border-radius: var(--seed-radius-full)
@@ -34,6 +35,7 @@
 }
 .seed-radiomark__root--tone_brand-checked_true-disabled_false {
     background-color: var(--seed-color-bg-brand-solid);
+    --seed-radiomark-pressed-color: var(--seed-color-bg-brand-solid-pressed);
     border-width: 0px;
     border-color: #00000000
 }
@@ -43,6 +45,7 @@
 }
 .seed-radiomark__root--tone_neutral-checked_true-disabled_false {
     background-color: var(--seed-color-bg-neutral-inverted);
+    --seed-radiomark-pressed-color: var(--seed-color-bg-neutral-inverted-pressed);
     border-width: 0px;
     border-color: #00000000
 }

--- a/packages/lynx-css/recipes/segmented-control.css
+++ b/packages/lynx-css/recipes/segmented-control.css
@@ -87,10 +87,16 @@
 .seed-segmented-control__label--disabled_true {
     color: var(--seed-color-fg-disabled)
 }
+.seed-segmented-control__item--disabled_false:active .seed-segmented-control__itemBackground {
+    opacity: 1
+}
 .seed-segmented-control__itemBackground--pressed_true {
     opacity: 1
 }
 .seed-segmented-control__indicator--hasSelection_false {
+    opacity: 0
+}
+.seed-segmented-control__itemBackground--disabled_true-pressed_true {
     opacity: 0
 }
 .seed-segmented-control__item--selected_true-disabled_true {

--- a/packages/lynx-css/recipes/segmented-control.mjs
+++ b/packages/lynx-css/recipes/segmented-control.mjs
@@ -37,6 +37,10 @@ const defaultVariant = {
 
 const compoundVariants = [
   {
+    "disabled": true,
+    "pressed": true
+  },
+  {
     "selected": true,
     "disabled": true
   }

--- a/packages/lynx-css/recipes/select-box.css
+++ b/packages/lynx-css/recipes/select-box.css
@@ -142,6 +142,9 @@
 .seed-select-box__description--disabled_true {
     color: var(--seed-color-fg-disabled)
 }
+.seed-select-box__root--disabled_false:active {
+    background-color: var(--seed-color-bg-transparent-pressed)
+}
 .seed-select-box__footer--footerOpen_true {
     opacity: 1;
     transition: height 400ms var(--seed-timing-function-easing), opacity var(--seed-duration-d6) var(--seed-timing-function-easing)

--- a/packages/lynx-qvism-preset/AGENTS.md
+++ b/packages/lynx-qvism-preset/AGENTS.md
@@ -15,6 +15,6 @@ Lynx 플랫폼 전용 qvism preset을 정의하는 private 패키지. `rootage`�
 - Recipe 작성 시 `src/utils/define.ts`의 `defineRecipe` / `defineSlotRecipe`를 사용한다.
 - `define.ts`는 SEED Lynx strict style type으로 style 입력을 좁힌다. `boxSizing`, `verticalAlign`, SVG stroke/fill CSS, `content`, CSS-wide keyword(`initial`, `inherit`, `unset`)처럼 Lynx preset source에서 허용하지 않는 property/value를 추가하지 않는다.
 - `inset` / `inset-*` shorthand는 Lynx preset source에서 사용하지 않는다. 전체 영역 채움은 `top` / `right` / `bottom` / `left` longhand로 작성하고, Lightning CSS의 `Features.LogicalProperties` include 옵션으로 최종 CSS에서도 longhand를 유지한다.
-- Lynx에서 상태는 pseudo selector보다 boolean/string variant로 모델링한다.
+- Lynx에서 상태는 기본적으로 boolean/string variant로 모델링한다. 단, Main Thread에서 즉시 시작해야 하는 pressed 시각 피드백은 `:active`를 사용할 수 있으며, enabled/interactive variant class로 disabled·loading 상태를 반드시 gate한다. trigger와 target이 다른 경우에는 trigger의 `:active` selector가 해당 content slot class만 대상으로 해야 한다.
 - Root와 text를 분리해야 하는 recipe는 qvism core에서 slot을 파생하지 않고 `defineSlotRecipe`로 slot을 명시한다.
 - Lynx 전용 selector/theme/platform 차이는 qvism core나 PostCSS 후처리에 넣지 않고 이 preset source에서 class selector와 명시적인 fallback 값으로 해결한다.

--- a/packages/lynx-qvism-preset/active-feedback.test.ts
+++ b/packages/lynx-qvism-preset/active-feedback.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+
+import accordion from "./src/recipes/accordion";
+import actionButton from "./src/recipes/action-button";
+import callout from "./src/recipes/callout";
+import checkbox from "./src/recipes/checkbox";
+import pageBanner from "./src/recipes/page-banner";
+import radio from "./src/recipes/radio";
+import segmentedControl from "./src/recipes/segmented-control";
+import { selectBox } from "./src/recipes/select-box";
+
+describe("Lynx active feedback", () => {
+  it("gates self feedback with enabled interaction variants", () => {
+    expect(actionButton.compoundVariants).toContainEqual({
+      variant: "brandSolid",
+      disabled: false,
+      loading: false,
+      css: {
+        root: expect.objectContaining({
+          "&:active": expect.any(Object),
+        }),
+      },
+    });
+    expect(callout.compoundVariants).toContainEqual({
+      tone: "neutral",
+      interactive: true,
+      css: {
+        root: expect.objectContaining({
+          "&:active": expect.any(Object),
+        }),
+      },
+    });
+  });
+
+  it("targets content feedback from the enabled trigger", () => {
+    expect(
+      accordion.variants.disabled.false.trigger?.["&:active .seed-accordion__pressedOverlay"],
+    ).toBeDefined();
+    expect(checkbox.variants.disabled.false.root?.["&:active .seed-checkmark__root"]).toBeDefined();
+    expect(radio.variants.disabled.false.root?.["&:active .seed-radiomark__root"]).toBeDefined();
+  });
+
+  it("transitions the page banner close button on the main thread", () => {
+    expect(pageBanner.variants.interactive.true.root).toHaveProperty("&:active");
+    expect(pageBanner.base.closeButton).toMatchObject({
+      transition: expect.stringContaining("background-color"),
+      "&:active": expect.objectContaining({ backgroundColor: expect.any(String) }),
+    });
+  });
+
+  it("gates select box and segmented feedback with resolved disabled state", () => {
+    expect(selectBox.variants.disabled.false.root["&:active"]).toBeDefined();
+    expect(selectBox.variants.disabled.true.root).not.toHaveProperty("&:active");
+    expect(
+      segmentedControl.variants.disabled.false.item[
+        "&:active .seed-segmented-control__itemBackground"
+      ],
+    ).toEqual({ opacity: 1 });
+    expect(segmentedControl.variants.disabled.true).not.toHaveProperty("item");
+    expect(segmentedControl.compoundVariants).toContainEqual({
+      disabled: true,
+      pressed: true,
+      css: { itemBackground: { opacity: 0 } },
+    });
+  });
+});

--- a/packages/lynx-qvism-preset/active-feedback.test.ts
+++ b/packages/lynx-qvism-preset/active-feedback.test.ts
@@ -41,11 +41,33 @@ describe("Lynx active feedback", () => {
   });
 
   it("transitions the page banner close button on the main thread", () => {
-    expect(pageBanner.variants.interactive.true.root).toHaveProperty("&:active");
     expect(pageBanner.base.closeButton).toMatchObject({
       transition: expect.stringContaining("background-color"),
       "&:active": expect.objectContaining({ backgroundColor: expect.any(String) }),
     });
+  });
+
+  it("gates page banner active backgrounds and matches the pressed fallback", () => {
+    expect(pageBanner.base.root).not.toHaveProperty("&:active");
+    expect(pageBanner.variants.interactive.true).not.toHaveProperty("root");
+    const compounds = pageBanner.compoundVariants ?? [];
+    const pressedVariants = compounds.filter((variant) => variant.pressed === true);
+    expect(pressedVariants).toHaveLength(11);
+    for (const pressed of pressedVariants) {
+      const active = compounds.find(
+        (variant) =>
+          variant.tone === pressed.tone &&
+          variant.variant === pressed.variant &&
+          variant.interactive === true,
+      );
+      expect(active?.css.root?.["&:active"]).toEqual(pressed.css.root);
+      expect(Object.keys(active?.css.root?.["&:active"] ?? {})).toEqual([
+        pressed.tone === "magic" ? "backgroundImage" : "backgroundColor",
+      ]);
+    }
+    for (const variant of compounds) {
+      if (variant.css.root?.["&:active"]) expect(variant.interactive).toBe(true);
+    }
   });
 
   it("gates select box and segmented feedback with resolved disabled state", () => {

--- a/packages/lynx-qvism-preset/src/recipes/accordion.ts
+++ b/packages/lynx-qvism-preset/src/recipes/accordion.ts
@@ -222,7 +222,13 @@ const accordion = defineSlotRecipe({
           color: itemVars.base.disabled.suffixIcon.color,
         },
       },
-      false: {},
+      false: {
+        trigger: {
+          "&:active .seed-accordion__pressedOverlay": {
+            backgroundColor: itemVars.base.pressed.trigger.color,
+          },
+        },
+      },
     },
   },
   compoundVariants: [

--- a/packages/lynx-qvism-preset/src/recipes/action-button.ts
+++ b/packages/lynx-qvism-preset/src/recipes/action-button.ts
@@ -409,9 +409,27 @@ const actionButton = defineSlotRecipe({
       css: { root: { background: vars.variantBrandSolid.pressed.root.color } },
     },
     {
+      variant: "brandSolid",
+      disabled: false,
+      loading: false,
+      css: {
+        root: {
+          "&:active": { background: vars.variantBrandSolid.pressed.root.color },
+        },
+      },
+    },
+    {
       variant: "neutralSolid",
       pressed: true,
       css: { root: { background: vars.variantNeutralSolid.pressed.root.color } },
+    },
+    {
+      variant: "neutralSolid",
+      disabled: false,
+      loading: false,
+      css: {
+        root: { "&:active": { background: vars.variantNeutralSolid.pressed.root.color } },
+      },
     },
     {
       variant: "neutralWeak",
@@ -419,9 +437,25 @@ const actionButton = defineSlotRecipe({
       css: { root: { background: vars.variantNeutralWeak.pressed.root.color } },
     },
     {
+      variant: "neutralWeak",
+      disabled: false,
+      loading: false,
+      css: {
+        root: { "&:active": { background: vars.variantNeutralWeak.pressed.root.color } },
+      },
+    },
+    {
       variant: "criticalSolid",
       pressed: true,
       css: { root: { background: vars.variantCriticalSolid.pressed.root.color } },
+    },
+    {
+      variant: "criticalSolid",
+      disabled: false,
+      loading: false,
+      css: {
+        root: { "&:active": { background: vars.variantCriticalSolid.pressed.root.color } },
+      },
     },
     {
       variant: "brandOutline",
@@ -429,14 +463,38 @@ const actionButton = defineSlotRecipe({
       css: { root: { background: vars.variantBrandOutline.pressed.root.color } },
     },
     {
+      variant: "brandOutline",
+      disabled: false,
+      loading: false,
+      css: {
+        root: { "&:active": { background: vars.variantBrandOutline.pressed.root.color } },
+      },
+    },
+    {
       variant: "neutralOutline",
       pressed: true,
       css: { root: { background: vars.variantNeutralOutline.pressed.root.color } },
     },
     {
+      variant: "neutralOutline",
+      disabled: false,
+      loading: false,
+      css: {
+        root: { "&:active": { background: vars.variantNeutralOutline.pressed.root.color } },
+      },
+    },
+    {
       variant: "ghost",
       pressed: true,
       css: { root: { background: vars.variantGhost.pressed.root.color } },
+    },
+    {
+      variant: "ghost",
+      disabled: false,
+      loading: false,
+      css: {
+        root: { "&:active": { background: vars.variantGhost.pressed.root.color } },
+      },
     },
 
     // ── variant × disabled — all slots ──────────────────────────────────────

--- a/packages/lynx-qvism-preset/src/recipes/callout.ts
+++ b/packages/lynx-qvism-preset/src/recipes/callout.ts
@@ -150,6 +150,10 @@ const callout = defineSlotRecipe({
       true: {},
       false: {},
     },
+    interactive: {
+      true: {},
+      false: {},
+    },
   },
   compoundVariants: [
     {
@@ -158,9 +162,21 @@ const callout = defineSlotRecipe({
       css: { root: { backgroundColor: vars.toneNeutral.pressed.root.color } },
     },
     {
+      tone: "neutral",
+      interactive: true,
+      css: { root: { "&:active": { backgroundColor: vars.toneNeutral.pressed.root.color } } },
+    },
+    {
       tone: "informative",
       pressed: true,
       css: { root: { backgroundColor: vars.toneInformative.pressed.root.color } },
+    },
+    {
+      tone: "informative",
+      interactive: true,
+      css: {
+        root: { "&:active": { backgroundColor: vars.toneInformative.pressed.root.color } },
+      },
     },
     {
       tone: "positive",
@@ -168,14 +184,29 @@ const callout = defineSlotRecipe({
       css: { root: { backgroundColor: vars.tonePositive.pressed.root.color } },
     },
     {
+      tone: "positive",
+      interactive: true,
+      css: { root: { "&:active": { backgroundColor: vars.tonePositive.pressed.root.color } } },
+    },
+    {
       tone: "warning",
       pressed: true,
       css: { root: { backgroundColor: vars.toneWarning.pressed.root.color } },
     },
     {
+      tone: "warning",
+      interactive: true,
+      css: { root: { "&:active": { backgroundColor: vars.toneWarning.pressed.root.color } } },
+    },
+    {
       tone: "critical",
       pressed: true,
       css: { root: { backgroundColor: vars.toneCritical.pressed.root.color } },
+    },
+    {
+      tone: "critical",
+      interactive: true,
+      css: { root: { "&:active": { backgroundColor: vars.toneCritical.pressed.root.color } } },
     },
     {
       tone: "magic",
@@ -186,10 +217,22 @@ const callout = defineSlotRecipe({
         },
       },
     },
+    {
+      tone: "magic",
+      interactive: true,
+      css: {
+        root: {
+          "&:active": {
+            backgroundImage: `linear-gradient(88deg, ${vars.toneMagic.pressed.root.gradient.serialized})`,
+          },
+        },
+      },
+    },
   ],
   defaultVariants: {
     tone: "neutral",
     pressed: false,
+    interactive: false,
   },
 });
 

--- a/packages/lynx-qvism-preset/src/recipes/checkbox.ts
+++ b/packages/lynx-qvism-preset/src/recipes/checkbox.ts
@@ -63,7 +63,16 @@ const checkboxRecipe = defineSlotRecipe({
       true: {
         label: { color: vars.base.disabled.label.color },
       },
-      false: {},
+      false: {
+        root: {
+          "&:active .seed-checkmark__root": {
+            backgroundColor: "var(--seed-checkmark-pressed-color)",
+          },
+          "&:active .seed-checkmark__background": {
+            opacity: 1,
+          },
+        },
+      },
     },
   },
   defaultVariants: {

--- a/packages/lynx-qvism-preset/src/recipes/checkmark.ts
+++ b/packages/lynx-qvism-preset/src/recipes/checkmark.ts
@@ -36,6 +36,7 @@ const checkmarkRecipe = defineSlotRecipe({
     variant: {
       square: {
         root: {
+          "--seed-checkmark-pressed-color": vars.variantSquare.pressed.root.color,
           borderWidth: vars.variantSquare.enabled.root.strokeWidth,
           borderStyle: "solid",
           borderColor: vars.variantSquare.enabled.root.strokeColor,
@@ -178,7 +179,10 @@ const checkmarkRecipe = defineSlotRecipe({
       checked: true,
       disabled: false,
       css: {
-        root: { backgroundColor: vars.variantSquareToneBrand.enabledSelected.root.color },
+        root: {
+          backgroundColor: vars.variantSquareToneBrand.enabledSelected.root.color,
+          "--seed-checkmark-pressed-color": vars.variantSquareToneBrand.pressedSelected.root.color,
+        },
         icon: { color: vars.variantSquareToneBrand.enabledSelected.icon.color },
       },
     },
@@ -188,7 +192,11 @@ const checkmarkRecipe = defineSlotRecipe({
       checked: true,
       disabled: false,
       css: {
-        root: { backgroundColor: vars.variantSquareToneNeutral.enabledSelected.root.color },
+        root: {
+          backgroundColor: vars.variantSquareToneNeutral.enabledSelected.root.color,
+          "--seed-checkmark-pressed-color":
+            vars.variantSquareToneNeutral.pressedSelected.root.color,
+        },
         icon: { color: vars.variantSquareToneNeutral.enabledSelected.icon.color },
       },
     },
@@ -198,7 +206,10 @@ const checkmarkRecipe = defineSlotRecipe({
       indeterminate: true,
       disabled: false,
       css: {
-        root: { backgroundColor: vars.variantSquareToneBrand.enabledSelected.root.color },
+        root: {
+          backgroundColor: vars.variantSquareToneBrand.enabledSelected.root.color,
+          "--seed-checkmark-pressed-color": vars.variantSquareToneBrand.pressedSelected.root.color,
+        },
         icon: { color: vars.variantSquareToneBrand.enabledSelected.icon.color },
       },
     },
@@ -208,7 +219,11 @@ const checkmarkRecipe = defineSlotRecipe({
       indeterminate: true,
       disabled: false,
       css: {
-        root: { backgroundColor: vars.variantSquareToneNeutral.enabledSelected.root.color },
+        root: {
+          backgroundColor: vars.variantSquareToneNeutral.enabledSelected.root.color,
+          "--seed-checkmark-pressed-color":
+            vars.variantSquareToneNeutral.pressedSelected.root.color,
+        },
         icon: { color: vars.variantSquareToneNeutral.enabledSelected.icon.color },
       },
     },

--- a/packages/lynx-qvism-preset/src/recipes/chip.ts
+++ b/packages/lynx-qvism-preset/src/recipes/chip.ts
@@ -256,10 +256,22 @@ const chip = defineSlotRecipe({
       css: { root: { background: vars.variantSolid.pressed.root.color } },
     },
     {
+      variant: "solid",
+      selected: false,
+      disabled: false,
+      css: { root: { "&:active": { background: vars.variantSolid.pressed.root.color } } },
+    },
+    {
       variant: "outlineStrong",
       pressed: true,
       selected: false,
       css: { root: { background: vars.variantOutlineStrong.pressed.root.color } },
+    },
+    {
+      variant: "outlineStrong",
+      selected: false,
+      disabled: false,
+      css: { root: { "&:active": { background: vars.variantOutlineStrong.pressed.root.color } } },
     },
     {
       variant: "outlineWeak",
@@ -268,10 +280,24 @@ const chip = defineSlotRecipe({
       css: { root: { background: vars.variantOutlineWeak.pressed.root.color } },
     },
     {
+      variant: "outlineWeak",
+      selected: false,
+      disabled: false,
+      css: { root: { "&:active": { background: vars.variantOutlineWeak.pressed.root.color } } },
+    },
+    {
       variant: "solid",
       selected: true,
       pressed: true,
       css: { root: { background: vars.variantSolid.selectedPressed.root.color } },
+    },
+    {
+      variant: "solid",
+      selected: true,
+      disabled: false,
+      css: {
+        root: { "&:active": { background: vars.variantSolid.selectedPressed.root.color } },
+      },
     },
     {
       variant: "outlineStrong",
@@ -280,10 +306,26 @@ const chip = defineSlotRecipe({
       css: { root: { background: vars.variantOutlineStrong.selectedPressed.root.color } },
     },
     {
+      variant: "outlineStrong",
+      selected: true,
+      disabled: false,
+      css: {
+        root: { "&:active": { background: vars.variantOutlineStrong.selectedPressed.root.color } },
+      },
+    },
+    {
       variant: "outlineWeak",
       selected: true,
       pressed: true,
       css: { root: { background: vars.variantOutlineWeak.selectedPressed.root.color } },
+    },
+    {
+      variant: "outlineWeak",
+      selected: true,
+      disabled: false,
+      css: {
+        root: { "&:active": { background: vars.variantOutlineWeak.selectedPressed.root.color } },
+      },
     },
   ],
   defaultVariants: {

--- a/packages/lynx-qvism-preset/src/recipes/page-banner.ts
+++ b/packages/lynx-qvism-preset/src/recipes/page-banner.ts
@@ -91,6 +91,10 @@ const pageBanner = defineSlotRecipe({
       marginLeft: `calc((${closeButtonVars.base.enabled.root.size} - ${closeButtonVars.base.enabled.icon.size}) * -0.5 + ${closeButtonVars.base.enabled.root.marginLeft})`,
       borderRadius: closeButtonVars.base.enabled.root.cornerRadius,
       backgroundColor: closeButtonVars.base.enabled.root.color,
+      transition: `background-color ${closeButtonVars.base.enabled.root.colorDuration} ${closeButtonVars.base.enabled.root.colorTimingFunction}`,
+      "&:active": {
+        backgroundColor: closeButtonVars.base.pressed.root.color,
+      },
     },
     prefixIcon: {
       flexShrink: 0,
@@ -129,6 +133,17 @@ const pageBanner = defineSlotRecipe({
       true: {},
       false: {},
     },
+    interactive: {
+      true: {
+        root: {
+          "&:active": {
+            backgroundColor: "var(--seed-page-banner-pressed-background-color)",
+            backgroundImage: "var(--seed-page-banner-pressed-background-image)",
+          },
+        },
+      },
+      false: {},
+    },
     closeButtonPressed: {
       true: {
         closeButton: { backgroundColor: closeButtonVars.base.pressed.root.color },
@@ -141,7 +156,11 @@ const pageBanner = defineSlotRecipe({
       tone: "neutral",
       variant: "weak",
       css: {
-        root: { backgroundColor: vars.toneNeutralVariantWeak.enabled.root.color },
+        root: {
+          backgroundColor: vars.toneNeutralVariantWeak.enabled.root.color,
+          "--seed-page-banner-pressed-background-color":
+            vars.toneNeutralVariantWeak.pressed.root.color,
+        },
         title: { color: vars.toneNeutralVariantWeak.enabled.title.color },
         description: { color: vars.toneNeutralVariantWeak.enabled.description.color },
         button: { color: vars.toneNeutralVariantWeak.enabled.button.color },
@@ -154,7 +173,11 @@ const pageBanner = defineSlotRecipe({
       tone: "neutral",
       variant: "solid",
       css: {
-        root: { backgroundColor: vars.toneNeutralVariantSolid.enabled.root.color },
+        root: {
+          backgroundColor: vars.toneNeutralVariantSolid.enabled.root.color,
+          "--seed-page-banner-pressed-background-color":
+            vars.toneNeutralVariantSolid.pressed.root.color,
+        },
         title: { color: vars.toneNeutralVariantSolid.enabled.title.color },
         description: { color: vars.toneNeutralVariantSolid.enabled.description.color },
         button: { color: vars.toneNeutralVariantSolid.enabled.button.color },
@@ -167,7 +190,11 @@ const pageBanner = defineSlotRecipe({
       tone: "informative",
       variant: "weak",
       css: {
-        root: { backgroundColor: vars.toneInformativeVariantWeak.enabled.root.color },
+        root: {
+          backgroundColor: vars.toneInformativeVariantWeak.enabled.root.color,
+          "--seed-page-banner-pressed-background-color":
+            vars.toneInformativeVariantWeak.pressed.root.color,
+        },
         title: { color: vars.toneInformativeVariantWeak.enabled.title.color },
         description: { color: vars.toneInformativeVariantWeak.enabled.description.color },
         button: { color: vars.toneInformativeVariantWeak.enabled.button.color },
@@ -180,7 +207,11 @@ const pageBanner = defineSlotRecipe({
       tone: "informative",
       variant: "solid",
       css: {
-        root: { backgroundColor: vars.toneInformativeVariantSolid.enabled.root.color },
+        root: {
+          backgroundColor: vars.toneInformativeVariantSolid.enabled.root.color,
+          "--seed-page-banner-pressed-background-color":
+            vars.toneInformativeVariantSolid.pressed.root.color,
+        },
         title: { color: vars.toneInformativeVariantSolid.enabled.title.color },
         description: { color: vars.toneInformativeVariantSolid.enabled.description.color },
         button: { color: vars.toneInformativeVariantSolid.enabled.button.color },
@@ -193,7 +224,11 @@ const pageBanner = defineSlotRecipe({
       tone: "positive",
       variant: "weak",
       css: {
-        root: { backgroundColor: vars.tonePositiveVariantWeak.enabled.root.color },
+        root: {
+          backgroundColor: vars.tonePositiveVariantWeak.enabled.root.color,
+          "--seed-page-banner-pressed-background-color":
+            vars.tonePositiveVariantWeak.pressed.root.color,
+        },
         title: { color: vars.tonePositiveVariantWeak.enabled.title.color },
         description: { color: vars.tonePositiveVariantWeak.enabled.description.color },
         button: { color: vars.tonePositiveVariantWeak.enabled.button.color },
@@ -206,7 +241,11 @@ const pageBanner = defineSlotRecipe({
       tone: "positive",
       variant: "solid",
       css: {
-        root: { backgroundColor: vars.tonePositiveVariantSolid.enabled.root.color },
+        root: {
+          backgroundColor: vars.tonePositiveVariantSolid.enabled.root.color,
+          "--seed-page-banner-pressed-background-color":
+            vars.tonePositiveVariantSolid.pressed.root.color,
+        },
         title: { color: vars.tonePositiveVariantSolid.enabled.title.color },
         description: { color: vars.tonePositiveVariantSolid.enabled.description.color },
         button: { color: vars.tonePositiveVariantSolid.enabled.button.color },
@@ -219,7 +258,11 @@ const pageBanner = defineSlotRecipe({
       tone: "warning",
       variant: "weak",
       css: {
-        root: { backgroundColor: vars.toneWarningVariantWeak.enabled.root.color },
+        root: {
+          backgroundColor: vars.toneWarningVariantWeak.enabled.root.color,
+          "--seed-page-banner-pressed-background-color":
+            vars.toneWarningVariantWeak.pressed.root.color,
+        },
         title: { color: vars.toneWarningVariantWeak.enabled.title.color },
         description: { color: vars.toneWarningVariantWeak.enabled.description.color },
         button: { color: vars.toneWarningVariantWeak.enabled.button.color },
@@ -232,7 +275,11 @@ const pageBanner = defineSlotRecipe({
       tone: "warning",
       variant: "solid",
       css: {
-        root: { backgroundColor: vars.toneWarningVariantSolid.enabled.root.color },
+        root: {
+          backgroundColor: vars.toneWarningVariantSolid.enabled.root.color,
+          "--seed-page-banner-pressed-background-color":
+            vars.toneWarningVariantSolid.pressed.root.color,
+        },
         title: { color: vars.toneWarningVariantSolid.enabled.title.color },
         description: { color: vars.toneWarningVariantSolid.enabled.description.color },
         button: { color: vars.toneWarningVariantSolid.enabled.button.color },
@@ -245,7 +292,11 @@ const pageBanner = defineSlotRecipe({
       tone: "critical",
       variant: "weak",
       css: {
-        root: { backgroundColor: vars.toneCriticalVariantWeak.enabled.root.color },
+        root: {
+          backgroundColor: vars.toneCriticalVariantWeak.enabled.root.color,
+          "--seed-page-banner-pressed-background-color":
+            vars.toneCriticalVariantWeak.pressed.root.color,
+        },
         title: { color: vars.toneCriticalVariantWeak.enabled.title.color },
         description: { color: vars.toneCriticalVariantWeak.enabled.description.color },
         button: { color: vars.toneCriticalVariantWeak.enabled.button.color },
@@ -258,7 +309,11 @@ const pageBanner = defineSlotRecipe({
       tone: "critical",
       variant: "solid",
       css: {
-        root: { backgroundColor: vars.toneCriticalVariantSolid.enabled.root.color },
+        root: {
+          backgroundColor: vars.toneCriticalVariantSolid.enabled.root.color,
+          "--seed-page-banner-pressed-background-color":
+            vars.toneCriticalVariantSolid.pressed.root.color,
+        },
         title: { color: vars.toneCriticalVariantSolid.enabled.title.color },
         description: { color: vars.toneCriticalVariantSolid.enabled.description.color },
         button: { color: vars.toneCriticalVariantSolid.enabled.button.color },
@@ -273,6 +328,7 @@ const pageBanner = defineSlotRecipe({
       css: {
         root: {
           backgroundImage: `linear-gradient(88deg, ${vars.toneMagicVariantWeak.enabled.root.gradient.serialized})`,
+          "--seed-page-banner-pressed-background-image": `linear-gradient(88deg, ${vars.toneMagicVariantWeak.pressed.root.gradient.serialized})`,
         },
         title: { color: vars.toneMagicVariantWeak.enabled.title.color },
         description: { color: vars.toneMagicVariantWeak.enabled.description.color },
@@ -358,6 +414,7 @@ const pageBanner = defineSlotRecipe({
     variant: "weak",
     pressed: false,
     closeButtonPressed: false,
+    interactive: false,
   },
 });
 

--- a/packages/lynx-qvism-preset/src/recipes/page-banner.ts
+++ b/packages/lynx-qvism-preset/src/recipes/page-banner.ts
@@ -134,14 +134,7 @@ const pageBanner = defineSlotRecipe({
       false: {},
     },
     interactive: {
-      true: {
-        root: {
-          "&:active": {
-            backgroundColor: "var(--seed-page-banner-pressed-background-color)",
-            backgroundImage: "var(--seed-page-banner-pressed-background-image)",
-          },
-        },
-      },
+      true: {},
       false: {},
     },
     closeButtonPressed: {
@@ -155,11 +148,141 @@ const pageBanner = defineSlotRecipe({
     {
       tone: "neutral",
       variant: "weak",
+      interactive: true,
+      css: {
+        root: {
+          "&:active": {
+            backgroundColor: vars.toneNeutralVariantWeak.pressed.root.color,
+          },
+        },
+      },
+    },
+    {
+      tone: "neutral",
+      variant: "solid",
+      interactive: true,
+      css: {
+        root: {
+          "&:active": {
+            backgroundColor: vars.toneNeutralVariantSolid.pressed.root.color,
+          },
+        },
+      },
+    },
+    {
+      tone: "informative",
+      variant: "weak",
+      interactive: true,
+      css: {
+        root: {
+          "&:active": {
+            backgroundColor: vars.toneInformativeVariantWeak.pressed.root.color,
+          },
+        },
+      },
+    },
+    {
+      tone: "informative",
+      variant: "solid",
+      interactive: true,
+      css: {
+        root: {
+          "&:active": {
+            backgroundColor: vars.toneInformativeVariantSolid.pressed.root.color,
+          },
+        },
+      },
+    },
+    {
+      tone: "positive",
+      variant: "weak",
+      interactive: true,
+      css: {
+        root: {
+          "&:active": {
+            backgroundColor: vars.tonePositiveVariantWeak.pressed.root.color,
+          },
+        },
+      },
+    },
+    {
+      tone: "positive",
+      variant: "solid",
+      interactive: true,
+      css: {
+        root: {
+          "&:active": {
+            backgroundColor: vars.tonePositiveVariantSolid.pressed.root.color,
+          },
+        },
+      },
+    },
+    {
+      tone: "warning",
+      variant: "weak",
+      interactive: true,
+      css: {
+        root: {
+          "&:active": {
+            backgroundColor: vars.toneWarningVariantWeak.pressed.root.color,
+          },
+        },
+      },
+    },
+    {
+      tone: "warning",
+      variant: "solid",
+      interactive: true,
+      css: {
+        root: {
+          "&:active": {
+            backgroundColor: vars.toneWarningVariantSolid.pressed.root.color,
+          },
+        },
+      },
+    },
+    {
+      tone: "critical",
+      variant: "weak",
+      interactive: true,
+      css: {
+        root: {
+          "&:active": {
+            backgroundColor: vars.toneCriticalVariantWeak.pressed.root.color,
+          },
+        },
+      },
+    },
+    {
+      tone: "critical",
+      variant: "solid",
+      interactive: true,
+      css: {
+        root: {
+          "&:active": {
+            backgroundColor: vars.toneCriticalVariantSolid.pressed.root.color,
+          },
+        },
+      },
+    },
+    {
+      tone: "magic",
+      variant: "weak",
+      interactive: true,
+      css: {
+        root: {
+          "&:active": {
+            backgroundImage: `linear-gradient(88deg, ${vars.toneMagicVariantWeak.pressed.root.gradient.serialized})`,
+          },
+        },
+      },
+    },
+    {
+      tone: "neutral",
+      variant: "weak",
       css: {
         root: {
           backgroundColor: vars.toneNeutralVariantWeak.enabled.root.color,
-          "--seed-page-banner-pressed-background-color":
-            vars.toneNeutralVariantWeak.pressed.root.color,
         },
         title: { color: vars.toneNeutralVariantWeak.enabled.title.color },
         description: { color: vars.toneNeutralVariantWeak.enabled.description.color },
@@ -175,8 +298,6 @@ const pageBanner = defineSlotRecipe({
       css: {
         root: {
           backgroundColor: vars.toneNeutralVariantSolid.enabled.root.color,
-          "--seed-page-banner-pressed-background-color":
-            vars.toneNeutralVariantSolid.pressed.root.color,
         },
         title: { color: vars.toneNeutralVariantSolid.enabled.title.color },
         description: { color: vars.toneNeutralVariantSolid.enabled.description.color },
@@ -192,8 +313,6 @@ const pageBanner = defineSlotRecipe({
       css: {
         root: {
           backgroundColor: vars.toneInformativeVariantWeak.enabled.root.color,
-          "--seed-page-banner-pressed-background-color":
-            vars.toneInformativeVariantWeak.pressed.root.color,
         },
         title: { color: vars.toneInformativeVariantWeak.enabled.title.color },
         description: { color: vars.toneInformativeVariantWeak.enabled.description.color },
@@ -209,8 +328,6 @@ const pageBanner = defineSlotRecipe({
       css: {
         root: {
           backgroundColor: vars.toneInformativeVariantSolid.enabled.root.color,
-          "--seed-page-banner-pressed-background-color":
-            vars.toneInformativeVariantSolid.pressed.root.color,
         },
         title: { color: vars.toneInformativeVariantSolid.enabled.title.color },
         description: { color: vars.toneInformativeVariantSolid.enabled.description.color },
@@ -226,8 +343,6 @@ const pageBanner = defineSlotRecipe({
       css: {
         root: {
           backgroundColor: vars.tonePositiveVariantWeak.enabled.root.color,
-          "--seed-page-banner-pressed-background-color":
-            vars.tonePositiveVariantWeak.pressed.root.color,
         },
         title: { color: vars.tonePositiveVariantWeak.enabled.title.color },
         description: { color: vars.tonePositiveVariantWeak.enabled.description.color },
@@ -243,8 +358,6 @@ const pageBanner = defineSlotRecipe({
       css: {
         root: {
           backgroundColor: vars.tonePositiveVariantSolid.enabled.root.color,
-          "--seed-page-banner-pressed-background-color":
-            vars.tonePositiveVariantSolid.pressed.root.color,
         },
         title: { color: vars.tonePositiveVariantSolid.enabled.title.color },
         description: { color: vars.tonePositiveVariantSolid.enabled.description.color },
@@ -260,8 +373,6 @@ const pageBanner = defineSlotRecipe({
       css: {
         root: {
           backgroundColor: vars.toneWarningVariantWeak.enabled.root.color,
-          "--seed-page-banner-pressed-background-color":
-            vars.toneWarningVariantWeak.pressed.root.color,
         },
         title: { color: vars.toneWarningVariantWeak.enabled.title.color },
         description: { color: vars.toneWarningVariantWeak.enabled.description.color },
@@ -277,8 +388,6 @@ const pageBanner = defineSlotRecipe({
       css: {
         root: {
           backgroundColor: vars.toneWarningVariantSolid.enabled.root.color,
-          "--seed-page-banner-pressed-background-color":
-            vars.toneWarningVariantSolid.pressed.root.color,
         },
         title: { color: vars.toneWarningVariantSolid.enabled.title.color },
         description: { color: vars.toneWarningVariantSolid.enabled.description.color },
@@ -294,8 +403,6 @@ const pageBanner = defineSlotRecipe({
       css: {
         root: {
           backgroundColor: vars.toneCriticalVariantWeak.enabled.root.color,
-          "--seed-page-banner-pressed-background-color":
-            vars.toneCriticalVariantWeak.pressed.root.color,
         },
         title: { color: vars.toneCriticalVariantWeak.enabled.title.color },
         description: { color: vars.toneCriticalVariantWeak.enabled.description.color },
@@ -311,8 +418,6 @@ const pageBanner = defineSlotRecipe({
       css: {
         root: {
           backgroundColor: vars.toneCriticalVariantSolid.enabled.root.color,
-          "--seed-page-banner-pressed-background-color":
-            vars.toneCriticalVariantSolid.pressed.root.color,
         },
         title: { color: vars.toneCriticalVariantSolid.enabled.title.color },
         description: { color: vars.toneCriticalVariantSolid.enabled.description.color },
@@ -328,7 +433,6 @@ const pageBanner = defineSlotRecipe({
       css: {
         root: {
           backgroundImage: `linear-gradient(88deg, ${vars.toneMagicVariantWeak.enabled.root.gradient.serialized})`,
-          "--seed-page-banner-pressed-background-image": `linear-gradient(88deg, ${vars.toneMagicVariantWeak.pressed.root.gradient.serialized})`,
         },
         title: { color: vars.toneMagicVariantWeak.enabled.title.color },
         description: { color: vars.toneMagicVariantWeak.enabled.description.color },

--- a/packages/lynx-qvism-preset/src/recipes/radio.ts
+++ b/packages/lynx-qvism-preset/src/recipes/radio.ts
@@ -63,7 +63,13 @@ const radioRecipe = defineSlotRecipe({
       true: {
         label: { color: vars.base.disabled.label.color },
       },
-      false: {},
+      false: {
+        root: {
+          "&:active .seed-radiomark__root": {
+            backgroundColor: "var(--seed-radiomark-pressed-color)",
+          },
+        },
+      },
     },
   },
   defaultVariants: {

--- a/packages/lynx-qvism-preset/src/recipes/radiomark.ts
+++ b/packages/lynx-qvism-preset/src/recipes/radiomark.ts
@@ -24,6 +24,7 @@ const radiomarkRecipe = defineSlotRecipe({
       borderRadius: vars.base.enabled.root.cornerRadius,
 
       transition: `background-color ${vars.base.enabled.root.colorDuration} ${vars.base.enabled.root.colorTimingFunction}`,
+      "--seed-radiomark-pressed-color": vars.base.enabledPressed.root.color,
     },
     icon: {
       borderRadius: vars.base.enabled.icon.cornerRadius,
@@ -79,6 +80,7 @@ const radiomarkRecipe = defineSlotRecipe({
       css: {
         root: {
           backgroundColor: vars.toneBrand.enabledSelected.root.color,
+          "--seed-radiomark-pressed-color": vars.toneBrand.enabledSelectedPressed.root.color,
           borderWidth: vars.base.enabledSelected.root.strokeWidth,
           borderColor: vars.base.enabledSelected.root.strokeColor,
         },
@@ -95,6 +97,7 @@ const radiomarkRecipe = defineSlotRecipe({
       css: {
         root: {
           backgroundColor: vars.toneNeutral.enabledSelected.root.color,
+          "--seed-radiomark-pressed-color": vars.toneNeutral.enabledSelectedPressed.root.color,
           borderWidth: vars.base.enabledSelected.root.strokeWidth,
           borderColor: vars.base.enabledSelected.root.strokeColor,
         },

--- a/packages/lynx-qvism-preset/src/recipes/segmented-control.ts
+++ b/packages/lynx-qvism-preset/src/recipes/segmented-control.ts
@@ -109,7 +109,13 @@ const segmentedControl = defineSlotRecipe({
           color: itemVars.base.disabled.label.color,
         },
       },
-      false: {},
+      false: {
+        item: {
+          "&:active .seed-segmented-control__itemBackground": {
+            opacity: 1,
+          },
+        },
+      },
     },
     pressed: {
       true: {
@@ -129,6 +135,15 @@ const segmentedControl = defineSlotRecipe({
     },
   },
   compoundVariants: [
+    {
+      disabled: true,
+      pressed: true,
+      css: {
+        itemBackground: {
+          opacity: 0,
+        },
+      },
+    },
     {
       selected: true,
       disabled: true,

--- a/packages/lynx-qvism-preset/src/recipes/select-box.ts
+++ b/packages/lynx-qvism-preset/src/recipes/select-box.ts
@@ -208,7 +208,13 @@ export const selectBox = defineSlotRecipe({
           color: vars.base.disabled.description.color,
         },
       },
-      false: {},
+      false: {
+        root: {
+          "&:active": {
+            backgroundColor: vars.base.enabledPressed.root.color,
+          },
+        },
+      },
     },
     footerOpen: {
       true: {

--- a/packages/lynx-qvism-preset/src/utils/define.ts
+++ b/packages/lynx-qvism-preset/src/utils/define.ts
@@ -122,12 +122,14 @@ type StrictLynxInput<T> = RejectCssWideKeywords<T>;
 /**
  * Style object constrained to the SEED Lynx preset contract. It starts from
  * Lynx's known longhand/shorthand CSS keys, then removes web-only properties
- * that SEED does not allow in preset sources. State styles should be modeled
- * as recipe variants instead of selector nesting. Supported pseudo-elements
- * may be added explicitly when they cannot be represented as variants.
+ * that SEED does not allow in preset sources. Interaction state is normally
+ * modeled as a recipe variant; `:active` is the narrow exception for feedback
+ * that must begin on the Lynx Main Thread.
  */
 export type LynxStyleObject = LynxStyleProperties & {
   "&::placeholder"?: LynxStyleProperties;
+  "&:active"?: LynxStyleProperties;
+  [selector: `&:active ${string}`]: LynxStyleProperties | undefined;
 };
 
 type LynxSlotRecord<S extends string> = Partial<Record<S, LynxStyleObject>>;

--- a/packages/lynx-react/src/components/Callout/Callout.tsx
+++ b/packages/lynx-react/src/components/Callout/Callout.tsx
@@ -48,7 +48,7 @@ function useCalloutContext(consumer: string) {
  * - 웹 focus ring은 지원하지 않습니다.
  */
 export interface CalloutRootProps
-  extends Omit<CalloutVariantProps, "pressed">,
+  extends Omit<CalloutVariantProps, "pressed" | "interactive">,
     LynxStyledElementProps,
     LynxPressableProps,
     LynxAccessibilityProps {
@@ -89,7 +89,7 @@ export const CalloutRoot = React.forwardRef<unknown, CalloutRootProps>((props, r
     onTouchEnd: bindtouchend,
     onTouchCancel: bindtouchcancel,
   });
-  const classNames = callout({ ...variantProps, pressed });
+  const classNames = callout({ ...variantProps, pressed, interactive: isInteractive });
   const dismiss = useMemoizedFn(() => {
     if (!open) return;
 

--- a/packages/lynx-react/src/components/PageBanner/PageBanner.tsx
+++ b/packages/lynx-react/src/components/PageBanner/PageBanner.tsx
@@ -50,7 +50,7 @@ function usePageBannerContext(consumer: string) {
  * - Does not provide a web focus ring.
  */
 export interface PageBannerRootProps
-  extends Omit<PageBannerVariantProps, "pressed" | "closeButtonPressed">,
+  extends Omit<PageBannerVariantProps, "pressed" | "closeButtonPressed" | "interactive">,
     LynxStyledElementProps,
     LynxPressableProps,
     LynxAccessibilityProps {
@@ -94,7 +94,11 @@ export const PageBannerRoot = React.forwardRef<unknown, PageBannerRootProps>((pr
     onTap: bindtap,
     mainThreadOnTap: mainThreadBindtap,
   });
-  const classNames = pageBanner({ ...variantProps, pressed: pressTap.pressed });
+  const classNames = pageBanner({
+    ...variantProps,
+    pressed: pressTap.pressed,
+    interactive: isInteractive,
+  });
   const dismiss = useMemoizedFn(() => {
     if (!open) return;
 


### PR DESCRIPTION
## 변경 사항

- #2135 위에 pressed 색상 피드백만 추가합니다. Scale Feedback 훅·유틸·컴포넌트 적용은 모두 #2135에 포함됩니다.
- Background Thread의 className 갱신을 기다리지 않고 Lynx CSS `:active`에서 시각 반응을 시작합니다.
- 대상: Action Button, Chip, Callout, Accordion, Checkbox, Radio Group, Page Banner의 actionable Root·Close Button, Select Box, Segmented Control.
- Self selector 또는 내부 slot selector로 색상/overlay를 변경하며 disabled·loading 상태에서는 활성 피드백을 차단합니다.
- 기존 `pressed` variant와 `usePressTap()`은 tap 처리와 상태 기반 렌더링을 위해 유지합니다.
- Select Box는 배경색, Segmented Control은 item background overlay를 Main Thread 입력에 연결합니다.
- `@seed-design/lynx-react`, `@seed-design/lynx-css`의 기존 minor changeset을 유지하고 적용 컴포넌트를 목록으로 정리합니다.

## PR Stack

- Base: #2135 (`feat/lynx-scale-feedback`)
- This PR: pressed 색상 변경만 포함

## 검증

- `bun generate:all`
- #2135의 Rootage workspace/lockfile 정렬을 포함합니다. `bun install --frozen-lockfile --ignore-scripts` 재검증이 통과했습니다.
- `bun test:all` — unit 1,975개 통과, 기존 scaffold 테스트 1개 실패. 최신 minor에서도 Result Section 예제 수에 대한 경고 차이가 재현되며 이번 변경 범위 밖입니다.
- `bun test:lynx-react` — 261개 통과. enabled/disabled active selector 검증은 unit 테스트에 포함됩니다.
- `bun --filter @seed-design/lynx-react build`
- 로컬 playground: lint, tooling 테스트, typecheck, 단일 bundle build, doctor
- PlayLynx에서 Select Box·Segmented Control의 press 중 색상 변화와 콘텐츠 축소를 확인했습니다.
- iOS/Android Karrot Alpha Engine 3.9 검증은 아직 완료하지 않았습니다. PlayLynx smoke test와 구분합니다.

## 참고

- CI에 특정 SEED PR/SHA를 고정하지 않습니다. native 검증은 선택한 SEED worktree를 로컬 playground에 링크해 수행합니다.
- 설계·구현·문서 정리에 LLM을 활용했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - Lynx 컴포넌트의 눌림(pressed) 색상 피드백이 탭과 동시에 빠르게 시작됩니다.
  - Action Button, Chip, Callout, Accordion, Checkbox, Radio, Select Box, Segmented Control, Page Banner에 적용되었습니다.
  - 짧은 탭에서도 일관된 색상 전환을 제공합니다.
  - 비활성화 또는 로딩 상태에서는 눌림 피드백이 표시되지 않습니다.
  - Page Banner 닫기 버튼에 부드러운 색상 전환을 추가했습니다.

- **문서**
  - Lynx의 눌림 색상 피드백 동작과 적용 방식을 문서화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->