### PR TITLE
fix(lynx-tabs): disable initial transitions

### DIFF
--- a/.changeset/quiet-tabs-settle.md
+++ b/.changeset/quiet-tabs-settle.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/lynx-react": patch
+---
+
+Lynx Tabs가 초기 렌더링 시 선택된 탭으로 이동하면서 Label 색상과 Indicator 위치·크기를 전환하던 문제를 수정합니다.

--- a/packages/lynx-css/all.css
+++ b/packages/lynx-css/all.css
@@ -2972,6 +2972,10 @@ text {
   top: 0;
 }
 
+.seed-tabs__indicator--transitionEnabled_false, .seed-tabs__triggerLabel--transitionEnabled_false {
+  transition-duration: 0s;
+}
+
 .seed-tabs__triggerLabel--selected_true {
   color: var(--seed-color-fg-neutral);
 }

--- a/packages/lynx-css/all.css
+++ b/packages/lynx-css/all.css
@@ -2889,6 +2889,9 @@ text {
 .seed-tabs__triggerLabel {
   white-space: nowrap;
   color: var(--seed-color-fg-neutral-subtle);
+  transition-property: color;
+  transition-duration: var(--seed-duration-d4);
+  transition-timing-function: var(--seed-timing-function-easing);
 }
 
 .seed-tabs__listContent--triggerLayout_fill {

--- a/packages/lynx-css/recipes/tabs.css
+++ b/packages/lynx-css/recipes/tabs.css
@@ -51,7 +51,10 @@
 }
 .seed-tabs__triggerLabel {
     white-space: nowrap;
-    color: var(--seed-color-fg-neutral-subtle)
+    color: var(--seed-color-fg-neutral-subtle);
+    transition-property: color;
+    transition-duration: var(--seed-duration-d4);
+    transition-timing-function: var(--seed-timing-function-easing)
 }
 .seed-tabs__listContent--triggerLayout_fill {
     width: 100%;

--- a/packages/lynx-css/recipes/tabs.css
+++ b/packages/lynx-css/recipes/tabs.css
@@ -122,6 +122,12 @@
     top: 0px;
     z-index: 1
 }
+.seed-tabs__indicator--transitionEnabled_false {
+    transition-duration: 0s
+}
+.seed-tabs__triggerLabel--transitionEnabled_false {
+    transition-duration: 0s
+}
 .seed-tabs__triggerLabel--selected_true {
     color: var(--seed-color-fg-neutral)
 }

--- a/packages/lynx-css/recipes/tabs.d.ts
+++ b/packages/lynx-css/recipes/tabs.d.ts
@@ -15,6 +15,10 @@ declare interface TabsVariant {
   * @default false
   */
   stickyList: boolean;
+/**
+  * @default true
+  */
+  transitionEnabled: boolean;
 selected: boolean;
 disabled: boolean;
 inCarousel: boolean;

--- a/packages/lynx-css/recipes/tabs.mjs
+++ b/packages/lynx-css/recipes/tabs.mjs
@@ -44,7 +44,8 @@ const defaultVariant = {
   "triggerLayout": "fill",
   "contentLayout": "hug",
   "size": "small",
-  "stickyList": false
+  "stickyList": false,
+  "transitionEnabled": true
 };
 
 const compoundVariants = [
@@ -68,6 +69,10 @@ export const tabsVariantMap = {
     "medium"
   ],
   "stickyList": [
+    true,
+    false
+  ],
+  "transitionEnabled": [
     true,
     false
   ],

--- a/packages/lynx-qvism-preset/src/recipes/tabs.ts
+++ b/packages/lynx-qvism-preset/src/recipes/tabs.ts
@@ -69,6 +69,9 @@ const tabs = defineSlotRecipe({
     triggerLabel: {
       whiteSpace: "nowrap",
       color: triggerVars.base.enabled.label.color,
+      transitionProperty: "color",
+      transitionDuration: vars.base.enabled.indicator.transformDuration,
+      transitionTimingFunction: vars.base.enabled.indicator.transformTimingFunction,
     },
   },
   variants: {

--- a/packages/lynx-qvism-preset/src/recipes/tabs.ts
+++ b/packages/lynx-qvism-preset/src/recipes/tabs.ts
@@ -163,6 +163,17 @@ const tabs = defineSlotRecipe({
       },
       false: {},
     },
+    transitionEnabled: {
+      true: {},
+      false: {
+        indicator: {
+          transitionDuration: "0s",
+        },
+        triggerLabel: {
+          transitionDuration: "0s",
+        },
+      },
+    },
     selected: {
       true: {
         triggerLabel: {
@@ -204,6 +215,7 @@ const tabs = defineSlotRecipe({
     contentLayout: "hug",
     size: "small",
     stickyList: false,
+    transitionEnabled: true,
   },
 });
 

--- a/packages/lynx-qvism-preset/tabs.test.ts
+++ b/packages/lynx-qvism-preset/tabs.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+
+import tabs from "./src/recipes/tabs";
+import { tab as triggerVars, tablist as vars } from "./src/vars/component";
+
+describe("Lynx tabs recipe", () => {
+  it("uses a positive label color transition with a disabled override", () => {
+    expect(tabs.base["triggerLabel"]).toEqual({
+      whiteSpace: "nowrap",
+      color: triggerVars.base.enabled.label.color,
+      transitionProperty: "color",
+      transitionDuration: vars.base.enabled.indicator.transformDuration,
+      transitionTimingFunction: vars.base.enabled.indicator.transformTimingFunction,
+    });
+    expect(tabs.variants["transitionEnabled"]["false"]["triggerLabel"]).toEqual({
+      transitionDuration: "0s",
+    });
+  });
+});

--- a/packages/lynx-qvism-preset/tabs.test.ts
+++ b/packages/lynx-qvism-preset/tabs.test.ts
@@ -4,7 +4,7 @@ import tabs from "./src/recipes/tabs";
 import { tab as triggerVars, tablist as vars } from "./src/vars/component";
 
 describe("Lynx tabs recipe", () => {
-  it("uses a positive label color transition with a disabled override", () => {
+  it("defines an enabled label transition and disabled overrides", () => {
     expect(tabs.base["triggerLabel"]).toEqual({
       whiteSpace: "nowrap",
       color: triggerVars.base.enabled.label.color,
@@ -13,6 +13,9 @@ describe("Lynx tabs recipe", () => {
       transitionTimingFunction: vars.base.enabled.indicator.transformTimingFunction,
     });
     expect(tabs.variants["transitionEnabled"]["false"]["triggerLabel"]).toEqual({
+      transitionDuration: "0s",
+    });
+    expect(tabs.variants["transitionEnabled"]["false"]["indicator"]).toEqual({
       transitionDuration: "0s",
     });
   });

--- a/packages/lynx-react/src/components/Tabs/Tabs.test.tsx
+++ b/packages/lynx-react/src/components/Tabs/Tabs.test.tsx
@@ -41,6 +41,17 @@ describe("Tabs", () => {
     expect(listContent?.querySelectorAll(".seed-tabs__trigger")).toHaveLength(2);
   });
 
+  it("disables label and indicator transitions during the initial render", () => {
+    const { container } = render(<BasicTabs defaultValue="two" />);
+    const labels = container.querySelectorAll<HTMLElement>(".seed-tabs__triggerLabel");
+    const indicator = container.querySelector<HTMLElement>(".seed-tabs__indicator");
+
+    expect(indicator).toHaveStyle({ transitionDuration: "0s" });
+    for (const label of labels) {
+      expect(label).toHaveStyle({ transitionDuration: "0s" });
+    }
+  });
+
   it("changes an uncontrolled value when a trigger is tapped", () => {
     const onValueChange = vi.fn();
     const { container } = render(<BasicTabs defaultValue="one" onValueChange={onValueChange} />);

--- a/packages/lynx-react/src/components/Tabs/Tabs.test.tsx
+++ b/packages/lynx-react/src/components/Tabs/Tabs.test.tsx
@@ -3,7 +3,12 @@ import { fireEvent, render } from "@lynx-js/react/testing-library";
 import { describe, expect, it, vi } from "vitest";
 
 import * as Tabs from "./Tabs.namespace";
-import { getTabsLayoutWidth, getTabsOrderedItems, getTabsTriggerRects } from "./Tabs.utils";
+import {
+  areTabsTransitionsEnabled,
+  getTabsLayoutWidth,
+  getTabsOrderedItems,
+  getTabsTriggerRects,
+} from "./Tabs.utils";
 
 function BasicTabs(props: {
   value?: string;
@@ -50,6 +55,13 @@ describe("Tabs", () => {
     for (const label of labels) {
       expect(label).toHaveStyle({ transitionDuration: "0s" });
     }
+  });
+
+  it("disables transitions when a dynamically added trigger is unmeasured", () => {
+    const rects = getTabsTriggerRects(["one", "two"], { one: 80, two: 80 });
+
+    expect(areTabsTransitionsEnabled(["one", "two"], rects)).toBe(true);
+    expect(areTabsTransitionsEnabled(["one", "two", "three"], rects)).toBe(false);
   });
 
   it("changes an uncontrolled value when a trigger is tapped", () => {

--- a/packages/lynx-react/src/components/Tabs/Tabs.test.tsx
+++ b/packages/lynx-react/src/components/Tabs/Tabs.test.tsx
@@ -51,9 +51,11 @@ describe("Tabs", () => {
     const labels = container.querySelectorAll<HTMLElement>(".seed-tabs__triggerLabel");
     const indicator = container.querySelector<HTMLElement>(".seed-tabs__indicator");
 
-    expect(indicator).toHaveStyle({ transitionDuration: "0s" });
+    expect(indicator).toHaveClass("seed-tabs__indicator--transitionEnabled_false");
+    expect(indicator?.style.transitionDuration).toBe("");
     for (const label of labels) {
-      expect(label).toHaveStyle({ transitionDuration: "0s" });
+      expect(label).toHaveClass("seed-tabs__triggerLabel--transitionEnabled_false");
+      expect(label.style.transitionDuration).toBe("");
     }
   });
 

--- a/packages/lynx-react/src/components/Tabs/Tabs.tsx
+++ b/packages/lynx-react/src/components/Tabs/Tabs.tsx
@@ -32,7 +32,10 @@ type NativeViewPagerProps = IntrinsicElements["viewpager"];
 type LayoutChangeHandler = NonNullable<NativeViewProps["bindlayoutchange"]>;
 type TriggerRect = TabsLayoutRect;
 type TriggerItem = { value: string; disabled: boolean };
-type TabsPublicVariantProps = Omit<TabsVariantProps, "selected" | "disabled" | "inCarousel">;
+type TabsPublicVariantProps = Omit<
+  TabsVariantProps,
+  "selected" | "disabled" | "inCarousel" | "transitionEnabled"
+>;
 
 const { ClassNamesProvider, useClassNames } = createSlotRecipeContext(tabs);
 
@@ -139,7 +142,6 @@ export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) =>
     onValueChange,
     ...nativeProps
   } = otherProps;
-  const classNames = tabs(variantProps);
   const [value, setValueInternal] = useControllableState<string | undefined>({
     value: valueProp,
     defaultValue,
@@ -175,6 +177,7 @@ export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) =>
     items.map((item) => item.value),
     triggerRects,
   );
+  const classNames = tabs({ ...variantProps, transitionEnabled: transitionsEnabled });
   const visualValue = indicatorValue ?? value;
   const indicatorIndex = items.findIndex((item) => item.value === visualValue);
   const selectedPagerIndex = value === undefined ? -1 : pagerValues.indexOf(value);
@@ -455,6 +458,7 @@ export const TabsTrigger = React.forwardRef<unknown, TabsTriggerProps>((props, r
     ...context.variantProps,
     selected: visuallySelected,
     disabled,
+    transitionEnabled: context.transitionsEnabled,
   });
   const label =
     typeof children === "string" || typeof children === "number" ? String(children) : undefined;
@@ -474,12 +478,7 @@ export const TabsTrigger = React.forwardRef<unknown, TabsTriggerProps>((props, r
       className={clsx(triggerClasses.trigger, className)}
       style={style}
     >
-      <text
-        className={triggerClasses.triggerLabel}
-        style={context.transitionsEnabled ? undefined : { transitionDuration: "0s" }}
-      >
-        {children}
-      </text>
+      <text className={triggerClasses.triggerLabel}>{children}</text>
     </view>
   );
 });
@@ -492,8 +491,7 @@ export interface TabsIndicatorProps extends LynxStyledElementProps {}
 export const TabsIndicator = React.forwardRef<unknown, TabsIndicatorProps>((props, ref) => {
   const { className, style, ...nativeProps } = props;
   const classNames = useClassNames();
-  const { indicatorRef, items, indicatorIndex, transitionsEnabled, triggerRects } =
-    useTabsContext("TabsIndicator");
+  const { indicatorRef, items, indicatorIndex, triggerRects } = useTabsContext("TabsIndicator");
   const position = indicatorIndex;
   const lowerIndex = Math.max(0, Math.floor(position));
   const upperIndex = Math.min(items.length - 1, Math.ceil(position));
@@ -519,7 +517,6 @@ export const TabsIndicator = React.forwardRef<unknown, TabsIndicatorProps>((prop
           "--tabs-indicator-x": `${x}px`,
           "--tabs-indicator-width": `${width}px`,
           ...style,
-          ...(transitionsEnabled ? {} : { transitionDuration: "0s" }),
         } as LynxViewProps["style"]
       }
     />

--- a/packages/lynx-react/src/components/Tabs/Tabs.tsx
+++ b/packages/lynx-react/src/components/Tabs/Tabs.tsx
@@ -20,6 +20,7 @@ import type {
 } from "../../types";
 import { createSlotRecipeContext } from "../../utils/create-slot-recipe-context";
 import {
+  areTabsTransitionsEnabled,
   getTabsLayoutWidth,
   getTabsOrderedItems,
   getTabsTriggerRects,
@@ -151,7 +152,6 @@ export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) =>
   const [contentValues, setContentValues] = React.useState<string[]>([]);
   const [indicatorValue, setIndicatorValue] = React.useState<string | undefined>();
   const [triggerWidths, setTriggerWidths] = React.useState<Record<string, number>>({});
-  const [transitionsEnabled, setTransitionsEnabled] = React.useState(false);
   const listRef = React.useRef<NodesRef | null>(null);
   const pagerRef = React.useRef<NodesRef | null>(null);
   const indicatorRef = React.useMainThreadRef<MainThread.Element>(null);
@@ -170,6 +170,10 @@ export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) =>
         triggerWidths,
       ),
     [items, triggerWidths],
+  );
+  const transitionsEnabled = areTabsTransitionsEnabled(
+    items.map((item) => item.value),
+    triggerRects,
   );
   const visualValue = indicatorValue ?? value;
   const indicatorIndex = items.findIndex((item) => item.value === visualValue);
@@ -274,17 +278,6 @@ export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) =>
     }
     if (selectedOffset !== null) invokeScrollToOffset(listRef.current, selectedOffset);
   }, [selectedPagerIndex, selectedOffset]);
-
-  React.useEffect(() => {
-    "background only";
-    if (
-      !transitionsEnabled &&
-      items.length > 0 &&
-      items.every((item) => triggerRects[item.value] !== undefined)
-    ) {
-      setTransitionsEnabled(true);
-    }
-  }, [items, transitionsEnabled, triggerRects]);
 
   const contextValue = React.useMemo<TabsContextValue>(
     () => ({

--- a/packages/lynx-react/src/components/Tabs/Tabs.tsx
+++ b/packages/lynx-react/src/components/Tabs/Tabs.tsx
@@ -65,6 +65,7 @@ interface TabsContextValue {
   selectedPagerIndex: number;
   indicatorRef: React.RefObject<MainThread.Element>;
   triggerRects: Record<string, TriggerRect>;
+  transitionsEnabled: boolean;
   registerTrigger: (value: string, disabled: boolean) => () => void;
   registerContent: (value: string) => () => void;
   updateTriggerDisabled: (value: string, disabled: boolean) => void;
@@ -150,6 +151,7 @@ export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) =>
   const [contentValues, setContentValues] = React.useState<string[]>([]);
   const [indicatorValue, setIndicatorValue] = React.useState<string | undefined>();
   const [triggerWidths, setTriggerWidths] = React.useState<Record<string, number>>({});
+  const [transitionsEnabled, setTransitionsEnabled] = React.useState(false);
   const listRef = React.useRef<NodesRef | null>(null);
   const pagerRef = React.useRef<NodesRef | null>(null);
   const indicatorRef = React.useMainThreadRef<MainThread.Element>(null);
@@ -273,6 +275,17 @@ export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) =>
     if (selectedOffset !== null) invokeScrollToOffset(listRef.current, selectedOffset);
   }, [selectedPagerIndex, selectedOffset]);
 
+  React.useEffect(() => {
+    "background only";
+    if (
+      !transitionsEnabled &&
+      items.length > 0 &&
+      items.every((item) => triggerRects[item.value] !== undefined)
+    ) {
+      setTransitionsEnabled(true);
+    }
+  }, [items, transitionsEnabled, triggerRects]);
+
   const contextValue = React.useMemo<TabsContextValue>(
     () => ({
       value,
@@ -283,6 +296,7 @@ export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) =>
       indicatorIndex,
       selectedPagerIndex,
       indicatorRef,
+      transitionsEnabled,
       triggerRects,
       registerTrigger,
       registerContent,
@@ -305,6 +319,7 @@ export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) =>
       selectedPagerIndex,
       indicatorRef,
       triggerRects,
+      transitionsEnabled,
       registerTrigger,
       registerContent,
       updateTriggerDisabled,
@@ -466,7 +481,12 @@ export const TabsTrigger = React.forwardRef<unknown, TabsTriggerProps>((props, r
       className={clsx(triggerClasses.trigger, className)}
       style={style}
     >
-      <text className={triggerClasses.triggerLabel}>{children}</text>
+      <text
+        className={triggerClasses.triggerLabel}
+        style={context.transitionsEnabled ? undefined : { transitionDuration: "0s" }}
+      >
+        {children}
+      </text>
     </view>
   );
 });
@@ -479,7 +499,8 @@ export interface TabsIndicatorProps extends LynxStyledElementProps {}
 export const TabsIndicator = React.forwardRef<unknown, TabsIndicatorProps>((props, ref) => {
   const { className, style, ...nativeProps } = props;
   const classNames = useClassNames();
-  const { indicatorRef, items, indicatorIndex, triggerRects } = useTabsContext("TabsIndicator");
+  const { indicatorRef, items, indicatorIndex, transitionsEnabled, triggerRects } =
+    useTabsContext("TabsIndicator");
   const position = indicatorIndex;
   const lowerIndex = Math.max(0, Math.floor(position));
   const upperIndex = Math.min(items.length - 1, Math.ceil(position));
@@ -505,6 +526,7 @@ export const TabsIndicator = React.forwardRef<unknown, TabsIndicatorProps>((prop
           "--tabs-indicator-x": `${x}px`,
           "--tabs-indicator-width": `${width}px`,
           ...style,
+          ...(transitionsEnabled ? {} : { transitionDuration: "0s" }),
         } as LynxViewProps["style"]
       }
     />

--- a/packages/lynx-react/src/components/Tabs/Tabs.utils.ts
+++ b/packages/lynx-react/src/components/Tabs/Tabs.utils.ts
@@ -54,3 +54,10 @@ export function getTabsTriggerRects(
 
   return rects;
 }
+
+export function areTabsTransitionsEnabled(
+  values: string[],
+  rects: Record<string, TabsLayoutRect>,
+): boolean {
+  return values.length > 0 && values.every((value) => rects[value] !== undefined);
+}

--- a/skills/seed-create-component/references/lynx-patterns.md
+++ b/skills/seed-create-component/references/lynx-patterns.md
@@ -48,6 +48,46 @@ Lynx compound 컴포넌트라고 해서 `createSlotRecipeContext`를 무조건 �
 - `inherit`, CSS-wide keyword, Web-only SVG stroke/fill CSS, `content`, unsupported shorthand에 의존하지 않는다.
 - style 변경은 `packages/lynx-qvism-preset/src/recipes/*` 또는 Rootage 원천에서 하고, generated `packages/lynx-css/*`는 직접 수정하지 않는다.
 
+## 초기 레이아웃 전환 방지
+
+위치·크기·색상처럼 **등록 또는 레이아웃 측정 결과에 따라 정해지는 값**에 transition을 적용하면, Lynx의 최초 렌더링 중간값에서 최종값으로 이동하는 과정까지 사용자 전환처럼 보일 수 있다. 선택 Indicator, 가변 너비 Trigger, Carousel처럼 초기 선택 상태와 측정값을 함께 쓰는 컴포넌트는 다음 패턴을 적용한다.
+
+- 최초 렌더링은 상태 변화가 아니라 초기화다. 필요한 자식 등록과 레이아웃 측정이 모두 끝날 때까지 관련 transition을 비활성화한다.
+- `useEffect`가 한 번 실행됐거나 첫 측정값이 들어왔다는 이유만으로 활성화하지 않는다. `items.every((item) => rects[item.value] !== undefined)`처럼 최종 스타일 계산에 필요한 값이 모두 준비됐다는 조건을 사용한다.
+- 임의의 timeout으로 초기화 완료 시점을 추정하지 않는다. 컴포넌트가 이미 소유한 등록·측정 상태에서 준비 조건을 계산한다.
+- 준비 전에는 transition 대상 전체에 inline `transitionDuration: "0s"`를 적용한다. Indicator의 위치·크기뿐 아니라 같은 초기 선택 과정에서 바뀌는 Label 색상도 함께 막는다.
+- 사용자 `style`을 허용하는 slot에서는 초기화 불변식이 덮어써지지 않도록 사용자 style을 병합한 **뒤**에 `transitionDuration: "0s"`를 둔다.
+- 준비 완료 플래그는 초기화 중에만 `false`이고, 한 번 `true`가 되면 일반적인 선택·swipe·layout 변경에는 기존 Recipe transition을 사용한다.
+
+```tsx
+const [transitionsEnabled, setTransitionsEnabled] = React.useState(false);
+
+React.useEffect(() => {
+  "background only";
+  if (
+    !transitionsEnabled &&
+    items.length > 0 &&
+    items.every((item) => rects[item.value] !== undefined)
+  ) {
+    setTransitionsEnabled(true);
+  }
+}, [items, rects, transitionsEnabled]);
+
+const initializationStyle = transitionsEnabled ? undefined : { transitionDuration: "0s" };
+
+<text className={labelClassName} style={initializationStyle} />;
+<view
+  className={indicatorClassName}
+  style={{
+    ...positionStyle,
+    ...style,
+    ...(transitionsEnabled ? {} : { transitionDuration: "0s" }),
+  }}
+/>;
+```
+
+회귀 테스트는 첫 번째가 아닌 항목을 초기 선택값으로 렌더링하고, 최초 렌더링 시 Label과 Indicator 모두 `transitionDuration: "0s"`인지 확인한다. 이 검증은 사용자의 실제 선택 이후 transition 자체를 제거하지 않았다는 전제와 함께 본다.
+
 ## Unsupported Web API 문서화
 
 Web과 Lynx의 차이는 타입과 문서가 같은 말을 해야 한다.

--- a/skills/seed-create-component/references/lynx-patterns.md
+++ b/skills/seed-create-component/references/lynx-patterns.md
@@ -53,25 +53,16 @@ Lynx compound 컴포넌트라고 해서 `createSlotRecipeContext`를 무조건 �
 위치·크기·색상처럼 **등록 또는 레이아웃 측정 결과에 따라 정해지는 값**에 transition을 적용하면, Lynx의 최초 렌더링 중간값에서 최종값으로 이동하는 과정까지 사용자 전환처럼 보일 수 있다. 선택 Indicator, 가변 너비 Trigger, Carousel처럼 초기 선택 상태와 측정값을 함께 쓰는 컴포넌트는 다음 패턴을 적용한다.
 
 - 최초 렌더링은 상태 변화가 아니라 초기화다. 필요한 자식 등록과 레이아웃 측정이 모두 끝날 때까지 관련 transition을 비활성화한다.
-- `useEffect`가 한 번 실행됐거나 첫 측정값이 들어왔다는 이유만으로 활성화하지 않는다. `items.every((item) => rects[item.value] !== undefined)`처럼 최종 스타일 계산에 필요한 값이 모두 준비됐다는 조건을 사용한다.
+- `useEffect`가 한 번 실행됐거나 첫 측정값이 들어왔다는 이유만으로 활성화하지 않는다. `items.every((item) => rects[item.value] !== undefined)`처럼 최종 스타일 계산에 필요한 값이 현재 모두 준비됐는지 매 렌더링에서 계산한다.
+- 준비 여부를 한 번 `true`로 만든 뒤 유지하지 않는다. 동적으로 자식이 추가되어 측정값이 다시 불완전해지면 transition도 다시 비활성화한다.
 - 임의의 timeout으로 초기화 완료 시점을 추정하지 않는다. 컴포넌트가 이미 소유한 등록·측정 상태에서 준비 조건을 계산한다.
 - 준비 전에는 transition 대상 전체에 inline `transitionDuration: "0s"`를 적용한다. Indicator의 위치·크기뿐 아니라 같은 초기 선택 과정에서 바뀌는 Label 색상도 함께 막는다.
 - 사용자 `style`을 허용하는 slot에서는 초기화 불변식이 덮어써지지 않도록 사용자 style을 병합한 **뒤**에 `transitionDuration: "0s"`를 둔다.
-- 준비 완료 플래그는 초기화 중에만 `false`이고, 한 번 `true`가 되면 일반적인 선택·swipe·layout 변경에는 기존 Recipe transition을 사용한다.
+- 현재 등록된 모든 대상의 측정이 끝난 동안에는 일반적인 선택·swipe·layout 변경에 기존 Recipe transition을 사용한다.
 
 ```tsx
-const [transitionsEnabled, setTransitionsEnabled] = React.useState(false);
-
-React.useEffect(() => {
-  "background only";
-  if (
-    !transitionsEnabled &&
-    items.length > 0 &&
-    items.every((item) => rects[item.value] !== undefined)
-  ) {
-    setTransitionsEnabled(true);
-  }
-}, [items, rects, transitionsEnabled]);
+const transitionsEnabled =
+  items.length > 0 && items.every((item) => rects[item.value] !== undefined);
 
 const initializationStyle = transitionsEnabled ? undefined : { transitionDuration: "0s" };
 
@@ -86,7 +77,7 @@ const initializationStyle = transitionsEnabled ? undefined : { transitionDuratio
 />;
 ```
 
-회귀 테스트는 첫 번째가 아닌 항목을 초기 선택값으로 렌더링하고, 최초 렌더링 시 Label과 Indicator 모두 `transitionDuration: "0s"`인지 확인한다. 이 검증은 사용자의 실제 선택 이후 transition 자체를 제거하지 않았다는 전제와 함께 본다.
+회귀 테스트는 첫 번째가 아닌 항목을 초기 선택값으로 렌더링하고, 최초 렌더링 시 Label과 Indicator 모두 `transitionDuration: "0s"`인지 확인한다. 자식을 동적으로 지원하는 컴포넌트라면 측정 완료 후 새 자식을 추가했을 때 transition이 다시 비활성화되는 경로도 검증한다.
 
 ## Unsupported Web API 문서화
 

--- a/skills/seed-create-component/references/lynx-patterns.md
+++ b/skills/seed-create-component/references/lynx-patterns.md
@@ -56,28 +56,36 @@ Lynx compound 컴포넌트라고 해서 `createSlotRecipeContext`를 무조건 �
 - `useEffect`가 한 번 실행됐거나 첫 측정값이 들어왔다는 이유만으로 활성화하지 않는다. `items.every((item) => rects[item.value] !== undefined)`처럼 최종 스타일 계산에 필요한 값이 현재 모두 준비됐는지 매 렌더링에서 계산한다.
 - 준비 여부를 한 번 `true`로 만든 뒤 유지하지 않는다. 동적으로 자식이 추가되어 측정값이 다시 불완전해지면 transition도 다시 비활성화한다.
 - 임의의 timeout으로 초기화 완료 시점을 추정하지 않는다. 컴포넌트가 이미 소유한 등록·측정 상태에서 준비 조건을 계산한다.
-- 준비 전에는 transition 대상 전체에 inline `transitionDuration: "0s"`를 적용한다. Indicator의 위치·크기뿐 아니라 같은 초기 선택 과정에서 바뀌는 Label 색상도 함께 막는다.
-- 사용자 `style`을 허용하는 slot에서는 초기화 불변식이 덮어써지지 않도록 사용자 style을 병합한 **뒤**에 `transitionDuration: "0s"`를 둔다.
+- 준비 전에는 transition 대상 전체가 `transitionDuration: "0s"`를 받도록 내부 boolean Recipe variant를 둔다. Indicator의 위치·크기뿐 아니라 같은 초기 선택 과정에서 바뀌는 Label 색상도 함께 막는다.
+- React 레이어에서 `transitionDuration`을 inline `style`로 지정하지 않는다. 준비 상태를 Recipe variant에 전달하고 각 slot의 className으로 적용한다.
 - 현재 등록된 모든 대상의 측정이 끝난 동안에는 일반적인 선택·swipe·layout 변경에 기존 Recipe transition을 사용한다.
 
 ```tsx
+const componentRecipe = defineSlotRecipe({
+  // ...
+  variants: {
+    transitionEnabled: {
+      true: {},
+      false: {
+        label: { transitionDuration: "0s" },
+        indicator: { transitionDuration: "0s" },
+      },
+    },
+  },
+  defaultVariants: {
+    transitionEnabled: true,
+  },
+});
+
 const transitionsEnabled =
   items.length > 0 && items.every((item) => rects[item.value] !== undefined);
+const classNames = componentRecipe({ ...variantProps, transitionEnabled: transitionsEnabled });
 
-const initializationStyle = transitionsEnabled ? undefined : { transitionDuration: "0s" };
-
-<text className={labelClassName} style={initializationStyle} />;
-<view
-  className={indicatorClassName}
-  style={{
-    ...positionStyle,
-    ...style,
-    ...(transitionsEnabled ? {} : { transitionDuration: "0s" }),
-  }}
-/>;
+<text className={classNames.label} />;
+<view className={classNames.indicator} />;
 ```
 
-회귀 테스트는 첫 번째가 아닌 항목을 초기 선택값으로 렌더링하고, 최초 렌더링 시 Label과 Indicator 모두 `transitionDuration: "0s"`인지 확인한다. 자식을 동적으로 지원하는 컴포넌트라면 측정 완료 후 새 자식을 추가했을 때 transition이 다시 비활성화되는 경로도 검증한다.
+회귀 테스트는 첫 번째가 아닌 항목을 초기 선택값으로 렌더링하고, 최초 렌더링 시 Label과 Indicator에 transition 비활성 Recipe className이 적용되는지 확인한다. 자식을 동적으로 지원하는 컴포넌트라면 측정 완료 후 새 자식을 추가했을 때 준비 상태가 다시 `false`가 되는 경로도 검증한다.
 
 ## Unsupported Web API 문서화
 

--- a/skills/seed-create-component/references/verification-checklist.md
+++ b/skills/seed-create-component/references/verification-checklist.md
@@ -66,6 +66,7 @@ Storybook 파일만 바꿨다면 [storybook.md](storybook.md)의 CSF Next 규칙
 - [ ] Recipe import가 대상 플랫폼과 일치하는가?
 - [ ] Headless와 Styled UI가 상태와 스타일 책임을 중복해서 소유하지 않는가?
 - [ ] 지원하지 않는 플랫폼 기능을 타입과 문서에서 같은 방식으로 제외했는가?
+- [ ] 등록·레이아웃 측정값에 의존하는 transition이 있다면, 필요한 값이 모두 준비될 때까지 Label·Indicator 등 관련 대상의 초기 transition을 비활성화했는가?
 
 ## 배포 준비
 

--- a/skills/seed-create-component/references/verification-checklist.md
+++ b/skills/seed-create-component/references/verification-checklist.md
@@ -66,7 +66,7 @@ Storybook 파일만 바꿨다면 [storybook.md](storybook.md)의 CSF Next 규칙
 - [ ] Recipe import가 대상 플랫폼과 일치하는가?
 - [ ] Headless와 Styled UI가 상태와 스타일 책임을 중복해서 소유하지 않는가?
 - [ ] 지원하지 않는 플랫폼 기능을 타입과 문서에서 같은 방식으로 제외했는가?
-- [ ] 등록·레이아웃 측정값에 의존하는 transition이 있다면, 필요한 값이 모두 준비될 때까지 Label·Indicator 등 관련 대상의 초기 transition을 비활성화했는가?
+- [ ] 등록·레이아웃 측정값에 의존하는 transition이 있다면, 동적 자식 추가를 포함해 현재 필요한 값이 모두 준비될 때까지 Label·Indicator 등 관련 대상의 transition을 비활성화했는가?
 
 ## 배포 준비
 

--- a/skills/seed-create-component/references/verification-checklist.md
+++ b/skills/seed-create-component/references/verification-checklist.md
@@ -66,7 +66,7 @@ Storybook 파일만 바꿨다면 [storybook.md](storybook.md)의 CSF Next 규칙
 - [ ] Recipe import가 대상 플랫폼과 일치하는가?
 - [ ] Headless와 Styled UI가 상태와 스타일 책임을 중복해서 소유하지 않는가?
 - [ ] 지원하지 않는 플랫폼 기능을 타입과 문서에서 같은 방식으로 제외했는가?
-- [ ] 등록·레이아웃 측정값에 의존하는 transition이 있다면, 동적 자식 추가를 포함해 현재 필요한 값이 모두 준비될 때까지 Label·Indicator 등 관련 대상의 transition을 비활성화했는가?
+- [ ] 등록·레이아웃 측정값에 의존하는 transition이 있다면, 동적 자식 추가를 포함해 현재 필요한 값이 모두 준비될 때까지 관련 slot의 Recipe className으로 transition을 비활성화했는가?
 
 ## 배포 준비
 


### PR DESCRIPTION
## 변경 사항

- Lynx Tabs가 최초 렌더링될 때 Label 색상과 Indicator 위치·크기에 전환 효과를 적용하지 않습니다.
- 등록된 모든 Trigger의 레이아웃 측정이 끝난 뒤부터 전환 효과를 활성화합니다.
- 초기 전환 시간이 `0s`인지 검증하는 회귀 테스트를 추가합니다.

## 검증

- `bun generate:all`
- `bun packages:build`
- `bun test:all`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * Lynx Tabs가 초기 렌더링 시 선택된 탭으로 이동할 때 라벨 색상과 인디케이터가 불필요하게 전환되던 문제를 수정했습니다.
  * 초기 레이아웃 측정이 완료되기 전에는 전환 애니메이션이 적용되지 않아 탭이 안정적으로 표시됩니다.
  * 탭이 동적으로 추가되어 레이아웃 측정이 다시 필요한 경우에도 전환 애니메이션이 일시적으로 비활성화됩니다.
  * 모든 탭의 레이아웃 측정이 완료되면 전환 애니메이션이 다시 활성화됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->