### PR TITLE
feat(lynx): add notification badge

### DIFF
--- a/.changeset/lynx-notification-badge.md
+++ b/.changeset/lynx-notification-badge.md
@@ -1,0 +1,9 @@
+---
+"@seed-design/lynx-react": minor
+"@seed-design/lynx-css": minor
+---
+
+Lynx Notification Badge 컴포넌트를 추가합니다.
+
+- `@seed-design/lynx-react`에서 `NotificationBadge`와 `NotificationBadgePositioner`를 사용할 수 있습니다.
+- `@seed-design/lynx-css/recipes/notification-badge`와 `notification-badge-positioner`에서 스타일 Recipe를 제공합니다.

--- a/docs/content/lynx/components/notification-badge.mdx
+++ b/docs/content/lynx/components/notification-badge.mdx
@@ -1,0 +1,48 @@
+---
+title: Notification Badge
+description: 아이콘이나 텍스트에 새로운 알림 또는 읽지 않은 항목이 있음을 표시하는 컴포넌트입니다.
+compatibility:
+  lynx:
+    engine: "1.0"
+---
+
+<AvailableSince packages="@seed-design/lynx-react@0.6.0, @seed-design/lynx-css@0.10.0" />
+
+## Installation
+
+```package-install
+@seed-design/lynx-react @seed-design/lynx-css
+```
+
+<Callout>
+Lynx `NotificationBadge`는 별도 Registry 컴포넌트 없이 `@seed-design/lynx-react` 패키지에서 직접 제공합니다.
+</Callout>
+
+## Usage
+
+<LynxComponentExample name="lynx/notification-badge/preview" height={320}>
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/notification-badge/preview.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+`NotificationBadgePositioner`를 알림을 표시할 요소 안에 배치합니다. 부모 요소에는 `position="relative"`를 지정해야 합니다.
+
+`size="large"`는 최대 4자의 알림 수를 표시할 때 사용합니다. `size="small"`은 라벨 없이 알림의 존재만 나타냅니다.
+
+작은 배지는 시각적인 장식으로 숨기고, 함께 사용하는 버튼이나 메뉴에 읽지 않은 상태를 설명하는 접근성 이름을 제공하세요.
+
+## Props
+
+<react-type-table path="../packages/lynx-react/src/components/NotificationBadge/NotificationBadge.tsx" name="NotificationBadgeProps" />
+
+<react-type-table path="../packages/lynx-react/src/components/NotificationBadge/NotificationBadge.tsx" name="NotificationBadgePositionerProps" />
+
+## 웹 버전과의 차이
+
+<Callout type="warning">
+Lynx 버전은 HTML `<span>` 대신 native `<text>`와 `<view>`를 렌더링합니다. HTML attribute와 `asChild`는 제공하지 않으며, native 접근성 속성과 `bind*` 이벤트를 사용합니다.
+</Callout>

--- a/docs/examples/lynx/notification-badge/preview.css
+++ b/docs/examples/lynx/notification-badge/preview.css
@@ -1,0 +1,11 @@
+/* biome-ignore lint/correctness/noUnknownTypeSelector: Lynx의 page 요소입니다. */
+page {
+  height: 100%;
+  background-color: var(--seed-color-bg-layer-default);
+}
+
+.notification-badge-preview {
+  width: 100%;
+  height: 100%;
+  justify-content: center;
+}

