### PR TITLE
fix(skills): bind Chromatic proxy to loopback and fix --against URLs

### DIFF
--- a/skills/chromatic-diff/scripts/proxy.ts
+++ b/skills/chromatic-diff/scripts/proxy.ts
@@ -28,6 +28,10 @@ function normalizeHost(input: string) {
 
 function serve(upstream: string, token: string) {
   const server = Bun.serve({
+    // Bun listens on every interface unless told otherwise, and this proxy
+    // attaches the account token to whatever it forwards, so the default would
+    // hand anyone on the network an authenticated read of a private Storybook.
+    hostname: "127.0.0.1",
     port: 0,
     idleTimeout: 120,
     async fetch(request) {

--- a/skills/chromatic-diff/scripts/resolve.ts
+++ b/skills/chromatic-diff/scripts/resolve.ts
@@ -176,7 +176,7 @@ function testProbe(testId: string) {
 async function findComparison(appId: string, against: string) {
   // Anchored on the scheme rather than the prefix, because a branch named
   // `http-client-refactor` would otherwise reach `new URL` and die there.
-  if (/^https?:\/\//.test(against)) {
+  if (/^https?:\/\//i.test(against)) {
     const target = parseTarget(against);
 
     if (target.appId !== appId) {

--- a/skills/chromatic-diff/scripts/resolve.ts
+++ b/skills/chromatic-diff/scripts/resolve.ts
@@ -173,14 +173,22 @@ function testProbe(testId: string) {
   };
 }
 
-async function resolveComparison(appId: string, against: string | undefined) {
-  if (!against) return null;
+async function findComparison(appId: string, against: string) {
+  // Anchored on the scheme rather than the prefix, because a branch named
+  // `http-client-refactor` would otherwise reach `new URL` and die there.
+  if (/^https?:\/\//.test(against)) {
+    const target = parseTarget(against);
 
-  if (against.startsWith("http")) {
-    const { buildNumber } = parseTarget(against);
+    if (target.appId !== appId) {
+      throw new Error(
+        `--against names Chromatic project ${target.appId}, but this build belongs to ${appId}. Story ids are scoped to a project, so the two Storybooks have no story in common to compare.`,
+      );
+    }
+
+    if (target.testId) return (await searchBuilds(appId, testProbe(target.testId)))?.build;
 
     return searchBuilds(appId, async (candidates) =>
-      candidates.find((item) => item.number === buildNumber),
+      candidates.find((item) => item.number === target.buildNumber),
     );
   }
 
@@ -198,6 +206,27 @@ async function resolveComparison(appId: string, against: string | undefined) {
   }
 
   return lastBuild(appId, `branches: [${JSON.stringify(against)}]`);
+}
+
+/**
+ * Resolves --against into the build to compare against.
+ *
+ * Throws when nothing matches, rather than returning empty. The caller's other
+ * branch is `Test.baseline`, so degrading into it would answer a different
+ * question from the one that was asked and leave one word of output as the only
+ * trace that the substitution happened.
+ */
+async function resolveComparison(appId: string, against: string | undefined) {
+  if (!against) return null;
+
+  const build = await findComparison(appId, against);
+  if (!build) {
+    throw new Error(
+      `--against ${against} matched no build. lastBuild returns only the newest build per branch and status, so a superseded build is out of reach — check the branch name, or name a build that is still the newest of its branch.`,
+    );
+  }
+
+  return build;
 }
 
 const storybookHost = (url: string | null | undefined) => (url ? new URL(url).host : null);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **보안**
  - 인증된 Storybook 조회가 외부 네트워크에 노출되지 않도록 로컬 연결로 제한했습니다.

- **버그 수정**
  - 비교 대상 빌드 지정 시 URL 형식과 테스트 ID를 더 정확하게 처리합니다.
  - 다른 프로젝트의 빌드를 비교 대상으로 지정하는 경우 명확한 오류를 표시합니다.
  - 빌드를 찾지 못했을 때 모호한 결과 대신 구체적인 오류 메시지를 제공합니다.
  - 숫자, 빌드 ID, 브랜치 이름을 통한 비교 대상 검색 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->