### PR TITLE
feat(lynx): add manner temp components

### DIFF
--- a/.changeset/warm-manners-arrive.md
+++ b/.changeset/warm-manners-arrive.md
@@ -1,0 +1,6 @@
+---
+"@seed-design/lynx-css": minor
+"@seed-design/lynx-react": minor
+---
+
+Lynx용 `MannerTemp`, `MannerTempEmote`, `MannerTempBadge` 컴포넌트를 추가합니다.

--- a/docs/content/lynx/components/manner-temp-badge.mdx
+++ b/docs/content/lynx/components/manner-temp-badge.mdx
@@ -1,0 +1,55 @@
+---
+title: Manner Temp Badge
+description: 매너온도를 작은 배지 형태로 표현하는 컴포넌트입니다.
+compatibility:
+  lynx:
+    engine: "1.0"
+---
+
+<AvailableSince packages="@seed-design/lynx-react@0.6.0, @seed-design/lynx-css@0.10.0" />
+
+<LynxComponentExample name="lynx/manner-temp-badge/preview">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/manner-temp-badge/preview.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+## 설치
+
+```package-install
+@seed-design/lynx-react @seed-design/lynx-css
+```
+
+<Callout>
+Lynx `MannerTempBadge`는 별도 `ui:manner-temp-badge` snippet 없이 `@seed-design/lynx-react` 패키지에서 직접 제공합니다.
+</Callout>
+
+## 속성
+
+<react-type-table path="../packages/lynx-react/src/components/MannerTempBadge/MannerTempBadge.tsx" name="MannerTempBadgeProps" />
+
+## 사용법
+
+`level`에 매너온도 구간을 지정하고 자식으로 표시할 온도를 전달합니다.
+
+```tsx
+import { MannerTempBadge } from "@seed-design/lynx-react";
+
+export function App() {
+  return <MannerTempBadge level="l4">36.5°C</MannerTempBadge>;
+}
+```
+
+## 웹 버전과의 차이
+
+<Callout type="warning">
+
+- **렌더링 요소.** HTML `<span>` 대신 native `<view>`와 `<text>`를 렌더링합니다.
+- **공개 경로.** React 문서의 `ui:manner-temp-badge` snippet과 달리 Lynx에서는 패키지 API를 직접 사용합니다.
+- **온도 변환.** Lynx 패키지는 `temperature`를 `level`로 바꾸지 않습니다. 제품의 매너온도 기준에 따라 `level`을 계산해 전달하세요.
+- **다형 렌더링.** 웹의 `asChild`와 HTML attribute 표면은 제공하지 않습니다.
+
+</Callout>

--- a/docs/content/lynx/components/manner-temp.mdx
+++ b/docs/content/lynx/components/manner-temp.mdx
@@ -1,0 +1,66 @@
+---
+title: Manner Temp
+description: 사용자의 매너온도를 온도와 표정 이미지로 표현하는 컴포넌트입니다.
+compatibility:
+  lynx:
+    engine: "2.14"
+---
+
+<AvailableSince packages="@seed-design/lynx-react@0.6.0, @seed-design/lynx-css@0.10.0" />
+
+<LynxComponentExample name="lynx/manner-temp/preview">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/manner-temp/preview.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+## 설치
+
+```package-install
+@seed-design/lynx-react @seed-design/lynx-css
+```
+
+<Callout>
+Lynx `MannerTemp`는 별도 `ui:manner-temp` snippet 없이 `@seed-design/lynx-react` 패키지에서 직접 제공합니다.
+</Callout>
+
+## 속성
+
+### `MannerTemp`
+
+<react-type-table path="../packages/lynx-react/src/components/MannerTemp/MannerTemp.tsx" name="MannerTempProps" />
+
+### `MannerTempEmote`
+
+<react-type-table path="../packages/lynx-react/src/components/MannerTemp/MannerTemp.tsx" name="MannerTempEmoteProps" />
+
+## 사용법
+
+`level`에 매너온도 구간을 지정합니다. `MannerTempEmote`를 자식으로 넣으면 같은 `level`의 표정 이미지를 표시합니다.
+
+```tsx
+import { MannerTemp, MannerTempEmote } from "@seed-design/lynx-react";
+
+export function App() {
+  return (
+    <MannerTemp level="l4">
+      36.5°C
+      <MannerTempEmote />
+    </MannerTemp>
+  );
+}
+```
+
+## 웹 버전과의 차이
+
+<Callout type="warning">
+
+- **렌더링 요소.** HTML `<span>`과 `<img>` 대신 native `<view>`, `<text>`, `<image>`를 렌더링합니다.
+- **공개 경로.** React 문서의 `ui:manner-temp` snippet과 달리 Lynx에서는 패키지 API를 직접 사용합니다.
+- **온도 변환.** Lynx 패키지는 `temperature`를 `level`로 바꾸지 않습니다. 제품의 매너온도 기준에 따라 `level`을 계산해 전달하세요.
+- **다형 렌더링.** 웹의 `asChild`와 HTML attribute 표면은 제공하지 않습니다.
+
+</Callout>

--- a/docs/examples/lynx/manner-temp-badge/preview.tsx
+++ b/docs/examples/lynx/manner-temp-badge/preview.tsx
@@ -1,0 +1,43 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { MannerTempBadge, useSeedClassName, VStack } from "@seed-design/lynx-react";
+
+const mannerTemps = [
+  ["l1", "12.5°C"],
+  ["l2", "30°C"],
+  ["l3", "36°C"],
+  ["l4", "36.5°C"],
+  ["l5", "37°C"],
+  ["l6", "40°C"],
+  ["l7", "45°C"],
+  ["l8", "55°C"],
+  ["l9", "65°C"],
+  ["l10", "80°C"],
+] as const;
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack
+        width="full"
+        height="full"
+        align="center"
+        justify="center"
+        gap="x1"
+        p="x4"
+        bg="bg.layerDefault"
+      >
+        {mannerTemps.map(([level, label]) => (
+          <MannerTempBadge key={level} level={level}>
+            {label}
+          </MannerTempBadge>
+        ))}
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/manner-temp-badge/styles.ts
+++ b/docs/examples/lynx/manner-temp-badge/styles.ts
@@ -1,0 +1,1 @@
+import "@seed-design/lynx-css/base.css";

