### PR TITLE
refactor(docs): use Tailwind v4 CSS variable shorthand

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -16,6 +16,8 @@ SEED Design 문서 사이트다. Next.js와 Fumadocs 기반으로 컴포넌트 �
 - 문서 UI와 Storybook은 본문과 분리된 참조 계층으로 관리한다.
 - `docs/registry/{react,lynx}/ui/` snippet은 stable user API이자 사용자가 복사해 커스터마이즈하는 계층이다. API를 변경할 때는 minimal user code와 convenience wrapper 여부를 먼저 확인한다.
 - snippet 변경 시 `bun generate:all`로 `docs/public/__registry__/` 공개 생성물을 항상 갱신한다. vendored consumer(`examples/stackflow-spa/src/seed-design/ui/`)의 영향은 실제 사용 여부에 따라 확인한다.
+- Tailwind utility에 CSS 변수를 넘길 때는 v4 축약 문법을 쓴다. `bg-[var(--x)]`가 아니라 `bg-(--x)`로 적고, `font-`나 `text-`처럼 한 namespace가 여러 속성에 걸리면 `font-(family-name:--x)`, `text-(length:--x)`처럼 타입을 함께 적는다. fallback도 `right-(--x,0px)`으로 그대로 넘어간다.
+- 그 변수를 `@seed-design/tailwind4-theme`가 이미 등록했다면 변수를 넘기지 말고 theme utility를 쓴다. `shadow-[var(--seed-shadow-s2)]`가 아니라 `shadow-s2`다. theme utility는 `@utility`가 정의된 namespace에서만 생성되므로(`px-*`는 있고 `left-*`는 없다) 없는 자리에서는 축약 문법으로 넘긴다.
 
 ### `app/global.css`를 수정할 때
 

--- a/docs/components/docs-menu.tsx
+++ b/docs/components/docs-menu.tsx
@@ -66,7 +66,5 @@ export function DocsPopoverContent({
   className,
   ...props
 }: ComponentPropsWithoutRef<typeof PopoverContent>) {
-  return (
-    <PopoverContent className={clsx("shadow-[var(--seed-shadow-s2)]!", className)} {...props} />
-  );
+  return <PopoverContent className={clsx("shadow-s2!", className)} {...props} />;
 }