--- a/docs/examples/lynx/notification-badge/preview.tsx
+++ b/docs/examples/lynx/notification-badge/preview.tsx
@@ -1,0 +1,50 @@
+import "./styles";
+
+import { root, type ReactNode } from "@lynx-js/react";
+import {
+  Box,
+  HStack,
+  NotificationBadge,
+  NotificationBadgePositioner,
+  Text,
+  useSeedClassName,
+} from "@seed-design/lynx-react";
+
+function IconAnchor({ children }: { children: ReactNode }) {
+  return (
+    <Box position="relative" width="24px" height="24px" bg="bg.neutralWeak" borderRadius="full">
+      {children}
+    </Box>
+  );
+}
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <HStack className="notification-badge-preview" gap="x8" align="center">
+        <IconAnchor>
+          <NotificationBadgePositioner size="small" attach="icon">
+            <NotificationBadge accessibility-elements-hidden={true} />
+          </NotificationBadgePositioner>
+        </IconAnchor>
+
+        <IconAnchor>
+          <NotificationBadgePositioner size="large" attach="icon">
+            <NotificationBadge>99+</NotificationBadge>
+          </NotificationBadgePositioner>
+        </IconAnchor>
+
+        <Box position="relative">
+          <Text color="fg.neutral">Inbox</Text>
+          <NotificationBadgePositioner size="small" attach="text">
+            <NotificationBadge accessibility-elements-hidden={true} />
+          </NotificationBadgePositioner>
+        </Box>
+      </HStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/notification-badge/styles.ts
+++ b/docs/examples/lynx/notification-badge/styles.ts
@@ -1,0 +1,2 @@
+import "@seed-design/lynx-css/base.css";
+import "./preview.css";

