### PR TITLE
feat(lynx): add result section

### DIFF
--- a/docs/content/lynx/components/result-section.mdx
+++ b/docs/content/lynx/components/result-section.mdx
@@ -1,0 +1,88 @@
+---
+title: Result Section
+description: 데이터 로딩 결과, 사용자의 액션 완료 여부 등 사용자 액션의 결과를 제공하는 템플릿입니다. 주로 전체 화면이나 특정 영역을 차지하여 다음 액션을 유도하거나 현재 상황을 안내합니다.
+---
+
+<AvailableSince packages="@seed-design/lynx-react@0.6.0, @seed-design/lynx-css@0.10.0" />
+
+<LynxComponentExample name="lynx/result-section/preview" height={544}>
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/result-section/preview.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+## Installation
+
+```package-install
+npx @seed-design/cli@latest add ui:result-section
+```
+
+<LynxManualInstallation name="result-section" />
+
+## Props
+
+<react-type-table
+  path="./registry/lynx/ui/result-section.tsx"
+  name="ResultSectionProps"
+/>
+
+## Examples
+
+### Sizes
+
+#### Large
+
+전체 화면을 차지하는 상태를 표현할 때 사용합니다.
+
+<LynxComponentExample name="lynx/result-section/large" height={544}>
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/result-section/large.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+#### Medium
+
+카드나 섹션처럼 화면의 일부 영역에서 상태를 표현할 때 사용합니다.
+
+<LynxComponentExample name="lynx/result-section/medium" height={544}>
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/result-section/medium.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### With CTA & Progress Circle
+
+화면의 주요 액션을 하단 CTA로 제공할 때는 Result Section 내부 버튼 대신 별도 Action Button을 배치할 수 있습니다.
+
+<LynxComponentExample name="lynx/result-section/with-cta-progress-circle" height={704}>
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/result-section/with-cta-progress-circle.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Success Example
+
+`asset`은 임의의 ReactLynx 노드를 받습니다. Lottie를 사용할 때는 앱에서 사용하는 Lynx Lottie 요소를 전달하고, 라이트·다크 모드에 맞는 에셋 선택도 앱에서 처리하세요. Result Section은 특정 애니메이션 라이브러리에 의존하지 않습니다.
+
+## Web Version Differences
+
+| 영역 | React Web | Lynx |
+| --- | --- | --- |
+| Native element | `div`, `span`, `button` | `view`, `text` |
+| Event | `onClick` | `bindtap`, `main-thread:bindtap` |
+| Root props | HTML attribute | Lynx native element prop과 `accessibility-*` |
+| Secondary action override | `color`, `fontWeight`, `bleedX`, `bleedY` 적용 | Lynx Action Button의 `ghost`, `small` 스타일 사용 |
+
+Result Section의 크기, 중앙 정렬, 에셋·문구·버튼 구성은 두 플랫폼에서 같습니다. 버튼의 접근 가능한 이름과 탭 이벤트는 `primaryActionProps`와 `secondaryActionProps`에 Lynx Action Button prop으로 전달합니다.

--- a/docs/examples/lynx/result-section/large.tsx
+++ b/docs/examples/lynx/result-section/large.tsx
@@ -1,0 +1,27 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { VStack, useSeedClassName } from "@seed-design/lynx-react";
+import { ResultSection } from "@/components/ui/result-section";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack width="full" height="full" align="center" justify="center">
+        <VStack minHeight="480px" width="320px" borderWidth={1} borderColor="stroke.neutralMuted">
+          <ResultSection
+            size="large"
+            title="cupidatat ad consequat"
+            description="Lorem ipsum dolor sit amet consectetur adipisicing elit."
+            primaryActionProps={{ children: "Primary Action" }}
+            secondaryActionProps={{ children: "Secondary Action" }}
+          />
+        </VStack>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/result-section/medium.tsx
+++ b/docs/examples/lynx/result-section/medium.tsx
@@ -1,0 +1,27 @@
+import "./styles";
+
+import { root } from "@lynx-js/react";
+import { VStack, useSeedClassName } from "@seed-design/lynx-react";
+import { ResultSection } from "@/components/ui/result-section";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack width="full" height="full" align="center" justify="center">
+        <VStack minHeight="480px" width="320px" borderWidth={1} borderColor="stroke.neutralMuted">
+          <ResultSection
+            size="medium"
+            title="cupidatat ad consequat"
+            description="Lorem ipsum dolor sit amet consectetur adipisicing elit."
+            primaryActionProps={{ children: "Primary Action" }}
+            secondaryActionProps={{ children: "Secondary Action" }}
+          />
+        </VStack>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/result-section/preview.css
+++ b/docs/examples/lynx/result-section/preview.css
@@ -1,0 +1,5 @@
+/* biome-ignore lint/correctness/noUnknownTypeSelector: Lynx의 page 요소입니다. */
+page {
+  height: 100%;
+  background-color: var(--seed-color-bg-layer-default);
+}