--- a/docs/components/landing/landing-header.tsx
+++ b/docs/components/landing/landing-header.tsx
@@ -90,7 +90,7 @@ export function LandingHeader({ variant, tone }: { variant: HeaderVariant; tone:
           // `right`: same scroll-lock trim the footer compensates for (see section-footer) —
           // <body> narrows by the removed scrollbar width while this fixed bar does not, which
           // would slide the right-hand actions out of line with the page under them.
-          "fixed inset-x-0 right-[var(--removed-body-scroll-bar-size,0px)] top-0 z-[1000]",
+          "fixed inset-x-0 right-(--removed-body-scroll-bar-size,0px) top-0 z-[1000]",
           LANDING_LIGHT_ONLY_COLOR_BRIDGE,
           `transition-transform ${EASE_DUR} motion-reduce:transition-none`,
           isHidden ? "-translate-y-full pointer-events-none" : "translate-y-0",
@@ -104,7 +104,7 @@ export function LandingHeader({ variant, tone }: { variant: HeaderVariant; tone:
             // Match the docs header's container (fumadocs --fd-layout-width default 97rem,
             // px-4) so the logo/actions sit at the same x → no layout shift when navigating
             // between landing and docs.
-            "mx-auto h-[76px] w-full max-w-[97rem] items-center px-4 text-[var(--landing-header-fg)]",
+            "mx-auto h-[76px] w-full max-w-[97rem] items-center px-4 text-(color:--landing-header-fg)",
             "min-[968px]:h-[72px] min-[968px]:px-3 min-[1120px]:h-[76px] min-[1120px]:px-4",
             "hidden min-[968px]:grid",
             TONE_CLASSES[tone],
@@ -130,7 +130,7 @@ export function LandingHeader({ variant, tone }: { variant: HeaderVariant; tone:
 
           {/* Logo: mark always; wordmark in a clipping wrapper that collapses to 0 width.
               Landing is light-only, so avoid Tailwind's global dark variant here. */}
-          <div className="relative z-10 col-start-2 row-start-1 flex items-center text-[var(--landing-header-fg)]">
+          <div className="relative z-10 col-start-2 row-start-1 flex items-center text-(color:--landing-header-fg)">
             <SeedMark className="h-10 w-auto shrink-0 min-[968px]:h-8 min-[1120px]:h-9 min-[1280px]:h-10" />
             <div
               className={clsx(
@@ -163,7 +163,7 @@ export function LandingHeader({ variant, tone }: { variant: HeaderVariant; tone:
               ponytail: pixel pads are tuned to the SEED wordmark width (measured on the deployed
               preview: nav centered within ~1px at 968/1120/1280 bands). Re-measure if the logo or
               wordmark changes. */}
-          <div className="relative z-10 col-start-6 row-start-1 flex items-center gap-1.5 text-[var(--landing-header-fg)]">
+          <div className="relative z-10 col-start-6 row-start-1 flex items-center gap-1.5 text-(color:--landing-header-fg)">
             <div
               aria-hidden
               className={clsx(
@@ -188,7 +188,7 @@ export function LandingHeader({ variant, tone }: { variant: HeaderVariant; tone:
             px = global gutter, items vertically centered. Logo mark plus playback, search, and menu. */}
         <div
           className={clsx(
-            "h-16 items-center justify-between px-spacing-x-global-gutter text-[var(--landing-header-fg)]",
+            "h-16 items-center justify-between px-spacing-x-global-gutter text-(color:--landing-header-fg)",
             "flex min-[968px]:hidden",
             TONE_CLASSES[tone],
           )}

--- a/docs/components/landing/section-layer.tsx
+++ b/docs/components/landing/section-layer.tsx
@@ -7,8 +7,8 @@ import type { CSSProperties, ReactNode } from "react";
  * the tablet band (e.g. bento, whose grid gets an aspect ratio there instead of 100dvh).
  */
 const MOBILE_STACK_SECTION = {
-  md: "h-auto md:h-[var(--region-h)]",
-  lg: "h-auto lg:h-[var(--region-h)]",
+  md: "h-auto md:h-(--region-h)",
+  lg: "h-auto lg:h-(--region-h)",
 } as const;
 const MOBILE_STACK_PANEL_STICKY = {
   md: "relative h-auto md:sticky md:top-0 md:h-dvh",

--- a/docs/components/landing/sections/section-footer.tsx
+++ b/docs/components/landing/sections/section-footer.tsx
@@ -50,7 +50,7 @@ export function SectionFooter() {
       // carrot into the strip the scrollbar vacated, so match the trim. The variable only
       // exists while locked; mobile is in normal flow, where `right` would shift the box.
       // `w-auto` goes with it — `w-full` over-constrains the box and `right` gets dropped.
-      className="relative flex w-full flex-col gap-8 overflow-hidden bg-palette-carrot-600 py-8 text-fg-neutral md:fixed md:inset-x-0 md:right-[var(--removed-body-scroll-bar-size,0px)] md:bottom-0 md:z-0 md:w-auto md:gap-14 md:py-12"
+      className="relative flex w-full flex-col gap-8 overflow-hidden bg-palette-carrot-600 py-8 text-fg-neutral md:fixed md:inset-x-0 md:right-(--removed-body-scroll-bar-size,0px) md:bottom-0 md:z-0 md:w-auto md:gap-14 md:py-12"
     >
       <div className="mx-auto flex w-full max-w-[1760px] flex-col gap-8 px-spacing-x-global-gutter md:flex-row md:justify-between md:gap-12 md:px-12">
         <div className="flex flex-col gap-3">

--- a/docs/components/search/promoted-section.tsx
+++ b/docs/components/search/promoted-section.tsx
@@ -13,7 +13,7 @@ export function Highlighted({ text, terms }: { text: string; terms: string[] }) 
       <mark
         // biome-ignore lint/suspicious/noArrayIndexKey: chunks are positional, and the list is rebuilt whenever the text or terms change
         key={index}
-        className="bg-[var(--selection-bg)] text-[var(--selection-fg)]"
+        className="bg-(--selection-bg) text-(color:--selection-fg)"
       >
         {chunk.text}
       </mark>

--- a/docs/components/search/result-markdown.tsx
+++ b/docs/components/search/result-markdown.tsx
@@ -216,9 +216,7 @@ const MARKDOWN_COMPONENTS: NonNullable<MarkdownProps["components"]> = {
       className="rounded-sm bg-bg-neutral-weak-alpha px-1 py-px font-mono text-[0.9em]"
     />
   ),
-  mark: (props) => (
-    <mark {...props} className="bg-[var(--selection-bg)] text-[var(--selection-fg)]" />
-  ),
+  mark: (props) => <mark {...props} className="bg-(--selection-bg) text-(color:--selection-fg)" />,
 };
 
 const COMPONENTS = { ...MARKDOWN_COMPONENTS, custom: MdxTagBadge };

--- a/docs/components/search/search.tsx
+++ b/docs/components/search/search.tsx
@@ -317,7 +317,7 @@ export default function DefaultSearchDialog({
 // gutter on both sides. Desktop keeps fumadocs' default (centered). `!` overrides
 // fumadocs' built-in position classes (left-1/2, top-4, translate, width).
 const LANDING_MOBILE_POSITION =
-  "max-md:!top-[66px] max-md:!left-[var(--seed-dimension-spacing-x-global-gutter)] max-md:!right-[var(--seed-dimension-spacing-x-global-gutter)] max-md:!bottom-auto max-md:!w-auto max-md:!max-w-none max-md:!translate-x-0 max-md:!translate-y-0";
+  "max-md:!top-[66px] max-md:!left-(--seed-dimension-spacing-x-global-gutter) max-md:!right-(--seed-dimension-spacing-x-global-gutter) max-md:!bottom-auto max-md:!w-auto max-md:!max-w-none max-md:!translate-x-0 max-md:!translate-y-0";
 
 /**
  * Landing(/) search dialog. RootProvider's `search.options` is typed to fumadocs'

--- a/docs/components/search/token-results.tsx
+++ b/docs/components/search/token-results.tsx
@@ -77,7 +77,7 @@ function TokenPreview({ entry }: { entry: TokenSearchEntry }) {
         <PreviewSurface>
           <span
             style={themed(background)}
-            className="flex w-full text-[15px] font-semibold leading-none text-[var(--token-preview-light)] dark:text-[var(--token-preview-dark)]"
+            className="flex w-full text-[15px] font-semibold leading-none text-(color:--token-preview-light) dark:text-(color:--token-preview-dark)"
           >
             <span className="flex-1 text-center">Aa</span>
             <span className="flex-1 text-center">Aa</span>
@@ -90,7 +90,7 @@ function TokenPreview({ entry }: { entry: TokenSearchEntry }) {
         <PreviewSurface>
           <span
             style={themed(background)}
-            className="h-0.5 w-2/3 bg-[var(--token-preview-light)] dark:bg-[var(--token-preview-dark)]"
+            className="h-0.5 w-2/3 bg-(--token-preview-light) dark:bg-(--token-preview-dark)"
           />
         </PreviewSurface>
       );
@@ -117,7 +117,7 @@ function TokenPreview({ entry }: { entry: TokenSearchEntry }) {
       <PreviewSurface>
         <span
           style={themed(boxShadow)}
-          className="size-6 rounded-md bg-bg-layer-floating shadow-[var(--token-preview-light)] dark:shadow-[var(--token-preview-dark)]"
+          className="size-6 rounded-md bg-bg-layer-floating shadow-(--token-preview-light) dark:shadow-(--token-preview-dark)"
         />
       </PreviewSurface>
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
  - Tailwind CSS v4에서 CSS 변수를 참조하는 권장 문법과 테마 유틸리티 사용 규칙을 문서에 추가했습니다.

- **스타일**
  - 문서 사이트 전반의 CSS 변수 기반 Tailwind 클래스 표기를 v4 권장 괄호 문법으로 통일했습니다.
  - 테마에 등록된 그림자 스타일에 해당 테마 유틸리티를 적용했습니다.
  - 시각적 결과와 기능 동작은 기존과 동일합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->