### PR TITLE
feat(css): expose the recommended font stack as a CSS variable

### DIFF
--- a/.changeset/plain-fonts-travel.md
+++ b/.changeset/plain-fonts-travel.md
@@ -1,0 +1,8 @@
+---
+"@seed-design/css": minor
+---
+
+권장 폰트 스택을 `--seed-font-family` CSS 변수로 제공합니다.
+
+- `base.css`를 불러온 뒤 `font-family: var(--seed-font-family)`로 참조할 수 있습니다.
+- SEED가 이 값을 자동으로 적용하지는 않으므로, 적용할 지점은 직접 선택해야 합니다.

--- a/docs/.storybook/preview-head.html
+++ b/docs/.storybook/preview-head.html
@@ -9,10 +9,7 @@
     }
 
     body {
-      font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo",
-        "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
-        "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
-        "Noto Color Emoji";
+      font-family: var(--seed-font-family);
       -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
     }
 

--- a/docs/components/component-preview.tsx
+++ b/docs/components/component-preview.tsx
@@ -8,13 +8,6 @@ interface ComponentPreviewProps {
   isolate?: boolean;
 }
 
-// Reset examples back to the system font (the docs `html` uses Pretendard) so SEED
-// component demos render in their native platform typeface. A comma-separated font
-// stack doesn't fit a Tailwind arbitrary class cleanly, so it lives in `style`;
-// `leading-[normal]` handles the line-height (Tailwind's `leading-normal` is 1.5).
-const SYSTEM_FONT_STACK =
-  'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif';
-
 export function ComponentPreview(props: ComponentPreviewProps) {
   const { name, isolate } = props;
 
@@ -38,14 +31,14 @@ export function ComponentPreview(props: ComponentPreviewProps) {
   return (
     <React.Suspense fallback={null}>
       <div
+        // The docs `html` uses Pretendard, so the font goes back to what a product using
+        // these components would render in. `leading-[normal]` because Tailwind's
+        // `leading-normal` is 1.5.
         className={cn(
           "not-prose leading-[normal] w-full flex flex-col justify-center items-center",
+          "bg-bg-layer-default font-(family-name:--seed-font-family)",
           isolate && "isolate",
         )}
-        style={{
-          backgroundColor: "var(--seed-color-bg-layer-default)",
-          fontFamily: SYSTEM_FONT_STACK,
-        }}
       >
         {Preview}
       </div>

--- a/docs/content/foundations/typography.mdx
+++ b/docs/content/foundations/typography.mdx
@@ -19,13 +19,31 @@ SEED 타이포그래피 시스템은 폰트 크기, 줄 높이, 폰트 두께 �
 
 사용자의 디바이스 환경을 고려하여, 시스템 폰트를 사용합니다. 이는 다양한 국가와 문화권에서 사용되는 여러 기기 및 운영 체제에서 일관된 사용자 경험과 가독성을 보장합니다.
 
-웹에서는 다음과 같은 폰트 스택을 적용할 수 있습니다:
+웹에서는 `@seed-design/css`가 권장 폰트 스택을 `--seed-font-family` 변수로 제공합니다. SEED는 이 값을 어디에도 자동으로 적용하지 않으므로, 필요한 지점에서 직접 참조해 주세요.
+
+```css
+body {
+  font-family: var(--seed-font-family);
+}
+```
+
+`html`이 아니라 `body`에 선언하는 편이 안전합니다. `fontScaling` 옵션을 켜면 iOS에서 `html`에 `font: -apple-system-body`가 적용되는데, 이 단축 속성이 `html`의 `font-family` 선언을 함께 지웁니다.
+
+변수에 담긴 값은 다음과 같습니다.
 
 ```css
 font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo",
   "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
   "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 ```
+
+<Callout type="warn" title="커스텀 폰트를 섞을 때에는 선언 순서를 지켜주세요">
+  Pretendard처럼 직접 준비한 폰트를 함께 쓰려면 `-apple-system`과 `BlinkMacSystemFont` **뒤**에
+  두세요. `BlinkMacSystemFont`보다 앞에 두면 macOS Chrome에서 시스템 폰트가 선택되지 않습니다.
+  `-apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", Pretendard, ...` 순서로 두면 한글은
+  Pretendard로, 나머지는 시스템 폰트로 그려집니다. 한편 Figma에서 보이는 `Figma Only iOS`는 미리
+  보기 전용 폰트이므로 `font-family`에 넣지 마세요.
+</Callout>
 
 ## 타이포그래피 토큰
 

--- a/docs/content/foundations/typography.mdx
+++ b/docs/content/foundations/typography.mdx
@@ -17,17 +17,9 @@ SEED 타이포그래피 시스템은 폰트 크기, 줄 높이, 폰트 두께 �
 
 ## 글꼴
 
-사용자의 디바이스 환경을 고려하여, 시스템 폰트를 사용합니다. 이는 다양한 국가와 문화권에서 사용되는 여러 기기 및 운영 체제에서 일관된 사용자 경험과 가독성을 보장합니다.
+사용자의 디바이스 환경을 고려하여, 각 플랫폼의 시스템 폰트를 사용합니다. 이는 다양한 국가와 문화권에서 사용되는 여러 기기 및 운영 체제에서 일관된 사용자 경험과 가독성을 보장합니다.
 
-웹에서는 `@seed-design/css`가 권장 폰트 스택을 `--seed-font-family` 변수로 제공합니다.
-
-```css
---seed-font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo",
-  "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
-  "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-```
-
-SEED는 이 값을 어디에도 자동으로 적용하지 않습니다. CSS에서 직접 참조하는 방법은 [Fonts](/react/getting-started/styling/fonts)에서 다룹니다.
+웹에서는 `font-family`를 선언하지 않으면 브라우저와 사용자 설정에 따라 글꼴이 정해지므로, 시스템 폰트를 쓰려면 폰트 스택을 직접 선언해야 합니다. `@seed-design/css`가 권장 스택을 `--seed-font-family` 변수로 제공하며, 값과 적용 방법은 [Fonts](/react/getting-started/styling/fonts)에서 다룹니다.
 
 ## 타이포그래피 토큰
 

--- a/docs/content/foundations/typography.mdx
+++ b/docs/content/foundations/typography.mdx
@@ -19,23 +19,15 @@ SEED 타이포그래피 시스템은 폰트 크기, 줄 높이, 폰트 두께 �
 
 사용자의 디바이스 환경을 고려하여, 시스템 폰트를 사용합니다. 이는 다양한 국가와 문화권에서 사용되는 여러 기기 및 운영 체제에서 일관된 사용자 경험과 가독성을 보장합니다.
 
-웹에서는 `@seed-design/css`가 권장 폰트 스택을 `--seed-font-family` 변수로 제공합니다. SEED는 이 값을 어디에도 자동으로 적용하지 않으므로, 필요한 지점에서 직접 참조해 주세요.
+웹에서는 `@seed-design/css`가 권장 폰트 스택을 `--seed-font-family` 변수로 제공합니다.
 
 ```css
-body {
-  font-family: var(--seed-font-family);
-}
-```
-
-`html`이 아니라 `body`에 선언하는 편이 안전합니다. `fontScaling` 옵션을 켜면 iOS에서 `html`에 `font: -apple-system-body`가 적용되는데, 이 단축 속성이 `html`의 `font-family` 선언을 함께 지웁니다.
-
-변수에 담긴 값은 다음과 같습니다.
-
-```css
-font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo",
+--seed-font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo",
   "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
   "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 ```
+
+SEED는 이 값을 어디에도 자동으로 적용하지 않습니다. CSS에서 직접 참조하는 방법은 [Fonts](/react/getting-started/styling/fonts)에서 다룹니다.
 
 ## 타이포그래피 토큰
 

--- a/docs/content/foundations/typography.mdx
+++ b/docs/content/foundations/typography.mdx
@@ -37,14 +37,6 @@ font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo",
   "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 ```
 
-<Callout type="warn" title="커스텀 폰트를 섞을 때에는 선언 순서를 지켜주세요">
-  Pretendard처럼 직접 준비한 폰트를 함께 쓰려면 `-apple-system`과 `BlinkMacSystemFont` **뒤**에
-  두세요. `BlinkMacSystemFont`보다 앞에 두면 macOS Chrome에서 시스템 폰트가 선택되지 않습니다.
-  `-apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", Pretendard, ...` 순서로 두면 한글은
-  Pretendard로, 나머지는 시스템 폰트로 그려집니다. 한편 Figma에서 보이는 `Figma Only iOS`는 미리
-  보기 전용 폰트이므로 `font-family`에 넣지 마세요.
-</Callout>
-
 ## 타이포그래피 토큰
 
 ### 폰트 크기 토큰

--- a/docs/content/react/getting-started/styling/fonts.mdx
+++ b/docs/content/react/getting-started/styling/fonts.mdx
@@ -1,0 +1,36 @@
+---
+title: Fonts
+description: SEED가 제공하는 권장 폰트 스택을 애플리케이션에 적용하는 방법을 알아봅니다.
+---
+
+## 개요
+
+`@seed-design/css`는 권장 폰트 스택을 `--seed-font-family` 변수로 제공합니다. SEED는 이 값을 어디에도 자동으로 적용하지 않으므로, 적용할 지점은 직접 선택해야 합니다.
+
+`base.css`나 `all.css`를 불러온 뒤 다음과 같이 참조합니다.
+
+```css title="style.css"
+body {
+  font-family: var(--seed-font-family);
+}
+```
+
+폰트 스택의 값은 [Typography](/foundations/typography)에서 확인할 수 있습니다.
+
+## `html`이 아니라 `body`에 선언하기
+
+[번들러 플러그인](/react/getting-started/installation/vite)의 `fontScaling` 옵션을 켜면, SEED가 iOS에서 다음 규칙을 적용합니다.
+
+```css
+@supports (font: -apple-system-body) {
+  html[data-seed-platform="ios"][data-seed-font-scaling="enabled"] {
+    font: -apple-system-body;
+  }
+}
+```
+
+`font`는 단축 속성이므로 `font-family`까지 함께 설정합니다. 그래서 `base.css`를 사용하는 경우, `html`에 직접 선언한 `font-family`가 이 규칙에 덮여 사라집니다.
+
+[`base.layered.css`](/react/getting-started/styling/cascade-layers)를 사용한다면 이 규칙이 `seed-base` 레이어 안에 있으므로, 레이어 밖 또는 이후 레이어의 선언이 우선합니다.
+
+규칙의 대상은 `html`뿐이므로, `body`에 선언한 `font-family`는 어느 빌드에서도 그대로 유지됩니다.

--- a/docs/content/react/getting-started/styling/fonts.mdx
+++ b/docs/content/react/getting-started/styling/fonts.mdx
@@ -5,9 +5,15 @@ description: SEED가 제공하는 권장 폰트 스택을 애플리케이션에 
 
 ## 개요
 
-`@seed-design/css`는 권장 폰트 스택을 `--seed-font-family` 변수로 제공합니다. SEED는 이 값을 어디에도 자동으로 적용하지 않으므로, 적용할 지점은 직접 선택해야 합니다.
+`@seed-design/css`는 권장 폰트 스택을 `--seed-font-family` 변수로 제공합니다.
 
-`base.css`나 `all.css`를 불러온 뒤 다음과 같이 참조합니다.
+```css
+--seed-font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo",
+  "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+  "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+```
+
+SEED는 이 값을 어디에도 자동으로 적용하지 않으므로, 적용할 지점은 직접 선택해야 합니다. `base.css`나 `all.css`를 불러온 뒤 다음과 같이 참조합니다.
 
 ```css title="style.css"
 body {
@@ -15,7 +21,7 @@ body {
 }
 ```
 
-폰트 스택의 값은 [Typography](/foundations/typography)에서 확인할 수 있습니다.
+이 스택을 고른 배경은 [Typography](/foundations/typography)에서 설명합니다.
 
 ## `html`이 아니라 `body`에 선언하기
 

--- a/docs/content/react/getting-started/styling/fonts.mdx
+++ b/docs/content/react/getting-started/styling/fonts.mdx
@@ -5,7 +5,7 @@ description: SEED가 제공하는 권장 폰트 스택을 애플리케이션에 
 
 ## 개요
 
-`@seed-design/css`는 권장 폰트 스택을 `--seed-font-family` 변수로 제공합니다.
+`@seed-design/css`는 권장 폰트 스택을 `--seed-font-family` 변수로 제공합니다. SEED가 시스템 폰트를 쓰는 이유는 [Typography](/foundations/typography)에서 다룹니다.
 
 ```css
 --seed-font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo",
@@ -20,8 +20,6 @@ body {
   font-family: var(--seed-font-family);
 }
 ```
-
-이 스택을 고른 배경은 [Typography](/foundations/typography)에서 설명합니다.
 
 ## `html`이 아니라 `body`에 선언하기
 

--- a/docs/content/react/getting-started/styling/meta.json
+++ b/docs/content/react/getting-started/styling/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Styling",
   "icon": "Palette",
-  "pages": ["theming", "tailwind-css", "cascade-layers"]
+  "pages": ["theming", "fonts", "tailwind-css", "cascade-layers"]
 }

--- a/docs/public/__docs__/index.json
+++ b/docs/public/__docs__/index.json
@@ -1792,6 +1792,12 @@
               "docUrl": "/react/getting-started/cli/configuration"
             },
             {
+              "id": "fonts",
+              "title": "Fonts",
+              "description": "SEED가 제공하는 권장 폰트 스택을 애플리케이션에 적용하는 방법을 알아봅니다.",
+              "docUrl": "/react/getting-started/styling/fonts"
+            },
+            {
               "id": "library-authors",
               "title": "Library Authors",
               "description": "SEED를 사용하는 공유 패키지와 SDK를 만들 때의 의존성 선언, 버전 범위, 2.0 마이그레이션 방법을 알아봅니다.",

--- a/examples/stackflow-spa/src/global.css
+++ b/examples/stackflow-spa/src/global.css
@@ -1,6 +1,5 @@
 body {
-  font-family:
-    -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family: var(--seed-font-family);
   background-color: var(--seed-color-bg-layer-default);
   overscroll-behavior: none;
 }

--- a/packages/css/all.css
+++ b/packages/css/all.css
@@ -18,6 +18,7 @@
 }
 
 :root {
+  --seed-font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --seed-font-size-multiplier: 1;
   --seed-font-size-limit-min: .8;
   --seed-font-size-limit-max: 1.5;

--- a/packages/css/all.layered.css
+++ b/packages/css/all.layered.css
@@ -19,6 +19,7 @@
   }
 
   :root {
+    --seed-font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     --seed-font-size-multiplier: 1;
     --seed-font-size-limit-min: .8;
     --seed-font-size-limit-max: 1.5;

--- a/packages/css/base.css
+++ b/packages/css/base.css
@@ -18,6 +18,7 @@
 }
 
 :root {
+  --seed-font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --seed-font-size-multiplier: 1;
   --seed-font-size-limit-min: .8;
   --seed-font-size-limit-max: 1.5;

--- a/packages/css/base.layered.css
+++ b/packages/css/base.layered.css
@@ -19,6 +19,7 @@
   }
 
   :root {
+    --seed-font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     --seed-font-size-multiplier: 1;
     --seed-font-size-limit-min: .8;
     --seed-font-size-limit-max: 1.5;

--- a/packages/qvism-preset/src/global.ts
+++ b/packages/qvism-preset/src/global.ts
@@ -18,6 +18,11 @@ export const globalCss = defineGlobalCss({
       "--seed-safe-area-bottom": "env(safe-area-inset-bottom)",
     },
 
+    // The recommended stack, published as a value only: nothing in SEED reads this
+    // variable, so a product opts in with `font-family: var(--seed-font-family)`.
+    "--seed-font-family":
+      '-apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+
     // Font scaling variables
     "--seed-font-size-multiplier": "1",
     "--seed-font-size-limit-min": "0.8",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 권장 시스템 글꼴 스택을 제공하는 `--seed-font-family` CSS 변수를 추가했습니다.
  - 필요한 영역에서 `font-family: var(--seed-font-family)`로 선택적으로 적용할 수 있습니다.

- **문서**
  - 글꼴 변수 적용 방법과 iOS 환경의 사용 시 주의사항을 안내하는 문서를 추가했습니다.
  - 타이포그래피 가이드의 글꼴 관련 안내를 간소화했습니다.

- **개선**
  - 문서 미리보기와 예제 앱이 새로운 글꼴 변수를 사용하도록 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->