### PR TITLE
fix(lynx-radio): align radio group items

### DIFF
--- a/.changeset/calm-radios-align.md
+++ b/.changeset/calm-radios-align.md
@@ -1,0 +1,6 @@
+---
+"@seed-design/lynx-css": patch
+"@seed-design/lynx-react": patch
+---
+
+Lynx `Radio Group`에서 라디오 표시와 라벨의 상단 여백이 적용되지 않아 수직 정렬이 어긋나던 문제를 수정합니다.

--- a/packages/lynx-css/all.css
+++ b/packages/lynx-css/all.css
@@ -2460,22 +2460,30 @@ text {
 
 .seed-radio__root--size_medium {
   min-height: var(--seed-dimension-x8);
-  --radiomark-margin-top: calc((var(--seed-dimension-x8) - var(--seed-dimension-x5)) / 2);
+}
+
+.seed-radio__control--size_medium {
+  margin-top: calc(var(--seed-dimension-x8) / 2 - var(--seed-dimension-x5) / 2);
 }
 
 .seed-radio__label--size_medium {
   font-size: var(--seed-font-size-t4);
   line-height: var(--seed-line-height-t4);
+  margin-top: calc(var(--seed-dimension-x8) / 2 - var(--seed-line-height-t4) / 2);
 }
 
 .seed-radio__root--size_large {
   min-height: var(--seed-dimension-x9);
-  --radiomark-margin-top: calc((var(--seed-dimension-x9) - var(--seed-dimension-x6)) / 2);
+}
+
+.seed-radio__control--size_large {
+  margin-top: calc(var(--seed-dimension-x9) / 2 - var(--seed-dimension-x6) / 2);
 }
 
 .seed-radio__label--size_large {
   font-size: var(--seed-font-size-t5);
   line-height: var(--seed-line-height-t5);
+  margin-top: calc(var(--seed-dimension-x9) / 2 - var(--seed-line-height-t5) / 2);
 }
 
 .seed-radio__label--disabled_true {
@@ -2489,7 +2497,6 @@ text {
 }
 
 .seed-radiomark__root {
-  margin-top: var(--radiomark-margin-top, 0);
   border-style: solid;
   border-width: 1px;
   border-color: var(--seed-color-stroke-neutral-weak);

--- a/packages/lynx-css/recipes/radio.css
+++ b/packages/lynx-css/recipes/radio.css
@@ -14,20 +14,26 @@
     font-weight: var(--seed-font-weight-bold)
 }
 .seed-radio__root--size_medium {
-    min-height: var(--seed-dimension-x8);
-    --radiomark-margin-top: calc((var(--seed-dimension-x8) - var(--seed-dimension-x5)) / 2)
+    min-height: var(--seed-dimension-x8)
+}
+.seed-radio__control--size_medium {
+    margin-top: calc(var(--seed-dimension-x8) / 2 - var(--seed-dimension-x5) / 2)
 }
 .seed-radio__label--size_medium {
     font-size: var(--seed-font-size-t4);
-    line-height: var(--seed-line-height-t4)
+    line-height: var(--seed-line-height-t4);
+    margin-top: calc(var(--seed-dimension-x8) / 2 - var(--seed-line-height-t4) / 2)
 }
 .seed-radio__root--size_large {
-    min-height: var(--seed-dimension-x9);
-    --radiomark-margin-top: calc((var(--seed-dimension-x9) - var(--seed-dimension-x6)) / 2)
+    min-height: var(--seed-dimension-x9)
+}
+.seed-radio__control--size_large {
+    margin-top: calc(var(--seed-dimension-x9) / 2 - var(--seed-dimension-x6) / 2)
 }
 .seed-radio__label--size_large {
     font-size: var(--seed-font-size-t5);
-    line-height: var(--seed-line-height-t5)
+    line-height: var(--seed-line-height-t5);
+    margin-top: calc(var(--seed-dimension-x9) / 2 - var(--seed-line-height-t5) / 2)
 }
 .seed-radio__label--disabled_true {
     color: var(--seed-color-fg-disabled)

--- a/packages/lynx-css/recipes/radio.d.ts
+++ b/packages/lynx-css/recipes/radio.d.ts
@@ -19,7 +19,7 @@ declare type RadioVariantMap = {
 
 export declare type RadioVariantProps = Partial<RadioVariant>;
 
-export declare type RadioSlotName = "root" | "label";
+export declare type RadioSlotName = "root" | "control" | "label";
 
 export declare const radioVariantMap: RadioVariantMap;
 

--- a/packages/lynx-css/recipes/radio.mjs
+++ b/packages/lynx-css/recipes/radio.mjs
@@ -7,6 +7,10 @@ const radioSlotNames = [
     "seed-radio__root"
   ],
   [
+    "control",
+    "seed-radio__control"
+  ],
+  [
     "label",
     "seed-radio__label"
   ]

--- a/packages/lynx-css/recipes/radiomark.css
+++ b/packages/lynx-css/recipes/radiomark.css
@@ -4,7 +4,6 @@
     align-items: center;
     justify-content: center;
     flex: none;
-    margin-top: var(--radiomark-margin-top, 0);
     border-width: 1px;
     border-style: solid;
     border-color: var(--seed-color-stroke-neutral-weak);

--- a/packages/lynx-qvism-preset/src/recipes/radio.ts
+++ b/packages/lynx-qvism-preset/src/recipes/radio.ts
@@ -4,14 +4,13 @@ import { defineSlotRecipe } from "../utils/define";
 /**
  * Lynx-전용 radio wrapper recipe.
  *
- * Checkbox 와 동일하게 root 는 top-align 하고, mark 는 각 size 의 터치 영역
- * 안에서만 margin 으로 수직 보정한다. 긴 label 이 2줄 이상으로 래핑되어도
- * radiomark 가 전체 label 높이의 가운데로 내려가지 않고, 한 줄 label 은 Lynx
- * text 렌더링 기준으로 자연 정렬되도록 label 자체는 별도 보정하지 않는다.
+ * root 는 top-align 하고, mark 와 label 은 각 size 의 터치 영역 안에서 margin 으로
+ * 수직 보정한다. 긴 label 이 2줄 이상으로 래핑되어도 radiomark 가 전체 label
+ * 높이의 가운데로 내려가지 않는다.
  */
 const radioRecipe = defineSlotRecipe({
   name: "radio",
-  slots: ["root", "label"],
+  slots: ["root", "control", "label"],
   base: {
     root: {
       display: "flex",
@@ -36,21 +35,27 @@ const radioRecipe = defineSlotRecipe({
       medium: {
         root: {
           minHeight: vars.sizeMedium.enabled.root.minHeight,
-          "--radiomark-margin-top": `calc((${vars.sizeMedium.enabled.root.minHeight} - ${radiomarkVars.sizeMedium.enabled.root.size}) / 2)`,
+        },
+        control: {
+          marginTop: `calc(${vars.sizeMedium.enabled.root.minHeight} / 2 - ${radiomarkVars.sizeMedium.enabled.root.size} / 2)`,
         },
         label: {
           fontSize: vars.sizeMedium.enabled.label.fontSize,
           lineHeight: vars.sizeMedium.enabled.label.lineHeight,
+          marginTop: `calc(${vars.sizeMedium.enabled.root.minHeight} / 2 - ${vars.sizeMedium.enabled.label.lineHeight} / 2)`,
         },
       },
       large: {
         root: {
           minHeight: vars.sizeLarge.enabled.root.minHeight,
-          "--radiomark-margin-top": `calc((${vars.sizeLarge.enabled.root.minHeight} - ${radiomarkVars.sizeLarge.enabled.root.size}) / 2)`,
+        },
+        control: {
+          marginTop: `calc(${vars.sizeLarge.enabled.root.minHeight} / 2 - ${radiomarkVars.sizeLarge.enabled.root.size} / 2)`,
         },
         label: {
           fontSize: vars.sizeLarge.enabled.label.fontSize,
           lineHeight: vars.sizeLarge.enabled.label.lineHeight,
+          marginTop: `calc(${vars.sizeLarge.enabled.root.minHeight} / 2 - ${vars.sizeLarge.enabled.label.lineHeight} / 2)`,
         },
       },
     },

--- a/packages/lynx-qvism-preset/src/recipes/radiomark.ts
+++ b/packages/lynx-qvism-preset/src/recipes/radiomark.ts
@@ -17,7 +17,6 @@ const radiomarkRecipe = defineSlotRecipe({
       alignItems: "center",
       justifyContent: "center",
       flex: "none",
-      marginTop: "var(--radiomark-margin-top, 0)",
 
       borderWidth: vars.base.enabled.root.strokeWidth,
       borderStyle: "solid",

--- a/packages/lynx-react/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/lynx-react/src/components/RadioGroup/RadioGroup.tsx
@@ -232,6 +232,7 @@ export const RadioGroupItemControl = React.forwardRef<unknown, RadioGroupItemCon
       pressed: itemContext.pressed,
     };
     const classes = radiomark(radiomarkVariantProps);
+    const controlClassName = radio(groupContext.radioVariantProps).control;
 
     return (
       <RadiomarkControlContext.Provider
@@ -239,7 +240,7 @@ export const RadioGroupItemControl = React.forwardRef<unknown, RadioGroupItemCon
       >
         <view
           {...(ref ? { ref: ref as LynxViewRef } : {})}
-          className={clsx(classes.root, className)}
+          className={clsx(classes.root, controlClassName, className)}
           {...nativeProps}
         >
           {children}


### PR DESCRIPTION
## 변경 사항

- Lynx Radio Group에서 라디오 표시와 라벨의 수직 정렬을 보정합니다.
- 여러 줄 라벨에서도 라디오 표시가 첫 줄 기준 위치를 유지하도록 합니다.
- Lynx CSS 생성물을 갱신하고 patch changeset을 추가합니다.

## 검증

- `bun generate:all`
- `bun packages:build`
- `bun test:all`
- PlayLynx iOS에서 Radio item 높이 36px 기준 Radiomark 상단 6px, Label 상단 7px 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Lynx 라디오 그룹에서 라디오 표시와 라벨의 상단 여백이 올바르게 적용되지 않아 수직 정렬이 어긋나던 문제를 수정했습니다.
  * 다양한 크기의 라디오 항목에서 라디오 표시와 라벨이 더욱 일관되게 정렬됩니다.
  * 라디오 그룹 항목의 스타일 적용을 개선해 시각적 정렬과 레이아웃 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->