### PR TITLE
refactor(examples): rework the home demo index navigation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -348,6 +348,7 @@
         "@stackflow/react": "^1.9.0",
         "@vanilla-extract/css": "^1.17.1",
         "clsx": "^2.1.1",
+        "lucide-react": "^1.40.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
       },
@@ -5134,7 +5135,7 @@
 
     "lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
-    "lucide-react": ["lucide-react@1.30.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tUIr2jXLbWpCkdtH8XP7P7YppM9ueWgTky99lpWDY6z5REs6B+O6ZQ3U5tHkUUY59ANyOv/PBcs8E4Fe3KO3eA=="],
+    "lucide-react": ["lucide-react@1.40.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-MaG+8WnOXkDWz9XeElj7TnQ890tTZUB0a36i03aRRCKGWE6e7jJpmdCvtxxuxcjjdqyN6m4sL6qlHVuSUDtYgg=="],
 
     "lynx-console": ["lynx-console@0.3.1", "", { "dependencies": { "devalue": "^5.6.4", "javascript-stringify": "^2.1.0" }, "peerDependencies": { "@lynx-js/react": "^0.110.0", "@lynx-js/types": "^3.6.0", "@types/react": "^18" } }, "sha512-lvkYeN6LYij8sVubswRJ5sPvLnxZ7rEhRrXrjLJT0pUhPxanJ4Y8sbTR7FVxE1rQY7jNBZQR6Rf4OYffX5y0Bw=="],
 
@@ -7079,6 +7080,8 @@
     "fumadocs-docgen/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "fumadocs-typescript/ts-morph": ["ts-morph@28.0.0", "", { "dependencies": { "@ts-morph/common": "~0.29.0", "code-block-writer": "^13.0.3" } }, "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g=="],
+
+    "fumadocs-ui/lucide-react": ["lucide-react@1.30.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tUIr2jXLbWpCkdtH8XP7P7YppM9ueWgTky99lpWDY6z5REs6B+O6ZQ3U5tHkUUY59ANyOv/PBcs8E4Fe3KO3eA=="],
 
     "get-uri/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 

--- a/examples/stackflow-spa/package.json
+++ b/examples/stackflow-spa/package.json
@@ -32,6 +32,7 @@
     "@stackflow/react": "^1.9.0",
     "@vanilla-extract/css": "^1.17.1",
     "clsx": "^2.1.1",
+    "lucide-react": "^1.40.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3"
   },

--- a/examples/stackflow-spa/src/activities/ActivityHome.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityHome.tsx
@@ -173,10 +173,15 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
             </DialogPushTrigger>
           ),
         },
