### PR TITLE
feat(css): add Pretendard to --seed-font-family

### DIFF
--- a/.changeset/plain-fonts-travel.md
+++ b/.changeset/plain-fonts-travel.md
@@ -6,3 +6,4 @@
 
 - `base.css`를 불러온 뒤 `font-family: var(--seed-font-family)`로 참조할 수 있습니다.
 - SEED가 이 값을 자동으로 적용하지는 않으므로, 적용할 지점은 직접 선택해야 합니다.
+- Apple 외 플랫폼에서, Pretendard 웹폰트를 로드하는 경우 Pretendard를 사용할 수 있도록 `Apple SD Gothic Neo` 다음 순서에 `Pretendard Variable`과 `Pretendard`를 포함합니다.

--- a/docs/content/foundations/typography.mdx
+++ b/docs/content/foundations/typography.mdx
@@ -17,9 +17,16 @@ SEED 타이포그래피 시스템은 폰트 크기, 줄 높이, 폰트 두께 �
 
 ## 글꼴
 
-사용자의 디바이스 환경을 고려하여, 각 플랫폼의 시스템 폰트를 사용합니다. 이는 다양한 국가와 문화권에서 사용되는 여러 기기 및 운영 체제에서 일관된 사용자 경험과 가독성을 보장합니다.
+사용자의 디바이스 환경을 고려하여, 대부분의 경우 각 플랫폼의 시스템 폰트를 사용합니다. 이는 다양한 국가와 문화권에서 사용되는 여러 기기 및 운영 체제에서 일관된 사용자 경험과 가독성을 보장합니다.
 