--- a/docs/examples/lynx/result-section/preview.tsx
+++ b/docs/examples/lynx/result-section/preview.tsx
@@ -1,0 +1,32 @@
+import "./styles";
+
+import IconDiamond from "@karrotmarket/lynx-multicolor-icon/IconDiamond";
+import { root } from "@lynx-js/react";
+import { Box, Icon, VStack, useSeedClassName } from "@seed-design/lynx-react";
+import { ResultSection } from "@/components/ui/result-section";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <page className={seedClassName}>
+      <VStack width="full" height="full" align="center" justify="center">
+        <VStack minHeight="480px" width="320px" borderWidth={1} borderColor="stroke.neutralMuted">
+          <ResultSection
+            asset={
+              <Box pb="x4">
+                <Icon icon={<IconDiamond />} size="x10" multicolor />
+              </Box>
+            }
+            title="결과 타이틀"
+            description="부가 설명을 적어주세요"
+            primaryActionProps={{ children: "Primary Action" }}
+            secondaryActionProps={{ children: "Secondary Action" }}
+          />
+        </VStack>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/examples/lynx/result-section/styles.ts
+++ b/docs/examples/lynx/result-section/styles.ts
@@ -1,0 +1,2 @@
+import "@seed-design/lynx-css/base.css";
+import "./preview.css";

--- a/docs/examples/lynx/result-section/with-cta-progress-circle.tsx
+++ b/docs/examples/lynx/result-section/with-cta-progress-circle.tsx
@@ -1,0 +1,74 @@
+import "./styles";
+
+import IconExclamationmarkCircleFill from "@karrotmarket/lynx-monochrome-icon/IconExclamationmarkCircleFill";
+import { root, useState } from "@lynx-js/react";
+import {
+  ActionButton,
+  AppBar,
+  Box,
+  Icon,
+  ProgressCircle,
+  VStack,
+  useSeedClassName,
+} from "@seed-design/lynx-react";
+import { ResultSection } from "@/components/ui/result-section";
+
+function Root() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+  const [loading, setLoading] = useState(false);
+
+  function handleRetry() {
+    "background only";
+    setLoading(true);
+    setTimeout(() => setLoading(false), 3000);
+  }
+
+  return (
+    <page className={seedClassName}>
+      <VStack width="full" height="full" align="center" justify="center">
+        <VStack height="640px" width="360px" borderWidth={1} borderColor="stroke.neutralMuted">
+          <AppBar.Root>
+            <AppBar.Main>
+              <AppBar.Title>환불 요청</AppBar.Title>
+            </AppBar.Main>
+          </AppBar.Root>
+          <VStack grow gap="x4" pb="safeArea">
+            <ResultSection
+              title={loading ? "환불을 요청하고 있어요" : "다시 시도해주세요"}
+              description={loading ? "잠시만 기다려주세요" : "환불 요청에 실패했어요"}
+              asset={
+                <Box pb="x4">
+                  {loading ? (
+                    <ProgressCircle.Root>
+                      <ProgressCircle.Range />
+                    </ProgressCircle.Root>
+                  ) : (
+                    <Icon
+                      icon={<IconExclamationmarkCircleFill color="var(--seed-color-fg-critical)" />}
+                      size="x10"
+                      color="fg.critical"
+                    />
+                  )}
+                </Box>
+              }
+            />
+            <Box px="spacingX.globalGutter" pt="x3" pb="x2">
+              <ActionButton
+                flexGrow
+                size="large"
+                variant="neutralSolid"
+                disabled={loading}
+                loading={loading}
+                bindtap={handleRetry}
+              >
+                다시 시도
+              </ActionButton>
+            </Box>
+          </VStack>
+        </VStack>
+      </VStack>
+    </page>
+  );
+}
+
+root.render(<Root />);