--- a/docs/public/__docs__/index.json
+++ b/docs/public/__docs__/index.json
@@ -2170,6 +2170,12 @@
               "docUrl": "/lynx/components/keyboard-avoiding-scroll-view"
             },
             {
+              "id": "notification-badge",
+              "title": "Notification Badge",
+              "description": "아이콘이나 텍스트에 새로운 알림 또는 읽지 않은 항목이 있음을 표시하는 컴포넌트입니다.",
+              "docUrl": "/lynx/components/notification-badge"
+            },
+            {
               "id": "page-banner",
               "title": "Page Banner",
               "description": "페이지 상단에서 전체 상태나 중요한 메시지를 전달하는 상위 레벨 메시지 컴포넌트입니다.",

--- a/packages/lynx-css/all.css
+++ b/packages/lynx-css/all.css
@@ -2837,6 +2837,74 @@ text {
   background-color: var(--seed-color-bg-neutral-inverted-pressed);
 }
 
+.seed-notification-badge__root {
+  background-color: var(--seed-color-bg-brand-solid);
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.seed-notification-badge__label {
+  text-align: center;
+  color: var(--seed-color-palette-static-white);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.seed-notification-badge__root--size_small {
+  border-radius: var(--seed-radius-full);
+  width: 6px;
+  height: 6px;
+}
+
+.seed-notification-badge__root--size_large {
+  width: max-content;
+  min-width: 18px;
+  min-height: 18px;
+  padding-left: var(--seed-dimension-x1);
+  padding-right: var(--seed-dimension-x1);
+  border-radius: var(--seed-radius-full);
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.seed-notification-badge__label--size_large {
+  font-size: var(--seed-font-size-t1-static);
+  line-height: var(--seed-line-height-t1-static);
+  font-weight: var(--seed-font-weight-bold);
+}
+
+.seed-notification-badge-positioner {
+  justify-content: center;
+  align-items: center;
+  width: max-content;
+  display: flex;
+  position: absolute;
+}
+
+.seed-notification-badge-positioner--attach_icon {
+  transform: translate(100%, -100%);
+}
+
+.seed-notification-badge-positioner--attach_text {
+  transform: translate(100%);
+}
+
+.seed-notification-badge-positioner--size_large-attach_icon {
+  top: 14px;
+  right: 8px;
+}
+
+.seed-notification-badge-positioner--size_small-attach_icon {
+  top: 7px;
+  right: 7px;
+}
+
+.seed-notification-badge-positioner--size_large-attach_text, .seed-notification-badge-positioner--size_small-attach_text {
+  right: -2px;
+}
+
 .seed-segmented-control__root {
   width: max-content;
   max-width: 100%;

--- a/packages/lynx-css/recipes/notification-badge-positioner.css
+++ b/packages/lynx-css/recipes/notification-badge-positioner.css
@@ -1,0 +1,29 @@
+.seed-notification-badge-positioner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    width: max-content
+}
+.seed-notification-badge-positioner--attach_icon {
+    transform: translate(100%, -100%)
+}
+.seed-notification-badge-positioner--attach_text {
+    transform: translate(100%, 0%)
+}
+.seed-notification-badge-positioner--size_small {}
+.seed-notification-badge-positioner--size_large {}
+.seed-notification-badge-positioner--size_large-attach_icon {
+    top: 14px;
+    right: 8px
+}
+.seed-notification-badge-positioner--size_small-attach_icon {
+    top: 7px;
+    right: 7px
+}
+.seed-notification-badge-positioner--size_large-attach_text {
+    right: calc(-1 * 2px)
+}
+.seed-notification-badge-positioner--size_small-attach_text {
+    right: calc(-1 * 2px)
+}

--- a/packages/lynx-css/recipes/notification-badge-positioner.d.ts
+++ b/packages/lynx-css/recipes/notification-badge-positioner.d.ts
@@ -1,0 +1,26 @@
+declare interface NotificationBadgePositionerVariant {
+  /**
+  * @default "icon"
+  */
+  attach: "icon" | "text";
+/**
+  * @default "large"
+  */
+  size: "small" | "large";
+}
+
+declare type NotificationBadgePositionerVariantMap = {
+  [key in keyof NotificationBadgePositionerVariant]: Array<NotificationBadgePositionerVariant[key]>;
+};
+
+export declare type NotificationBadgePositionerVariantProps = Partial<NotificationBadgePositionerVariant>;
+
+export declare const notificationBadgePositionerVariantMap: NotificationBadgePositionerVariantMap;
+
+export declare const notificationBadgePositioner: ((
+  props?: NotificationBadgePositionerVariantProps,
+) => string) & {
+  splitVariantProps: <T extends NotificationBadgePositionerVariantProps>(
+    props: T,
+  ) => [NotificationBadgePositionerVariantProps, Omit<T, keyof NotificationBadgePositionerVariantProps>];
+}

--- a/packages/lynx-css/recipes/notification-badge-positioner.mjs
+++ b/packages/lynx-css/recipes/notification-badge-positioner.mjs
@@ -1,0 +1,51 @@
+import './notification-badge-positioner.css';
+import { createClassName, mergeVariants, splitVariantProps } from "./shared.mjs";
+
+const defaultVariant = {
+  "size": "large",
+  "attach": "icon"
+};
+
+const compoundVariants = [
+  {
+    "size": "large",
+    "attach": "icon"
+  },
+  {
+    "size": "small",
+    "attach": "icon"
+  },
+  {
+    "size": "large",
+    "attach": "text"
+  },
+  {
+    "size": "small",
+    "attach": "text"
+  }
+];
+
+export const notificationBadgePositionerVariantMap = {
+  "attach": [
+    "icon",
+    "text"
+  ],
+  "size": [
+    "small",
+    "large"
+  ]
+};
+
+export const notificationBadgePositionerVariantKeys = Object.keys(notificationBadgePositionerVariantMap);
+
+export function notificationBadgePositioner(props) {
+  return createClassName(
+    "seed-notification-badge-positioner",
+    mergeVariants(defaultVariant, props),
+    compoundVariants,
+  );
+}
+
+Object.assign(notificationBadgePositioner, { splitVariantProps: (props) => splitVariantProps(props, notificationBadgePositionerVariantMap) });
+
+// @recipe(seed): notification-badge-positioner

--- a/packages/lynx-css/recipes/notification-badge.css
+++ b/packages/lynx-css/recipes/notification-badge.css
@@ -1,0 +1,33 @@
+.seed-notification-badge__root {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    background-color: var(--seed-color-bg-brand-solid)
+}
+.seed-notification-badge__label {
+    text-align: center;
+    color: var(--seed-color-palette-static-white);
+    white-space: nowrap;
+    flex-shrink: 0
+}
+.seed-notification-badge__root--size_small {
+    width: 6px;
+    height: 6px;
+    border-radius: var(--seed-radius-full)
+}
+.seed-notification-badge__root--size_large {
+    width: max-content;
+    min-width: 18px;
+    min-height: 18px;
+    padding-left: var(--seed-dimension-x1);
+    padding-right: var(--seed-dimension-x1);
+    padding-top: 0px;
+    padding-bottom: 0px;
+    border-radius: var(--seed-radius-full)
+}
+.seed-notification-badge__label--size_large {
+    font-size: var(--seed-font-size-t1-static);
+    line-height: var(--seed-line-height-t1-static);
+    font-weight: var(--seed-font-weight-bold)
+}

--- a/packages/lynx-css/recipes/notification-badge.d.ts
+++ b/packages/lynx-css/recipes/notification-badge.d.ts
@@ -1,0 +1,27 @@
+declare interface NotificationBadgeVariant {
+  /**
+  * - `small`: 간결한 도트 형태로, 텍스트 없이 상태 변화만 표시합니다. 알림의 존재 여부만 중요하거나 공간이 제한된 경우에 적합합니다. 내부 라벨은 지원하지 않습니다.
+  * - `large`: 라벨을 포함해 구체적인 알림 수나 상태 정보를 제공합니다. 세부 정보가 중요하고 충분한 공간이 있을 때 사용합니다. 내부 라벨을 반드시 포함해야 합니다.
+  *
+  * @default "large"
+  */
+  size: "small" | "large";
+}
+
+declare type NotificationBadgeVariantMap = {
+  [key in keyof NotificationBadgeVariant]: Array<NotificationBadgeVariant[key]>;
+};
+
+export declare type NotificationBadgeVariantProps = Partial<NotificationBadgeVariant>;
+
+export declare type NotificationBadgeSlotName = "root" | "label";
+
+export declare const notificationBadgeVariantMap: NotificationBadgeVariantMap;
+
+export declare const notificationBadge: ((
+  props?: NotificationBadgeVariantProps,
+) => Record<NotificationBadgeSlotName, string>) & {
+  splitVariantProps: <T extends NotificationBadgeVariantProps>(
+    props: T,
+  ) => [NotificationBadgeVariantProps, Omit<T, keyof NotificationBadgeVariantProps>];
+}

--- a/packages/lynx-css/recipes/notification-badge.mjs
+++ b/packages/lynx-css/recipes/notification-badge.mjs
@@ -1,0 +1,43 @@
+import './notification-badge.css';
+import { createClassName, mergeVariants, splitVariantProps } from "./shared.mjs";
+
+const notificationBadgeSlotNames = [
+  [
+    "root",
+    "seed-notification-badge__root"
+  ],
+  [
+    "label",
+    "seed-notification-badge__label"
+  ]
+];
+
+const defaultVariant = {
+  "size": "large"
+};
+
+const compoundVariants = [];
+
+export const notificationBadgeVariantMap = {
+  "size": [
+    "small",
+    "large"
+  ]
+};
+
+export const notificationBadgeVariantKeys = Object.keys(notificationBadgeVariantMap);
+
+export function notificationBadge(props) {
+  return Object.fromEntries(
+    notificationBadgeSlotNames.map(([slot, className]) => {
+      return [
+        slot,
+        createClassName(className, mergeVariants(defaultVariant, props), compoundVariants),
+      ];
+    }),
+  );
+}
+
+Object.assign(notificationBadge, { splitVariantProps: (props) => splitVariantProps(props, notificationBadgeVariantMap) });
+
+// @recipe(seed): notification-badge

--- a/packages/lynx-qvism-preset/src/recipes.ts
+++ b/packages/lynx-qvism-preset/src/recipes.ts
@@ -15,6 +15,7 @@ import pageBanner from "./recipes/page-banner";
 import radio from "./recipes/radio";
 import radioGroup from "./recipes/radio-group";
 import radiomark from "./recipes/radiomark";
+import { notificationBadge, notificationBadgePositioner } from "./recipes/notification-badge";
 import segmentedControl from "./recipes/segmented-control";
 import { selectBox, selectBoxCheckmark, selectBoxGroup } from "./recipes/select-box";
 import switchRecipe from "./recipes/switch";
@@ -45,6 +46,8 @@ export const recipes = {
   radio,
   radioGroup,
   radiomark,
+  notificationBadge,
+  notificationBadgePositioner,
   segmentedControl,
   selectBox,
   selectBoxCheckmark,

--- a/packages/lynx-qvism-preset/src/recipes/notification-badge.ts
+++ b/packages/lynx-qvism-preset/src/recipes/notification-badge.ts
@@ -1,0 +1,119 @@
+import spec from "@seed-design/rootage-artifacts/components/notification-badge";
+
+import { defineRecipe, defineSlotRecipe } from "../utils/define";
+import { notificationBadge as vars } from "../vars/component";
+
+export const notificationBadgePositioner = defineRecipe({
+  name: "notification-badge-positioner",
+  base: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    position: "absolute",
+    width: "max-content",
+  },
+  variants: {
+    attach: {
+      icon: {
+        transform: "translate(100%, -100%)",
+      },
+      text: {
+        transform: "translate(100%, 0%)",
+      },
+    },
+    size: {
+      small: {},
+      large: {},
+    },
+  },
+  compoundVariants: [
+    {
+      size: "large",
+      attach: "icon",
+      css: {
+        top: vars.sizeLarge.enabled.root.iconAttachedInsetTop,
+        right: vars.sizeLarge.enabled.root.iconAttachedInsetEnd,
+      },
+    },
+    {
+      size: "small",
+      attach: "icon",
+      css: {
+        top: vars.sizeSmall.enabled.root.iconAttachedInsetTop,
+        right: vars.sizeSmall.enabled.root.iconAttachedInsetEnd,
+      },
+    },
+    {
+      size: "large",
+      attach: "text",
+      css: {
+        right: `calc(-1 * ${vars.sizeLarge.enabled.root.textAttachedGap})`,
+      },
+    },
+    {
+      size: "small",
+      attach: "text",
+      css: {
+        right: `calc(-1 * ${vars.sizeSmall.enabled.root.textAttachedGap})`,
+      },
+    },
+  ],
+  defaultVariants: {
+    size: "large",
+    attach: "icon",
+  },
+});
+
+export const notificationBadge = defineSlotRecipe({
+  name: "notification-badge",
+  slots: ["root", "label"],
+  base: {
+    root: {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      flexShrink: 0,
+      backgroundColor: vars.base.enabled.root.color,
+    },
+    label: {
+      textAlign: "center",
+      color: vars.base.enabled.label.color,
+      whiteSpace: "nowrap",
+      flexShrink: 0,
+    },
+  },
+  variants: {
+    size: {
+      small: {
+        root: {
+          width: vars.sizeSmall.enabled.root.size,
+          height: vars.sizeSmall.enabled.root.size,
+          borderRadius: vars.sizeSmall.enabled.root.cornerRadius,
+        },
+      },
+      large: {
+        root: {
+          width: "max-content",
+          minWidth: vars.sizeLarge.enabled.root.minWidth,
+          minHeight: vars.sizeLarge.enabled.root.minHeight,
+          paddingLeft: vars.sizeLarge.enabled.root.paddingX,
+          paddingRight: vars.sizeLarge.enabled.root.paddingX,
+          paddingTop: vars.sizeLarge.enabled.root.paddingY,
+          paddingBottom: vars.sizeLarge.enabled.root.paddingY,
+          borderRadius: vars.sizeLarge.enabled.root.cornerRadius,
+        },
+        label: {
+          fontSize: vars.sizeLarge.enabled.label.fontSize,
+          lineHeight: vars.sizeLarge.enabled.label.lineHeight,
+          fontWeight: vars.sizeLarge.enabled.label.fontWeight,
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    size: "large",
+  },
+  metadata: {
+    variants: spec.data.schema.variants,
+  },
+});

--- a/packages/lynx-react/src/components/NotificationBadge/NotificationBadge.test.tsx
+++ b/packages/lynx-react/src/components/NotificationBadge/NotificationBadge.test.tsx
@@ -1,0 +1,28 @@
+import "@testing-library/jest-dom";
+import { render } from "@lynx-js/react/testing-library";
+import { describe, expect, it } from "vitest";
+
+import { NotificationBadge, NotificationBadgePositioner } from "./NotificationBadge";
+
+describe("NotificationBadge", () => {
+  it("inherits the positioner's size and preserves user class names", () => {
+    render(
+      <view>
+        <NotificationBadgePositioner attach="text" size="small" className="custom-positioner">
+          <NotificationBadge className="custom-badge" />
+        </NotificationBadgePositioner>
+      </view>,
+    );
+
+    const positioner = elementTree.root?.querySelector(".seed-notification-badge-positioner");
+    const badge = elementTree.root?.querySelector(".seed-notification-badge__root");
+    const label = elementTree.root?.querySelector(".seed-notification-badge__label");
+
+    expect(positioner).toHaveClass("custom-positioner");
+    expect(positioner).toHaveClass("seed-notification-badge-positioner--attach_text");
+    expect(positioner).toHaveClass("seed-notification-badge-positioner--size_small");
+    expect(badge).toHaveClass("custom-badge");
+    expect(badge).toHaveClass("seed-notification-badge__root--size_small");
+    expect(label).toHaveAttribute("text-single-line-vertical-align", "center");
+  });
+});

--- a/packages/lynx-react/src/components/NotificationBadge/NotificationBadge.tsx
+++ b/packages/lynx-react/src/components/NotificationBadge/NotificationBadge.tsx
@@ -1,0 +1,80 @@
+import {
+  notificationBadge,
+  type NotificationBadgeVariantProps,
+} from "@seed-design/lynx-css/recipes/notification-badge";
+import {
+  notificationBadgePositioner,
+  type NotificationBadgePositionerVariantProps,
+} from "@seed-design/lynx-css/recipes/notification-badge-positioner";
+import clsx from "clsx";
+import * as React from "@lynx-js/react";
+
+import type {
+  LynxAccessibilityProps,
+  LynxStyledElementProps,
+  LynxViewRef,
+} from "../../types";
+
+const NotificationBadgeContext = React.createContext<NotificationBadgeVariantProps | null>(null);
+
+/**
+ * @platform Lynx
+ *
+ * 웹 Notification Badge와 동일한 `size` variant를 제공하며, Lynx native `<view>`와
+ * `<text>`를 직접 렌더링합니다. `NotificationBadgePositioner` 안에서는 Positioner의 `size`를
+ * 기본값으로 사용하고, Badge에 직접 전달한 `size`가 이를 덮어씁니다.
+ */
+export interface NotificationBadgeProps
+  extends NotificationBadgeVariantProps,
+    LynxStyledElementProps,
+    LynxAccessibilityProps {}
+
+export const NotificationBadge = React.forwardRef<unknown, NotificationBadgeProps>(
+  (innerProps, ref) => {
+    const contextProps = React.useContext(NotificationBadgeContext);
+    const props = { ...contextProps, ...innerProps };
+    const [variantProps, otherProps] = notificationBadge.splitVariantProps(props);
+    const classes = notificationBadge(variantProps);
+    const { children, className, ...nativeProps } = otherProps;
+
+    return (
+      <view
+        {...(ref ? { ref: ref as LynxViewRef } : {})}
+        {...nativeProps}
+        className={clsx(classes.root, className)}
+      >
+        <text className={classes.label} text-single-line-vertical-align="center">
+          {children}
+        </text>
+      </view>
+    );
+  },
+);
+
+NotificationBadge.displayName = "NotificationBadge";
+
+export interface NotificationBadgePositionerProps
+  extends NotificationBadgePositionerVariantProps,
+    LynxStyledElementProps {}
+
+export const NotificationBadgePositioner = React.forwardRef<
+  unknown,
+  NotificationBadgePositionerProps
+>((props, ref) => {
+  const [variantProps, otherProps] = notificationBadgePositioner.splitVariantProps(props);
+  const { children, className, ...nativeProps } = otherProps;
+
+  return (
+    <NotificationBadgeContext.Provider value={{ size: variantProps.size }}>
+      <view
+        {...(ref ? { ref: ref as LynxViewRef } : {})}
+        {...nativeProps}
+        className={clsx(notificationBadgePositioner(variantProps), className)}
+      >
+        {children}
+      </view>
+    </NotificationBadgeContext.Provider>
+  );
+});
+
+NotificationBadgePositioner.displayName = "NotificationBadgePositioner";

--- a/packages/lynx-react/src/components/NotificationBadge/NotificationBadge.tsx
+++ b/packages/lynx-react/src/components/NotificationBadge/NotificationBadge.tsx
@@ -63,9 +63,10 @@ export const NotificationBadgePositioner = React.forwardRef<
 >((props, ref) => {
   const [variantProps, otherProps] = notificationBadgePositioner.splitVariantProps(props);
   const { children, className, ...nativeProps } = otherProps;
+  const contextValue = React.useMemo(() => ({ size: variantProps.size }), [variantProps.size]);
 
   return (
-    <NotificationBadgeContext.Provider value={{ size: variantProps.size }}>
+    <NotificationBadgeContext.Provider value={contextValue}>
       <view
         {...(ref ? { ref: ref as LynxViewRef } : {})}
         {...nativeProps}

--- a/packages/lynx-react/src/components/NotificationBadge/index.ts
+++ b/packages/lynx-react/src/components/NotificationBadge/index.ts
@@ -1,0 +1,6 @@
+export {
+  NotificationBadge,
+  NotificationBadgePositioner,
+  type NotificationBadgePositionerProps,
+  type NotificationBadgeProps,
+} from "./NotificationBadge";

--- a/packages/lynx-react/src/components/NotificationBadge/index.ts
+++ b/packages/lynx-react/src/components/NotificationBadge/index.ts
@@ -1,6 +1,1 @@
-export {
-  NotificationBadge,
-  NotificationBadgePositioner,
-  type NotificationBadgePositionerProps,
-  type NotificationBadgeProps,
-} from "./NotificationBadge";
+export * from "./NotificationBadge";

--- a/packages/lynx-react/src/components/index.ts
+++ b/packages/lynx-react/src/components/index.ts
@@ -11,6 +11,7 @@ export * from "./Divider";
 export * from "./Field";
 export * from "./Icon";
 export * from "./KeyboardAvoidingScrollView";
+export * from "./NotificationBadge";
 export * from "./PageBanner";
 export * from "./ProgressCircle";
 export * from "./RadioGroup";


### PR DESCRIPTION
## 변경 내용

- Lynx용 `NotificationBadge`와 `NotificationBadgePositioner`를 추가합니다.
- 배지 Recipe와 생성 CSS를 추가합니다.
- Lynx 문서와 실행 예제를 추가합니다.
- iOS와 Android에서 숫자 배지의 너비와 텍스트 정렬을 맞춥니다.
- `@seed-design/lynx-react`와 `@seed-design/lynx-css` minor changeset을 추가합니다.

## 검증

- iOS PlayLynx와 Android 실제 실행 확인
- `bun test:lynx-react`
- `bun docs:test`
- `bun packages:build`
- `bun test:all`
- Lynx Recipe와 문서 생성 후 변경 없음 확인

## 참고

`bun generate:all`은 `origin/minor`에 이미 있는 React `mask` Recipe의 `buildMask` 오류로 중단됩니다. 이번 변경은 해당 경로를 수정하지 않으며, Lynx Recipe와 문서 생성은 별도로 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - Lynx용 `NotificationBadge` 및 `NotificationBadgePositioner` 컴포넌트를 추가했습니다.
  - 아이콘·텍스트 부착 위치와 small·large 크기 옵션을 지원합니다.
  - Lynx React 및 CSS 레시피를 통해 배지 스타일을 제공합니다.

- **문서**
  - 사용법, 접근성 지침, Props 및 Lynx 환경의 동작 차이를 안내하는 문서를 추가했습니다.
  - 다양한 배지 표시 예제를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->