-웹에서는 `font-family`를 선언하지 않으면 브라우저와 사용자 설정에 따라 글꼴이 정해지므로, 시스템 폰트를 쓰려면 폰트 스택을 직접 선언해야 합니다. `@seed-design/css`가 권장 스택을 `--seed-font-family` 변수로 제공하며, 값과 적용 방법은 [Fonts](/react/getting-started/styling/fonts)에서 다룹니다.
+| 플랫폼              | 권장 글꼴        |
+| ------------------- | ---------------- |
+| iOS, Android, macOS | 시스템 기본 글꼴 |
+| Windows             | Pretendard       |
+
+Windows에서는 시스템 글꼴인 맑은 고딕과 Segoe UI가 디자인 의도와 어긋나는 경우가 많아 [Pretendard](https://github.com/orioncactus/pretendard)를 사용합니다. 사용자 기기에 Pretendard가 없고 제품이 Pretendard 웹폰트를 준비하지 않았다면 맑은 고딕과 Segoe UI로 표시됩니다.
+
+웹 환경에서 권장 폰트 패밀리를 적용하는 방법에 대해서는 [Fonts](/react/getting-started/styling/fonts)에서 자세히 다룹니다.
 
 ## 타이포그래피 토큰
 
@@ -44,10 +51,11 @@ SEED 타이포그래피 시스템은 폰트 크기, 줄 높이, 폰트 두께 �
 <TokenReference groups={["font-weight"]} />
 
 <Callout type="warn" title="medium은 플랫폼에 따라 두께가 조금 다르게 보여요">
-  시스템 폰트를 사용하기 때문에, 같은 medium(500)이라도 플랫폼마다 실제로 그려지는 글꼴이
-  다릅니다. 한글에서는 iOS(Apple SD Gothic Neo)보다 Android 쪽 획이 조금 더 두껍게 보일 수
-  있습니다. Android는 기기·OS 버전·제조사 설정에 따라 기본 글꼴과 대체 순서가 달라서(예: Noto
-  Sans KR 계열), 차이의 정도도 기기마다 다릅니다.
+  시스템 폰트를 사용하기 때문에, 같은 medium(500)이라도 플랫폼마다 실제로
+  그려지는 글꼴이 다릅니다. 한글에서는 iOS(Apple SD Gothic Neo)보다 Android 쪽
+  획이 조금 더 두껍게 보일 수 있습니다. Android는 기기·OS 버전·제조사 설정에
+  따라 기본 글꼴과 대체 순서가 달라서(예: Noto Sans KR 계열), 차이의 정도도
+  기기마다 다릅니다.
 </Callout>
 
 ## 타이포그래피 컴포넌트

--- a/docs/content/react/getting-started/styling/fonts.mdx
+++ b/docs/content/react/getting-started/styling/fonts.mdx
@@ -5,12 +5,14 @@ description: SEED가 제공하는 권장 폰트 스택을 애플리케이션에 
 
 ## 개요
 
-`@seed-design/css`는 권장 폰트 스택을 `--seed-font-family` 변수로 제공합니다. SEED가 시스템 폰트를 쓰는 이유는 [Typography](/foundations/typography)에서 다룹니다.
+`@seed-design/css`는 권장 폰트 스택을 `--seed-font-family` 변수로 제공합니다. 어떤 글꼴을 권장하는지와 그 이유는 [Typography](/foundations/typography)에서 다룹니다.
 
 ```css
---seed-font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo",
-  "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
-  "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+--seed-font-family:
+  -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo",
+  "Pretendard Variable", Pretendard, "Segoe UI", Roboto, "Helvetica Neue",
+  Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+  "Segoe UI Symbol", "Noto Color Emoji";
 ```
 
 SEED는 이 값을 어디에도 자동으로 적용하지 않으므로, 적용할 지점은 직접 선택해야 합니다. `base.css`나 `all.css`를 불러온 뒤 다음과 같이 참조합니다.
@@ -33,8 +35,13 @@ body {
 }
 ```
 
-`font`는 단축 속성이므로 `font-family`까지 함께 설정합니다. 그래서 `base.css`를 사용하는 경우, `html`에 직접 선언한 `font-family`가 이 규칙에 덮여 사라집니다.
+이때 `font`가 shorthand로서 `font-family`까지 함께 설정하므로, `fontScaling`을 사용한 환경에서는 `html`에 직접 선언한 `font-family`가 이 규칙에 덮여 무시될 수 있습니다.
 
-[`base.layered.css`](/react/getting-started/styling/cascade-layers)를 사용한다면 이 규칙이 `seed-base` 레이어 안에 있으므로, 레이어 밖 또는 이후 레이어의 선언이 우선합니다.
+- `base.css`를 사용하는 경우, `font-family`를 `body`에 선언해야 합니다.
+- `base.layered.css`([Cascade Layers](/react/getting-started/styling/cascade-layers))를 사용하는 경우, `font-family`를 `body`에 선언하는 것을 권장합니다. `html`에 선언해야 한다면, 레이어 밖(unlayered)에 두거나 `seed-base` 이후 레이어에 선언하세요.
 
-규칙의 대상은 `html`뿐이므로, `body`에 선언한 `font-family`는 어느 빌드에서도 그대로 유지됩니다.
+## Windows에서 Pretendard 보여주기
+
+Windows에서 맑은 고딕 대신 Pretendard를 보여주려면 제품이 `--seed-font-family`를 사용하는 동시에 Pretendard 웹폰트를 직접 로드해야 합니다. `--seed-font-family`는 권장 이름을 나열할 뿐 폰트를 내려받지 않습니다.
+
+일반적으로 여러 글꼴 두께를 사용하므로 가변 다이나믹 서브셋을 권장합니다. 자세한 내용은 [Pretendard](https://github.com/orioncactus/pretendard) 프로젝트를 참고하세요.

--- a/packages/css/all.css
+++ b/packages/css/all.css
@@ -18,7 +18,7 @@
 }
 
 :root {
-  --seed-font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --seed-font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Pretendard Variable", Pretendard, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --seed-font-size-multiplier: 1;
   --seed-font-size-limit-min: .8;
   --seed-font-size-limit-max: 1.5;

--- a/packages/css/all.layered.css
+++ b/packages/css/all.layered.css
@@ -19,7 +19,7 @@
   }
 
   :root {
-    --seed-font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --seed-font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Pretendard Variable", Pretendard, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     --seed-font-size-multiplier: 1;
     --seed-font-size-limit-min: .8;
     --seed-font-size-limit-max: 1.5;

--- a/packages/css/base.css
+++ b/packages/css/base.css
@@ -18,7 +18,7 @@
 }
 
 :root {
-  --seed-font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --seed-font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Pretendard Variable", Pretendard, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --seed-font-size-multiplier: 1;
   --seed-font-size-limit-min: .8;
   --seed-font-size-limit-max: 1.5;

--- a/packages/css/base.layered.css
+++ b/packages/css/base.layered.css
@@ -19,7 +19,7 @@
   }
 
   :root {
-    --seed-font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --seed-font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Pretendard Variable", Pretendard, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     --seed-font-size-multiplier: 1;
     --seed-font-size-limit-min: .8;
     --seed-font-size-limit-max: 1.5;

--- a/packages/qvism-preset/src/global.ts
+++ b/packages/qvism-preset/src/global.ts
@@ -18,10 +18,35 @@ export const globalCss = defineGlobalCss({
       "--seed-safe-area-bottom": "env(safe-area-inset-bottom)",
     },
 
-    // The recommended stack, published as a value only: nothing in SEED reads this
-    // variable, so a product opts in with `font-family: var(--seed-font-family)`.
-    "--seed-font-family":
-      '-apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+    // users can opt in with `font-family: var(--seed-font-family)`.
+    // see: https://seed-design.io/foundations/typography
+    "--seed-font-family": [
+      // SF Pro under WebKit. note: the literal "SF Pro" resolves only for users who installed the font themselves
+      "-apple-system",
+      // SF Pro under Chromium (macOS).
+      "BlinkMacSystemFont",
+      // 한글 on Apple platforms
+      '"Apple SD Gothic Neo"',
+
+      // when loaded (for Windows, mostly)
+      '"Pretendard Variable"',
+      "Pretendard",
+      // on Windows without Pretendard loaded/installed
+      '"Segoe UI"',
+
+      // fallbacks
+      "Roboto",
+      '"Helvetica Neue"',
+      "Arial",
+      '"Noto Sans"',
+
+      "sans-serif",
+
+      '"Apple Color Emoji"',
+      '"Segoe UI Emoji"',
+      '"Segoe UI Symbol"',
+      '"Noto Color Emoji"',
+    ].join(", "),
 
     // Font scaling variables
     "--seed-font-size-multiplier": "1",


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHNWBdmtRAjs78ST7Krxpy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Apple 외 플랫폼에서도 Pretendard 웹폰트를 사용할 수 있도록 권장 글꼴 스택을 업데이트했습니다.
  * Windows에서 Pretendard가 없을 때 사용할 대체 글꼴 안내를 추가했습니다.

* **문서**
  * 플랫폼별 권장 글꼴과 웹폰트 로드 방법을 보강했습니다.
  * 글꼴 크기 조정 시 적용 방식과 Cascade Layer 설정 안내를 추가했습니다.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->