--- a/docs/public/__docs__/index.json
+++ b/docs/public/__docs__/index.json
@@ -2227,6 +2227,19 @@
               ]
             },
             {
+              "id": "result-section",
+              "title": "Result Section",
+              "description": "데이터 로딩 결과, 사용자의 액션 완료 여부 등 사용자 액션의 결과를 제공하는 템플릿입니다. 주로 전체 화면이나 특정 영역을 차지하여 다음 액션을 유도하거나 현재 상황을 안내합니다.",
+              "docUrl": "/lynx/components/result-section",
+              "snippetKey": "lynx/ui:result-section",
+              "snippets": [
+                {
+                  "label": "react",
+                  "path": "result-section.tsx"
+                }
+              ]
+            },
+            {
               "id": "segmented-control",
               "title": "Segmented Control",
               "description": "여러 옵션 중 하나를 선택하여 관련 콘텐츠를 즉시 필터링하거나 전환할 때 사용하는 컴포넌트입니다.",

--- a/docs/public/__registry__/lynx/ui/index.json
+++ b/docs/public/__registry__/lynx/ui/index.json
@@ -130,6 +130,21 @@
     {
       "snippets": [
         {
+          "path": "result-section.tsx",
+          "dependencies": {
+            "@seed-design/lynx-react": ">=0.1.0 <1.0.0",
+            "@seed-design/lynx-css": ">=0.1.0 <1.0.0"
+          }
+        }
+      ],
+      "id": "result-section",
+      "dependencies": [
+        "@seed-design/lynx-react"
+      ]
+    },
+    {
+      "snippets": [
+        {
           "path": "segmented-control.tsx",
           "dependencies": {
             "@seed-design/lynx-react": ">=0.6.0 <1.0.0",

--- a/docs/public/__registry__/lynx/ui/result-section.json
+++ b/docs/public/__registry__/lynx/ui/result-section.json
@@ -1,0 +1,16 @@
+{
+  "id": "result-section",
+  "dependencies": [
+    "@seed-design/lynx-react"
+  ],
+  "snippets": [
+    {
+      "path": "result-section.tsx",
+      "content": "/**\n * @file ui:result-section\n * @requires @seed-design/lynx-react@>=0.1.0 <1.0.0\n * @requires @seed-design/lynx-css@>=0.1.0 <1.0.0\n **/\n\nimport * as React from \"@lynx-js/react\";\nimport {\n  ActionButton,\n  Text,\n  VStack,\n  type ActionButtonProps,\n  type TextProps,\n  type VStackProps,\n} from \"@seed-design/lynx-react\";\n\nexport interface ResultSectionProps extends Omit<VStackProps, \"children\"> {\n  /**\n   * @default \"large\"\n   */\n  size?: \"large\" | \"medium\";\n\n  asset?: React.ReactNode;\n  title?: React.ReactNode;\n  description?: React.ReactNode;\n\n  primaryActionProps?: ActionButtonProps;\n  secondaryActionProps?: ActionButtonProps;\n}\n\nconst textStyles = {\n  title: {\n    large: \"t8Bold\",\n    medium: \"t5Bold\",\n  },\n  description: {\n    large: \"t5Regular\",\n    medium: \"t4Regular\",\n  },\n} as const satisfies Record<\n  string,\n  Record<NonNullable<ResultSectionProps[\"size\"]>, NonNullable<TextProps[\"textStyle\"]>>\n>;\n\nconst textContainerProperties = {\n  large: {\n    gap: \"x3\",\n    pb: \"x7\",\n  },\n  medium: {\n    gap: \"x2\",\n    pb: \"x6\",\n  },\n} as const satisfies Record<NonNullable<ResultSectionProps[\"size\"]>, VStackProps>;\n\n/**\n * @see https://seed-design.io/lynx/components/result-section\n */\nexport const ResultSection = React.forwardRef<unknown, ResultSectionProps>((props, ref) => {\n  const {\n    size = \"large\",\n    asset,\n    title,\n    description,\n    primaryActionProps,\n    secondaryActionProps,\n    ...otherProps\n  } = props;\n\n  return (\n    <VStack\n      {...(ref ? { ref } : {})}\n      justify=\"center\"\n      align=\"center\"\n      px=\"x12\"\n      py=\"x4\"\n      grow\n      {...otherProps}\n    >\n      {asset}\n      <VStack {...textContainerProperties[size]}>\n        <Text align=\"center\" color=\"fg.neutral\" textStyle={textStyles.title[size]}>\n          {title}\n        </Text>\n        <Text align=\"center\" color=\"fg.neutralMuted\" textStyle={textStyles.description[size]}>\n          {description}\n        </Text>\n      </VStack>\n      {primaryActionProps || secondaryActionProps ? (\n        <VStack align=\"center\" gap=\"x5\">\n          {primaryActionProps ? (\n            <ActionButton variant=\"neutralWeak\" size=\"medium\" {...primaryActionProps} />\n          ) : null}\n          {secondaryActionProps ? (\n            <ActionButton variant=\"ghost\" size=\"small\" {...secondaryActionProps} />\n          ) : null}\n        </VStack>\n      ) : null}\n    </VStack>\n  );\n});\nResultSection.displayName = \"ResultSection\";\n\n/**\n * This file is a snippet from SEED Design, helping you get started quickly with @seed-design/* packages.\n * You can extend this snippet however you want.\n */\n",
+      "dependencies": {
+        "@seed-design/lynx-react": ">=0.1.0 <1.0.0",
+        "@seed-design/lynx-css": ">=0.1.0 <1.0.0"
+      }
+    }
+  ]
+}

--- a/docs/registry/lynx/registry-ui.ts
+++ b/docs/registry/lynx/registry-ui.ts
@@ -103,6 +103,15 @@ export const registryUI: Registry = {
       ],
     },
     {
+      id: "result-section",
+      snippets: [
+        {
+          path: "result-section.tsx",
+          dependencies: lynxSeedPackageRanges,
+        },
+      ],
+    },
+    {
       id: "segmented-control",
       snippets: [
         {

--- a/docs/registry/lynx/ui/result-section.tsx
+++ b/docs/registry/lynx/ui/result-section.tsx
@@ -1,0 +1,96 @@
+import * as React from "@lynx-js/react";
+import {
+  ActionButton,
+  Text,
+  VStack,
+  type ActionButtonProps,
+  type TextProps,
+  type VStackProps,
+} from "@seed-design/lynx-react";
+
+export interface ResultSectionProps extends Omit<VStackProps, "children"> {
+  /**
+   * @default "large"
+   */
+  size?: "large" | "medium";
+
+  asset?: React.ReactNode;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+
+  primaryActionProps?: ActionButtonProps;
+  secondaryActionProps?: ActionButtonProps;
+}
+
+const textStyles = {
+  title: {
+    large: "t8Bold",
+    medium: "t5Bold",
+  },
+  description: {
+    large: "t5Regular",
+    medium: "t4Regular",
+  },
+} as const satisfies Record<
+  string,
+  Record<NonNullable<ResultSectionProps["size"]>, NonNullable<TextProps["textStyle"]>>
+>;
+
+const textContainerProperties = {
+  large: {
+    gap: "x3",
+    pb: "x7",
+  },
+  medium: {
+    gap: "x2",
+    pb: "x6",
+  },
+} as const satisfies Record<NonNullable<ResultSectionProps["size"]>, VStackProps>;
+
+/**
+ * @see https://seed-design.io/lynx/components/result-section
+ */
+export const ResultSection = React.forwardRef<unknown, ResultSectionProps>((props, ref) => {
+  const {
+    size = "large",
+    asset,
+    title,
+    description,
+    primaryActionProps,
+    secondaryActionProps,
+    ...otherProps
+  } = props;
+
+  return (
+    <VStack
+      {...(ref ? { ref } : {})}
+      justify="center"
+      align="center"
+      px="x12"
+      py="x4"
+      grow
+      {...otherProps}
+    >
+      {asset}
+      <VStack {...textContainerProperties[size]}>
+        <Text align="center" color="fg.neutral" textStyle={textStyles.title[size]}>
+          {title}
+        </Text>
+        <Text align="center" color="fg.neutralMuted" textStyle={textStyles.description[size]}>
+          {description}
+        </Text>
+      </VStack>
+      {primaryActionProps || secondaryActionProps ? (
+        <VStack align="center" gap="x5">
+          {primaryActionProps ? (
+            <ActionButton variant="neutralWeak" size="medium" {...primaryActionProps} />
+          ) : null}
+          {secondaryActionProps ? (
+            <ActionButton variant="ghost" size="small" {...secondaryActionProps} />
+          ) : null}
+        </VStack>
+      ) : null}
+    </VStack>
+  );
+});
+ResultSection.displayName = "ResultSection";


### PR DESCRIPTION
## 변경 내용

- Lynx Registry에 Result Section snippet을 추가했습니다.
- Large, Medium 크기와 asset, title, description, primary/secondary action 조합을 지원합니다.
- Multicolor Icon, 중앙 정렬, AppBar 기반 CTA 예제를 React 문서와 맞췄습니다.
- CTA 예제는 실패 상태에서 시작하고 다시 시도 시 로딩 상태로 전환한 뒤 3초 후 실패 상태로 돌아옵니다.
- Lottie는 Lynx 구현체가 없어 사용 방법만 문서화했습니다.

## 검증

- `bun test:all`
- `bun --filter @seed-design/docs typecheck:lynx-examples`
- `bun --filter @seed-design/docs build:lynx-examples`
- `bun docs:build`
- 정적 문서에서 기본 예제와 CTA 예제의 크기, 중앙 정렬, 자산, 상태 전환을 확인했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Lynx 환경에서 사용할 수 있는 `ResultSection` 컴포넌트를 추가했습니다.
  * 대형·중형 레이아웃, 제목·설명·이미지, 기본·보조 액션 버튼을 지원합니다.
  * 로딩 상태와 재시도 동작을 포함한 진행 원형 예제를 추가했습니다.

* **문서**
  * `ResultSection`의 설치 방법, Props, 크기별 사용법 및 React Web과 Lynx의 차이점을 문서화했습니다.
  * 미리보기와 다양한 사용 예제를 추가했습니다.
  * Lynx 컴포넌트 레지스트리에 `ResultSection`을 등록했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->