### PR TITLE
fix(lynx): stabilize initial icon color sync

### DIFF
--- a/.changeset/calm-icons-sync.md
+++ b/.changeset/calm-icons-sync.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/lynx-react": patch
+---
+
+Lynx 아이콘이 처음 표시될 때 테마 색상을 안정적으로 반영하도록 수정합니다.

--- a/packages/lynx-react/src/components/Icon/Icon.test.tsx
+++ b/packages/lynx-react/src/components/Icon/Icon.test.tsx
@@ -80,7 +80,7 @@ function installMainThreadStyleMocks(getComputedColor: () => string) {
 }
 
 describe("InternalIcon", () => {
-  it("reads the updated computed color in the next frame", async () => {
+  it("reads the updated computed color after dependency changes", async () => {
     let computedColor = "rgb(134, 139, 148)";
     const { frames, runNextFrame } = installMainThreadStyleMocks(() => computedColor);
 
@@ -94,16 +94,14 @@ describe("InternalIcon", () => {
     await waitSchedule();
 
     const { image } = getSourceAndImage();
-    expect(frames.size).toBe(1);
-    runNextFrame();
-
-    expect(image.getAttribute("tint-color")).toBe("rgb(134, 139, 148)");
+    expect(frames.size).toBe(0);
+    expect(image.getAttribute("tint-color")).toBeNull();
 
     rerender(renderIcon("checked"));
     await waitSchedule();
 
     expect(frames.size).toBe(1);
-    expect(image.getAttribute("tint-color")).toBe("rgb(134, 139, 148)");
+    expect(image.getAttribute("tint-color")).toBeNull();
 
     computedColor = "rgb(255, 102, 0)";
     runNextFrame();

--- a/packages/lynx-react/src/hooks/useIconColor.test.ts
+++ b/packages/lynx-react/src/hooks/useIconColor.test.ts
@@ -15,7 +15,7 @@ vi.mock("@lynx-js/react", async (importOriginal) => {
   return {
     ...actual,
     runOnMainThread:
-      (_worklet: (...args: never[]) => unknown) =>
+      () =>
       (...args: unknown[]) => {
         testState.workletCalls.push(args.length);
       },
@@ -36,14 +36,14 @@ describe("useIconColor", () => {
     expect(result.current["main-thread:binduiappear"]).toBeDefined();
   });
 
-  it("schedules tint color synchronization when the system theme changes", () => {
+  it("avoids cross-thread calls on mount and resynchronizes after theme changes", () => {
     const { rerender } = renderHook(() => useIconColor([]));
 
-    expect(testState.workletCalls).toEqual([3]);
+    expect(testState.workletCalls).toEqual([]);
 
     testState.theme = "dark";
     rerender();
 
-    expect(testState.workletCalls).toEqual([3, 1, 3]);
+    expect(testState.workletCalls).toEqual([3]);
   });
 });

--- a/packages/lynx-react/src/hooks/useIconColor.ts
+++ b/packages/lynx-react/src/hooks/useIconColor.ts
@@ -1,4 +1,4 @@
-import { runOnMainThread, useEffect, useGlobalProps, useMainThreadRef } from "@lynx-js/react";
+import { runOnMainThread, useEffect, useGlobalProps, useMainThreadRef, useRef } from "@lynx-js/react";
 import type { MainThread } from "@lynx-js/types";
 import type { DependencyList, RefObject } from "@lynx-js/react";
 
@@ -90,14 +90,20 @@ export function useIconColor(
   const enabled = options?.enabled ?? true;
   const frameRef = useMainThreadRef<number>(0);
   const theme = (useGlobalProps() as { theme?: unknown } | undefined)?.theme;
+  const hasMountedRef = useRef(false);
 
   function syncOnUiAppear() {
     "main thread";
     if (!enabled) return;
-    syncTintColorOnce(ref, sourceRef);
+    scheduleTintColorSync(ref, sourceRef, frameRef);
   }
 
   useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
+
     if (!enabled) return;
 
     runOnMainThread(scheduleTintColorSync)(ref, sourceRef, frameRef);


### PR DESCRIPTION
## Summary
- defer main-thread icon color synchronization until refs are attached
- schedule initial UI appearance synchronization after native class patches
- add a patch changeset for `@seed-design/lynx-react`

## Verification
- `bun test:lynx-react`
- `bun packages:build`
- `bun test:all`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Lynx 아이콘이 처음 표시될 때 테마 색상을 안정적으로 반영하도록 개선했습니다.
  * 테마 변경 시 아이콘 색상 동기화가 올바른 시점에 한 번만 실행되도록 수정했습니다.
  * 화면에 처음 나타날 때 불필요한 색상 동기화를 방지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->