### PR TITLE
fix(stackflow): dismiss input focus when swipe back starts

### DIFF
--- a/.changeset/quiet-edges-blur.md
+++ b/.changeset/quiet-edges-blur.md
@@ -1,0 +1,5 @@
+---
+"@seed-design/stackflow": patch
+---
+
+AppScreen에서 입력 중 스와이프백을 시작할 때 포커스를 해제하여 키보드와 입력 커서가 전환 중 남는 문제를 수정합니다.

--- a/examples/stackflow-spa/e2e/swipe-back-keyboard.e2e.ts
+++ b/examples/stackflow-spa/e2e/swipe-back-keyboard.e2e.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+
+test.use({ screenshot: "on" });
+
+test("스와이프백 시작 시 입력 포커스를 해제하고 취소해도 다시 포커스하지 않는다", async ({
+  page,
+}) => {
+  await page.goto("/swipe-back-keyboard");
+  await page.getByRole("button", { name: "입력 화면 한 장 더 열기" }).click();
+  const input = page.getByRole("textbox", { name: "검색어" }).last();
+  await input.tap();
+  await input.fill("당근 검색");
+  await expect(input).toBeFocused();
+  const initialX = await input.evaluate((element) => element.getBoundingClientRect().x);
+
+  // Hit-test the actual left edge. Keep the finger down while asserting focus:
+  // a blur caused only by popping/unmounting the screen must not pass this test.
+  const target = await page.evaluateHandle(() => document.elementFromPoint(5, 300)!);
+  const touch = { identifier: 1, clientX: 5, clientY: 300 };
+  await target.evaluate((element, point) => {
+    const finger = { ...point, target: element };
+    element.dispatchEvent(
+      Object.assign(new Event("touchstart", { bubbles: true }), {
+        touches: [finger],
+        changedTouches: [finger],
+      }),
+    );
+  }, touch);
+  await expect(input).not.toBeFocused();
+  await expect(input).toBeVisible();
+
+  await target.evaluate(async (element, point) => {
+    // Velocity is measured on touchmove, so wait before moving as well.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const finger = { ...point, clientX: 25, target: element };
+    element.dispatchEvent(
+      Object.assign(new Event("touchmove", { bubbles: true }), {
+        touches: [finger],
+        changedTouches: [finger],
+      }),
+    );
+  }, touch);
+  await expect
+    .poll(() => input.evaluate((element) => element.getBoundingClientRect().x))
+    .toBeGreaterThan(initialX + 10);
+  await target.evaluate((element, point) => {
+    const finger = { ...point, clientX: 25, target: element };
+    element.dispatchEvent(
+      Object.assign(new Event("touchend", { bubbles: true }), {
+        touches: [],
+        changedTouches: [finger],
+      }),
+    );
+  }, touch);
+  await expect
+    .poll(() => input.evaluate((element) => element.getBoundingClientRect().x))
+    .toBeCloseTo(initialX, 0);
+  await expect(input).toBeVisible();
+  await expect(input).toHaveValue("당근 검색");
+  await expect(input).not.toBeFocused();
+});

--- a/examples/stackflow-spa/src/activities/ActivityHome.tsx
+++ b/examples/stackflow-spa/src/activities/ActivityHome.tsx
@@ -110,6 +110,7 @@ const ActivityHome: StaticActivityComponentType<"ActivityHome"> = ({ params }) =
         { title: "투명 App Bar", ...to("ActivityTransparentBar", {}) },
         { title: "@stackflow/plugin-basic-ui", ...to("ActivityPluginBasicUI", {}) },
         { title: "중복 pop 가드", ...to("ActivityPopTest", {}) },