--- a/docs/examples/lynx/manner-temp/preview.tsx
+++ b/docs/examples/lynx/manner-temp/preview.tsx
@@ -1,0 +1,44 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { MannerTemp, MannerTempEmote, useSeedClassName, VStack } from "@seed-design/lynx-react";
+
+const mannerTemps = [
+  ["l1", "12.5°C"],
+  ["l2", "30°C"],
+  ["l3", "36°C"],
+  ["l4", "36.5°C"],
+  ["l5", "37°C"],
+  ["l6", "40°C"],
+  ["l7", "45°C"],
+  ["l8", "55°C"],
+  ["l9", "65°C"],
+  ["l10", "80°C"],
+] as const;
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack
+        width="full"
+        height="full"
+        align="center"
+        justify="center"
+        gap="x1"
+        p="x4"
+        bg="bg.layerDefault"
+      >
+        {mannerTemps.map(([level, label]) => (
+          <MannerTemp key={level} level={level}>
+            {label}
+            <MannerTempEmote />
+          </MannerTemp>
+        ))}
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/manner-temp/styles.ts
+++ b/docs/examples/lynx/manner-temp/styles.ts
@@ -1,0 +1,1 @@
+import "@seed-design/lynx-css/base.css";

--- a/docs/public/__docs__/index.json
+++ b/docs/public/__docs__/index.json
@@ -2170,6 +2170,18 @@
               "docUrl": "/lynx/components/keyboard-avoiding-scroll-view"
             },
             {
+              "id": "manner-temp",
+              "title": "Manner Temp",
+              "description": "사용자의 매너온도를 온도와 표정 이미지로 표현하는 컴포넌트입니다.",
+              "docUrl": "/lynx/components/manner-temp"
+            },
+            {
+              "id": "manner-temp-badge",
+              "title": "Manner Temp Badge",
+              "description": "매너온도를 작은 배지 형태로 표현하는 컴포넌트입니다.",
+              "docUrl": "/lynx/components/manner-temp-badge"
+            },
+            {
               "id": "notification-badge",
               "title": "Notification Badge",
               "description": "아이콘이나 텍스트에 새로운 알림 또는 읽지 않은 항목이 있음을 표시하는 컴포넌트입니다.",

--- a/examples/lynx-spa/src/App.tsx
+++ b/examples/lynx-spa/src/App.tsx
@@ -19,6 +19,7 @@ import {
   LayoutStressTailwindPage,
 } from "./pages/LayoutPrimitiveStressPages.jsx";
 import { LayoutPrimitivesPage } from "./pages/LayoutPrimitivesPage.jsx";
+import { MannerTempPage } from "./pages/MannerTempPage.jsx";
 import { NestedVarsTestPage } from "./pages/NestedVarsTestPage.jsx";
 import { PageBannerPage } from "./pages/PageBannerPage.jsx";
 import { ProgressCirclePage } from "./pages/ProgressCirclePage.jsx";
@@ -52,6 +53,7 @@ export type Page =
   | "bottom-sheet"
   | "callout"
   | "checkbox"
+  | "manner-temp"
   | "page-banner"
   | "progress-circle"
   | "radio-group"
@@ -92,6 +94,7 @@ const FULLSCREEN_PAGES = new Set<Page>([
   "bottom-sheet",
   "callout",
   "checkbox",
+  "manner-temp",
   "page-banner",
   "progress-circle",
   "radio-group",
@@ -158,6 +161,7 @@ export function App(props: { onRender?: () => void }) {
         {currentPage === "bottom-sheet" && <BottomSheetPage />}
         {currentPage === "callout" && <CalloutPage />}
         {currentPage === "checkbox" && <CheckboxPage />}
+        {currentPage === "manner-temp" && <MannerTempPage />}
         {currentPage === "page-banner" && <PageBannerPage />}
         {currentPage === "progress-circle" && <ProgressCirclePage />}
         {currentPage === "radio-group" && <RadioGroupPage />}

--- a/examples/lynx-spa/src/pages/HomePage.tsx
+++ b/examples/lynx-spa/src/pages/HomePage.tsx
@@ -47,6 +47,7 @@ export function HomePage({ navigate }: { navigate: (page: Page) => void }) {
       <ListItem title="BottomSheet" onTap={() => navigate("bottom-sheet")} />
       <ListItem title="Callout" onTap={() => navigate("callout")} />
       <ListItem title="Checkbox" onTap={() => navigate("checkbox")} />
+      <ListItem title="Manner Temp" onTap={() => navigate("manner-temp")} />
       <ListItem title="PageBanner" onTap={() => navigate("page-banner")} />
       <ListItem title="ProgressCircle" onTap={() => navigate("progress-circle")} />
       <ListItem title="RadioGroup" onTap={() => navigate("radio-group")} />

--- a/examples/lynx-spa/src/pages/MannerTempPage.tsx
+++ b/examples/lynx-spa/src/pages/MannerTempPage.tsx
@@ -1,0 +1,58 @@
+import { mannerTempVariantMap } from "@seed-design/lynx-css/recipes/manner-temp";
+import { MannerTemp, MannerTempBadge, MannerTempEmote, VStack } from "@seed-design/lynx-react";
+
+import { CatalogExamples, CatalogSectionTitle } from "../components/catalog-examples.jsx";
+import {
+  defineVariantAxes,
+  VariantCatalog,
+  type VariantCatalogValues,
+} from "../components/variant-catalog.jsx";
+
+const variants = defineVariantAxes([
+  {
+    key: "level",
+    options: mannerTempVariantMap.level,
+    defaultValue: "l1",
+  },
+]);
+
+type MannerTempValues = VariantCatalogValues<typeof variants>;
+
+function renderMannerTemp(values: MannerTempValues) {
+  return (
+    <VStack gap="x2" align="center">
+      <MannerTemp level={values.level}>
+        36.5°C
+        <MannerTempEmote />
+      </MannerTemp>
+      <MannerTempBadge level={values.level}>36.5°C</MannerTempBadge>
+    </VStack>
+  );
+}
+
+function MannerTempExamples() {
+  return (
+    <CatalogExamples title="Manner Temp" gap="12px">
+      <CatalogSectionTitle>Levels</CatalogSectionTitle>
+      <view className="flex flex-row flex-wrap gap-x3 items-center">
+        {mannerTempVariantMap.level.map((level) => (
+          <VStack key={level} gap="x1" align="center">
+            <MannerTemp level={level}>
+              36.5°C
+              <MannerTempEmote />
+            </MannerTemp>
+            <MannerTempBadge level={level}>36.5°C</MannerTempBadge>
+          </VStack>
+        ))}
+      </view>
+    </CatalogExamples>
+  );
+}
+
+export function MannerTempPage() {
+  return (
+    <VariantCatalog variants={variants} examples={<MannerTempExamples />}>
+      {(values) => renderMannerTemp(values)}
+    </VariantCatalog>
+  );
+}

--- a/packages/lynx-css/all.css
+++ b/packages/lynx-css/all.css
@@ -2441,6 +2441,171 @@ text {
   font-weight: var(--seed-font-weight-bold);
 }
 
+.seed-manner-temp__root {
+  justify-content: flex-start;
+  align-items: center;
+  gap: var(--seed-dimension-x1);
+  flex-direction: row;
+  flex-shrink: 0;
+  display: flex;
+}
+
+.seed-manner-temp__label {
+  font-size: var(--seed-font-size-t5);
+  line-height: var(--seed-line-height-t5);
+  font-weight: var(--seed-font-weight-bold);
+}
+
+.seed-manner-temp__emote {
+  width: var(--seed-dimension-x8);
+  height: var(--seed-dimension-x8);
+  margin-left: calc(var(--seed-dimension-x1) * -1);
+  margin-right: calc(var(--seed-dimension-x1) * -1);
+  margin-top: calc(var(--seed-dimension-x1) * -1);
+  margin-bottom: calc(var(--seed-dimension-x1) * -1);
+  flex-shrink: 0;
+}
+
+.seed-manner-temp__label--level_l1 {
+  color: var(--seed-color-manner-temp-l1-text);
+}
+
+.seed-manner-temp__label--level_l2 {
+  color: var(--seed-color-manner-temp-l2-text);
+}
+
+.seed-manner-temp__label--level_l3 {
+  color: var(--seed-color-manner-temp-l3-text);
+}
+
+.seed-manner-temp__label--level_l4 {
+  color: var(--seed-color-manner-temp-l4-text);
+}
+
+.seed-manner-temp__label--level_l5 {
+  color: var(--seed-color-manner-temp-l5-text);
+}
+
+.seed-manner-temp__label--level_l6 {
+  color: var(--seed-color-manner-temp-l6-text);
+}
+
+.seed-manner-temp__label--level_l7 {
+  color: var(--seed-color-manner-temp-l7-text);
+}
+
+.seed-manner-temp__label--level_l8 {
+  color: var(--seed-color-manner-temp-l8-text);
+}
+
+.seed-manner-temp__label--level_l9 {
+  color: var(--seed-color-manner-temp-l9-text);
+}
+
+.seed-manner-temp__label--level_l10 {
+  color: var(--seed-color-manner-temp-l10-text);
+}
+
+.seed-manner-temp-badge__root {
+  min-height: var(--seed-dimension-x5);
+  padding-left: var(--seed-dimension-x1_5);
+  padding-right: var(--seed-dimension-x1_5);
+  padding-top: var(--seed-dimension-x0_5);
+  padding-bottom: var(--seed-dimension-x0_5);
+  border-radius: var(--seed-radius-full);
+  flex-direction: row;
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.seed-manner-temp-badge__label {
+  font-size: var(--seed-font-size-t1);
+  line-height: var(--seed-line-height-t1);
+  font-weight: var(--seed-font-weight-bold);
+}
+
+.seed-manner-temp-badge__root--level_l1 {
+  background-color: var(--seed-color-manner-temp-l1-bg);
+}
+
+.seed-manner-temp-badge__label--level_l1 {
+  color: var(--seed-color-manner-temp-l1-text);
+}
+
+.seed-manner-temp-badge__root--level_l2 {
+  background-color: var(--seed-color-manner-temp-l2-bg);
+}
+
+.seed-manner-temp-badge__label--level_l2 {
+  color: var(--seed-color-manner-temp-l2-text);
+}
+
+.seed-manner-temp-badge__root--level_l3 {
+  background-color: var(--seed-color-manner-temp-l3-bg);
+}
+
+.seed-manner-temp-badge__label--level_l3 {
+  color: var(--seed-color-manner-temp-l3-text);
+}
+
+.seed-manner-temp-badge__root--level_l4 {
+  background-color: var(--seed-color-manner-temp-l4-bg);
+}
+
+.seed-manner-temp-badge__label--level_l4 {
+  color: var(--seed-color-manner-temp-l4-text);
+}
+
+.seed-manner-temp-badge__root--level_l5 {
+  background-color: var(--seed-color-manner-temp-l5-bg);
+}
+
+.seed-manner-temp-badge__label--level_l5 {
+  color: var(--seed-color-manner-temp-l5-text);
+}
+
+.seed-manner-temp-badge__root--level_l6 {
+  background-color: var(--seed-color-manner-temp-l6-bg);
+}
+
+.seed-manner-temp-badge__label--level_l6 {
+  color: var(--seed-color-manner-temp-l6-text);
+}
+
+.seed-manner-temp-badge__root--level_l7 {
+  background-color: var(--seed-color-manner-temp-l7-bg);
+}
+
+.seed-manner-temp-badge__label--level_l7 {
+  color: var(--seed-color-manner-temp-l7-text);
+}
+
+.seed-manner-temp-badge__root--level_l8 {
+  background-color: var(--seed-color-manner-temp-l8-bg);
+}
+
+.seed-manner-temp-badge__label--level_l8 {
+  color: var(--seed-color-manner-temp-l8-text);
+}
+
+.seed-manner-temp-badge__root--level_l9 {
+  background-color: var(--seed-color-manner-temp-l9-bg);
+}
+
+.seed-manner-temp-badge__label--level_l9 {
+  color: var(--seed-color-manner-temp-l9-text);
+}
+
+.seed-manner-temp-badge__root--level_l10 {
+  background-color: var(--seed-color-manner-temp-l10-bg);
+}
+
+.seed-manner-temp-badge__label--level_l10 {
+  color: var(--seed-color-manner-temp-l10-text);
+}
+
 .seed-page-banner__root {
   width: 100%;
   min-height: var(--seed-dimension-x10);

--- a/packages/lynx-css/recipes/manner-temp-badge.css
+++ b/packages/lynx-css/recipes/manner-temp-badge.css
@@ -1,0 +1,78 @@
+.seed-manner-temp-badge__root {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    min-height: var(--seed-dimension-x5);
+    padding-left: var(--seed-dimension-x1_5);
+    padding-right: var(--seed-dimension-x1_5);
+    padding-top: var(--seed-dimension-x0_5);
+    padding-bottom: var(--seed-dimension-x0_5);
+    border-radius: var(--seed-radius-full)
+}
+.seed-manner-temp-badge__label {
+    font-size: var(--seed-font-size-t1);
+    line-height: var(--seed-line-height-t1);
+    font-weight: var(--seed-font-weight-bold)
+}
+.seed-manner-temp-badge__root--level_l1 {
+    background-color: var(--seed-color-manner-temp-l1-bg)
+}
+.seed-manner-temp-badge__label--level_l1 {
+    color: var(--seed-color-manner-temp-l1-text)
+}
+.seed-manner-temp-badge__root--level_l2 {
+    background-color: var(--seed-color-manner-temp-l2-bg)
+}
+.seed-manner-temp-badge__label--level_l2 {
+    color: var(--seed-color-manner-temp-l2-text)
+}
+.seed-manner-temp-badge__root--level_l3 {
+    background-color: var(--seed-color-manner-temp-l3-bg)
+}
+.seed-manner-temp-badge__label--level_l3 {
+    color: var(--seed-color-manner-temp-l3-text)
+}
+.seed-manner-temp-badge__root--level_l4 {
+    background-color: var(--seed-color-manner-temp-l4-bg)
+}
+.seed-manner-temp-badge__label--level_l4 {
+    color: var(--seed-color-manner-temp-l4-text)
+}
+.seed-manner-temp-badge__root--level_l5 {
+    background-color: var(--seed-color-manner-temp-l5-bg)
+}
+.seed-manner-temp-badge__label--level_l5 {
+    color: var(--seed-color-manner-temp-l5-text)
+}
+.seed-manner-temp-badge__root--level_l6 {
+    background-color: var(--seed-color-manner-temp-l6-bg)
+}
+.seed-manner-temp-badge__label--level_l6 {
+    color: var(--seed-color-manner-temp-l6-text)
+}
+.seed-manner-temp-badge__root--level_l7 {
+    background-color: var(--seed-color-manner-temp-l7-bg)
+}
+.seed-manner-temp-badge__label--level_l7 {
+    color: var(--seed-color-manner-temp-l7-text)
+}
+.seed-manner-temp-badge__root--level_l8 {
+    background-color: var(--seed-color-manner-temp-l8-bg)
+}
+.seed-manner-temp-badge__label--level_l8 {
+    color: var(--seed-color-manner-temp-l8-text)
+}
+.seed-manner-temp-badge__root--level_l9 {
+    background-color: var(--seed-color-manner-temp-l9-bg)
+}
+.seed-manner-temp-badge__label--level_l9 {
+    color: var(--seed-color-manner-temp-l9-text)
+}
+.seed-manner-temp-badge__root--level_l10 {
+    background-color: var(--seed-color-manner-temp-l10-bg)
+}
+.seed-manner-temp-badge__label--level_l10 {
+    color: var(--seed-color-manner-temp-l10-text)
+}

--- a/packages/lynx-css/recipes/manner-temp-badge.d.ts
+++ b/packages/lynx-css/recipes/manner-temp-badge.d.ts
@@ -1,0 +1,24 @@
+declare interface MannerTempBadgeVariant {
+  /**
+  * @default "l1"
+  */
+  level: "l1" | "l2" | "l3" | "l4" | "l5" | "l6" | "l7" | "l8" | "l9" | "l10";
+}
+
+declare type MannerTempBadgeVariantMap = {
+  [key in keyof MannerTempBadgeVariant]: Array<MannerTempBadgeVariant[key]>;
+};
+
+export declare type MannerTempBadgeVariantProps = Partial<MannerTempBadgeVariant>;
+
+export declare type MannerTempBadgeSlotName = "root" | "label";
+
+export declare const mannerTempBadgeVariantMap: MannerTempBadgeVariantMap;
+
+export declare const mannerTempBadge: ((
+  props?: MannerTempBadgeVariantProps,
+) => Record<MannerTempBadgeSlotName, string>) & {
+  splitVariantProps: <T extends MannerTempBadgeVariantProps>(
+    props: T,
+  ) => [MannerTempBadgeVariantProps, Omit<T, keyof MannerTempBadgeVariantProps>];
+}

--- a/packages/lynx-css/recipes/manner-temp-badge.mjs
+++ b/packages/lynx-css/recipes/manner-temp-badge.mjs
@@ -1,0 +1,51 @@
+import './manner-temp-badge.css';
+import { createClassName, mergeVariants, splitVariantProps } from "./shared.mjs";
+
+const mannerTempBadgeSlotNames = [
+  [
+    "root",
+    "seed-manner-temp-badge__root"
+  ],
+  [
+    "label",
+    "seed-manner-temp-badge__label"
+  ]
+];
+
+const defaultVariant = {
+  "level": "l1"
+};
+
+const compoundVariants = [];
+
+export const mannerTempBadgeVariantMap = {
+  "level": [
+    "l1",
+    "l2",
+    "l3",
+    "l4",
+    "l5",
+    "l6",
+    "l7",
+    "l8",
+    "l9",
+    "l10"
+  ]
+};
+
+export const mannerTempBadgeVariantKeys = Object.keys(mannerTempBadgeVariantMap);
+
+export function mannerTempBadge(props) {
+  return Object.fromEntries(
+    mannerTempBadgeSlotNames.map(([slot, className]) => {
+      return [
+        slot,
+        createClassName(className, mergeVariants(defaultVariant, props), compoundVariants),
+      ];
+    }),
+  );
+}
+
+Object.assign(mannerTempBadge, { splitVariantProps: (props) => splitVariantProps(props, mannerTempBadgeVariantMap) });
+
+// @recipe(seed): manner-temp-badge

--- a/packages/lynx-css/recipes/manner-temp.css
+++ b/packages/lynx-css/recipes/manner-temp.css
@@ -1,0 +1,52 @@
+.seed-manner-temp__root {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    flex-shrink: 0;
+    gap: var(--seed-dimension-x1)
+}
+.seed-manner-temp__label {
+    font-size: var(--seed-font-size-t5);
+    line-height: var(--seed-line-height-t5);
+    font-weight: var(--seed-font-weight-bold)
+}
+.seed-manner-temp__emote {
+    width: var(--seed-dimension-x8);
+    height: var(--seed-dimension-x8);
+    margin-left: calc(var(--seed-dimension-x1) * -1);
+    margin-right: calc(var(--seed-dimension-x1) * -1);
+    margin-top: calc(var(--seed-dimension-x1) * -1);
+    margin-bottom: calc(var(--seed-dimension-x1) * -1);
+    flex-shrink: 0
+}
+.seed-manner-temp__label--level_l1 {
+    color: var(--seed-color-manner-temp-l1-text)
+}
+.seed-manner-temp__label--level_l2 {
+    color: var(--seed-color-manner-temp-l2-text)
+}
+.seed-manner-temp__label--level_l3 {
+    color: var(--seed-color-manner-temp-l3-text)
+}
+.seed-manner-temp__label--level_l4 {
+    color: var(--seed-color-manner-temp-l4-text)
+}
+.seed-manner-temp__label--level_l5 {
+    color: var(--seed-color-manner-temp-l5-text)
+}
+.seed-manner-temp__label--level_l6 {
+    color: var(--seed-color-manner-temp-l6-text)
+}
+.seed-manner-temp__label--level_l7 {
+    color: var(--seed-color-manner-temp-l7-text)
+}
+.seed-manner-temp__label--level_l8 {
+    color: var(--seed-color-manner-temp-l8-text)
+}
+.seed-manner-temp__label--level_l9 {
+    color: var(--seed-color-manner-temp-l9-text)
+}
+.seed-manner-temp__label--level_l10 {
+    color: var(--seed-color-manner-temp-l10-text)
+}

--- a/packages/lynx-css/recipes/manner-temp.d.ts
+++ b/packages/lynx-css/recipes/manner-temp.d.ts
@@ -1,0 +1,24 @@
+declare interface MannerTempVariant {
+  /**
+  * @default "l1"
+  */
+  level: "l1" | "l2" | "l3" | "l4" | "l5" | "l6" | "l7" | "l8" | "l9" | "l10";
+}
+
+declare type MannerTempVariantMap = {
+  [key in keyof MannerTempVariant]: Array<MannerTempVariant[key]>;
+};
+
+export declare type MannerTempVariantProps = Partial<MannerTempVariant>;
+
+export declare type MannerTempSlotName = "root" | "label" | "emote";
+
+export declare const mannerTempVariantMap: MannerTempVariantMap;
+
+export declare const mannerTemp: ((
+  props?: MannerTempVariantProps,
+) => Record<MannerTempSlotName, string>) & {
+  splitVariantProps: <T extends MannerTempVariantProps>(
+    props: T,
+  ) => [MannerTempVariantProps, Omit<T, keyof MannerTempVariantProps>];
+}

--- a/packages/lynx-css/recipes/manner-temp.mjs
+++ b/packages/lynx-css/recipes/manner-temp.mjs
@@ -1,0 +1,55 @@
+import './manner-temp.css';
+import { createClassName, mergeVariants, splitVariantProps } from "./shared.mjs";
+
+const mannerTempSlotNames = [
+  [
+    "root",
+    "seed-manner-temp__root"
+  ],
+  [
+    "label",
+    "seed-manner-temp__label"
+  ],
+  [
+    "emote",
+    "seed-manner-temp__emote"
+  ]
+];
+
+const defaultVariant = {
+  "level": "l1"
+};
+
+const compoundVariants = [];
+
+export const mannerTempVariantMap = {
+  "level": [
+    "l1",
+    "l2",
+    "l3",
+    "l4",
+    "l5",
+    "l6",
+    "l7",
+    "l8",
+    "l9",
+    "l10"
+  ]
+};
+
+export const mannerTempVariantKeys = Object.keys(mannerTempVariantMap);
+
+export function mannerTemp(props) {
+  return Object.fromEntries(
+    mannerTempSlotNames.map(([slot, className]) => {
+      return [
+        slot,
+        createClassName(className, mergeVariants(defaultVariant, props), compoundVariants),
+      ];
+    }),
+  );
+}
+
+Object.assign(mannerTemp, { splitVariantProps: (props) => splitVariantProps(props, mannerTempVariantMap) });
+
+// @recipe(seed): manner-temp

--- a/packages/lynx-qvism-preset/src/recipes.ts
+++ b/packages/lynx-qvism-preset/src/recipes.ts
@@ -11,6 +11,8 @@ import checkmark from "./recipes/checkmark";
 import chip from "./recipes/chip";
 import field from "./recipes/field";
 import fieldLabel from "./recipes/field-label";
+import mannerTemp from "./recipes/manner-temp";
+import mannerTempBadge from "./recipes/manner-temp-badge";
 import pageBanner from "./recipes/page-banner";
 import radio from "./recipes/radio";
 import radioGroup from "./recipes/radio-group";
@@ -42,6 +44,8 @@ export const recipes = {
   chip,
   field,
   fieldLabel,
+  mannerTemp,
+  mannerTempBadge,
   pageBanner,
   radio,
   radioGroup,

--- a/packages/lynx-qvism-preset/src/recipes/manner-temp-badge.ts
+++ b/packages/lynx-qvism-preset/src/recipes/manner-temp-badge.ts
@@ -1,0 +1,76 @@
+import { mannerTempBadge as vars } from "../vars/component";
+import { defineSlotRecipe } from "../utils/define";
+
+const mannerTempBadge = defineSlotRecipe({
+  name: "manner-temp-badge",
+  slots: ["root", "label"],
+  base: {
+    root: {
+      display: "flex",
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      flexShrink: 0,
+      minHeight: vars.base.enabled.root.minHeight,
+      paddingLeft: vars.base.enabled.root.paddingX,
+      paddingRight: vars.base.enabled.root.paddingX,
+      paddingTop: vars.base.enabled.root.paddingY,
+      paddingBottom: vars.base.enabled.root.paddingY,
+      borderRadius: vars.base.enabled.root.cornerRadius,
+    },
+    label: {
+      fontSize: vars.base.enabled.label.fontSize,
+      lineHeight: vars.base.enabled.label.lineHeight,
+      fontWeight: vars.base.enabled.label.fontWeight,
+    },
+  },
+  variants: {
+    level: {
+      l1: {
+        root: { backgroundColor: vars.levelL1.enabled.root.color },
+        label: { color: vars.levelL1.enabled.label.color },
+      },
+      l2: {
+        root: { backgroundColor: vars.levelL2.enabled.root.color },
+        label: { color: vars.levelL2.enabled.label.color },
+      },
+      l3: {
+        root: { backgroundColor: vars.levelL3.enabled.root.color },
+        label: { color: vars.levelL3.enabled.label.color },
+      },
+      l4: {
+        root: { backgroundColor: vars.levelL4.enabled.root.color },
+        label: { color: vars.levelL4.enabled.label.color },
+      },
+      l5: {
+        root: { backgroundColor: vars.levelL5.enabled.root.color },
+        label: { color: vars.levelL5.enabled.label.color },
+      },
+      l6: {
+        root: { backgroundColor: vars.levelL6.enabled.root.color },
+        label: { color: vars.levelL6.enabled.label.color },
+      },
+      l7: {
+        root: { backgroundColor: vars.levelL7.enabled.root.color },
+        label: { color: vars.levelL7.enabled.label.color },
+      },
+      l8: {
+        root: { backgroundColor: vars.levelL8.enabled.root.color },
+        label: { color: vars.levelL8.enabled.label.color },
+      },
+      l9: {
+        root: { backgroundColor: vars.levelL9.enabled.root.color },
+        label: { color: vars.levelL9.enabled.label.color },
+      },
+      l10: {
+        root: { backgroundColor: vars.levelL10.enabled.root.color },
+        label: { color: vars.levelL10.enabled.label.color },
+      },
+    },
+  },
+  defaultVariants: {
+    level: "l1",
+  },
+});
+
+export default mannerTempBadge;

--- a/packages/lynx-qvism-preset/src/recipes/manner-temp.ts
+++ b/packages/lynx-qvism-preset/src/recipes/manner-temp.ts
@@ -1,0 +1,50 @@
+import { mannerTemp as vars } from "../vars/component";
+import { defineSlotRecipe } from "../utils/define";
+
+const mannerTemp = defineSlotRecipe({
+  name: "manner-temp",
+  slots: ["root", "label", "emote"],
+  base: {
+    root: {
+      display: "flex",
+      flexDirection: "row",
+      justifyContent: "flex-start",
+      alignItems: "center",
+      flexShrink: 0,
+      gap: vars.base.enabled.root.gap,
+    },
+    label: {
+      fontSize: vars.base.enabled.label.fontSize,
+      lineHeight: vars.base.enabled.label.lineHeight,
+      fontWeight: vars.base.enabled.label.fontWeight,
+    },
+    emote: {
+      width: vars.base.enabled.emote.size,
+      height: vars.base.enabled.emote.size,
+      marginLeft: `calc(${vars.base.enabled.emote.bleed} * -1)`,
+      marginRight: `calc(${vars.base.enabled.emote.bleed} * -1)`,
+      marginTop: `calc(${vars.base.enabled.emote.bleed} * -1)`,
+      marginBottom: `calc(${vars.base.enabled.emote.bleed} * -1)`,
+      flexShrink: 0,
+    },
+  },
+  variants: {
+    level: {
+      l1: { label: { color: vars.levelL1.enabled.label.color } },
+      l2: { label: { color: vars.levelL2.enabled.label.color } },
+      l3: { label: { color: vars.levelL3.enabled.label.color } },
+      l4: { label: { color: vars.levelL4.enabled.label.color } },
+      l5: { label: { color: vars.levelL5.enabled.label.color } },
+      l6: { label: { color: vars.levelL6.enabled.label.color } },
+      l7: { label: { color: vars.levelL7.enabled.label.color } },
+      l8: { label: { color: vars.levelL8.enabled.label.color } },
+      l9: { label: { color: vars.levelL9.enabled.label.color } },
+      l10: { label: { color: vars.levelL10.enabled.label.color } },
+    },
+  },
+  defaultVariants: {
+    level: "l1",
+  },
+});
+
+export default mannerTemp;

--- a/packages/lynx-react/src/components/MannerTemp/MannerTemp.test.tsx
+++ b/packages/lynx-react/src/components/MannerTemp/MannerTemp.test.tsx
@@ -1,0 +1,41 @@
+import "@testing-library/jest-dom";
+import { getQueriesForElement, render } from "@lynx-js/react/testing-library";
+import { describe, expect, it } from "vitest";
+
+import { MannerTemp, MannerTempEmote } from "./MannerTemp";
+
+function getRenderedRoot() {
+  const root = elementTree.root;
+
+  if (!root) {
+    throw new Error("Expected Lynx render root to exist.");
+  }
+
+  return root;
+}
+
+describe("MannerTemp", () => {
+  it("renders the label and emote with the selected level", () => {
+    render(
+      <MannerTemp className="custom-manner-temp" level="l6">
+        40°C
+        <MannerTempEmote />
+      </MannerTemp>,
+    );
+
+    const root = getRenderedRoot();
+    const { getByText } = getQueriesForElement(root);
+    const mannerTempRoot = root.querySelector(".seed-manner-temp__root");
+    const label = getByText("40°C");
+    const emote = root.querySelector(".seed-manner-temp__emote");
+
+    expect(mannerTempRoot).toHaveClass("custom-manner-temp");
+    expect(mannerTempRoot).toHaveClass("seed-manner-temp__root--level_l6");
+    expect(label).toHaveClass("seed-manner-temp__label");
+    expect(label).toHaveClass("seed-manner-temp__label--level_l6");
+    expect(emote).toHaveAttribute(
+      "src",
+      expect.stringContaining("bf8f9b4d-c72e-4bf2-a094-460d3ad1b11f"),
+    );
+  });
+});

--- a/packages/lynx-react/src/components/MannerTemp/MannerTemp.tsx
+++ b/packages/lynx-react/src/components/MannerTemp/MannerTemp.tsx
@@ -1,0 +1,85 @@
+import { mannerTemp, type MannerTempVariantProps } from "@seed-design/lynx-css/recipes/manner-temp";
+import type { NodesRef } from "@lynx-js/types";
+import clsx from "clsx";
+import * as React from "@lynx-js/react";
+import { isValidElement } from "@lynx-js/react";
+
+import type { LynxStyledElementProps, LynxViewRef } from "../../types";
+import { toArray } from "../../utils/children";
+
+type MannerTempLevel = NonNullable<MannerTempVariantProps["level"]>;
+
+const emoteSources = {
+  l1: "https://assetstorage.krrt.io/1123529253537884138/b63c9b3c-410c-4cf5-ba83-d787a03c3c57/width_96_height_96.webp",
+  l2: "https://assetstorage.krrt.io/1123529253537884138/8e4bc458-f6d4-41ce-bfa2-17ea34022f5b/width_96_height_96.webp",
+  l3: "https://assetstorage.krrt.io/1123529253537884138/906ff501-edf6-402d-a3a4-a93ce9e04d30/width_96_height_96.webp",
+  l4: "https://assetstorage.krrt.io/1123529253537884138/10753976-b25d-4e4c-84b2-dbbe196dd0d9/width_96_height_96.webp",
+  l5: "https://assetstorage.krrt.io/1123529253537884138/ddfbd296-5089-408c-aa37-919f45074e5e/width_96_height_96.webp",
+  l6: "https://assetstorage.krrt.io/1123529253537884138/bf8f9b4d-c72e-4bf2-a094-460d3ad1b11f/width_96_height_96.webp",
+  l7: "https://assetstorage.krrt.io/1123529253537884138/9906a459-a4e3-4521-a6e5-0cc24c0aa763/width_96_height_96.webp",
+  l8: "https://assetstorage.krrt.io/1123529253537884138/438edadb-d31d-4711-aebd-a72f303fdf49/width_96_height_96.webp",
+  l9: "https://assetstorage.krrt.io/1123529253537884138/61f6c297-11da-4d72-ba90-20cd69c09c22/width_96_height_96.webp",
+  l10: "https://assetstorage.krrt.io/1123529253537884138/6cc410ac-3a55-4542-b49f-53551db74c4d/width_96_height_96.webp",
+} satisfies Record<MannerTempLevel, string>;
+
+const MannerTempLevelContext = React.createContext<MannerTempLevel | null>(null);
+
+export interface MannerTempEmoteProps extends LynxStyledElementProps {
+  level?: MannerTempLevel;
+}
+
+export const MannerTempEmote = React.forwardRef<unknown, MannerTempEmoteProps>((props, ref) => {
+  const contextLevel = React.useContext(MannerTempLevelContext);
+  const { level = contextLevel ?? "l1", children: _children, className, ...nativeProps } = props;
+  const classes = mannerTemp({ level });
+
+  return (
+    <image
+      {...(ref ? { ref: ref as React.Ref<NodesRef> } : {})}
+      {...nativeProps}
+      src={emoteSources[level]}
+      mode="aspectFit"
+      accessibility-elements-hidden={true}
+      className={clsx(classes.emote, className)}
+    />
+  );
+});
+
+MannerTempEmote.displayName = "MannerTempEmote";
+
+function isMannerTempEmote(node: React.ReactNode) {
+  return isValidElement(node) && node.type === MannerTempEmote;
+}
+
+/**
+ * @platform Lynx
+ *
+ * React와 같은 `level` variant와 `MannerTempEmote` 조합을 제공합니다.
+ * HTML `<span>` 대신 native `<view>` / `<text>` / `<image>`를 렌더링합니다.
+ */
+export interface MannerTempProps extends MannerTempVariantProps, LynxStyledElementProps {}
+
+export const MannerTemp = React.forwardRef<unknown, MannerTempProps>((props, ref) => {
+  const [variantProps, otherProps] = mannerTemp.splitVariantProps(props);
+  const classes = mannerTemp(variantProps);
+  const { children, className, ...nativeProps } = otherProps;
+  const childArray = toArray(children);
+  const emoteChildren = childArray.filter(isMannerTempEmote);
+  const labelChildren = childArray.filter((child) => !isMannerTempEmote(child));
+  const level = variantProps.level ?? "l1";
+
+  return (
+    <MannerTempLevelContext.Provider value={level}>
+      <view
+        {...(ref ? { ref: ref as LynxViewRef } : {})}
+        {...nativeProps}
+        className={clsx(classes.root, className)}
+      >
+        <text className={classes.label}>{labelChildren}</text>
+        {emoteChildren}
+      </view>
+    </MannerTempLevelContext.Provider>
+  );
+});
+
+MannerTemp.displayName = "MannerTemp";

--- a/packages/lynx-react/src/components/MannerTemp/index.ts
+++ b/packages/lynx-react/src/components/MannerTemp/index.ts
@@ -1,0 +1,6 @@
+export {
+  MannerTemp,
+  MannerTempEmote,
+  type MannerTempEmoteProps,
+  type MannerTempProps,
+} from "./MannerTemp";

--- a/packages/lynx-react/src/components/MannerTemp/index.ts
+++ b/packages/lynx-react/src/components/MannerTemp/index.ts
@@ -1,6 +1,1 @@
-export {
-  MannerTemp,
-  MannerTempEmote,
-  type MannerTempEmoteProps,
-  type MannerTempProps,
-} from "./MannerTemp";
+export * from "./MannerTemp";

--- a/packages/lynx-react/src/components/MannerTempBadge/MannerTempBadge.test.tsx
+++ b/packages/lynx-react/src/components/MannerTempBadge/MannerTempBadge.test.tsx
@@ -1,0 +1,35 @@
+import "@testing-library/jest-dom";
+import { getQueriesForElement, render } from "@lynx-js/react/testing-library";
+import { describe, expect, it } from "vitest";
+
+import { MannerTempBadge } from "./MannerTempBadge";
+
+function getRenderedRoot() {
+  const root = elementTree.root;
+
+  if (!root) {
+    throw new Error("Expected Lynx render root to exist.");
+  }
+
+  return root;
+}
+
+describe("MannerTempBadge", () => {
+  it("renders the label with the selected level and preserves className", () => {
+    render(
+      <MannerTempBadge className="custom-manner-temp-badge" level="l10">
+        80°C
+      </MannerTempBadge>,
+    );
+
+    const root = getRenderedRoot();
+    const { getByText } = getQueriesForElement(root);
+    const badgeRoot = root.querySelector(".seed-manner-temp-badge__root");
+    const label = getByText("80°C");
+
+    expect(badgeRoot).toHaveClass("custom-manner-temp-badge");
+    expect(badgeRoot).toHaveClass("seed-manner-temp-badge__root--level_l10");
+    expect(label).toHaveClass("seed-manner-temp-badge__label");
+    expect(label).toHaveClass("seed-manner-temp-badge__label--level_l10");
+  });
+});

--- a/packages/lynx-react/src/components/MannerTempBadge/MannerTempBadge.tsx
+++ b/packages/lynx-react/src/components/MannerTempBadge/MannerTempBadge.tsx
@@ -1,0 +1,34 @@
+import {
+  mannerTempBadge,
+  type MannerTempBadgeVariantProps,
+} from "@seed-design/lynx-css/recipes/manner-temp-badge";
+import clsx from "clsx";
+import * as React from "@lynx-js/react";
+
+import type { LynxStyledElementProps, LynxViewRef } from "../../types";
+
+/**
+ * @platform Lynx
+ *
+ * React와 같은 `level` variant를 제공하지만, HTML `<span>` 대신 native
+ * `<view>` / `<text>`를 렌더링합니다.
+ */
+export interface MannerTempBadgeProps extends MannerTempBadgeVariantProps, LynxStyledElementProps {}
+
+export const MannerTempBadge = React.forwardRef<unknown, MannerTempBadgeProps>((props, ref) => {
+  const [variantProps, otherProps] = mannerTempBadge.splitVariantProps(props);
+  const classes = mannerTempBadge(variantProps);
+  const { children, className, ...nativeProps } = otherProps;
+
+  return (
+    <view
+      {...(ref ? { ref: ref as LynxViewRef } : {})}
+      {...nativeProps}
+      className={clsx(classes.root, className)}
+    >
+      <text className={classes.label}>{children}</text>
+    </view>
+  );
+});
+
+MannerTempBadge.displayName = "MannerTempBadge";

--- a/packages/lynx-react/src/components/MannerTempBadge/index.ts
+++ b/packages/lynx-react/src/components/MannerTempBadge/index.ts
@@ -1,1 +1,1 @@
-export { MannerTempBadge, type MannerTempBadgeProps } from "./MannerTempBadge";
+export * from "./MannerTempBadge";

--- a/packages/lynx-react/src/components/MannerTempBadge/index.ts
+++ b/packages/lynx-react/src/components/MannerTempBadge/index.ts
@@ -1,0 +1,1 @@
+export { MannerTempBadge, type MannerTempBadgeProps } from "./MannerTempBadge";

--- a/packages/lynx-react/src/components/index.ts
+++ b/packages/lynx-react/src/components/index.ts
@@ -11,6 +11,8 @@ export * from "./Divider";
 export * from "./Field";
 export * from "./Icon";
 export * from "./KeyboardAvoidingScrollView";
+export * from "./MannerTemp";
+export * from "./MannerTempBadge";
 export * from "./NotificationBadge";
 export * from "./PageBanner";
 export * from "./ProgressCircle";


### PR DESCRIPTION
## 변경 사항

- Lynx용 `MannerTemp`, `MannerTempEmote`, `MannerTempBadge` 컴포넌트를 추가했습니다.
- Lynx CSS 레시피와 공개 export를 연결했습니다.
- 컴포넌트 문서와 가운데 정렬된 예시를 추가했습니다.
- `@seed-design/lynx-css`, `@seed-design/lynx-react` minor changeset을 추가했습니다.

## 검증

- `bun generate:all`
- `bun docs:test` — 306개 통과
- `bun packages:build`
- `bun test:all` — 일반 1,961개, Lynx 247개 통과

관련 작업: DES-2416

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Lynx용 `MannerTemp`, `MannerTempEmote`, `MannerTempBadge` 컴포넌트를 추가했습니다.
  * 10단계 매너 온도 레벨별 색상과 스타일을 제공합니다.
  * Lynx 예제 앱에서 매너 온도 컴포넌트를 확인할 수 있습니다.

* **문서**
  * 설치 방법, 속성, 사용 예제 및 웹 버전과의 차이를 안내하는 Lynx 컴포넌트 문서를 추가했습니다.

* **테스트**
  * 컴포넌트 렌더링, 레벨별 스타일 및 사용자 클래스 적용을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->