### PR TITLE
fix(docs): deduplicate lucide-react to share Fumadocs context

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7081,8 +7081,6 @@
 
     "fumadocs-typescript/ts-morph": ["ts-morph@28.0.0", "", { "dependencies": { "@ts-morph/common": "~0.29.0", "code-block-writer": "^13.0.3" } }, "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g=="],
 
-    "fumadocs-ui/lucide-react": ["lucide-react@1.30.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tUIr2jXLbWpCkdtH8XP7P7YppM9ueWgTky99lpWDY6z5REs6B+O6ZQ3U5tHkUUY59ANyOv/PBcs8E4Fe3KO3eA=="],
-
     "get-uri/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "get-uri/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],


### PR DESCRIPTION
## Summary

`dev` 문서 배포가 `/lynx` prerender 중 `You need to wrap your application inside FrameworkProvider` 오류로 실패합니다. #2179에서 추가한 `lucide-react@^1.40.0`과 lockfile에 남은 Fumadocs UI 전용 `1.30.0` 때문에 Bun isolated 설치가 서로 다른 peer dependency를 가진 `fumadocs-core` 인스턴스를 만들고, Provider와 소비자의 Context가 분리됩니다.

`bun.lock`의 `fumadocs-ui/lucide-react@1.30.0` 항목을 제거해 기존 공통 `1.40.0`을 사용합니다. 두 소비자의 선언 범위를 모두 만족하며 package.json, overrides 또는 Fumadocs 버전 변경은 없습니다. 공개 패키지 변경이 없어 changeset은 추가하지 않습니다.

## Validation

- Bun 1.3.13, 동일한 workspace manifests 및 수정 lockfile의 깨끗한 임시 설치에서 `bun install --frozen-lockfile --ignore-scripts` 통과
- docs와 fumadocs-ui에서 resolve한 `fumadocs-core/framework`의 실제 경로 일치 확인
- UI 경로의 FrameworkProvider와 docs 경로의 usePathname을 함께 사용하는 최소 서버 렌더링 통과 (`<span>/lynx</span>`); 수정 전 동일 테스트는 CI 오류 재현
- `git diff --check` 통과
- 실제 PR 체크아웃에서 `bun ecosystem:build`, `bun install --frozen-lockfile`, `bun packages:build` 통과
- `NODE_OPTIONS=--max-old-space-size=6144 bun docs:build` 전체 통과 (exit 0): 970개 정적 페이지, llms-full 및 changelog 1265개 생성 완료, `docs/out/lynx.html` 확인
- 로컬 검증 범위: Figma 파일 설정이 없어 이미지 740개는 기존 placeholder fallback 사용. 실제 Figma 이미지 다운로드는 미검증
- 실행 환경: 샌드박스에서 정지해 제한 없는 실행으로 재시도했으며, 이후 디스크 부족(ENOSPC)은 이번 조사용 임시 설치본 정리 후 해소. 최종 전체 빌드는 성공
- 설치 및 빌드 후 추적 파일 변경 없음

실패 실행: https://github.com/daangn/seed-design/actions/runs/34176537322/job/101912081091