+        { title: "SidePanel", onClick: () => push("ActivitySidePanel", {}) },
+        {
+          title: "ResponsiveSidePanel",
+          onClick: () => push("ActivityResponsiveSidePanel", {}),
+        },
       ],
     },
     {
-      title: "Dialog & Panel",
+      title: "Dialog",
       icon: AppWindowIcon,
       items: [
         {
@@ -219,11 +224,6 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
             const result = await receive<any>(push("ActivityAlertDialog", {}));
             console.log(result.message);
           },
-        },
-        { title: "SidePanel", onClick: () => push("ActivitySidePanel", {}) },
-        {
-          title: "ResponsiveSidePanel",
-          onClick: () => push("ActivityResponsiveSidePanel", {}),
         },
         {
           title: "ResponsiveDialog",

--- a/examples/stackflow-spa/src/activities/ActivityHome.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityHome.tsx
@@ -106,11 +106,11 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
       title: "AppScreen",
       icon: LayersIcon,
       items: [
-        { title: "AppBar 슬롯 · 긴 제목", ...to("ActivityLayerBar", {}) },
-        { title: "transparent", ...to("ActivityTransparentBar", {}) },
+        { title: "App Bar 슬롯과 긴 제목", ...to("ActivityLayerBar", {}) },
+        { title: "투명 App Bar", ...to("ActivityTransparentBar", {}) },
         { title: "@stackflow/plugin-basic-ui", ...to("ActivityPluginBasicUI", {}) },
-        { title: "Pop Test (중복 pop 가드)", ...to("ActivityPopTest", {}) },
-        { title: "animate: false Test (밀림 버그)", ...to("ActivityAnimateFalseTest", {}) },
+        { title: "중복 pop 가드", ...to("ActivityPopTest", {}) },
+        { title: "animate: false 밀림 버그", ...to("ActivityAnimateFalseTest", {}) },
         { title: `홈 다시 push (깊이: ${activityIndex})`, ...to("ActivityHome", {}) },
         ...appScreenVariantMap.transitionStyle.map((transitionStyle) => ({
           title: `전환: ${transitionStyle}`,
@@ -122,24 +122,27 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
       title: "Drawer",
       icon: PanelBottomIcon,
       items: [
-        { title: "BottomSheet", ...to("ActivityBottomSheet", {}) },
-        { title: "BottomSheet: modal 토글", ...to("ActivityBottomSheetModalTest", {}) },
-        { title: "BottomSheet: TextField only", ...to("ActivityBottomSheetTextField", {}) },
+        { title: "Bottom Sheet", ...to("ActivityBottomSheet", {}) },
+        { title: "Bottom Sheet modal 토글", ...to("ActivityBottomSheetModalTest", {}) },
+        { title: "Text Field만 있는 Bottom Sheet", ...to("ActivityBottomSheetTextField", {}) },
         {
-          title: "BottomSheet: snapPoints × 입력 포커스",
+          title: "Bottom Sheet snapPoints와 입력 포커스",
           ...to("ActivityBottomSheetInputFocus", {}),
         },
         {
-          title: "BottomSheet: Keyboard Playground",
+          title: "Bottom Sheet Keyboard Playground",
           ...to("ActivityBottomSheetKeyboardPlayground", {}),
         },
         {
-          title: "BottomSheet × AlertDialog (step)",
+          title: "Bottom Sheet 위 Alert Dialog (step)",
           ...to("ActivityBottomSheetWithAlertDialogStep", {}),
         },
-        { title: "BottomSheet × AlertDialog (activity)", ...to("ActivityNestedBottomSheet", {}) },
         {
-          title: "MenuSheet",
+          title: "Bottom Sheet 위 Alert Dialog (activity)",
+          ...to("ActivityNestedBottomSheet", {}),
+        },
+        {
+          title: "Menu Sheet",
           component: (
             <DialogPushTrigger
               callbackActivity={menuSheetCallback}
@@ -148,12 +151,12 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
                 console.log(result?.action);
               }}
             >
-              <ListButtonItem title="MenuSheet" detail="ActivityMenuSheet" />
+              <ListButtonItem title="Menu Sheet" detail="ActivityMenuSheet" />
             </DialogPushTrigger>
           ),
         },
         {
-          title: "SwipeableMenuSheet",
+          title: "Swipeable Menu Sheet",
           component: (
             <DialogPushTrigger
               callbackActivity={swipeableMenuSheetCallback}
@@ -162,12 +165,12 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
                 console.log(result?.action);
               }}
             >
-              <ListButtonItem title="SwipeableMenuSheet" detail="ActivitySwipeableMenuSheet" />
+              <ListButtonItem title="Swipeable Menu Sheet" detail="ActivitySwipeableMenuSheet" />
             </DialogPushTrigger>
           ),
         },
-        { title: "SidePanel", ...to("ActivitySidePanel", {}) },
-        { title: "ResponsiveSidePanel", ...to("ActivityResponsiveSidePanel", {}) },
+        { title: "Side Panel", ...to("ActivitySidePanel", {}) },
+        { title: "Responsive Side Panel", ...to("ActivityResponsiveSidePanel", {}) },
       ],
     },
     {
@@ -175,11 +178,11 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
       icon: AppWindowIcon,
       items: [
         {
-          title: "AlertDialog (step)",
+          title: "Alert Dialog (step)",
           component: (
             <AlertDialogRoot {...overlayProps}>
               <AlertDialogTrigger asChild>
-                <ListButtonItem title="AlertDialog (step)" />
+                <ListButtonItem title="Alert Dialog (step)" />
               </AlertDialogTrigger>
               <Portal>
                 <AlertDialogContent layerIndex={useActivityZIndexBase({ activityOffset: 1 })}>
@@ -209,14 +212,14 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
           ),
         },
         {
-          title: "AlertDialog (activity)",
+          title: "Alert Dialog (activity)",
           detail: "ActivityAlertDialog",
           onClick: async () => {
             const result = await receive<any>(push("ActivityAlertDialog", {}));
             console.log(result.message);
           },
         },
-        { title: "ResponsiveDialog", ...to("ActivityResponsiveDialog", {}) },
+        { title: "Responsive Dialog", ...to("ActivityResponsiveDialog", {}) },
       ],
     },
     {
@@ -225,11 +228,11 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
       items: [
         { title: "Menu", ...to("ActivityMenu", {}) },
         {
-          title: "ListButtonItem 트리거",
+          title: "List Button Item으로 여는 Menu",
           component: (
             <MenuRoot size="medium" matchReferenceWidth>
               <MenuTrigger asChild>
-                <ListButtonItem title="ListButtonItem 트리거" />
+                <ListButtonItem title="List Button Item으로 여는 Menu" />
               </MenuTrigger>
               <MenuContent>
                 <MenuGroup>
@@ -243,7 +246,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
             </MenuRoot>
           ),
         },
-        { title: "HelpBubble", ...to("ActivityHelpBubble", {}) },
+        { title: "Help Bubble", ...to("ActivityHelpBubble", {}) },
       ],
     },
     {
@@ -251,9 +254,9 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
       icon: RefreshCwIcon,
       items: [
         { title: "기본", ...to("ActivityPullToRefreshPreview", {}) },
-        { title: "Tabs 조합", ...to("ActivityPullToRefreshTabs", {}) },
+        { title: "Tabs와 조합", ...to("ActivityPullToRefreshTabs", {}) },
         { title: "preventPull", ...to("ActivityPullToRefreshPreventPull", {}) },
-        { title: "Article preventPull (텍스트 선택)", ...to("ActivityArticlePreventPull", {}) },
+        { title: "Article 텍스트 선택 중 당김 차단", ...to("ActivityArticlePreventPull", {}) },
       ],
     },
     {
@@ -261,13 +264,13 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
       icon: CompassIcon,
       items: [
         { title: "Tabs", ...to("ActivityTabs", {}) },
-        { title: "AnimatedTabs", ...to("ActivityAnimatedTabs", {}) },
-        { title: "SwipeableTabs", ...to("ActivitySwipeableTabs", {}) },
-        { title: "Tabs autoHeight × 지연 로딩", ...to("ActivityTabsAutoHeightLazy", {}) },
-        { title: "ChipTabs × ScrollFog", ...to("ActivityChipTabsScrollFog", {}) },
+        { title: "Animated Tabs", ...to("ActivityAnimatedTabs", {}) },
+        { title: "Swipeable Tabs", ...to("ActivitySwipeableTabs", {}) },
+        { title: "Tabs autoHeight와 지연 로딩", ...to("ActivityTabsAutoHeightLazy", {}) },
+        { title: "Chip Tabs와 Scroll Fog", ...to("ActivityChipTabsScrollFog", {}) },
         { title: "Pagination", ...to("ActivityPagination", {}) },
         {
-          title: "SideNavigation",
+          title: "Side Navigation",
           detail: "ActivitySideNavigation",
           onClick: () => replace("ActivitySideNavigation", {}),
         },
@@ -277,13 +280,13 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
       title: "List",
       icon: ListIcon,
       items: [
-        { title: "ListItem", ...to("ActivityListItem", {}) },
-        { title: "ListImageFrame", ...to("ActivityListImageFrame", {}) },
-        { title: "ListButtonItem", ...to("ActivityListButtonItem", {}) },
-        { title: "ListLinkItem", ...to("ActivityListLinkItem", {}) },
-        { title: "ListSwitchItem", ...to("ActivityListSwitchItem", {}) },
-        { title: "ListCheckItem", ...to("ActivityListCheckItem", {}) },
-        { title: "ListRadioItem", ...to("ActivityListRadioItem", {}) },
+        { title: "List Item", ...to("ActivityListItem", {}) },
+        { title: "List Image Frame", ...to("ActivityListImageFrame", {}) },
+        { title: "List Button Item", ...to("ActivityListButtonItem", {}) },
+        { title: "List Link Item", ...to("ActivityListLinkItem", {}) },
+        { title: "List Switch Item", ...to("ActivityListSwitchItem", {}) },
+        { title: "List Check Item", ...to("ActivityListCheckItem", {}) },
+        { title: "List Radio Item", ...to("ActivityListRadioItem", {}) },
       ],
     },
     {
@@ -292,26 +295,26 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
       items: [
         { title: "Switch", ...to("ActivitySwitch", {}) },
         { title: "Checkbox", ...to("ActivityCheckbox", {}) },
-        { title: "QuantityPicker", ...to("ActivityQuantityPicker", {}) },
-        { title: "RadioGroup", ...to("ActivityRadioGroup", {}) },
-        { title: "SegmentedControl", ...to("ActivitySegmentedControl", {}) },
+        { title: "Quantity Picker", ...to("ActivityQuantityPicker", {}) },
+        { title: "Radio Group", ...to("ActivityRadioGroup", {}) },
+        { title: "Segmented Control", ...to("ActivitySegmentedControl", {}) },
         { title: "Select", ...to("ActivitySelect", {}) },
-        { title: "TimePicker", ...to("ActivityTimePicker", {}) },
-        { title: "WheelPicker", ...to("ActivityWheelPicker", {}) },
-        { title: "AttachmentField", ...to("ActivityAttachmentField", {}) },
-        { title: "AttachmentDisplayField", ...to("ActivityAttachmentDisplayField", {}) },
-        { title: "조합 예제", ...to("ActivityForm", {}) },
+        { title: "Time Picker", ...to("ActivityTimePicker", {}) },
+        { title: "Wheel Picker", ...to("ActivityWheelPicker", {}) },
+        { title: "Attachment Field", ...to("ActivityAttachmentField", {}) },
+        { title: "Attachment Display Field", ...to("ActivityAttachmentDisplayField", {}) },
+        { title: "여러 필드 조합", ...to("ActivityForm", {}) },
       ],
     },
     {
       title: "Button & Chip",
       icon: MousePointerClickIcon,
       items: [
-        { title: "ActionButton", ...to("ActivityActionButton", {}) },
-        { title: "ToggleButton", ...to("ActivityToggleButton", {}) },
-        { title: "ReactionButton", ...to("ActivityReactionButton", {}) },
-        { title: "Chip.Button", ...to("ActivityChipButton", {}) },
-        { title: "Chip.Toggle", ...to("ActivityChipToggle", {}) },
+        { title: "Action Button", ...to("ActivityActionButton", {}) },
+        { title: "Toggle Button", ...to("ActivityToggleButton", {}) },
+        { title: "Reaction Button", ...to("ActivityReactionButton", {}) },
+        { title: "Chip Button", ...to("ActivityChipButton", {}) },
+        { title: "Chip Toggle", ...to("ActivityChipToggle", {}) },
       ],
     },
     {
@@ -319,12 +322,12 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
       icon: ImageIcon,
       items: [
         { title: "Avatar", ...to("ActivityAvatar", {}) },
-        { title: "AvatarStack", ...to("ActivityAvatarStack", {}) },
+        { title: "Avatar Stack", ...to("ActivityAvatarStack", {}) },
         { title: "Badge", ...to("ActivityBadge", {}) },
-        { title: "MannerTempBadge", ...to("ActivityMannerTempLevel", {}) },
+        { title: "Manner Temp Badge", ...to("ActivityMannerTempLevel", {}) },
         { title: "Accordion", ...to("ActivityAccordion", {}) },
-        { title: "ErrorState", ...to("ActivityErrorState", {}) },
-        { title: "ResultSection", ...to("ActivityResultSection", {}) },
+        { title: "Error State", ...to("ActivityErrorState", {}) },
+        { title: "Result Section", ...to("ActivityResultSection", {}) },
       ],
     },
     {
@@ -368,7 +371,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
           // 기존 스낵바를 먼저 닫고 다음 tick에 새 스낵바를 띄우는 패턴.
           // dismiss 상태 전이가 적용된 뒤에 create가 실행되므로
           // 항상 새 스낵바부터 활성화되는 것을 보장한다.
-          title: "dismiss+setTimeout workaround",
+          title: "dismiss 후 setTimeout 우회",
           onClick: () => {
             snackbarAdapter.dismiss();
             setTimeout(() => {
@@ -384,16 +387,16 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
       title: "Foundation",
       icon: PaletteIcon,
       items: [
-        { title: "Box margin 프롭", ...to("ActivityMarginPlayground", {}) },
-        { title: "IACVT Leak Check (구형 iOS)", ...to("ActivityIacvtLeak", {}) },
-        { title: "SidePanel IACVT (구형 iOS)", ...to("ActivityIacvtSidePanel", {}) },
-        { title: "Overlay IACVT (구형 iOS)", ...to("ActivityIacvtOverlay", {}) },
-        { title: "Margin/Bleed IACVT (구형 iOS)", ...to("ActivityIacvtMargin", {}) },
+        { title: "Box margin prop", ...to("ActivityMarginPlayground", {}) },
+        { title: "IACVT 상속 누수 (구형 iOS)", ...to("ActivityIacvtLeak", {}) },
+        { title: "Side Panel IACVT (구형 iOS)", ...to("ActivityIacvtSidePanel", {}) },
+        { title: "오버레이 IACVT (구형 iOS)", ...to("ActivityIacvtOverlay", {}) },
+        { title: "margin·bleed IACVT (구형 iOS)", ...to("ActivityIacvtMargin", {}) },
         { title: "IACVT: initial 폴백 가설 (순수 CSS)", ...to("ActivityIacvtExperiment", {}) },
-        { title: "Font Multiplier Layout", ...to("ActivityFontMultiplierLayout", {}) },
-        { title: "Typography Scale", ...to("ActivityTypographyScale", {}) },
-        { title: "누름 축소 피드백", ...to("ActivityScaleFeedback", {}) },
-        { title: "PartialDarkMode", ...to("ActivityPartialDarkMode", {}) },
+        { title: "폰트 배율 레이아웃", ...to("ActivityFontMultiplierLayout", {}) },
+        { title: "타이포그래피 스케일", ...to("ActivityTypographyScale", {}) },
+        { title: "Scale Feedback", ...to("ActivityScaleFeedback", {}) },
+        { title: "부분 다크 모드", ...to("ActivityPartialDarkMode", {}) },
         { title: "v2 변수 × v3 토큰 혼용", ...to("ActivityMixedVersionTest", {}) },
       ],
     },

--- a/examples/stackflow-spa/src/activities/ActivityHome.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityHome.tsx
@@ -120,29 +120,29 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
       title: "Drawer",
       icon: PanelBottomIcon,
       items: [
-        { title: "기본", onClick: () => push("ActivityBottomSheet", {}) },
+        { title: "BottomSheet", onClick: () => push("ActivityBottomSheet", {}) },
         {
-          title: "modal 토글",
+          title: "BottomSheet: modal 토글",
           onClick: () => push("ActivityBottomSheetModalTest", {}),
         },
         {
-          title: "TextField only",
+          title: "BottomSheet: TextField only",
           onClick: () => push("ActivityBottomSheetTextField", {}),
         },
         {
-          title: "snapPoints × 입력 포커스",
+          title: "BottomSheet: snapPoints × 입력 포커스",
           onClick: () => push("ActivityBottomSheetInputFocus", {}),
         },
         {
-          title: "Keyboard Playground",
+          title: "BottomSheet: Keyboard Playground",
           onClick: () => push("ActivityBottomSheetKeyboardPlayground", {}),
         },
         {
-          title: "AlertDialog 중첩 (step)",
+          title: "BottomSheet × AlertDialog (step)",
           onClick: () => push("ActivityBottomSheetWithAlertDialogStep", {}),
         },
         {
-          title: "AlertDialog 중첩 (activity)",
+          title: "BottomSheet × AlertDialog (activity)",
           onClick: () => push("ActivityNestedBottomSheet", {}),
         },
         {

--- a/examples/stackflow-spa/src/activities/ActivityHome.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityHome.tsx
@@ -1,9 +1,17 @@
-import { Grid, Portal, VStack, useSnackbarAdapter } from "@seed-design/react";
+import {
+  Box,
+  Grid,
+  HStack,
+  Icon,
+  Portal,
+  Text,
+  VStack,
+  useSnackbarAdapter,
+} from "@seed-design/react";
 import { vars } from "@seed-design/css/vars";
 import { useActivity, useFlow, type StaticActivityComponentType } from "@stackflow/react/future";
 import * as React from "react";
 import { List, ListButtonItem } from "seed-design/ui/list";
-import { ListHeader } from "seed-design/ui/list-header";
 import {
   AppBar,
   AppBarBackButton,
@@ -29,6 +37,7 @@ import { useStepOverlay } from "seed-design/stackflow/use-step-overlay";
 import { menuSheetCallback } from "./ActivityMenuSheet";
 import { swipeableMenuSheetCallback } from "./ActivitySwipeableMenuSheet";
 import { MenuRoot, MenuTrigger, MenuContent, MenuGroup, MenuItem } from "seed-design/ui/menu";
+import { ChipTabsList, ChipTabsRoot, ChipTabsTrigger } from "seed-design/ui/chip-tabs";
 import { appScreenVariantMap } from "@seed-design/css/recipes/app-screen";
 
 import {
@@ -37,8 +46,29 @@ import {
   IconPencilLine,
   IconTrashcanLine,
 } from "@karrotmarket/react-monochrome-icon";
+// 섹션 제목 아이콘은 화면 껍데기·시트·패널처럼 UI 구조 자체를 가리켜야 하는데,
+// @karrotmarket/react-monochrome-icon은 당근 제품 도메인 위주라 그 개념을 담은 아이콘이 없다.
+import {
+  AppWindowIcon,
+  CompassIcon,
+  ImageIcon,
+  LayersIcon,
+  ListIcon,
+  MessageSquareDashedIcon,
+  MousePointerClickIcon,
+  PaletteIcon,
+  PanelBottomIcon,
+  RefreshCwIcon,
+  SquareMenuIcon,
+  TextCursorInputIcon,
+  type LucideIcon,
+} from "lucide-react";
 import { receive } from "@stackflow/compat-await-push";
 import { useActivityZIndexBase } from "@seed-design/stackflow";
+
+// 칩 스트립과 섹션 제목 사이 간격(px). 그리드 위쪽 여백, 제목이 고정되는 자리, 칩 점프
+// 오프셋이 이 값을 함께 써서 스크롤 전후로 간격이 달라지지 않는다.
+const HEADER_GAP = 8;
 
 type NavigationItem =
   | { title: string; onClick: () => void; component?: never }
@@ -46,6 +76,7 @@ type NavigationItem =
 
 type NavigationSection = {
   title: string;
+  icon: LucideIcon;
   items: NavigationItem[];
 };
 
@@ -64,19 +95,18 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
 
   const { zIndex: activityIndex } = useActivity();
 
+  // 항목 이름은 섹션 제목이 이미 말한 단어를 되풀이하지 않는다. 다만 ListButtonItem·ActionButton처럼
+  // 문자열 자체가 실제 export 이름인 항목은, 접두어를 떼면 없는 이름이 되므로 그대로 둔다.
   const navigationSections: NavigationSection[] = [
-    // 화면 껍데기 자체를 prop으로 조작하는 화면. push/pop 옵션이 주제인 화면은 Stack & Transition으로 간다.
+    // 화면 껍데기의 prop과 그 위에서 일어나는 스택 동작. 둘 다 AppScreen이 소유하거나
+    // AppScreen을 통해서만 검증되므로 한 섹션으로 둔다.
     {
-      title: "App Screen",
+      title: "AppScreen",
+      icon: LayersIcon,
       items: [
         { title: "AppBar 슬롯 · 긴 제목", onClick: () => push("ActivityLayerBar", {}) },
-        { title: "AppScreen transparent", onClick: () => push("ActivityTransparentBar", {}) },
+        { title: "transparent", onClick: () => push("ActivityTransparentBar", {}) },
         { title: "@stackflow/plugin-basic-ui", onClick: () => push("ActivityPluginBasicUI", {}) },
-      ],
-    },
-    {
-      title: "Stack & Transition",
-      items: [
         { title: "Pop Test (중복 pop 가드)", onClick: () => push("ActivityPopTest", {}) },
         {
           title: "animate: false Test (밀림 버그)",
@@ -87,38 +117,40 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
           onClick: () => push("ActivityHome", {}),
         },
         ...appScreenVariantMap.transitionStyle.map((transitionStyle) => ({
-          title: `전환 스타일: ${transitionStyle}`,
+          title: `전환: ${transitionStyle}`,
           onClick: () => push("ActivityTransitionStyle", { transitionStyle }),
         })),
       ],
     },
-    // 화면 아래에서 올라오는 시트. 중앙·가장자리 고정 오버레이는 Dialog & Panel로 간다.
+    // 화면 아래 가장자리에서 올라오는 오버레이. 중앙·좌우 가장자리에 고정되는 것은 Dialog & Panel,
+    // 트리거 요소에 앵커되는 것은 Menu & Popover로 간다.
     {
-      title: "Bottom Sheet",
+      title: "Drawer",
+      icon: PanelBottomIcon,
       items: [
-        { title: "BottomSheet", onClick: () => push("ActivityBottomSheet", {}) },
+        { title: "기본", onClick: () => push("ActivityBottomSheet", {}) },
         {
-          title: "BottomSheet modal 토글",
+          title: "modal 토글",
           onClick: () => push("ActivityBottomSheetModalTest", {}),
         },
         {
-          title: "BottomSheet (TextField only)",
+          title: "TextField only",
           onClick: () => push("ActivityBottomSheetTextField", {}),
         },
         {
-          title: "BottomSheet snapPoints × 입력 포커스",
+          title: "snapPoints × 입력 포커스",
           onClick: () => push("ActivityBottomSheetInputFocus", {}),
         },
         {
-          title: "BottomSheet Keyboard Playground",
+          title: "Keyboard Playground",
           onClick: () => push("ActivityBottomSheetKeyboardPlayground", {}),
         },
         {
-          title: "BottomSheet × AlertDialog (step)",
+          title: "AlertDialog 중첩 (step)",
           onClick: () => push("ActivityBottomSheetWithAlertDialogStep", {}),
         },
         {
-          title: "BottomSheet × AlertDialog (activity)",
+          title: "AlertDialog 중첩 (activity)",
           onClick: () => push("ActivityNestedBottomSheet", {}),
         },
         {
@@ -155,6 +187,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
     // 검증 대상 API가 ResponsiveSidePanel/ResponsiveDialog이므로 여기에 둔다.
     {
       title: "Dialog & Panel",
+      icon: AppWindowIcon,
       items: [
         {
           title: "AlertDialog (step)",
@@ -211,14 +244,15 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
     // 트리거 요소에 앵커되는 오버레이의 배치·정렬.
     {
       title: "Menu & Popover",
+      icon: SquareMenuIcon,
       items: [
         { title: "Menu", onClick: () => push("ActivityMenu", {}) },
         {
-          title: "Menu from ListButtonItem",
+          title: "ListButtonItem 트리거",
           component: (
             <MenuRoot size="medium" matchReferenceWidth>
               <MenuTrigger asChild>
-                <ListButtonItem title="Menu from ListButtonItem" />
+                <ListButtonItem title="ListButtonItem 트리거" />
               </MenuTrigger>
               <MenuContent>
                 <MenuGroup>
@@ -238,11 +272,12 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
     // PTR 제스처의 발동·차단 조건. 스와이프백 제스처는 App Screen으로 간다.
     {
       title: "Pull to Refresh",
+      icon: RefreshCwIcon,
       items: [
-        { title: "PullToRefresh", onClick: () => push("ActivityPullToRefreshPreview", {}) },
-        { title: "PullToRefresh × Tabs", onClick: () => push("ActivityPullToRefreshTabs", {}) },
+        { title: "기본", onClick: () => push("ActivityPullToRefreshPreview", {}) },
+        { title: "Tabs 조합", onClick: () => push("ActivityPullToRefreshTabs", {}) },
         {
-          title: "PullToRefresh (preventPull)",
+          title: "preventPull",
           onClick: () => push("ActivityPullToRefreshPreventPull", {}),
         },
         {
@@ -254,6 +289,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
     // 콘텐츠 묶음 사이를 이동시키는 컨트롤. 화면 스택 이동은 Stack & Transition으로 간다.
     {
       title: "Navigation",
+      icon: CompassIcon,
       items: [
         { title: "Tabs", onClick: () => push("ActivityTabs", {}) },
         { title: "AnimatedTabs", onClick: () => push("ActivityAnimatedTabs", {}) },
@@ -273,6 +309,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
     // List 계열 아이템의 prefix/suffix 조합. 그 안에 쓰이는 Checkbox·Switch·Radio 자체는 Form으로 간다.
     {
       title: "List",
+      icon: ListIcon,
       items: [
         { title: "ListItem", onClick: () => push("ActivityListItem", {}) },
         { title: "ListImageFrame", onClick: () => push("ActivityListImageFrame", {}) },
@@ -286,6 +323,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
     // 값을 입력·선택받는 컨트롤. 누르기만 하는 버튼·칩은 Button & Chip으로 간다.
     {
       title: "Form",
+      icon: TextCursorInputIcon,
       items: [
         { title: "Switch", onClick: () => push("ActivitySwitch", {}) },
         { title: "Checkbox", onClick: () => push("ActivityCheckbox", {}) },
@@ -300,11 +338,12 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
           title: "AttachmentDisplayField",
           onClick: () => push("ActivityAttachmentDisplayField", {}),
         },
-        { title: "Form 조합 예제", onClick: () => push("ActivityForm", {}) },
+        { title: "조합 예제", onClick: () => push("ActivityForm", {}) },
       ],
     },
     {
       title: "Button & Chip",
+      icon: MousePointerClickIcon,
       items: [
         { title: "ActionButton", onClick: () => push("ActivityActionButton", {}) },
         { title: "ToggleButton", onClick: () => push("ActivityToggleButton", {}) },
@@ -316,6 +355,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
     // 정보를 보여주기만 하는 컴포넌트와 화면 전체 상태 표현.
     {
       title: "Content Display",
+      icon: ImageIcon,
       items: [
         { title: "Avatar", onClick: () => push("ActivityAvatar", {}) },
         { title: "AvatarStack", onClick: () => push("ActivityAvatarStack", {}) },
@@ -328,16 +368,17 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
     },
     {
       title: "Snackbar",
+      icon: MessageSquareDashedIcon,
       items: [
         {
-          title: "Snackbar",
+          title: "기본",
           onClick: () =>
             snackbarAdapter.create({
               render: () => <Snackbar message="Disco Party!" actionLabel="Dance" />,
             }),
         },
         {
-          title: "Snackbar (positive)",
+          title: "positive",
           onClick: () =>
             snackbarAdapter.create({
               render: () => (
@@ -346,7 +387,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
             }),
         },
         {
-          title: "Snackbar (critical)",
+          title: "critical",
           onClick: () =>
             snackbarAdapter.create({
               render: () => (
@@ -355,7 +396,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
             }),
         },
         {
-          title: "Snackbar (queued)",
+          title: "queued",
           onClick: () =>
             snackbarAdapter.create({
               strategy: "queued",
@@ -366,7 +407,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
           // 기존 스낵바를 먼저 닫고 다음 tick에 새 스낵바를 띄우는 패턴.
           // dismiss 상태 전이가 적용된 뒤에 create가 실행되므로
           // 항상 새 스낵바부터 활성화되는 것을 보장한다.
-          title: "Snackbar (dismiss+setTimeout workaround)",
+          title: "dismiss+setTimeout workaround",
           onClick: () => {
             snackbarAdapter.dismiss();
             setTimeout(() => {
@@ -382,6 +423,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
     // 보는 화면.
     {
       title: "Foundation",
+      icon: PaletteIcon,
       items: [
         { title: "Box margin 프롭", onClick: () => push("ActivityMarginPlayground", {}) },
         { title: "IACVT Leak Check (구형 iOS)", onClick: () => push("ActivityIacvtLeak", {}) },
@@ -404,6 +446,99 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
     },
   ];
 
+  const scrollContainerRef = React.useRef<HTMLDivElement>(null);
+  const stripRef = React.useRef<HTMLDivElement>(null);
+  // 섹션 제목이 고정될 자리가 칩 스트립 바로 아래여야 해서, 스트립의 실제 높이를 잰다.
+  const [stripHeight, setStripHeight] = React.useState(0);
+  // 등록이 렌더 순서대로 일어나므로 Map의 키 순서가 곧 화면에 놓인 섹션 순서다.
+  const sectionRefs = React.useRef(new Map<string, HTMLElement>());
+  const isJumpingRef = React.useRef(false);
+  const [activeSection, setActiveSection] = React.useState(navigationSections[0].title);
+
+  React.useEffect(() => {
+    const strip = stripRef.current;
+    if (!strip) return;
+
+    const observer = new ResizeObserver(() => setStripHeight(strip.offsetHeight));
+    observer.observe(strip);
+    return () => observer.disconnect();
+  }, []);
+
+  React.useEffect(() => {
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) return;
+
+    const visibleTitles = new Set<string>();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const title = (entry.target as HTMLElement).dataset.sectionTitle;
+          if (!title) continue;
+
+          if (entry.isIntersecting) visibleTitles.add(title);
+          else visibleTitles.delete(title);
+        }
+
+        if (isJumpingRef.current) return;
+
+        // 띠에 걸린 것 중 마지막 섹션을 고른다. 첫 섹션을 고르면 이미 위로 밀려나는 중인 섹션이
+        // 다음 섹션이 화면을 다 채울 때까지 활성으로 남는다.
+        const current = [...sectionRefs.current.keys()]
+          .filter((title) => visibleTitles.has(title))
+          .pop();
+        if (current) setActiveSection(current);
+      },
+      // 스크롤 컨테이너 위쪽 20%만 관측한다.
+      { root: scrollContainer, rootMargin: "0px 0px -80% 0px" },
+    );
+
+    for (const section of sectionRefs.current.values()) {
+      observer.observe(section);
+    }
+    return () => observer.disconnect();
+  }, []);
+
+  React.useEffect(() => {
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) return;
+
+    let settleTimer: ReturnType<typeof setTimeout>;
+    const releaseWhenSettled = () => {
+      if (!isJumpingRef.current) return;
+
+      clearTimeout(settleTimer);
+      settleTimer = setTimeout(() => {
+        isJumpingRef.current = false;
+      }, 120);
+    };
+
+    scrollContainer.addEventListener("scroll", releaseWhenSettled, { passive: true });
+    return () => {
+      clearTimeout(settleTimer);
+      scrollContainer.removeEventListener("scroll", releaseWhenSettled);
+    };
+  }, []);
+
+  function jumpToSection(title: string) {
+    const scrollContainer = scrollContainerRef.current;
+    const section = sectionRefs.current.get(title);
+    if (!scrollContainer || !section) return;
+
+    // 부드러운 스크롤이 중간 섹션들을 훑고 지나가는 동안 활성 칩이 튀지 않도록 동기화를 멈춘다.
+    isJumpingRef.current = true;
+    setActiveSection(title);
+    scrollContainer.scrollTo({
+      top:
+        scrollContainer.scrollTop +
+        section.getBoundingClientRect().top -
+        scrollContainer.getBoundingClientRect().top -
+        Number.parseFloat(getComputedStyle(scrollContainer).paddingTop) -
+        stripHeight -
+        HEADER_GAP,
+      behavior: "smooth",
+    });
+  }
+
   return (
     <AppScreen transitionStyle={params.transitionStyle}>
       <AppBar bg="bg.layerBasement">
@@ -420,6 +555,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
         </AppBarRight>
       </AppBar>
       <AppScreenContent
+        ref={scrollContainerRef}
         ptr
         // layer의 배경색은 recipe가 layerDefault로 고정하고 style prop을 받지 않는다.
         // PTR로 당겼을 때 드러나는 영역까지 카드 배경과 이어지려면 여기서 덮어야 한다.
@@ -429,19 +565,112 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
         }}
       >
         <VStack pb="safeArea" minHeight="100%">
-          <Grid columns={{ base: 1, md: 2, lg: 3, xl: 4 }} gap="x4" px="x4" pb="x4">
+          <Box ref={stripRef} position="sticky" top={0} zIndex={2} bg="bg.layerBasement">
+            <ChipTabsRoot
+              value={activeSection}
+              onValueChange={jumpToSection}
+              variant="neutralSolid"
+            >
+              <ChipTabsList style={{ padding: "8px 16px" }}>
+                {navigationSections.map((section) => (
+                  <ChipTabsTrigger key={section.title} value={section.title}>
+                    {section.title}
+                  </ChipTabsTrigger>
+                ))}
+              </ChipTabsList>
+            </ChipTabsRoot>
+          </Box>
+          <Grid
+            columns={{ base: 1, md: 2, lg: 3, xl: 4 }}
+            gap="x5"
+            px="x4"
+            pt={`${HEADER_GAP}px`}
+            pb="x4"
+          >
             {navigationSections.map((section) => (
-              <VStack key={section.title} py="x1_5" borderRadius="r3_5" bg="bg.layerDefault">
-                <ListHeader as="h2">{section.title}</ListHeader>
-                <List itemBorderRadius="r2">
-                  {section.items.map((item) =>
-                    item.component ? (
-                      <React.Fragment key={item.title}>{item.component}</React.Fragment>
-                    ) : (
-                      <ListButtonItem key={item.title} onClick={item.onClick} title={item.title} />
-                    ),
-                  )}
-                </List>
+              <VStack
+                key={section.title}
+                data-section-title={section.title}
+                ref={(node) => {
+                  if (node) sectionRefs.current.set(section.title, node);
+                  else sectionRefs.current.delete(section.title);
+                }}
+              >
+                {/*
+                  카드 위쪽 여백을 섹션 gap이 아니라 제목의 pb로 준다. 쉬고 있을 때의 간격은
+                  같으면서, 제목이 고정됐을 때는 그 8px까지 제목의 배경이 덮어서 카드 항목이
+                  제목 글자에 닿지 않는다.
+                */}
+                <HStack
+                  align="center"
+                  gap="x1_5"
+                  px="x1"
+                  pt="x1"
+                  pb="x2"
+                  position="sticky"
+                  top={`${stripHeight + HEADER_GAP}px`}
+                  zIndex={1}
+                  bg="bg.layerBasement"
+                >
+                  {/*
+                    제목이 스트립에서 HEADER_GAP만큼 떨어져 고정되므로 그 사이에 틈이 생긴다.
+                    제목의 배경을 그 틈까지 위로 늘려서 카드 항목이 제목 위로 새어 나오지 않게
+                    한다. 섹션 사이 간격이 이보다 넓어서, 고정되기 전에는 그 간격 안에 들어가
+                    페이지 배경과 겹치므로 보이지 않는다.
+                  */}
+                  <Box
+                    position="absolute"
+                    bottom="100%"
+                    left={0}
+                    right={0}
+                    height={`${HEADER_GAP}px`}
+                    bg="bg.layerBasement"
+                  />
+                  <Icon svg={<section.icon />} size="x4_5" color="fg.neutralSubtle" />
+                  <Text as="h2" textStyle="t5Medium" color="fg.neutral">
+                    {section.title}
+                  </Text>
+                  {/*
+                    카드의 둥근 윗변을 제목 아래에 고정하는 캡. 제목이 sticky라서 그 자식으로
+                    두면 별도 오프셋 계산 없이 제목을 따라다닌다.
+
+                    칠하는 것은 두 위쪽 모서리의 바깥 쐐기뿐이다. 바깥으로 퍼지는 box-shadow는
+                    둥근 테두리 모양의 바깥만 칠하고, clip-path가 그 그림자를 다시 사각형 안으로
+                    자르므로, 사각형 안이면서 곡선 바깥인 쐐기만 남는다. 가운데가 비어 있어서
+                    항목이 캡 높이만큼 늦게 드러나지 않고 카드 윗변에서 바로 곡선을 따라 잘린다.
+
+                    칠하는 색이 페이지 배경과 같아서, 여러 열에서 카드가 먼저 끝나고 제목만 남는
+                    구간에서는 캡이 보이지 않는다.
+                  */}
+                  <Box
+                    position="absolute"
+                    top="100%"
+                    left={0}
+                    right={0}
+                    height="x3_5"
+                    borderTopLeftRadius="r3_5"
+                    borderTopRightRadius="r3_5"
+                    style={{
+                      boxShadow: `0 0 0 ${vars.$radius.r3_5} ${vars.$color.bg.layerBasement}`,
+                      clipPath: "inset(0)",
+                    }}
+                  />
+                </HStack>
+                <VStack py="x1_5" borderRadius="r3_5" bg="bg.layerDefault">
+                  <List itemBorderRadius="r2">
+                    {section.items.map((item) =>
+                      item.component ? (
+                        <React.Fragment key={item.title}>{item.component}</React.Fragment>
+                      ) : (
+                        <ListButtonItem
+                          key={item.title}
+                          onClick={item.onClick}
+                          title={item.title}
+                        />
+                      ),
+                    )}
+                  </List>
+                </VStack>
               </VStack>
             ))}
           </Grid>

--- a/examples/stackflow-spa/src/activities/ActivityHome.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityHome.tsx
@@ -462,12 +462,19 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
 
         if (isJumpingRef.current) return;
 
-        // 띠에 걸린 것 중 마지막 섹션을 고른다. 첫 섹션을 고르면 이미 위로 밀려나는 중인 섹션이
-        // 다음 섹션이 화면을 다 채울 때까지 활성으로 남는다.
-        const current = [...sectionRefs.current.keys()]
-          .filter((title) => visibleTitles.has(title))
-          .pop();
-        if (current) setActiveSection(current);
+        // 띠에 걸린 마지막 행에서 첫 섹션을 고른다. 마지막 섹션을 고르면 여러 열로 렌더될 때 한
+        // 행이 통째로 띠에 들어와 오른쪽 끝 카드가 활성이 되고, 첫 행을 고르면 이미 위로 밀려나는
+        // 행이 다음 행이 화면을 다 채울 때까지 활성으로 남는다.
+        const visible = [...sectionRefs.current.entries()].filter(([title]) =>
+          visibleTitles.has(title),
+        );
+        if (visible.length > 0) {
+          const rowTop = Math.max(...visible.map(([, el]) => el.getBoundingClientRect().top));
+          const current = visible.find(
+            ([, el]) => Math.abs(el.getBoundingClientRect().top - rowTop) < 1,
+          )?.[0];
+          if (current) setActiveSection(current);
+        }
       },
       // 스크롤 컨테이너 위쪽 20%만 관측한다.
       { root: scrollContainer, rootMargin: "0px 0px -80% 0px" },

--- a/examples/stackflow-spa/src/activities/ActivityHome.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityHome.tsx
@@ -73,15 +73,17 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
   const { zIndex: activityIndex } = useActivity();
 
   const navigationSections: NavigationSection[] = [
+    // 화면 껍데기 자체를 prop으로 조작하는 화면. push/pop 옵션이 주제인 화면은 Stack & Transition으로 간다.
     {
-      title: "AppBar",
+      title: "App Screen",
       items: [
-        { title: "LayerBar", onClick: () => push("ActivityLayerBar", {}) },
-        { title: "TransparentBar", onClick: () => push("ActivityTransparentBar", {}) },
+        { title: "AppBar 슬롯 · 긴 제목", onClick: () => push("ActivityLayerBar", {}) },
+        { title: "AppScreen transparent", onClick: () => push("ActivityTransparentBar", {}) },
+        { title: "@stackflow/plugin-basic-ui", onClick: () => push("ActivityPluginBasicUI", {}) },
       ],
     },
     {
-      title: "AppScreen",
+      title: "Stack & Transition",
       items: [
         { title: "Pop Test (중복 pop 가드)", onClick: () => push("ActivityPopTest", {}) },
         {
@@ -89,39 +91,78 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
           onClick: () => push("ActivityAnimateFalseTest", {}),
         },
         {
-          title: `Push to here (current activityIndex: ${activityIndex})`,
+          title: `홈 다시 push (깊이: ${activityIndex})`,
           onClick: () => push("ActivityHome", {}),
         },
-        { title: "@stackflow/plugin-basic-ui", onClick: () => push("ActivityPluginBasicUI", {}) },
         ...appScreenVariantMap.transitionStyle.map((transitionStyle) => ({
-          title: `ActivityTransitionStyle (${transitionStyle})`,
+          title: `전환 스타일: ${transitionStyle}`,
           onClick: () => push("ActivityTransitionStyle", { transitionStyle }),
         })),
       ],
     },
+    // 화면 아래에서 올라오는 시트. 중앙·가장자리 고정 오버레이는 Dialog & Panel로 간다.
     {
-      title: "Avatars",
+      title: "Bottom Sheet",
       items: [
-        { title: "AvatarStack", onClick: () => push("ActivityAvatarStack", {}) },
-        { title: "Avatar", onClick: () => push("ActivityAvatar", {}) },
-      ],
-    },
-    {
-      title: "Box",
-      items: [
-        { title: "Margin Playground", onClick: () => push("ActivityMarginPlayground", {}) },
-        { title: "IACVT Leak Check (구형 iOS)", onClick: () => push("ActivityIacvtLeak", {}) },
-        { title: "SidePanel IACVT (구형 iOS)", onClick: () => push("ActivityIacvtSidePanel", {}) },
-        { title: "Overlay IACVT (구형 iOS)", onClick: () => push("ActivityIacvtOverlay", {}) },
-        { title: "Margin/Bleed IACVT (구형 iOS)", onClick: () => push("ActivityIacvtMargin", {}) },
+        { title: "BottomSheet", onClick: () => push("ActivityBottomSheet", {}) },
         {
-          title: "IACVT initial-fallback 실험 (구형 iOS)",
-          onClick: () => push("ActivityIacvtExperiment", {}),
+          title: "BottomSheet modal 토글",
+          onClick: () => push("ActivityBottomSheetModalTest", {}),
+        },
+        {
+          title: "BottomSheet (TextField only)",
+          onClick: () => push("ActivityBottomSheetTextField", {}),
+        },
+        {
+          title: "BottomSheet snapPoints × 입력 포커스",
+          onClick: () => push("ActivityBottomSheetInputFocus", {}),
+        },
+        {
+          title: "BottomSheet Keyboard Playground",
+          onClick: () => push("ActivityBottomSheetKeyboardPlayground", {}),
+        },
+        {
+          title: "BottomSheet × AlertDialog (step)",
+          onClick: () => push("ActivityBottomSheetWithAlertDialogStep", {}),
+        },
+        {
+          title: "BottomSheet × AlertDialog (activity)",
+          onClick: () => push("ActivityNestedBottomSheet", {}),
+        },
+        {
+          title: "MenuSheet",
+          component: (
+            <DialogPushTrigger
+              callbackActivity={menuSheetCallback}
+              params={{}}
+              onPop={(result) => {
+                console.log(result?.action);
+              }}
+            >
+              <ListButtonItem title="MenuSheet" />
+            </DialogPushTrigger>
+          ),
+        },
+        {
+          title: "SwipeableMenuSheet",
+          component: (
+            <DialogPushTrigger
+              callbackActivity={swipeableMenuSheetCallback}
+              params={{}}
+              onPop={(result) => {
+                console.log(result?.action);
+              }}
+            >
+              <ListButtonItem title="SwipeableMenuSheet" />
+            </DialogPushTrigger>
+          ),
         },
       ],
     },
+    // 화면 중앙 또는 가장자리에 고정되는 오버레이. Responsive 계열은 좁은 화면에서 시트로 렌더되지만
+    // 검증 대상 API가 ResponsiveSidePanel/ResponsiveDialog이므로 여기에 둔다.
     {
-      title: "AlertDialogs",
+      title: "Dialog & Panel",
       items: [
         {
           title: "AlertDialog (step)",
@@ -164,18 +205,20 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
             console.log(result.message);
           },
         },
+        { title: "SidePanel", onClick: () => push("ActivitySidePanel", {}) },
+        {
+          title: "ResponsiveSidePanel",
+          onClick: () => push("ActivityResponsiveSidePanel", {}),
+        },
+        {
+          title: "ResponsiveDialog",
+          onClick: () => push("ActivityResponsiveDialog", {}),
+        },
       ],
     },
+    // 트리거 요소에 앵커되는 오버레이의 배치·정렬.
     {
-      title: "Buttons",
-      items: [
-        { title: "ActionButton", onClick: () => push("ActivityActionButton", {}) },
-        { title: "ToggleButton", onClick: () => push("ActivityToggleButton", {}) },
-        { title: "ReactionButton", onClick: () => push("ActivityReactionButton", {}) },
-      ],
-    },
-    {
-      title: "Menu",
+      title: "Menu & Popover",
       items: [
         { title: "Menu", onClick: () => push("ActivityMenu", {}) },
         {
@@ -197,73 +240,45 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
             </MenuRoot>
           ),
         },
+        { title: "HelpBubble", onClick: () => push("ActivityHelpBubble", {}) },
       ],
     },
+    // PTR 제스처의 발동·차단 조건. 스와이프백 제스처는 App Screen으로 간다.
     {
-      title: "BottomSheets",
+      title: "Pull to Refresh",
       items: [
-        { title: "BottomSheet", onClick: () => push("ActivityBottomSheet", {}) },
+        { title: "PullToRefresh", onClick: () => push("ActivityPullToRefreshPreview", {}) },
+        { title: "PullToRefresh × Tabs", onClick: () => push("ActivityPullToRefreshTabs", {}) },
         {
-          title: "BottomSheet Modal Test",
-          onClick: () => push("ActivityBottomSheetModalTest", {}),
+          title: "PullToRefresh (preventPull)",
+          onClick: () => push("ActivityPullToRefreshPreventPull", {}),
         },
         {
-          title: "BottomSheet (TextField only)",
-          onClick: () => push("ActivityBottomSheetTextField", {}),
-        },
-        {
-          title: "BottomSheet Share (snapPoints)",
-          onClick: () => push("ActivityBottomSheetInputFocus", {}),
-        },
-        {
-          title: "BottomSheet Keyboard Playground",
-          onClick: () => push("ActivityBottomSheetKeyboardPlayground", {}),
-        },
-        {
-          title: "BottomSheet × AlertDialog (Step)",
-          onClick: () => push("ActivityBottomSheetWithAlertDialogStep", {}),
-        },
-        {
-          title: "BottomSheet × AlertDialog (Activity)",
-          onClick: () => push("ActivityNestedBottomSheet", {}),
-        },
-        {
-          title: "MenuSheet",
-          component: (
-            <DialogPushTrigger
-              callbackActivity={menuSheetCallback}
-              params={{}}
-              onPop={(result) => {
-                console.log(result?.action);
-              }}
-            >
-              <ListButtonItem title="MenuSheet" />
-            </DialogPushTrigger>
-          ),
-        },
-        {
-          title: "SwipeableMenuSheet",
-          component: (
-            <DialogPushTrigger
-              callbackActivity={swipeableMenuSheetCallback}
-              params={{}}
-              onPop={(result) => {
-                console.log(result?.action);
-              }}
-            >
-              <ListButtonItem title="SwipeableMenuSheet" />
-            </DialogPushTrigger>
-          ),
+          title: "Article preventPull (텍스트 선택)",
+          onClick: () => push("ActivityArticlePreventPull", {}),
         },
       ],
     },
+    // 콘텐츠 묶음 사이를 이동시키는 컨트롤. 화면 스택 이동은 Stack & Transition으로 간다.
     {
-      title: "Chips",
+      title: "Navigation",
       items: [
-        { title: "Chip.Button", onClick: () => push("ActivityChipButton", {}) },
-        { title: "Chip.Toggle", onClick: () => push("ActivityChipToggle", {}) },
+        { title: "Tabs", onClick: () => push("ActivityTabs", {}) },
+        { title: "AnimatedTabs", onClick: () => push("ActivityAnimatedTabs", {}) },
+        { title: "SwipeableTabs", onClick: () => push("ActivitySwipeableTabs", {}) },
+        {
+          title: "Tabs autoHeight × 지연 로딩",
+          onClick: () => push("ActivityTabsAutoHeightLazy", {}),
+        },
+        {
+          title: "ChipTabs × ScrollFog",
+          onClick: () => push("ActivityChipTabsScrollFog", {}),
+        },
+        { title: "Pagination", onClick: () => push("ActivityPagination", {}) },
+        { title: "SideNavigation", onClick: () => replace("ActivitySideNavigation", {}) },
       ],
     },
+    // List 계열 아이템의 prefix/suffix 조합. 그 안에 쓰이는 Checkbox·Switch·Radio 자체는 Form으로 간다.
     {
       title: "List",
       items: [
@@ -276,23 +291,51 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
         { title: "ListRadioItem", onClick: () => push("ActivityListRadioItem", {}) },
       ],
     },
+    // 값을 입력·선택받는 컨트롤. 누르기만 하는 버튼·칩은 Button & Chip으로 간다.
     {
-      title: "PullToRefresh",
+      title: "Form",
       items: [
-        { title: "PullToRefresh", onClick: () => push("ActivityPullToRefreshPreview", {}) },
-        { title: "PullToRefresh × Tabs", onClick: () => push("ActivityPullToRefreshTabs", {}) },
+        { title: "Switch", onClick: () => push("ActivitySwitch", {}) },
+        { title: "Checkbox", onClick: () => push("ActivityCheckbox", {}) },
+        { title: "QuantityPicker", onClick: () => push("ActivityQuantityPicker", {}) },
+        { title: "RadioGroup", onClick: () => push("ActivityRadioGroup", {}) },
+        { title: "SegmentedControl", onClick: () => push("ActivitySegmentedControl", {}) },
+        { title: "Select", onClick: () => push("ActivitySelect", {}) },
+        { title: "TimePicker", onClick: () => push("ActivityTimePicker", {}) },
+        { title: "WheelPicker", onClick: () => push("ActivityWheelPicker", {}) },
+        { title: "AttachmentField", onClick: () => push("ActivityAttachmentField", {}) },
         {
-          title: "PullToRefresh (preventPull)",
-          onClick: () => push("ActivityPullToRefreshPreventPull", {}),
+          title: "AttachmentDisplayField",
+          onClick: () => push("ActivityAttachmentDisplayField", {}),
         },
-        {
-          title: "Article (preventPull)",
-          onClick: () => push("ActivityArticlePreventPull", {}),
-        },
+        { title: "Form 조합 예제", onClick: () => push("ActivityForm", {}) },
       ],
     },
     {
-      title: "Snackbars",
+      title: "Button & Chip",
+      items: [
+        { title: "ActionButton", onClick: () => push("ActivityActionButton", {}) },
+        { title: "ToggleButton", onClick: () => push("ActivityToggleButton", {}) },
+        { title: "ReactionButton", onClick: () => push("ActivityReactionButton", {}) },
+        { title: "Chip.Button", onClick: () => push("ActivityChipButton", {}) },
+        { title: "Chip.Toggle", onClick: () => push("ActivityChipToggle", {}) },
+      ],
+    },
+    // 정보를 보여주기만 하는 컴포넌트와 화면 전체 상태 표현.
+    {
+      title: "Content Display",
+      items: [
+        { title: "Avatar", onClick: () => push("ActivityAvatar", {}) },
+        { title: "AvatarStack", onClick: () => push("ActivityAvatarStack", {}) },
+        { title: "Badge", onClick: () => push("ActivityBadge", {}) },
+        { title: "MannerTempBadge", onClick: () => push("ActivityMannerTempLevel", {}) },
+        { title: "Accordion", onClick: () => push("ActivityAccordion", {}) },
+        { title: "ErrorState", onClick: () => push("ActivityErrorState", {}) },
+        { title: "ResultSection", onClick: () => push("ActivityResultSection", {}) },
+      ],
+    },
+    {
+      title: "Snackbar",
       items: [
         {
           title: "Snackbar",
@@ -343,74 +386,28 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
         },
       ],
     },
+    // 특정 컴포넌트가 아니라 그 아래 스타일 레이어(토큰·스타일 프롭·컬러 모드·폰트 배율·CSS 변수 엔진)를
+    // 보는 화면.
     {
-      title: "Tabs",
+      title: "Foundation",
       items: [
-        { title: "Tabs", onClick: () => push("ActivityTabs", {}) },
-        { title: "AnimatedTabs", onClick: () => push("ActivityAnimatedTabs", {}) },
-        { title: "SwipeableTabs", onClick: () => push("ActivitySwipeableTabs", {}) },
+        { title: "Box margin 프롭", onClick: () => push("ActivityMarginPlayground", {}) },
+        { title: "IACVT Leak Check (구형 iOS)", onClick: () => push("ActivityIacvtLeak", {}) },
+        { title: "SidePanel IACVT (구형 iOS)", onClick: () => push("ActivityIacvtSidePanel", {}) },
+        { title: "Overlay IACVT (구형 iOS)", onClick: () => push("ActivityIacvtOverlay", {}) },
+        { title: "Margin/Bleed IACVT (구형 iOS)", onClick: () => push("ActivityIacvtMargin", {}) },
         {
-          title: "TabsAutoHeightLazy",
-          onClick: () => push("ActivityTabsAutoHeightLazy", {}),
+          title: "IACVT: initial 폴백 가설 (순수 CSS)",
+          onClick: () => push("ActivityIacvtExperiment", {}),
         },
-        {
-          title: "ChipTabsScrollFog",
-          onClick: () => push("ActivityChipTabsScrollFog", {}),
-        },
-      ],
-    },
-    {
-      title: "Forms",
-      items: [
-        { title: "Switch", onClick: () => push("ActivitySwitch", {}) },
-        { title: "Checkbox", onClick: () => push("ActivityCheckbox", {}) },
-        { title: "Quantity Picker", onClick: () => push("ActivityQuantityPicker", {}) },
-        { title: "RadioGroup", onClick: () => push("ActivityRadioGroup", {}) },
-        { title: "SegmentedControl", onClick: () => push("ActivitySegmentedControl", {}) },
-        { title: "Select", onClick: () => push("ActivitySelect", {}) },
-        { title: "TimePicker", onClick: () => push("ActivityTimePicker", {}) },
-        { title: "Wheel Picker", onClick: () => push("ActivityWheelPicker", {}) },
-        { title: "AttachmentField", onClick: () => push("ActivityAttachmentField", {}) },
-        {
-          title: "AttachmentDisplayField",
-          onClick: () => push("ActivityAttachmentDisplayField", {}),
-        },
-        { title: "Form", onClick: () => push("ActivityForm", {}) },
-      ],
-    },
-    {
-      title: "Other Components",
-      items: [
-        { title: "Accordion", onClick: () => push("ActivityAccordion", {}) },
-        { title: "Pagination", onClick: () => push("ActivityPagination", {}) },
-        { title: "HelpBubble", onClick: () => push("ActivityHelpBubble", {}) },
-        { title: "Badge", onClick: () => push("ActivityBadge", {}) },
-        { title: "MannerTempLevel", onClick: () => push("ActivityMannerTempLevel", {}) },
-        { title: "ErrorState", onClick: () => push("ActivityErrorState", {}) },
-        { title: "ResultSection", onClick: () => push("ActivityResultSection", {}) },
-        { title: "SideNavigation", onClick: () => replace("ActivitySideNavigation", {}) },
-        { title: "SidePanel", onClick: () => push("ActivitySidePanel", {}) },
-        {
-          title: "ResponsiveSidePanel",
-          onClick: () => push("ActivityResponsiveSidePanel", {}),
-        },
-        {
-          title: "ResponsiveDialog",
-          onClick: () => push("ActivityResponsiveDialog", {}),
-        },
-      ],
-    },
-    {
-      title: "Misc",
-      items: [
         {
           title: "Font Multiplier Layout",
           onClick: () => push("ActivityFontMultiplierLayout", {}),
         },
         { title: "Typography Scale", onClick: () => push("ActivityTypographyScale", {}) },
-        { title: "Scale Feedback", onClick: () => push("ActivityScaleFeedback", {}) },
+        { title: "누름 축소 피드백", onClick: () => push("ActivityScaleFeedback", {}) },
         { title: "PartialDarkMode", onClick: () => push("ActivityPartialDarkMode", {}) },
-        { title: "Mixed Version Test", onClick: () => push("ActivityMixedVersionTest", {}) },
+        { title: "v2 변수 × v3 토큰 혼용", onClick: () => push("ActivityMixedVersionTest", {}) },
       ],
     },
   ];

--- a/examples/stackflow-spa/src/activities/ActivityHome.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityHome.tsx
@@ -46,8 +46,6 @@ import {
   IconPencilLine,
   IconTrashcanLine,
 } from "@karrotmarket/react-monochrome-icon";
-// 섹션 제목 아이콘은 화면 껍데기·시트·패널처럼 UI 구조 자체를 가리켜야 하는데,
-// @karrotmarket/react-monochrome-icon은 당근 제품 도메인 위주라 그 개념을 담은 아이콘이 없다.
 import {
   AppWindowIcon,
   CompassIcon,
@@ -95,11 +93,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
 
   const { zIndex: activityIndex } = useActivity();
 
-  // 항목 이름은 섹션 제목이 이미 말한 단어를 되풀이하지 않는다. 다만 ListButtonItem·ActionButton처럼
-  // 문자열 자체가 실제 export 이름인 항목은, 접두어를 떼면 없는 이름이 되므로 그대로 둔다.
   const navigationSections: NavigationSection[] = [
-    // 화면 껍데기의 prop과 그 위에서 일어나는 스택 동작. 둘 다 AppScreen이 소유하거나
-    // AppScreen을 통해서만 검증되므로 한 섹션으로 둔다.
     {
       title: "AppScreen",
       icon: LayersIcon,
@@ -122,8 +116,6 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
         })),
       ],
     },
-    // 화면 아래 가장자리에서 올라오는 오버레이. 중앙·좌우 가장자리에 고정되는 것은 Dialog & Panel,
-    // 트리거 요소에 앵커되는 것은 Menu & Popover로 간다.
     {
       title: "Drawer",
       icon: PanelBottomIcon,
@@ -183,8 +175,6 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
         },
       ],
     },
-    // 화면 중앙 또는 가장자리에 고정되는 오버레이. Responsive 계열은 좁은 화면에서 시트로 렌더되지만
-    // 검증 대상 API가 ResponsiveSidePanel/ResponsiveDialog이므로 여기에 둔다.
     {
       title: "Dialog & Panel",
       icon: AppWindowIcon,
@@ -241,7 +231,6 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
         },
       ],
     },
-    // 트리거 요소에 앵커되는 오버레이의 배치·정렬.
     {
       title: "Menu & Popover",
       icon: SquareMenuIcon,
@@ -269,7 +258,6 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
         { title: "HelpBubble", onClick: () => push("ActivityHelpBubble", {}) },
       ],
     },
-    // PTR 제스처의 발동·차단 조건. 스와이프백 제스처는 App Screen으로 간다.
     {
       title: "Pull to Refresh",
       icon: RefreshCwIcon,
@@ -286,7 +274,6 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
         },
       ],
     },
-    // 콘텐츠 묶음 사이를 이동시키는 컨트롤. 화면 스택 이동은 Stack & Transition으로 간다.
     {
       title: "Navigation",
       icon: CompassIcon,
@@ -306,7 +293,6 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
         { title: "SideNavigation", onClick: () => replace("ActivitySideNavigation", {}) },
       ],
     },
-    // List 계열 아이템의 prefix/suffix 조합. 그 안에 쓰이는 Checkbox·Switch·Radio 자체는 Form으로 간다.
     {
       title: "List",
       icon: ListIcon,
@@ -320,7 +306,6 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
         { title: "ListRadioItem", onClick: () => push("ActivityListRadioItem", {}) },
       ],
     },
-    // 값을 입력·선택받는 컨트롤. 누르기만 하는 버튼·칩은 Button & Chip으로 간다.
     {
       title: "Form",
       icon: TextCursorInputIcon,
@@ -352,7 +337,6 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
         { title: "Chip.Toggle", onClick: () => push("ActivityChipToggle", {}) },
       ],
     },
-    // 정보를 보여주기만 하는 컴포넌트와 화면 전체 상태 표현.
     {
       title: "Content Display",
       icon: ImageIcon,
@@ -419,8 +403,6 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
         },
       ],
     },
-    // 특정 컴포넌트가 아니라 그 아래 스타일 레이어(토큰·스타일 프롭·컬러 모드·폰트 배율·CSS 변수 엔진)를
-    // 보는 화면.
     {
       title: "Foundation",
       icon: PaletteIcon,
@@ -448,7 +430,6 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
 
   const scrollContainerRef = React.useRef<HTMLDivElement>(null);
   const stripRef = React.useRef<HTMLDivElement>(null);
-  // 섹션 제목이 고정될 자리가 칩 스트립 바로 아래여야 해서, 스트립의 실제 높이를 잰다.
   const [stripHeight, setStripHeight] = React.useState(0);
   // 등록이 렌더 순서대로 일어나므로 Map의 키 순서가 곧 화면에 놓인 섹션 순서다.
   const sectionRefs = React.useRef(new Map<string, HTMLElement>());

--- a/examples/stackflow-spa/src/activities/ActivityHome.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityHome.tsx
@@ -9,6 +9,7 @@ import {
   useSnackbarAdapter,
 } from "@seed-design/react";
 import { vars } from "@seed-design/css/vars";
+import type { InferActivityParams, RegisteredActivityName } from "@stackflow/config";
 import { useActivity, useFlow, type StaticActivityComponentType } from "@stackflow/react/future";
 import * as React from "react";
 import { List, ListButtonItem } from "seed-design/ui/list";
@@ -69,8 +70,8 @@ import { useActivityZIndexBase } from "@seed-design/stackflow";
 const HEADER_GAP = 8;
 
 type NavigationItem =
-  | { title: string; onClick: () => void; component?: never }
-  | { title: string; onClick?: never; component?: React.ReactNode };
+  | { title: string; detail?: string; onClick: () => void; component?: never }
+  | { title: string; detail?: never; onClick?: never; component?: React.ReactNode };
 
 type NavigationSection = {
   title: string;
@@ -93,26 +94,27 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
 
   const { zIndex: activityIndex } = useActivity();
 
+  // 항목이 여는 액티비티 이름을 detail로 함께 내보낸다. 이름이 곧 파일 이름이라, 데모에서 본
+  // 화면의 소스를 찾을 때 목록에서 읽은 이름을 그대로 검색할 수 있다.
+  const to = <K extends RegisteredActivityName>(activity: K, params: InferActivityParams<K>) => ({
+    detail: activity,
+    onClick: () => push(activity, params),
+  });
+
   const navigationSections: NavigationSection[] = [
     {
       title: "AppScreen",
       icon: LayersIcon,
       items: [
-        { title: "AppBar 슬롯 · 긴 제목", onClick: () => push("ActivityLayerBar", {}) },
-        { title: "transparent", onClick: () => push("ActivityTransparentBar", {}) },
-        { title: "@stackflow/plugin-basic-ui", onClick: () => push("ActivityPluginBasicUI", {}) },
-        { title: "Pop Test (중복 pop 가드)", onClick: () => push("ActivityPopTest", {}) },
-        {
-          title: "animate: false Test (밀림 버그)",
-          onClick: () => push("ActivityAnimateFalseTest", {}),
-        },
-        {
-          title: `홈 다시 push (깊이: ${activityIndex})`,
-          onClick: () => push("ActivityHome", {}),
-        },
+        { title: "AppBar 슬롯 · 긴 제목", ...to("ActivityLayerBar", {}) },
+        { title: "transparent", ...to("ActivityTransparentBar", {}) },
+        { title: "@stackflow/plugin-basic-ui", ...to("ActivityPluginBasicUI", {}) },
+        { title: "Pop Test (중복 pop 가드)", ...to("ActivityPopTest", {}) },
+        { title: "animate: false Test (밀림 버그)", ...to("ActivityAnimateFalseTest", {}) },
+        { title: `홈 다시 push (깊이: ${activityIndex})`, ...to("ActivityHome", {}) },
         ...appScreenVariantMap.transitionStyle.map((transitionStyle) => ({
           title: `전환: ${transitionStyle}`,
-          onClick: () => push("ActivityTransitionStyle", { transitionStyle }),
+          ...to("ActivityTransitionStyle", { transitionStyle }),
         })),
       ],
     },
@@ -120,31 +122,22 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
       title: "Drawer",
       icon: PanelBottomIcon,
       items: [
-        { title: "BottomSheet", onClick: () => push("ActivityBottomSheet", {}) },
-        {
-          title: "BottomSheet: modal 토글",
-          onClick: () => push("ActivityBottomSheetModalTest", {}),
-        },
-        {
-          title: "BottomSheet: TextField only",
-          onClick: () => push("ActivityBottomSheetTextField", {}),
-        },
+        { title: "BottomSheet", ...to("ActivityBottomSheet", {}) },
+        { title: "BottomSheet: modal 토글", ...to("ActivityBottomSheetModalTest", {}) },
+        { title: "BottomSheet: TextField only", ...to("ActivityBottomSheetTextField", {}) },
         {
           title: "BottomSheet: snapPoints × 입력 포커스",
-          onClick: () => push("ActivityBottomSheetInputFocus", {}),
+          ...to("ActivityBottomSheetInputFocus", {}),
         },
         {
           title: "BottomSheet: Keyboard Playground",
-          onClick: () => push("ActivityBottomSheetKeyboardPlayground", {}),
+          ...to("ActivityBottomSheetKeyboardPlayground", {}),
         },
         {
           title: "BottomSheet × AlertDialog (step)",
-          onClick: () => push("ActivityBottomSheetWithAlertDialogStep", {}),
+          ...to("ActivityBottomSheetWithAlertDialogStep", {}),
         },
-        {
-          title: "BottomSheet × AlertDialog (activity)",
-          onClick: () => push("ActivityNestedBottomSheet", {}),
-        },
+        { title: "BottomSheet × AlertDialog (activity)", ...to("ActivityNestedBottomSheet", {}) },
         {
           title: "MenuSheet",
           component: (
@@ -155,7 +148,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
                 console.log(result?.action);
               }}
             >
-              <ListButtonItem title="MenuSheet" />
+              <ListButtonItem title="MenuSheet" detail="ActivityMenuSheet" />
             </DialogPushTrigger>
           ),
         },
@@ -169,15 +162,12 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
                 console.log(result?.action);
               }}
             >
-              <ListButtonItem title="SwipeableMenuSheet" />
+              <ListButtonItem title="SwipeableMenuSheet" detail="ActivitySwipeableMenuSheet" />
             </DialogPushTrigger>
           ),
         },
-        { title: "SidePanel", onClick: () => push("ActivitySidePanel", {}) },
-        {
-          title: "ResponsiveSidePanel",
-          onClick: () => push("ActivityResponsiveSidePanel", {}),
-        },
+        { title: "SidePanel", ...to("ActivitySidePanel", {}) },
+        { title: "ResponsiveSidePanel", ...to("ActivityResponsiveSidePanel", {}) },
       ],
     },
     {
@@ -220,22 +210,20 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
         },
         {
           title: "AlertDialog (activity)",
+          detail: "ActivityAlertDialog",
           onClick: async () => {
             const result = await receive<any>(push("ActivityAlertDialog", {}));
             console.log(result.message);
           },
         },
-        {
-          title: "ResponsiveDialog",
-          onClick: () => push("ActivityResponsiveDialog", {}),
-        },
+        { title: "ResponsiveDialog", ...to("ActivityResponsiveDialog", {}) },
       ],
     },
     {
       title: "Menu & Popover",
       icon: SquareMenuIcon,
       items: [
-        { title: "Menu", onClick: () => push("ActivityMenu", {}) },
+        { title: "Menu", ...to("ActivityMenu", {}) },
         {
           title: "ListButtonItem 트리거",
           component: (
@@ -255,99 +243,88 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
             </MenuRoot>
           ),
         },
-        { title: "HelpBubble", onClick: () => push("ActivityHelpBubble", {}) },
+        { title: "HelpBubble", ...to("ActivityHelpBubble", {}) },
       ],
     },
     {
       title: "Pull to Refresh",
       icon: RefreshCwIcon,
       items: [
-        { title: "기본", onClick: () => push("ActivityPullToRefreshPreview", {}) },
-        { title: "Tabs 조합", onClick: () => push("ActivityPullToRefreshTabs", {}) },
-        {
-          title: "preventPull",
-          onClick: () => push("ActivityPullToRefreshPreventPull", {}),
-        },
-        {
-          title: "Article preventPull (텍스트 선택)",
-          onClick: () => push("ActivityArticlePreventPull", {}),
-        },
+        { title: "기본", ...to("ActivityPullToRefreshPreview", {}) },
+        { title: "Tabs 조합", ...to("ActivityPullToRefreshTabs", {}) },
+        { title: "preventPull", ...to("ActivityPullToRefreshPreventPull", {}) },
+        { title: "Article preventPull (텍스트 선택)", ...to("ActivityArticlePreventPull", {}) },
       ],
     },
     {
       title: "Navigation",
       icon: CompassIcon,
       items: [
-        { title: "Tabs", onClick: () => push("ActivityTabs", {}) },
-        { title: "AnimatedTabs", onClick: () => push("ActivityAnimatedTabs", {}) },
-        { title: "SwipeableTabs", onClick: () => push("ActivitySwipeableTabs", {}) },
+        { title: "Tabs", ...to("ActivityTabs", {}) },
+        { title: "AnimatedTabs", ...to("ActivityAnimatedTabs", {}) },
+        { title: "SwipeableTabs", ...to("ActivitySwipeableTabs", {}) },
+        { title: "Tabs autoHeight × 지연 로딩", ...to("ActivityTabsAutoHeightLazy", {}) },
+        { title: "ChipTabs × ScrollFog", ...to("ActivityChipTabsScrollFog", {}) },
+        { title: "Pagination", ...to("ActivityPagination", {}) },
         {
-          title: "Tabs autoHeight × 지연 로딩",
-          onClick: () => push("ActivityTabsAutoHeightLazy", {}),
+          title: "SideNavigation",
+          detail: "ActivitySideNavigation",
+          onClick: () => replace("ActivitySideNavigation", {}),
         },
-        {
-          title: "ChipTabs × ScrollFog",
-          onClick: () => push("ActivityChipTabsScrollFog", {}),
-        },
-        { title: "Pagination", onClick: () => push("ActivityPagination", {}) },
-        { title: "SideNavigation", onClick: () => replace("ActivitySideNavigation", {}) },
       ],
     },
     {
       title: "List",
       icon: ListIcon,
       items: [
-        { title: "ListItem", onClick: () => push("ActivityListItem", {}) },
-        { title: "ListImageFrame", onClick: () => push("ActivityListImageFrame", {}) },
-        { title: "ListButtonItem", onClick: () => push("ActivityListButtonItem", {}) },
-        { title: "ListLinkItem", onClick: () => push("ActivityListLinkItem", {}) },
-        { title: "ListSwitchItem", onClick: () => push("ActivityListSwitchItem", {}) },
-        { title: "ListCheckItem", onClick: () => push("ActivityListCheckItem", {}) },
-        { title: "ListRadioItem", onClick: () => push("ActivityListRadioItem", {}) },
+        { title: "ListItem", ...to("ActivityListItem", {}) },
+        { title: "ListImageFrame", ...to("ActivityListImageFrame", {}) },
+        { title: "ListButtonItem", ...to("ActivityListButtonItem", {}) },
+        { title: "ListLinkItem", ...to("ActivityListLinkItem", {}) },
+        { title: "ListSwitchItem", ...to("ActivityListSwitchItem", {}) },
+        { title: "ListCheckItem", ...to("ActivityListCheckItem", {}) },
+        { title: "ListRadioItem", ...to("ActivityListRadioItem", {}) },
       ],
     },
     {
       title: "Form",
       icon: TextCursorInputIcon,
       items: [
-        { title: "Switch", onClick: () => push("ActivitySwitch", {}) },
-        { title: "Checkbox", onClick: () => push("ActivityCheckbox", {}) },
-        { title: "QuantityPicker", onClick: () => push("ActivityQuantityPicker", {}) },
-        { title: "RadioGroup", onClick: () => push("ActivityRadioGroup", {}) },
-        { title: "SegmentedControl", onClick: () => push("ActivitySegmentedControl", {}) },
-        { title: "Select", onClick: () => push("ActivitySelect", {}) },
-        { title: "TimePicker", onClick: () => push("ActivityTimePicker", {}) },
-        { title: "WheelPicker", onClick: () => push("ActivityWheelPicker", {}) },
-        { title: "AttachmentField", onClick: () => push("ActivityAttachmentField", {}) },
-        {
-          title: "AttachmentDisplayField",
-          onClick: () => push("ActivityAttachmentDisplayField", {}),
-        },
-        { title: "조합 예제", onClick: () => push("ActivityForm", {}) },
+        { title: "Switch", ...to("ActivitySwitch", {}) },
+        { title: "Checkbox", ...to("ActivityCheckbox", {}) },
+        { title: "QuantityPicker", ...to("ActivityQuantityPicker", {}) },
+        { title: "RadioGroup", ...to("ActivityRadioGroup", {}) },
+        { title: "SegmentedControl", ...to("ActivitySegmentedControl", {}) },
+        { title: "Select", ...to("ActivitySelect", {}) },
+        { title: "TimePicker", ...to("ActivityTimePicker", {}) },
+        { title: "WheelPicker", ...to("ActivityWheelPicker", {}) },
+        { title: "AttachmentField", ...to("ActivityAttachmentField", {}) },
+        { title: "AttachmentDisplayField", ...to("ActivityAttachmentDisplayField", {}) },
+        { title: "조합 예제", ...to("ActivityForm", {}) },
       ],
     },
     {
       title: "Button & Chip",
       icon: MousePointerClickIcon,
       items: [
-        { title: "ActionButton", onClick: () => push("ActivityActionButton", {}) },
-        { title: "ToggleButton", onClick: () => push("ActivityToggleButton", {}) },
-        { title: "ReactionButton", onClick: () => push("ActivityReactionButton", {}) },
-        { title: "Chip.Button", onClick: () => push("ActivityChipButton", {}) },
-        { title: "Chip.Toggle", onClick: () => push("ActivityChipToggle", {}) },
+        { title: "ActionButton", ...to("ActivityActionButton", {}) },
+        { title: "ToggleButton", ...to("ActivityToggleButton", {}) },
+        { title: "ReactionButton", ...to("ActivityReactionButton", {}) },
+        { title: "Chip.Button", ...to("ActivityChipButton", {}) },
+        { title: "Chip.Toggle", ...to("ActivityChipToggle", {}) },
       ],
     },
     {
       title: "Content Display",
       icon: ImageIcon,
       items: [
-        { title: "Avatar", onClick: () => push("ActivityAvatar", {}) },
-        { title: "AvatarStack", onClick: () => push("ActivityAvatarStack", {}) },
-        { title: "Badge", onClick: () => push("ActivityBadge", {}) },
-        { title: "MannerTempBadge", onClick: () => push("ActivityMannerTempLevel", {}) },
-        { title: "Accordion", onClick: () => push("ActivityAccordion", {}) },
-        { title: "ErrorState", onClick: () => push("ActivityErrorState", {}) },
-        { title: "ResultSection", onClick: () => push("ActivityResultSection", {}) },
+        { title: "Avatar", ...to("ActivityAvatar", {}) },
+        { title: "AvatarStack", ...to("ActivityAvatarStack", {}) },
+        { title: "Badge", ...to("ActivityBadge", {}) },
+        { title: "MannerTempBadge", ...to("ActivityMannerTempLevel", {}) },
+        { title: "Accordion", ...to("ActivityAccordion", {}) },
+        { title: "ErrorState", ...to("ActivityErrorState", {}) },
+        { title: "ResultSection", ...to("ActivityResultSection", {}) },
       ],
     },
     {
@@ -407,23 +384,17 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
       title: "Foundation",
       icon: PaletteIcon,
       items: [
-        { title: "Box margin 프롭", onClick: () => push("ActivityMarginPlayground", {}) },
-        { title: "IACVT Leak Check (구형 iOS)", onClick: () => push("ActivityIacvtLeak", {}) },
-        { title: "SidePanel IACVT (구형 iOS)", onClick: () => push("ActivityIacvtSidePanel", {}) },
-        { title: "Overlay IACVT (구형 iOS)", onClick: () => push("ActivityIacvtOverlay", {}) },
-        { title: "Margin/Bleed IACVT (구형 iOS)", onClick: () => push("ActivityIacvtMargin", {}) },
-        {
-          title: "IACVT: initial 폴백 가설 (순수 CSS)",
-          onClick: () => push("ActivityIacvtExperiment", {}),
-        },
-        {
-          title: "Font Multiplier Layout",
-          onClick: () => push("ActivityFontMultiplierLayout", {}),
-        },
-        { title: "Typography Scale", onClick: () => push("ActivityTypographyScale", {}) },
-        { title: "누름 축소 피드백", onClick: () => push("ActivityScaleFeedback", {}) },
-        { title: "PartialDarkMode", onClick: () => push("ActivityPartialDarkMode", {}) },
-        { title: "v2 변수 × v3 토큰 혼용", onClick: () => push("ActivityMixedVersionTest", {}) },
+        { title: "Box margin 프롭", ...to("ActivityMarginPlayground", {}) },
+        { title: "IACVT Leak Check (구형 iOS)", ...to("ActivityIacvtLeak", {}) },
+        { title: "SidePanel IACVT (구형 iOS)", ...to("ActivityIacvtSidePanel", {}) },
+        { title: "Overlay IACVT (구형 iOS)", ...to("ActivityIacvtOverlay", {}) },
+        { title: "Margin/Bleed IACVT (구형 iOS)", ...to("ActivityIacvtMargin", {}) },
+        { title: "IACVT: initial 폴백 가설 (순수 CSS)", ...to("ActivityIacvtExperiment", {}) },
+        { title: "Font Multiplier Layout", ...to("ActivityFontMultiplierLayout", {}) },
+        { title: "Typography Scale", ...to("ActivityTypographyScale", {}) },
+        { title: "누름 축소 피드백", ...to("ActivityScaleFeedback", {}) },
+        { title: "PartialDarkMode", ...to("ActivityPartialDarkMode", {}) },
+        { title: "v2 변수 × v3 토큰 혼용", ...to("ActivityMixedVersionTest", {}) },
       ],
     },
   ];
@@ -654,6 +625,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
                           key={item.title}
                           onClick={item.onClick}
                           title={item.title}
+                          detail={item.detail}
                         />
                       ),
                     )}

--- a/examples/stackflow-spa/src/activities/ActivityHome.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityHome.tsx
@@ -1,11 +1,5 @@
-import {
-  Box,
-  Divider,
-  Portal,
-  PullToRefresh,
-  VStack,
-  useSnackbarAdapter,
-} from "@seed-design/react";
+import { Grid, Portal, VStack, useSnackbarAdapter } from "@seed-design/react";
+import { vars } from "@seed-design/css/vars";
 import { useActivity, useFlow, type StaticActivityComponentType } from "@stackflow/react/future";
 import * as React from "react";
 import { List, ListButtonItem } from "seed-design/ui/list";
@@ -34,12 +28,10 @@ import { Snackbar } from "seed-design/ui/snackbar";
 import { useStepOverlay } from "seed-design/stackflow/use-step-overlay";
 import { menuSheetCallback } from "./ActivityMenuSheet";
 import { swipeableMenuSheetCallback } from "./ActivitySwipeableMenuSheet";
-import { Callout } from "seed-design/ui/callout";
 import { MenuRoot, MenuTrigger, MenuContent, MenuGroup, MenuItem } from "seed-design/ui/menu";
 import { appScreenVariantMap } from "@seed-design/css/recipes/app-screen";
 
 import {
-  IconHandPointUpLine,
   IconBellLine,
   IconPlusLine,
   IconPencilLine,
@@ -414,7 +406,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
 
   return (
     <AppScreen transitionStyle={params.transitionStyle}>
-      <AppBar>
+      <AppBar bg="bg.layerBasement">
         {activityIndex > 0 && (
           <AppBarLeft>
             <AppBarBackButton />
@@ -429,45 +421,30 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
       </AppBar>
       <AppScreenContent
         ptr
+        // layer의 배경색은 recipe가 layerDefault로 고정하고 style prop을 받지 않는다.
+        // PTR로 당겼을 때 드러나는 영역까지 카드 배경과 이어지려면 여기서 덮어야 한다.
+        style={{ backgroundColor: vars.$color.bg.layerBasement }}
         onPtrRefresh={async () => {
           await new Promise((resolve) => setTimeout(resolve, 1000));
         }}
       >
-        <VStack gap="spacingY.componentDefault" pb="safeArea">
-          <Box px="spacingX.globalGutter">
-            <Callout
-              tone="critical"
-              prefixIcon={<IconHandPointUpLine />}
-              title="foobar"
-              description="이 영역에서는 Pull to Refresh 동작이 발생하지 않습니다. Exercitation cillum velit
-              aliquip deserunt Lorem. Eiusmod proident duis occaecat consequat veniam do commodo
-              occaecat duis irure ea sunt officia cupidatat."
-              {...PullToRefresh.preventPull}
-            />
-          </Box>
-          <VStack gap="spacingY.componentDefault" pb="spacingY.componentDefault">
-            {navigationSections.map((section, sectionIndex) => (
-              <>
-                <VStack key={section.title}>
-                  <ListHeader>{section.title}</ListHeader>
-                  <List>
-                    {section.items.map((item) =>
-                      item.component ? (
-                        <React.Fragment key={item.title}>{item.component}</React.Fragment>
-                      ) : (
-                        <ListButtonItem
-                          key={item.title}
-                          onClick={item.onClick}
-                          title={item.title}
-                        />
-                      ),
-                    )}
-                  </List>
-                </VStack>
-                {sectionIndex < navigationSections.length - 1 && <Divider />}
-              </>
+        <VStack pb="safeArea" minHeight="100%">
+          <Grid columns={{ base: 1, md: 2, lg: 3, xl: 4 }} gap="x4" px="x4" pb="x4">
+            {navigationSections.map((section) => (
+              <VStack key={section.title} py="x1_5" borderRadius="r3_5" bg="bg.layerDefault">
+                <ListHeader as="h2">{section.title}</ListHeader>
+                <List itemBorderRadius="r2">
+                  {section.items.map((item) =>
+                    item.component ? (
+                      <React.Fragment key={item.title}>{item.component}</React.Fragment>
+                    ) : (
+                      <ListButtonItem key={item.title} onClick={item.onClick} title={item.title} />
+                    ),
+                  )}
+                </List>
+              </VStack>
             ))}
-          </VStack>
+          </Grid>
         </VStack>
       </AppScreenContent>
     </AppScreen>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 데모 내비게이션을 주제별 섹션과 아이콘 중심 구조로 재구성했습니다.
  * 반응형 카드 그리드와 상단 칩 메뉴를 적용해 항목 탐색이 쉬워졌습니다.
  * 스크롤 위치와 현재 섹션 및 선택 메뉴가 자동으로 동기화됩니다.
  * 섹션 헤더가 고정되어 긴 목록에서도 현재 위치를 확인할 수 있습니다.
  * 여러 열 화면에서 활성 항목 선택이 더 자연스럽게 동작합니다.
  * Drawer 및 Dialog 데모 항목의 분류와 제목을 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->