### PR TITLE
fix(lynx-text-field): apply placeholder colors

### DIFF
--- a/.changeset/calm-lynxes-type.md
+++ b/.changeset/calm-lynxes-type.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/lynx-css": patch
+---
+
+Lynx `TextField`의 placeholder가 활성 및 비활성 상태에 맞는 색상 토큰을 사용하도록 수정합니다.

--- a/packages/lynx-css/all.css
+++ b/packages/lynx-css/all.css
@@ -3814,6 +3814,11 @@ text {
   padding: 0;
 }
 
+.seed-text-input__value::placeholder {
+  color: var(--seed-color-fg-placeholder);
+  font-weight: var(--seed-font-weight-regular);
+}
+
 .seed-text-input__textareaRoot {
   flex-direction: column;
   flex-grow: 1;
@@ -3903,7 +3908,7 @@ text {
   border-color: var(--seed-color-stroke-critical-solid);
 }
 
-.seed-text-input__value--disabled_true, .seed-text-input__prefixText--disabled_true, .seed-text-input__prefixIcon--disabled_true, .seed-text-input__suffixText--disabled_true, .seed-text-input__suffixIcon--disabled_true {
+.seed-text-input__value--disabled_true, .seed-text-input__value--disabled_true::placeholder, .seed-text-input__prefixText--disabled_true, .seed-text-input__prefixIcon--disabled_true, .seed-text-input__suffixText--disabled_true, .seed-text-input__suffixIcon--disabled_true {
   color: var(--seed-color-fg-disabled);
 }
 

--- a/packages/lynx-css/recipes/text-input.css
+++ b/packages/lynx-css/recipes/text-input.css
@@ -4,11 +4,11 @@
     width: 100%;
     align-items: center;
     overflow: hidden;
-    position: relative
+    position: relative;
 }
 .seed-text-input__baseStroke {
     position: absolute;
-    pointer-events: none
+    pointer-events: none;
 }
 .seed-text-input__stroke {
     position: absolute;
@@ -18,7 +18,7 @@
     left: 0;
     border-color: transparent;
     transition: border-color 0.1s var(--seed-timing-function-easing);
-    pointer-events: none
+    pointer-events: none;
 }
 .seed-text-input__value {
     flex-grow: 1;
@@ -28,7 +28,11 @@
     border-width: 0;
     background-color: transparent;
     color: var(--seed-color-fg-neutral);
-    font-weight: var(--seed-font-weight-regular)
+    font-weight: var(--seed-font-weight-regular);
+}
+.seed-text-input__value::placeholder {
+    color: var(--seed-color-fg-placeholder);
+    font-weight: var(--seed-font-weight-regular);
 }
 .seed-text-input__textareaRoot {
     flex-grow: 1;
@@ -36,7 +40,7 @@
     align-self: stretch;
     display: flex;
     flex-direction: column;
-    position: relative
+    position: relative;
 }
 .seed-text-input__textareaAutoresizeRoot {}
 .seed-text-input__textareaValue {}
@@ -44,26 +48,26 @@
 .seed-text-input__textareaNativeAutoresize {
     width: 100%;
     height: auto;
-    flex-shrink: 0
+    flex-shrink: 0;
 }
 .seed-text-input__textareaAndroidAutoresize {}
 .seed-text-input__prefixText {
     color: var(--seed-color-fg-neutral-subtle);
     font-weight: var(--seed-font-weight-regular);
-    flex-shrink: 0
+    flex-shrink: 0;
 }
 .seed-text-input__prefixIcon {
     color: var(--seed-color-fg-neutral-muted);
-    flex-shrink: 0
+    flex-shrink: 0;
 }
 .seed-text-input__suffixText {
     color: var(--seed-color-fg-neutral-subtle);
     font-weight: var(--seed-font-weight-regular);
-    flex-shrink: 0
+    flex-shrink: 0;
 }
 .seed-text-input__suffixIcon {
     color: var(--seed-color-fg-neutral-muted);
-    flex-shrink: 0
+    flex-shrink: 0;
 }
 .seed-text-input__baseStroke--variant_outline {
     top: 0;
@@ -72,202 +76,205 @@
     left: 0;
     border-color: var(--seed-color-stroke-neutral-weak);
     border-style: solid;
-    border-width: 1px
+    border-width: 1px;
 }
 .seed-text-input__stroke--variant_outline {
     border-style: solid;
-    border-width: 2px
+    border-width: 2px;
 }
 .seed-text-input__root--variant_underline {
-    overflow: visible
+    overflow: visible;
 }
 .seed-text-input__baseStroke--variant_underline {
     right: 0;
     bottom: 0;
     left: 0;
     height: 1px;
-    background-color: var(--seed-color-stroke-neutral-weak)
+    background-color: var(--seed-color-stroke-neutral-weak);
 }
 .seed-text-input__stroke--variant_underline {
     border-width: 0;
     border-bottom-style: solid;
-    border-bottom-width: 2px
+    border-bottom-width: 2px;
 }
 .seed-text-input__textareaAutoresizeRoot--size_large {
     min-height: 94px;
     padding-top: var(--seed-dimension-x3_5);
-    padding-bottom: var(--seed-dimension-x3_5)
+    padding-bottom: var(--seed-dimension-x3_5);
 }
 .seed-text-input__textareaAndroidAutoresize--size_large {
     min-height: 94px;
     padding-top: var(--seed-dimension-x3_5);
-    padding-bottom: var(--seed-dimension-x3_5)
+    padding-bottom: var(--seed-dimension-x3_5);
 }
 .seed-text-input__textareaFixed--size_large {
     min-height: 94px;
     padding-top: var(--seed-dimension-x3_5);
-    padding-bottom: var(--seed-dimension-x3_5)
+    padding-bottom: var(--seed-dimension-x3_5);
 }
 .seed-text-input__textareaAutoresizeRoot--size_medium {
     min-height: 82px;
     padding-top: var(--seed-dimension-x3);
-    padding-bottom: var(--seed-dimension-x3)
+    padding-bottom: var(--seed-dimension-x3);
 }
 .seed-text-input__textareaAndroidAutoresize--size_medium {
     min-height: 82px;
     padding-top: var(--seed-dimension-x3);
-    padding-bottom: var(--seed-dimension-x3)
+    padding-bottom: var(--seed-dimension-x3);
 }
 .seed-text-input__textareaFixed--size_medium {
     min-height: 82px;
     padding-top: var(--seed-dimension-x3);
-    padding-bottom: var(--seed-dimension-x3)
+    padding-bottom: var(--seed-dimension-x3);
 }
 .seed-text-input__stroke--focused_true {
-    border-color: var(--seed-color-stroke-neutral-contrast)
+    border-color: var(--seed-color-stroke-neutral-contrast);
 }
 .seed-text-input__stroke--invalid_true {
-    border-color: var(--seed-color-stroke-critical-solid)
+    border-color: var(--seed-color-stroke-critical-solid);
 }
 .seed-text-input__value--disabled_true {
-    color: var(--seed-color-fg-disabled)
+    color: var(--seed-color-fg-disabled);
+}
+.seed-text-input__value--disabled_true::placeholder {
+    color: var(--seed-color-fg-disabled);
 }
 .seed-text-input__prefixText--disabled_true {
-    color: var(--seed-color-fg-disabled)
+    color: var(--seed-color-fg-disabled);
 }
 .seed-text-input__prefixIcon--disabled_true {
-    color: var(--seed-color-fg-disabled)
+    color: var(--seed-color-fg-disabled);
 }
 .seed-text-input__suffixText--disabled_true {
-    color: var(--seed-color-fg-disabled)
+    color: var(--seed-color-fg-disabled);
 }
 .seed-text-input__suffixIcon--disabled_true {
-    color: var(--seed-color-fg-disabled)
+    color: var(--seed-color-fg-disabled);
 }
 .seed-text-input__root--variant_outline-size_large {
     gap: var(--seed-dimension-x2_5);
     min-height: var(--seed-dimension-x13);
     border-radius: var(--seed-radius-r3);
     padding-left: var(--seed-dimension-x4);
-    padding-right: var(--seed-dimension-x4)
+    padding-right: var(--seed-dimension-x4);
 }
 .seed-text-input__stroke--variant_outline-size_large {
-    border-radius: var(--seed-radius-r3)
+    border-radius: var(--seed-radius-r3);
 }
 .seed-text-input__baseStroke--variant_outline-size_large {
-    border-radius: var(--seed-radius-r3)
+    border-radius: var(--seed-radius-r3);
 }
 .seed-text-input__value--variant_outline-size_large {
     font-size: var(--seed-font-size-t5);
-    line-height: var(--seed-line-height-t5)
+    line-height: var(--seed-line-height-t5);
 }
 .seed-text-input__prefixText--variant_outline-size_large {
     font-size: var(--seed-font-size-t5);
-    line-height: var(--seed-line-height-t5)
+    line-height: var(--seed-line-height-t5);
 }
 .seed-text-input__prefixIcon--variant_outline-size_large {
     width: var(--seed-dimension-x5);
-    height: var(--seed-dimension-x5)
+    height: var(--seed-dimension-x5);
 }
 .seed-text-input__suffixText--variant_outline-size_large {
     font-size: var(--seed-font-size-t5);
-    line-height: var(--seed-line-height-t5)
+    line-height: var(--seed-line-height-t5);
 }
 .seed-text-input__suffixIcon--variant_outline-size_large {
     width: var(--seed-dimension-x5);
-    height: var(--seed-dimension-x5)
+    height: var(--seed-dimension-x5);
 }
 .seed-text-input__root--variant_outline-size_medium {
     gap: var(--seed-dimension-x2);
     min-height: var(--seed-dimension-x10);
     border-radius: var(--seed-radius-r2);
     padding-left: var(--seed-dimension-x3_5);
-    padding-right: var(--seed-dimension-x3_5)
+    padding-right: var(--seed-dimension-x3_5);
 }
 .seed-text-input__stroke--variant_outline-size_medium {
-    border-radius: var(--seed-radius-r2)
+    border-radius: var(--seed-radius-r2);
 }
 .seed-text-input__baseStroke--variant_outline-size_medium {
-    border-radius: var(--seed-radius-r2)
+    border-radius: var(--seed-radius-r2);
 }
 .seed-text-input__value--variant_outline-size_medium {
     font-size: var(--seed-font-size-t4);
-    line-height: var(--seed-line-height-t4)
+    line-height: var(--seed-line-height-t4);
 }
 .seed-text-input__prefixText--variant_outline-size_medium {
     font-size: var(--seed-font-size-t4);
-    line-height: var(--seed-line-height-t4)
+    line-height: var(--seed-line-height-t4);
 }
 .seed-text-input__prefixIcon--variant_outline-size_medium {
     width: var(--seed-dimension-x4);
-    height: var(--seed-dimension-x4)
+    height: var(--seed-dimension-x4);
 }
 .seed-text-input__suffixText--variant_outline-size_medium {
     font-size: var(--seed-font-size-t4);
-    line-height: var(--seed-line-height-t4)
+    line-height: var(--seed-line-height-t4);
 }
 .seed-text-input__suffixIcon--variant_outline-size_medium {
     width: var(--seed-dimension-x4);
-    height: var(--seed-dimension-x4)
+    height: var(--seed-dimension-x4);
 }
 .seed-text-input__root--variant_underline-size_large {
     gap: var(--seed-dimension-x2_5);
     min-height: var(--seed-dimension-x10);
     padding-top: var(--seed-dimension-x2);
-    padding-bottom: var(--seed-dimension-x2)
+    padding-bottom: var(--seed-dimension-x2);
 }
 .seed-text-input__value--variant_underline-size_large {
     font-size: var(--seed-font-size-t6);
-    line-height: var(--seed-line-height-t6)
+    line-height: var(--seed-line-height-t6);
 }
 .seed-text-input__prefixText--variant_underline-size_large {
     font-size: var(--seed-font-size-t6);
-    line-height: var(--seed-line-height-t6)
+    line-height: var(--seed-line-height-t6);
 }
 .seed-text-input__prefixIcon--variant_underline-size_large {
     width: var(--seed-dimension-x6);
-    height: var(--seed-dimension-x6)
+    height: var(--seed-dimension-x6);
 }
 .seed-text-input__suffixText--variant_underline-size_large {
     font-size: var(--seed-font-size-t6);
-    line-height: var(--seed-line-height-t6)
+    line-height: var(--seed-line-height-t6);
 }
 .seed-text-input__suffixIcon--variant_underline-size_large {
     width: var(--seed-dimension-x6);
-    height: var(--seed-dimension-x6)
+    height: var(--seed-dimension-x6);
 }
 .seed-text-input__root--variant_underline-size_medium {
     gap: var(--seed-dimension-x2);
     min-height: 34px;
     padding-top: var(--seed-dimension-x1_5);
-    padding-bottom: var(--seed-dimension-x1_5)
+    padding-bottom: var(--seed-dimension-x1_5);
 }
 .seed-text-input__value--variant_underline-size_medium {
     font-size: var(--seed-font-size-t5);
-    line-height: var(--seed-line-height-t5)
+    line-height: var(--seed-line-height-t5);
 }
 .seed-text-input__prefixText--variant_underline-size_medium {
     font-size: var(--seed-font-size-t5);
-    line-height: var(--seed-line-height-t5)
+    line-height: var(--seed-line-height-t5);
 }
 .seed-text-input__prefixIcon--variant_underline-size_medium {
     width: var(--seed-dimension-x5);
-    height: var(--seed-dimension-x5)
+    height: var(--seed-dimension-x5);
 }
 .seed-text-input__suffixText--variant_underline-size_medium {
     font-size: var(--seed-font-size-t5);
-    line-height: var(--seed-line-height-t5)
+    line-height: var(--seed-line-height-t5);
 }
 .seed-text-input__suffixIcon--variant_underline-size_medium {
     width: var(--seed-dimension-x5);
-    height: var(--seed-dimension-x5)
+    height: var(--seed-dimension-x5);
 }
 .seed-text-input__root--variant_outline-readOnly_true-disabled_false {
-    background: var(--seed-color-bg-disabled)
+    background: var(--seed-color-bg-disabled);
 }
 .seed-text-input__value--variant_underline-readOnly_true-disabled_false {
-    color: var(--seed-color-fg-neutral-muted)
+    color: var(--seed-color-fg-neutral-muted);
 }
 .seed-text-input__root--variant_outline-disabled_true {
-    background: var(--seed-color-bg-disabled)
+    background: var(--seed-color-bg-disabled);
 }

--- a/packages/lynx-qvism-preset/src/recipes/text-input.ts
+++ b/packages/lynx-qvism-preset/src/recipes/text-input.ts
@@ -1,5 +1,6 @@
 import { textInput as vars } from "../vars/component";
 import { defineSlotRecipe } from "../utils/define";
+import { pseudo } from "../utils/pseudo";
 
 const textInput = defineSlotRecipe({
   name: "text-input",
@@ -51,6 +52,10 @@ const textInput = defineSlotRecipe({
       backgroundColor: "transparent",
       color: vars.base.enabled.value.color,
       fontWeight: vars.base.enabled.value.fontWeight,
+      [pseudo("::placeholder")]: {
+        color: vars.base.enabled.placeholder.color,
+        fontWeight: vars.base.enabled.placeholder.fontWeight,
+      },
     },
     textareaRoot: {
       flexGrow: 1,
@@ -181,7 +186,12 @@ const textInput = defineSlotRecipe({
     },
     disabled: {
       true: {
-        value: { color: vars.base.disabled.value.color },
+        value: {
+          color: vars.base.disabled.value.color,
+          [pseudo("::placeholder")]: {
+            color: vars.base.disabled.placeholder.color,
+          },
+        },
         prefixText: { color: vars.base.disabled.prefixText.color },
         prefixIcon: { color: vars.base.disabled.prefixIcon.color },
         suffixText: { color: vars.base.disabled.suffixText.color },

--- a/packages/lynx-qvism-preset/src/utils/define.ts
+++ b/packages/lynx-qvism-preset/src/utils/define.ts
@@ -123,9 +123,12 @@ type StrictLynxInput<T> = RejectCssWideKeywords<T>;
  * Style object constrained to the SEED Lynx preset contract. It starts from
  * Lynx's known longhand/shorthand CSS keys, then removes web-only properties
  * that SEED does not allow in preset sources. State styles should be modeled
- * as recipe variants instead of selector nesting.
+ * as recipe variants instead of selector nesting. Supported pseudo-elements
+ * may be added explicitly when they cannot be represented as variants.
  */
-export type LynxStyleObject = LynxStyleProperties;
+export type LynxStyleObject = LynxStyleProperties & {
+  "&::placeholder"?: LynxStyleProperties;
+};
 
 type LynxSlotRecord<S extends string> = Partial<Record<S, LynxStyleObject>>;
 

--- a/packages/lynx-qvism-preset/text-input.test.ts
+++ b/packages/lynx-qvism-preset/text-input.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+
+import textInput from "./src/recipes/text-input";
+import { textInput as vars } from "./src/vars/component";
+import { pseudo } from "./src/utils/pseudo";
+
+describe("Lynx text input recipe", () => {
+  it("uses the component tokens for enabled and disabled placeholders", () => {
+    expect(textInput.base["value"][pseudo("::placeholder")]).toEqual({
+      color: vars.base.enabled.placeholder.color,
+      fontWeight: vars.base.enabled.placeholder.fontWeight,
+    });
+    expect(
+      textInput.variants["disabled"]["true"]["value"][pseudo("::placeholder")],
+    ).toEqual({
+      color: vars.base.disabled.placeholder.color,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Apply the enabled placeholder color and font-weight tokens to the shared Lynx TextField value slot.
- Override the placeholder color with the disabled token.
- Cover the recipe mapping with a regression test; the shared value class applies to both input and textarea.

## Testing

- bun generate:all
- bun test packages/lynx-qvism-preset
- bun --filter @seed-design/lynx-qvism-preset typecheck
- bun packages:build
- bun test:all

## Verification notes

- Native Lynx device verification was not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - Lynx 텍스트 입력 필드의 플레이스홀더가 활성 상태에 맞는 색상과 글꼴 굵기를 표시하도록 개선했습니다.
  - 비활성화된 텍스트 입력 필드에서는 플레이스홀더가 비활성 상태 전용 색상으로 표시됩니다.
  - 텍스트 입력 필드의 플레이스홀더 스타일이 상태별 디자인 토큰을 일관되게 사용하도록 수정했습니다.

- **테스트**
  - 활성 및 비활성 상태에서 플레이스홀더 색상과 글꼴 굵기가 올바르게 적용되는지 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->