+        { title: "스와이프백 키보드", ...to("ActivitySwipeBackKeyboard", {}) },
         { title: "animate: false 밀림 버그", ...to("ActivityAnimateFalseTest", {}) },
         { title: `홈 다시 push (깊이: ${activityIndex})`, ...to("ActivityHome", {}) },
         ...appScreenVariantMap.transitionStyle.map((transitionStyle) => ({

--- a/examples/stackflow-spa/src/activities/ActivitySwipeBackKeyboard.tsx
+++ b/examples/stackflow-spa/src/activities/ActivitySwipeBackKeyboard.tsx
@@ -1,0 +1,69 @@
+import { VStack } from "@seed-design/react";
+import { useFlow, type StaticActivityComponentType } from "@stackflow/react/future";
+import { useState } from "react";
+import { ActionButton } from "seed-design/ui/action-button";
+import { AppBar, AppBarBackButton, AppBarLeft, AppBarMain } from "seed-design/ui/app-bar";
+import { AppScreen, AppScreenContent } from "seed-design/ui/app-screen";
+
+declare module "@stackflow/config" {
+  interface Register {
+    ActivitySwipeBackKeyboard: {};
+  }
+}
+
+const ActivitySwipeBackKeyboard: StaticActivityComponentType<"ActivitySwipeBackKeyboard"> = () => {
+  const { push } = useFlow();
+  const [focused, setFocused] = useState(false);
+
+  return (
+    <AppScreen theme="cupertino" transitionStyle="slideFromRightIOS">
+      <AppBar>
+        <AppBarLeft>
+          <AppBarBackButton />
+        </AppBarLeft>
+        <AppBarMain>스와이프백 키보드</AppBarMain>
+      </AppBar>
+      <AppScreenContent>
+        <VStack gap="x5" p="x5">
+          <p>
+            입력 화면을 한 장 더 열고 글을 입력한 뒤, 왼쪽 가장자리에서 천천히 오른쪽으로
+            밀어보세요.
+          </p>
+          <ActionButton onClick={() => push("ActivitySwipeBackKeyboard", {})}>
+            입력 화면 한 장 더 열기
+          </ActionButton>
+          <label>
+            검색어
+            <input
+              aria-label="검색어"
+              placeholder="여기를 눌러 키보드를 여세요"
+              onFocus={() => setFocused(true)}
+              onBlur={() => setFocused(false)}
+              style={{
+                display: "block",
+                width: "100%",
+                boxSizing: "border-box",
+                marginTop: 8,
+                padding: 12,
+                fontSize: 16,
+                border: "1px solid #868b94",
+                borderRadius: 8,
+              }}
+            />
+          </label>
+          <p role="status">입력 포커스: {focused ? "있음" : "없음"}</p>
+          <p>
+            정상 동작: 가장자리를 터치하면 입력 포커스가 해제되고 키보드가 내려가기 시작합니다.
+            화면을 조금 밀었다가 되돌려 취소해도 키보드는 다시 열리지 않습니다.
+          </p>
+          <p>
+            실제 키보드와 커서 잔상은 iPhone의 Safari 또는 앱 웹뷰에서 확인하세요. 데스크톱에서는
+            모바일 터치 에뮬레이션으로 포커스 상태를 확인할 수 있습니다.
+          </p>
+        </VStack>
+      </AppScreenContent>
+    </AppScreen>
+  );
+};
+
+export default ActivitySwipeBackKeyboard;

--- a/examples/stackflow-spa/src/stackflow/Stack.tsx
+++ b/examples/stackflow-spa/src/stackflow/Stack.tsx
@@ -105,6 +105,7 @@ export const { Stack, actions, stepActions } = stackflow({
     ActivityScaleFeedback: lazy(() => import("../activities/ActivityScaleFeedback")),
     ActivitySegmentedControl: lazy(() => import("../activities/ActivitySegmentedControl")),
     ActivitySelect: lazy(() => import("../activities/ActivitySelect")),
+    ActivitySwipeBackKeyboard: lazy(() => import("../activities/ActivitySwipeBackKeyboard")),
     ActivitySwitch: lazy(() => import("../activities/ActivitySwitch")),
     ActivitySideNavigation: lazy(() => import("../activities/ActivitySideNavigation")),
     ActivitySidePanel: lazy(() => import("../activities/ActivitySidePanel")),

--- a/examples/stackflow-spa/src/stackflow/stackflow.config.ts
+++ b/examples/stackflow-spa/src/stackflow/stackflow.config.ts
@@ -77,6 +77,7 @@ export const config = defineConfig({
     { route: "/side-navigation", name: "ActivitySideNavigation" },
     { route: "/side-panel", name: "ActivitySidePanel" },
     { route: "/side-panel-activity", name: "ActivitySidePanelActivity" },
+    { route: "/swipe-back-keyboard", name: "ActivitySwipeBackKeyboard" },
     { route: "/swipeable-menu-sheet", name: "ActivitySwipeableMenuSheet" },
     { route: "/swipeable-tabs", name: "ActivitySwipeableTabs" },
     { route: "/switch", name: "ActivitySwitch" },

--- a/packages/stackflow/src/primitive/GlobalInteraction/useSwipeBack.ts
+++ b/packages/stackflow/src/primitive/GlobalInteraction/useSwipeBack.ts
@@ -50,6 +50,15 @@ export function useSwipeBack(props: UseSwipeBackProps) {
       edgeProps: {
         tabIndex: -1,
         onTouchStart: (e: React.TouchEvent) => {
+          // Dismiss input focus before moving the screen, even if the swipe is cancelled.
+          const activeElement = e.currentTarget.ownerDocument.activeElement;
+          if (
+            activeElement &&
+            "blur" in activeElement &&
+            typeof activeElement.blur === "function"
+          ) {
+            activeElement.blur();
+          }
           const x0 = e.touches[0].clientX;
           const t0 = Date.now();
           startSwipeBack({ x0, t0 });


### PR DESCRIPTION
입력에 포커스한 상태에서 AppScreen의 엣지 스와이프백을 시작하면 키보드와 커서가 전환 중 남는 문제를 수정합니다. 엣지 `touchstart`에서 해당 문서의 activeElement를 blur하여, 화면이 움직이기 전에 입력 포커스를 해제합니다. 스와이프를 취소해도 자동 재포커스하지 않으며 입력값은 유지합니다.

- `stackflow-spa`에 `/swipe-back-keyboard` 수동 확인 화면과 홈 진입 링크를 추가했습니다.
- E2E는 입력 포커스 → 엣지 터치 → 화면 이동 → 취소 후 원위치 복귀와 입력값 유지를 검증합니다. 화면이 닫히기 전에 blur를 단언하므로 unmount로 인한 포커스 해제는 통과하지 않습니다.
- `@seed-design/stackflow` patch changeset을 포함합니다.

검증:
- 수정 전 Chromium·WebKit 모두 `not.toBeFocused()` 실패, 수정 후 동일 검증 통과
- stackflow-spa 전체 E2E: 로컬 10 passed (Chromium·WebKit), [GitHub Actions Test E2E 통과](https://github.com/daangn/seed-design/actions/runs/34461770225)
- Stackflow 테스트: 8 passed
- packages:build 및 stackflow-spa build 통과
- 사용자가 수정 전 예제에서 현상 재현 확인

E2E는 브라우저에 합성 터치 이벤트를 전달하여 포커스와 레이아웃을 검증합니다. 실제 iPhone OS 키보드의 하강 애니메이션과 커서 잔상에 대한 수정 후 기기 QA는 별도 확인이 필요합니다.

관련 제보: https://daangn.slack.com/archives/C09EF3GA3FC/p1788946566771169


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 입력 중 스와이프 백을 시작하면 입력 포커스가 해제되어 키보드와 커서가 화면 전환 중 남아 있지 않도록 수정했습니다.

* **예제**
  * 스와이프 백 중 키보드 동작을 확인할 수 있는 새 데모 화면을 추가했습니다.

* **테스트**
  * 입력 포커스 해제, 화면 이동 취소, 입력값 보존 동작을 검증하는 자동화 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->