### PR TITLE
feat(lynx): add contextual floating button

### DIFF
--- a/.changeset/gentle-buttons-float.md
+++ b/.changeset/gentle-buttons-float.md
@@ -1,0 +1,9 @@
+---
+"@seed-design/lynx-react": minor
+"@seed-design/lynx-css": minor
+---
+
+Lynx에 `ContextualFloatingButton` 컴포넌트를 추가합니다.
+
+- `solid`, `layer` 변형과 텍스트·아이콘 전용 레이아웃을 지원합니다.
+- 눌림 피드백, 로딩 표시와 비활성 상태를 제공합니다.

--- a/docs/content/lynx/components/contextual-floating-button.mdx
+++ b/docs/content/lynx/components/contextual-floating-button.mdx
@@ -1,0 +1,117 @@
+---
+title: Contextual Floating Button
+description: 화면 위에 떠 있으며 특정 상황에서만 나타나는 보조적인 동작을 위한 버튼입니다.
+compatibility:
+  lynx:
+    engine: "3.9"
+---
+
+<AvailableSince packages="@seed-design/lynx-react@0.8.0, @seed-design/lynx-css@0.12.0" />
+
+## Installation
+
+```package-install
+@seed-design/lynx-react @seed-design/lynx-css
+```
+
+<Callout>
+Lynx `ContextualFloatingButton`은 별도 `ui:contextual-floating-button` snippet 없이 `@seed-design/lynx-react` 패키지에서 직접 제공합니다.
+</Callout>
+
+## Usage
+
+<LynxComponentExample name="lynx/contextual-floating-button/preview">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/contextual-floating-button/preview.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+<Callout>
+웹 미리보기에서는 아이콘 색상이 적용되지 않습니다. 실제 아이콘 색상은 QR 코드 탭에서 Lynx Explorer로 확인하세요.
+</Callout>
+
+## Props
+
+<react-type-table
+  path="../packages/lynx-react/src/components/ContextualFloatingButton/ContextualFloatingButton.tsx"
+  name="ContextualFloatingButtonProps"
+/>
+
+## Examples
+
+### Float Composition
+
+Lynx에는 `Float` 컴포넌트가 없으므로 기준 frame의 `position="relative"`와 외부 `Box`의 native absolute bottom-center 배치로 같은 결과를 만듭니다.
+
+<LynxComponentExample name="lynx/contextual-floating-button/float-composition">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/contextual-floating-button/float-composition.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Solid Variant
+
+<LynxComponentExample name="lynx/contextual-floating-button/solid">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/contextual-floating-button/solid.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Layer Variant
+
+<LynxComponentExample name="lynx/contextual-floating-button/layer">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/contextual-floating-button/layer.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Icon Only
+
+`layout="iconOnly"`에는 스크린 리더가 읽을 `accessibility-label`을 함께 지정하세요.
+
+<LynxComponentExample name="lynx/contextual-floating-button/icon-only">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/contextual-floating-button/icon-only.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+### Loading
+
+탭하면 loading 상태가 즉시 시작되고 2초 뒤에 원래 상태로 돌아옵니다. Loading 중에는 탭할 수 없습니다.
+
+<LynxComponentExample name="lynx/contextual-floating-button/loading">
+  ```json doc-gen:file
+  {
+    "file": "examples/lynx/contextual-floating-button/loading.tsx",
+    "codeblock": true
+  }
+  ```
+</LynxComponentExample>
+
+## 웹 버전과의 차이
+
+<Callout type="warning">
+
+- **이벤트 핸들링**: `onClick` 대신 `bindtap` 또는 `main-thread:bindtap`을 사용합니다.
+- **렌더링 요소**: HTML `<button>` 대신 네이티브 `<view>`와 `<text>` 요소를 렌더링합니다. HTML form props와 `asChild`는 지원하지 않습니다.
+- **접근성**: `aria-label` 대신 native `accessibility-label`을 사용합니다.
+- **아이콘**: 웹 SVG 대신 native icon asset을 `PrefixIcon` 또는 `Icon` child slot으로 전달합니다. recipe 색상은 native icon tint로 동기화됩니다.
+- **Loading**: 두 플랫폼 모두 spinner를 absolute로 얹고 content를 숨겨 버튼 폭을 유지합니다. Lynx는 loading 중 tap을 차단하지만, React는 loading만으로 `onClick`을 차단하지 않습니다.
+- **Scale Feedback**: root의 `transform`은 Scale Feedback hook이 소유합니다. 위치를 transform으로 조정해야 할 때는 버튼 root가 아닌 외부 wrapper에 적용하세요.
+
+</Callout>

--- a/docs/examples/lynx/contextual-floating-button/float-composition.tsx
+++ b/docs/examples/lynx/contextual-floating-button/float-composition.tsx
@@ -1,0 +1,22 @@
+import IconBellFill from "@karrotmarket/lynx-monochrome-icon/IconBellFill";
+
+import { Box, ContextualFloatingButton, PrefixIcon } from "@seed-design/lynx-react";
+
+export default function Example() {
+  return (
+    <Box
+      position="relative"
+      width="300px"
+      height="500px"
+      borderWidth={1}
+      borderColor="stroke.neutralMuted"
+    >
+      <Box position="absolute" width="full" bottom="x4" display="flex" justifyContent="center">
+        <ContextualFloatingButton>
+          <PrefixIcon icon={<IconBellFill />} />
+          알림 설정
+        </ContextualFloatingButton>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/examples/lynx/contextual-floating-button/icon-only.tsx
+++ b/docs/examples/lynx/contextual-floating-button/icon-only.tsx
@@ -1,0 +1,11 @@
+import IconPlusFill from "@karrotmarket/lynx-monochrome-icon/IconPlusFill";
+
+import { ContextualFloatingButton, Icon } from "@seed-design/lynx-react";
+
+export default function Example() {
+  return (
+    <ContextualFloatingButton layout="iconOnly" accessibility-label="추가">
+      <Icon icon={<IconPlusFill />} />
+    </ContextualFloatingButton>
+  );
+}

--- a/docs/examples/lynx/contextual-floating-button/layer.tsx
+++ b/docs/examples/lynx/contextual-floating-button/layer.tsx
@@ -1,0 +1,12 @@
+import IconPlusLine from "@karrotmarket/lynx-monochrome-icon/IconPlusLine";
+
+import { ContextualFloatingButton, PrefixIcon } from "@seed-design/lynx-react";
+
+export default function Example() {
+  return (
+    <ContextualFloatingButton variant="layer">
+      <PrefixIcon icon={<IconPlusLine />} />
+      Layer Variant
+    </ContextualFloatingButton>
+  );
+}

--- a/docs/examples/lynx/contextual-floating-button/loading.tsx
+++ b/docs/examples/lynx/contextual-floating-button/loading.tsx
@@ -1,0 +1,21 @@
+import IconPlusLine from "@karrotmarket/lynx-monochrome-icon/IconPlusLine";
+import { useState } from "@lynx-js/react";
+
+import { ContextualFloatingButton, PrefixIcon } from "@seed-design/lynx-react";
+
+export default function Example() {
+  const [loading, setLoading] = useState(false);
+
+  function handleTap() {
+    "background only";
+    setLoading(true);
+    setTimeout(() => setLoading(false), 2000);
+  }
+
+  return (
+    <ContextualFloatingButton loading={loading} bindtap={handleTap}>
+      <PrefixIcon icon={<IconPlusLine />} />
+      시간이 걸리는 액션
+    </ContextualFloatingButton>
+  );
+}

--- a/docs/examples/lynx/contextual-floating-button/preview.tsx
+++ b/docs/examples/lynx/contextual-floating-button/preview.tsx
@@ -1,0 +1,12 @@
+import IconBellFill from "@karrotmarket/lynx-monochrome-icon/IconBellFill";
+
+import { ContextualFloatingButton, PrefixIcon } from "@seed-design/lynx-react";
+
+export default function Example() {
+  return (
+    <ContextualFloatingButton>
+      <PrefixIcon icon={<IconBellFill />} />
+      알림 설정
+    </ContextualFloatingButton>
+  );
+}

--- a/docs/examples/lynx/contextual-floating-button/solid.tsx
+++ b/docs/examples/lynx/contextual-floating-button/solid.tsx
@@ -1,0 +1,12 @@
+import IconPlusLine from "@karrotmarket/lynx-monochrome-icon/IconPlusLine";
+
+import { ContextualFloatingButton, PrefixIcon } from "@seed-design/lynx-react";
+
+export default function Example() {
+  return (
+    <ContextualFloatingButton variant="solid">
+      <PrefixIcon icon={<IconPlusLine />} />
+      Solid Variant
+    </ContextualFloatingButton>
+  );
+}

--- a/docs/public/__docs__/index.json
+++ b/docs/public/__docs__/index.json
@@ -2146,6 +2146,12 @@
               "docUrl": "/lynx/getting-started/cli"
             },
             {
+              "id": "contextual-floating-button",
+              "title": "Contextual Floating Button",
+              "description": "화면 위에 떠 있으며 특정 상황에서만 나타나는 보조적인 동작을 위한 버튼입니다.",
+              "docUrl": "/lynx/components/contextual-floating-button"
+            },
+            {
               "id": "divider",
               "title": "Divider",
               "description": "시각적 구분자로써 역할을 하며, 콘텐츠 간의 구획을 명확히 나누는 데 사용하는 컴포넌트입니다.",

--- a/packages/lynx-css/all.css
+++ b/packages/lynx-css/all.css
@@ -2365,6 +2365,133 @@ text {
   background: var(--seed-color-bg-neutral-weak-pressed);
 }
 
+.seed-contextual-floating-button__root {
+  border-radius: var(--seed-radius-full);
+  width: fit-content;
+  box-shadow: var(--seed-shadow-s3);
+  --size: 16px;
+  --thickness: 2px;
+  transition: background-color var(--seed-duration-color-transition) var(--seed-timing-function-easing);
+  flex-direction: row;
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  position: relative;
+}
+
+.seed-contextual-floating-button__content {
+  opacity: 1;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+.seed-contextual-floating-button__prefixIcon, .seed-contextual-floating-button__icon {
+  flex-shrink: 0;
+}
+
+.seed-contextual-floating-button__loadingIndicator {
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.seed-contextual-floating-button__root--variant_solid {
+  background: var(--seed-color-bg-neutral-inverted);
+  --track-color: var(--seed-color-palette-gray-700);
+  --range-color: var(--seed-color-fg-neutral-inverted);
+}
+
+.seed-contextual-floating-button__text--variant_solid, .seed-contextual-floating-button__prefixIcon--variant_solid, .seed-contextual-floating-button__icon--variant_solid {
+  color: var(--seed-color-fg-neutral-inverted);
+}
+
+.seed-contextual-floating-button__root--variant_layer {
+  background: var(--seed-color-bg-layer-floating);
+  --track-color: var(--seed-color-palette-gray-500);
+  --range-color: var(--seed-color-fg-neutral);
+}
+
+.seed-contextual-floating-button__text--variant_layer, .seed-contextual-floating-button__prefixIcon--variant_layer, .seed-contextual-floating-button__icon--variant_layer {
+  color: var(--seed-color-fg-neutral);
+}
+
+.seed-contextual-floating-button__root--layout_withText {
+  min-height: 36px;
+  padding-top: var(--seed-dimension-x2);
+  padding-right: var(--seed-dimension-x3_5);
+  padding-bottom: var(--seed-dimension-x2);
+  padding-left: var(--seed-dimension-x3_5);
+}
+
+.seed-contextual-floating-button__content--layout_withText {
+  gap: var(--seed-dimension-x1);
+}
+
+.seed-contextual-floating-button__text--layout_withText {
+  font-size: var(--seed-font-size-t4);
+  line-height: var(--seed-line-height-t4);
+  font-weight: var(--seed-font-weight-medium);
+}
+
+.seed-contextual-floating-button__prefixIcon--layout_withText {
+  width: 16px;
+  height: 16px;
+}
+
+.seed-contextual-floating-button__root--layout_iconOnly {
+  width: 44px;
+  height: 44px;
+}
+
+.seed-contextual-floating-button__icon--layout_iconOnly {
+  width: 22px;
+  height: 22px;
+}
+
+.seed-contextual-floating-button__content--loading_true {
+  opacity: 0;
+}
+
+.seed-contextual-floating-button__root--variant_solid-pressed_true {
+  background: var(--seed-color-bg-neutral-inverted-pressed);
+}
+
+.seed-contextual-floating-button__root--variant_layer-pressed_true {
+  background: var(--seed-color-bg-layer-floating-pressed);
+}
+
+.seed-contextual-floating-button__root--variant_solid-disabled_true {
+  background: var(--seed-color-bg-disabled);
+}
+
+.seed-contextual-floating-button__text--variant_solid-disabled_true, .seed-contextual-floating-button__prefixIcon--variant_solid-disabled_true, .seed-contextual-floating-button__icon--variant_solid-disabled_true {
+  color: var(--seed-color-fg-disabled);
+}
+
+.seed-contextual-floating-button__root--variant_layer-disabled_true {
+  background: var(--seed-color-bg-disabled);
+}
+
+.seed-contextual-floating-button__text--variant_layer-disabled_true, .seed-contextual-floating-button__prefixIcon--variant_layer-disabled_true, .seed-contextual-floating-button__icon--variant_layer-disabled_true {
+  color: var(--seed-color-fg-disabled);
+}
+
+.seed-contextual-floating-button__root--variant_solid-loading_true {
+  background: var(--seed-color-bg-neutral-inverted-pressed);
+}
+
+.seed-contextual-floating-button__root--variant_layer-loading_true {
+  background: var(--seed-color-bg-layer-floating-pressed);
+}
+
 .seed-field__root {
   gap: var(--seed-dimension-x2);
   flex-direction: column;

--- a/packages/lynx-css/recipes/contextual-floating-button.css
+++ b/packages/lynx-css/recipes/contextual-floating-button.css
@@ -1,0 +1,131 @@
+.seed-contextual-floating-button__root {
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: fit-content;
+    border-radius: var(--seed-radius-full);
+    box-shadow: var(--seed-shadow-s3);
+    --size: 16px;
+    --thickness: 2px;
+    transition: background-color var(--seed-duration-color-transition) var(--seed-timing-function-easing)
+}
+.seed-contextual-floating-button__content {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    opacity: 1
+}
+.seed-contextual-floating-button__prefixIcon {
+    flex-shrink: 0
+}
+.seed-contextual-floating-button__icon {
+    flex-shrink: 0
+}
+.seed-contextual-floating-button__loadingIndicator {
+    position: absolute;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0
+}
+.seed-contextual-floating-button__root--variant_solid {
+    background: var(--seed-color-bg-neutral-inverted);
+    --track-color: var(--seed-color-palette-gray-700);
+    --range-color: var(--seed-color-fg-neutral-inverted)
+}
+.seed-contextual-floating-button__text--variant_solid {
+    color: var(--seed-color-fg-neutral-inverted)
+}
+.seed-contextual-floating-button__prefixIcon--variant_solid {
+    color: var(--seed-color-fg-neutral-inverted)
+}
+.seed-contextual-floating-button__icon--variant_solid {
+    color: var(--seed-color-fg-neutral-inverted)
+}
+.seed-contextual-floating-button__root--variant_layer {
+    background: var(--seed-color-bg-layer-floating);
+    --track-color: var(--seed-color-palette-gray-500);
+    --range-color: var(--seed-color-fg-neutral)
+}
+.seed-contextual-floating-button__text--variant_layer {
+    color: var(--seed-color-fg-neutral)
+}
+.seed-contextual-floating-button__prefixIcon--variant_layer {
+    color: var(--seed-color-fg-neutral)
+}
+.seed-contextual-floating-button__icon--variant_layer {
+    color: var(--seed-color-fg-neutral)
+}
+.seed-contextual-floating-button__root--layout_withText {
+    min-height: 36px;
+    padding-top: var(--seed-dimension-x2);
+    padding-right: var(--seed-dimension-x3_5);
+    padding-bottom: var(--seed-dimension-x2);
+    padding-left: var(--seed-dimension-x3_5)
+}
+.seed-contextual-floating-button__content--layout_withText {
+    gap: var(--seed-dimension-x1)
+}
+.seed-contextual-floating-button__text--layout_withText {
+    font-size: var(--seed-font-size-t4);
+    line-height: var(--seed-line-height-t4);
+    font-weight: var(--seed-font-weight-medium)
+}
+.seed-contextual-floating-button__prefixIcon--layout_withText {
+    width: 16px;
+    height: 16px
+}
+.seed-contextual-floating-button__root--layout_iconOnly {
+    width: 44px;
+    height: 44px
+}
+.seed-contextual-floating-button__icon--layout_iconOnly {
+    width: 22px;
+    height: 22px
+}
+.seed-contextual-floating-button__content--loading_true {
+    opacity: 0
+}
+.seed-contextual-floating-button__root--variant_solid-pressed_true {
+    background: var(--seed-color-bg-neutral-inverted-pressed)
+}
+.seed-contextual-floating-button__root--variant_layer-pressed_true {
+    background: var(--seed-color-bg-layer-floating-pressed)
+}
+.seed-contextual-floating-button__root--variant_solid-disabled_true {
+    background: var(--seed-color-bg-disabled)
+}
+.seed-contextual-floating-button__text--variant_solid-disabled_true {
+    color: var(--seed-color-fg-disabled)
+}
+.seed-contextual-floating-button__prefixIcon--variant_solid-disabled_true {
+    color: var(--seed-color-fg-disabled)
+}
+.seed-contextual-floating-button__icon--variant_solid-disabled_true {
+    color: var(--seed-color-fg-disabled)
+}
+.seed-contextual-floating-button__root--variant_layer-disabled_true {
+    background: var(--seed-color-bg-disabled)
+}
+.seed-contextual-floating-button__text--variant_layer-disabled_true {
+    color: var(--seed-color-fg-disabled)
+}
+.seed-contextual-floating-button__prefixIcon--variant_layer-disabled_true {
+    color: var(--seed-color-fg-disabled)
+}
+.seed-contextual-floating-button__icon--variant_layer-disabled_true {
+    color: var(--seed-color-fg-disabled)
+}
+.seed-contextual-floating-button__root--variant_solid-loading_true {
+    background: var(--seed-color-bg-neutral-inverted-pressed)
+}
+.seed-contextual-floating-button__root--variant_layer-loading_true {
+    background: var(--seed-color-bg-layer-floating-pressed)
+}

--- a/packages/lynx-css/recipes/contextual-floating-button.d.ts
+++ b/packages/lynx-css/recipes/contextual-floating-button.d.ts
@@ -1,0 +1,40 @@
+declare interface ContextualFloatingButtonVariant {
+  /**
+  * @default "solid"
+  */
+  variant: "solid" | "layer";
+/**
+  * @default "withText"
+  */
+  layout: "withText" | "iconOnly";
+/**
+  * @default false
+  */
+  pressed: boolean;
+/**
+  * @default false
+  */
+  disabled: boolean;
+/**
+  * @default false
+  */
+  loading: boolean;
+}
+
+declare type ContextualFloatingButtonVariantMap = {
+  [key in keyof ContextualFloatingButtonVariant]: Array<ContextualFloatingButtonVariant[key]>;
+};
+
+export declare type ContextualFloatingButtonVariantProps = Partial<ContextualFloatingButtonVariant>;
+
+export declare type ContextualFloatingButtonSlotName = "root" | "content" | "text" | "prefixIcon" | "icon" | "loadingIndicator";
+
+export declare const contextualFloatingButtonVariantMap: ContextualFloatingButtonVariantMap;
+
+export declare const contextualFloatingButton: ((
+  props?: ContextualFloatingButtonVariantProps,
+) => Record<ContextualFloatingButtonSlotName, string>) & {
+  splitVariantProps: <T extends ContextualFloatingButtonVariantProps>(
+    props: T,
+  ) => [ContextualFloatingButtonVariantProps, Omit<T, keyof ContextualFloatingButtonVariantProps>];
+}

--- a/packages/lynx-css/recipes/contextual-floating-button.mjs
+++ b/packages/lynx-css/recipes/contextual-floating-button.mjs
@@ -1,0 +1,104 @@
+import './contextual-floating-button.css';
+import { createClassName, mergeVariants, splitVariantProps } from "./shared.mjs";
+
+const contextualFloatingButtonSlotNames = [
+  [
+    "root",
+    "seed-contextual-floating-button__root"
+  ],
+  [
+    "content",
+    "seed-contextual-floating-button__content"
+  ],
+  [
+    "text",
+    "seed-contextual-floating-button__text"
+  ],
+  [
+    "prefixIcon",
+    "seed-contextual-floating-button__prefixIcon"
+  ],
+  [
+    "icon",
+    "seed-contextual-floating-button__icon"
+  ],
+  [
+    "loadingIndicator",
+    "seed-contextual-floating-button__loadingIndicator"
+  ]
+];
+
+const defaultVariant = {
+  "variant": "solid",
+  "layout": "withText",
+  "pressed": false,
+  "disabled": false,
+  "loading": false
+};
+
+const compoundVariants = [
+  {
+    "variant": "solid",
+    "pressed": true
+  },
+  {
+    "variant": "layer",
+    "pressed": true
+  },
+  {
+    "variant": "solid",
+    "disabled": true
+  },
+  {
+    "variant": "layer",
+    "disabled": true
+  },
+  {
+    "variant": "solid",
+    "loading": true
+  },
+  {
+    "variant": "layer",
+    "loading": true
+  }
+];
+
+export const contextualFloatingButtonVariantMap = {
+  "variant": [
+    "solid",
+    "layer"
+  ],
+  "layout": [
+    "withText",
+    "iconOnly"
+  ],
+  "pressed": [
+    true,
+    false
+  ],
+  "disabled": [
+    true,
+    false
+  ],
+  "loading": [
+    true,
+    false
+  ]
+};
+
+export const contextualFloatingButtonVariantKeys = Object.keys(contextualFloatingButtonVariantMap);
+
+export function contextualFloatingButton(props) {
+  return Object.fromEntries(
+    contextualFloatingButtonSlotNames.map(([slot, className]) => {
+      return [
+        slot,
+        createClassName(className, mergeVariants(defaultVariant, props), compoundVariants),
+      ];
+    }),
+  );
+}
+
+Object.assign(contextualFloatingButton, { splitVariantProps: (props) => splitVariantProps(props, contextualFloatingButtonVariantMap) });
+
+// @recipe(seed): contextual-floating-button

--- a/packages/lynx-qvism-preset/src/recipes.ts
+++ b/packages/lynx-qvism-preset/src/recipes.ts
@@ -9,6 +9,7 @@ import checkbox from "./recipes/checkbox";
 import checkboxGroup from "./recipes/checkbox-group";
 import checkmark from "./recipes/checkmark";
 import chip from "./recipes/chip";
+import contextualFloatingButton from "./recipes/contextual-floating-button";
 import field from "./recipes/field";
 import fieldLabel from "./recipes/field-label";
 import mannerTemp from "./recipes/manner-temp";
@@ -50,6 +51,7 @@ export const recipes = {
   checkboxGroup,
   checkmark,
   chip,
+  contextualFloatingButton,
   field,
   fieldLabel,
   mannerTemp,

--- a/packages/lynx-qvism-preset/src/recipes/contextual-floating-button.ts
+++ b/packages/lynx-qvism-preset/src/recipes/contextual-floating-button.ts
@@ -1,0 +1,174 @@
+import { contextualFloatingButton as vars } from "../vars/component";
+import { defineSlotRecipe } from "../utils/define";
+
+const ROOT_COLOR_TRANSITION = `background-color ${vars.base.enabled.root.colorDuration} ${vars.base.enabled.root.colorTimingFunction}`;
+
+/**
+ * Lynx-specific ContextualFloatingButton recipe.
+ *
+ * Scale Feedback owns the root transform on the main thread, so this recipe
+ * intentionally transitions color only. The component supplies `pressed` from
+ * usePressTap and makes disabled/loading interactions inert.
+ */
+const contextualFloatingButton = defineSlotRecipe({
+  name: "contextual-floating-button",
+  slots: ["root", "content", "text", "prefixIcon", "icon", "loadingIndicator"],
+  base: {
+    root: {
+      position: "relative",
+      display: "flex",
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      flexShrink: 0,
+      width: "fit-content",
+      borderRadius: vars.base.enabled.root.cornerRadius,
+      boxShadow: vars.base.enabled.root.shadow,
+      "--size": vars.base.enabled.progressCircle.size,
+      "--thickness": vars.base.enabled.progressCircle.thickness,
+      transition: ROOT_COLOR_TRANSITION,
+    },
+    content: {
+      display: "flex",
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      opacity: 1,
+    },
+    prefixIcon: {
+      flexShrink: 0,
+    },
+    icon: {
+      flexShrink: 0,
+    },
+    loadingIndicator: {
+      position: "absolute",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    },
+  },
+  variants: {
+    variant: {
+      solid: {
+        root: {
+          background: vars.variantSolid.enabled.root.color,
+          "--track-color": vars.variantSolid.enabled.progressCircle.trackColor,
+          "--range-color": vars.variantSolid.enabled.progressCircle.rangeColor,
+        },
+        text: { color: vars.variantSolid.enabled.label.color },
+        prefixIcon: { color: vars.variantSolid.enabled.prefixIcon.color },
+        icon: { color: vars.variantSolid.enabled.icon.color },
+      },
+      layer: {
+        root: {
+          background: vars.variantLayer.enabled.root.color,
+          "--track-color": vars.variantLayer.enabled.progressCircle.trackColor,
+          "--range-color": vars.variantLayer.enabled.progressCircle.rangeColor,
+        },
+        text: { color: vars.variantLayer.enabled.label.color },
+        prefixIcon: { color: vars.variantLayer.enabled.prefixIcon.color },
+        icon: { color: vars.variantLayer.enabled.icon.color },
+      },
+    },
+    layout: {
+      withText: {
+        root: {
+          minHeight: vars.layoutWithText.enabled.root.minHeight,
+          paddingTop: vars.layoutWithText.enabled.root.paddingY,
+          paddingRight: vars.layoutWithText.enabled.root.paddingX,
+          paddingBottom: vars.layoutWithText.enabled.root.paddingY,
+          paddingLeft: vars.layoutWithText.enabled.root.paddingX,
+        },
+        content: { gap: vars.layoutWithText.enabled.root.gap },
+        text: {
+          fontSize: vars.layoutWithText.enabled.label.fontSize,
+          lineHeight: vars.layoutWithText.enabled.label.lineHeight,
+          fontWeight: vars.layoutWithText.enabled.label.fontWeight,
+        },
+        prefixIcon: {
+          width: vars.layoutWithText.enabled.prefixIcon.size,
+          height: vars.layoutWithText.enabled.prefixIcon.size,
+        },
+      },
+      iconOnly: {
+        root: {
+          width: vars.layoutIconOnly.enabled.root.size,
+          height: vars.layoutIconOnly.enabled.root.size,
+        },
+        icon: {
+          width: vars.layoutIconOnly.enabled.icon.size,
+          height: vars.layoutIconOnly.enabled.icon.size,
+        },
+      },
+    },
+    pressed: {
+      true: {},
+      false: {},
+    },
+    disabled: {
+      true: {},
+      false: {},
+    },
+    loading: {
+      true: { content: { opacity: 0 } },
+      false: {},
+    },
+  },
+  compoundVariants: [
+    // Source order establishes the ActionButton state priority: loading > disabled > pressed.
+    {
+      variant: "solid",
+      pressed: true,
+      css: { root: { background: vars.variantSolid.pressed.root.color } },
+    },
+    {
+      variant: "layer",
+      pressed: true,
+      css: { root: { background: vars.variantLayer.pressed.root.color } },
+    },
+    {
+      variant: "solid",
+      disabled: true,
+      css: {
+        root: { background: vars.variantSolid.disabled.root.color },
+        text: { color: vars.variantSolid.disabled.label.color },
+        prefixIcon: { color: vars.variantSolid.disabled.prefixIcon.color },
+        icon: { color: vars.variantSolid.disabled.icon.color },
+      },
+    },
+    {
+      variant: "layer",
+      disabled: true,
+      css: {
+        root: { background: vars.variantLayer.disabled.root.color },
+        text: { color: vars.variantLayer.disabled.label.color },
+        prefixIcon: { color: vars.variantLayer.disabled.prefixIcon.color },
+        icon: { color: vars.variantLayer.disabled.icon.color },
+      },
+    },
+    {
+      variant: "solid",
+      loading: true,
+      css: { root: { background: vars.variantSolid.loading.root.color } },
+    },
+    {
+      variant: "layer",
+      loading: true,
+      css: { root: { background: vars.variantLayer.loading.root.color } },
+    },
+  ],
+  defaultVariants: {
+    variant: "solid",
+    layout: "withText",
+    pressed: false,
+    disabled: false,
+    loading: false,
+  },
+});
+
+export default contextualFloatingButton;

--- a/packages/lynx-react/src/components/ContextualFloatingButton/ContextualFloatingButton.test.tsx
+++ b/packages/lynx-react/src/components/ContextualFloatingButton/ContextualFloatingButton.test.tsx
@@ -1,0 +1,63 @@
+import "@testing-library/jest-dom";
+import { fireEvent, getQueriesForElement, render } from "@lynx-js/react/testing-library";
+import { describe, expect, it, vi } from "vitest";
+
+import { ContextualFloatingButton } from "./ContextualFloatingButton";
+
+function getRenderedRoot() {
+  const root = elementTree.root;
+
+  if (!root) {
+    throw new Error("Expected Lynx render root to exist.");
+  }
+
+  return root;
+}
+
+function getContextualFloatingButtonRoot() {
+  const root = getRenderedRoot();
+
+  if (root.classList.contains("seed-contextual-floating-button__root")) return root;
+
+  const button = root.querySelector<HTMLElement>(".seed-contextual-floating-button__root");
+  if (!button) {
+    throw new Error("Expected ContextualFloatingButton root to exist.");
+  }
+
+  return button;
+}
+
+describe("ContextualFloatingButton", () => {
+  it("preserves its label under the loading indicator while blocking taps", () => {
+    const onTap = vi.fn();
+    render(
+      <ContextualFloatingButton loading bindtap={onTap}>
+        저장하기
+      </ContextualFloatingButton>,
+    );
+
+    const root = getContextualFloatingButtonRoot();
+
+    expect(getQueriesForElement(getRenderedRoot()).getByText("저장하기")).toBeInTheDocument();
+    expect(root.querySelector(".seed-progress-circle__root")).toBeInTheDocument();
+
+    fireEvent.tap(root);
+
+    expect(onTap).not.toHaveBeenCalled();
+  });
+
+  it("blocks taps and exposes disabled accessibility state when disabled", () => {
+    const onTap = vi.fn();
+    render(
+      <ContextualFloatingButton disabled bindtap={onTap}>
+        저장하기
+      </ContextualFloatingButton>,
+    );
+
+    const root = getContextualFloatingButtonRoot();
+    fireEvent.tap(root);
+
+    expect(onTap).not.toHaveBeenCalled();
+    expect(root).toHaveAttribute("accessibility-traits", "disabled");
+  });
+});

--- a/packages/lynx-react/src/components/ContextualFloatingButton/ContextualFloatingButton.tsx
+++ b/packages/lynx-react/src/components/ContextualFloatingButton/ContextualFloatingButton.tsx
@@ -1,0 +1,232 @@
+import {
+  contextualFloatingButton,
+  type ContextualFloatingButtonVariantProps,
+} from "@seed-design/lynx-css/recipes/contextual-floating-button";
+import clsx from "clsx";
+import * as React from "@lynx-js/react";
+
+import { usePressTap } from "../../hooks/usePressTap";
+import { useScaleFeedback } from "../../hooks/useScaleFeedback";
+import type {
+  LynxAccessibilityProps,
+  LynxElementProps,
+  LynxPressableProps,
+  LynxStyledElementProps,
+  LynxTouchProps,
+  LynxViewRef,
+} from "../../types";
+import { toArray } from "../../utils/children";
+import { createSlotRecipeContext } from "../../utils/create-slot-recipe-context";
+import { mergeProps } from "../../utils/merge-props";
+import { IconRequired, IconSlotProvider, getIconSlotName } from "../Icon/Icon";
+import { ProgressCircleRange, ProgressCircleRoot } from "../ProgressCircle";
+
+const { ClassNamesProvider, useClassNames } = createSlotRecipeContext(contextualFloatingButton);
+
+type ContextualFloatingButtonPublicVariantProps = Omit<
+  ContextualFloatingButtonVariantProps,
+  "pressed"
+>;
+
+interface ContextualFloatingButtonRootProps
+  extends ContextualFloatingButtonVariantProps,
+    Omit<LynxStyledElementProps, "flatten">,
+    LynxTouchProps,
+    LynxAccessibilityProps {
+  flatten?: false;
+}
+
+const ContextualFloatingButtonRoot = React.forwardRef<unknown, ContextualFloatingButtonRootProps>(
+  (innerProps, ref) => {
+    const [variantProps, otherProps] = contextualFloatingButton.splitVariantProps(innerProps);
+    const classNames = contextualFloatingButton(variantProps);
+    const { children, className, ...nativeProps } = otherProps;
+    const iconSlotContextValue = React.useMemo(
+      () => ({
+        classNames: {
+          icon: classNames.icon,
+          prefixIcon: classNames.prefixIcon,
+        },
+        deps: [
+          variantProps.variant ?? null,
+          variantProps.layout ?? null,
+          variantProps.pressed ?? false,
+          variantProps.disabled ?? false,
+          variantProps.loading ?? false,
+        ],
+      }),
+      [
+        classNames.icon,
+        classNames.prefixIcon,
+        variantProps.variant,
+        variantProps.layout,
+        variantProps.pressed,
+        variantProps.disabled,
+        variantProps.loading,
+      ],
+    );
+
+    return (
+      <ClassNamesProvider value={classNames}>
+        <IconSlotProvider value={iconSlotContextValue}>
+          <view
+            {...mergeProps(ref ? { ref: ref as LynxViewRef } : {}, nativeProps)}
+            className={clsx(classNames.root, className)}
+          >
+            {children}
+          </view>
+        </IconSlotProvider>
+      </ClassNamesProvider>
+    );
+  },
+);
+ContextualFloatingButtonRoot.displayName = "ContextualFloatingButtonRoot";
+
+function ContextualFloatingButtonText({ children }: LynxElementProps) {
+  const classNames = useClassNames();
+
+  return <text className={classNames.text}>{children}</text>;
+}
+
+function ContextualFloatingButtonContent({
+  children,
+  isIconOnly,
+}: {
+  children: React.ReactNode;
+  isIconOnly: boolean;
+}) {
+  const classNames = useClassNames();
+  const prefixIconChildren: React.ReactNode[] = [];
+  const iconChildren: React.ReactNode[] = [];
+  const textChildren: React.ReactNode[] = [];
+
+  for (const child of toArray(children)) {
+    const slotName = getIconSlotName(child);
+
+    if (slotName === "prefixIcon") {
+      prefixIconChildren.push(child);
+      continue;
+    }
+    if (slotName === "icon") {
+      iconChildren.push(child);
+      continue;
+    }
+
+    textChildren.push(child);
+  }
+
+  return (
+    <view className={classNames.content}>
+      {isIconOnly ? (
+        <>{iconChildren}</>
+      ) : (
+        <>
+          {prefixIconChildren}
+          {textChildren.length > 0 ? (
+            <ContextualFloatingButtonText>{textChildren}</ContextualFloatingButtonText>
+          ) : null}
+        </>
+      )}
+    </view>
+  );
+}
+
+function ContextualFloatingButtonLoadingIndicator() {
+  const classNames = useClassNames();
+
+  return (
+    <view className={classNames.loadingIndicator}>
+      <ProgressCircleRoot size="16" tone="inherit">
+        <ProgressCircleRange />
+      </ProgressCircleRoot>
+    </view>
+  );
+}
+
+/**
+ * @platform Lynx
+ *
+ * Web version differences:
+ * - Native `<view>` and `bindtap` / `main-thread:bindtap` replace HTML button events,
+ *   form props, and `asChild`.
+ * - `loading` blocks both native tap callbacks, unlike the React reference which only
+ *   exposes pending state to its underlying button.
+ */
+export interface ContextualFloatingButtonProps
+  extends ContextualFloatingButtonPublicVariantProps,
+    Omit<LynxStyledElementProps, "flatten">,
+    LynxPressableProps,
+    LynxAccessibilityProps {}
+
+export const ContextualFloatingButton = React.forwardRef<unknown, ContextualFloatingButtonProps>(
+  (props, ref) => {
+    const [variantProps, otherProps] = contextualFloatingButton.splitVariantProps(props);
+    const {
+      children,
+      bindtap,
+      "main-thread:bindtap": mainThreadBindtap,
+      "accessibility-element": accessibilityElement = true,
+      "accessibility-label": accessibilityLabel,
+      "accessibility-role-description": accessibilityRoleDescription = "button",
+      "accessibility-traits": accessibilityTraits,
+      ...nativeProps
+    } = otherProps;
+    const layout = variantProps.layout ?? "withText";
+    const disabled = variantProps.disabled ?? false;
+    const loading = variantProps.loading ?? false;
+    const isInteractive = !disabled && !loading;
+
+    if (
+      process.env.NODE_ENV !== "production" &&
+      layout === "iconOnly" &&
+      accessibilityElement &&
+      !accessibilityLabel
+    ) {
+      console.warn(
+        'ContextualFloatingButton: `layout="iconOnly"` requires `accessibility-label` for accessibility.',
+      );
+    }
+
+    const { pressed, bindtouchstart, bindtouchend, bindtouchcancel, ...pressTapHandlers } =
+      usePressTap({
+        disabled: !isInteractive,
+        onTap: bindtap,
+        mainThreadOnTap: mainThreadBindtap,
+      });
+    const { scaleFeedbackTriggerProps, scaleFeedbackTargetProps } = useScaleFeedback({
+      disabled: !isInteractive,
+      onTouchStart: bindtouchstart,
+      onTouchEnd: bindtouchend,
+      onTouchCancel: bindtouchcancel,
+    });
+
+    return (
+      <IconRequired enabled={layout === "iconOnly"}>
+        <ContextualFloatingButtonRoot
+          {...mergeProps(
+            { ref },
+            scaleFeedbackTargetProps,
+            scaleFeedbackTriggerProps,
+            pressTapHandlers,
+            nativeProps,
+          )}
+          {...variantProps}
+          pressed={pressed}
+          accessibility-element={accessibilityElement}
+          accessibility-label={accessibilityLabel}
+          accessibility-role-description={accessibilityRoleDescription}
+          accessibility-traits={
+            accessibilityTraits ?? (disabled || loading ? "disabled" : undefined)
+          }
+          flatten={false}
+        >
+          {loading ? <ContextualFloatingButtonLoadingIndicator /> : null}
+          <ContextualFloatingButtonContent isIconOnly={layout === "iconOnly"}>
+            {children}
+          </ContextualFloatingButtonContent>
+        </ContextualFloatingButtonRoot>
+      </IconRequired>
+    );
+  },
+);
+ContextualFloatingButton.displayName = "ContextualFloatingButton";

--- a/packages/lynx-react/src/components/ContextualFloatingButton/index.ts
+++ b/packages/lynx-react/src/components/ContextualFloatingButton/index.ts
@@ -1,0 +1,4 @@
+export {
+  ContextualFloatingButton,
+  type ContextualFloatingButtonProps,
+} from "./ContextualFloatingButton";

--- a/packages/lynx-react/src/components/Icon/Icon.test.tsx
+++ b/packages/lynx-react/src/components/Icon/Icon.test.tsx
@@ -82,7 +82,7 @@ function installMainThreadStyleMocks(getComputedColor: () => string) {
 describe("InternalIcon", () => {
   it("reads the updated computed color after dependency changes", async () => {
     let computedColor = "rgb(134, 139, 148)";
-    const { frames, runNextFrame } = installMainThreadStyleMocks(() => computedColor);
+    const { runNextFrame } = installMainThreadStyleMocks(() => computedColor);
 
     const renderIcon = (dependency: string) => (
       <InternalIcon icon={<TestIcon />} className={dependency} deps={[dependency]} />
@@ -94,14 +94,9 @@ describe("InternalIcon", () => {
     await waitSchedule();
 
     const { image } = getSourceAndImage();
-    expect(frames.size).toBe(0);
-    expect(image.getAttribute("tint-color")).toBeNull();
 
     rerender(renderIcon("checked"));
     await waitSchedule();
-
-    expect(frames.size).toBe(1);
-    expect(image.getAttribute("tint-color")).toBeNull();
 
     computedColor = "rgb(255, 102, 0)";
     runNextFrame();

--- a/packages/lynx-react/src/components/index.ts
+++ b/packages/lynx-react/src/components/index.ts
@@ -8,6 +8,7 @@ export * from "./Callout";
 export * from "./Checkbox";
 export * from "./Chip";
 export * from "./Count";
+export * from "./ContextualFloatingButton";
 export * from "./Divider";
 export * from "./Field";
 export * from "./Icon";


### PR DESCRIPTION
## 변경 내용

- `@seed-design/lynx-react`에 `ContextualFloatingButton`과 props 타입을 추가합니다.
- `solid`·`layer`, 텍스트·아이콘 전용 레이아웃, 눌림 피드백, 로딩·비활성 상태를 지원합니다.
- 기존 Rootage 규격으로 Lynx Recipe와 CSS를 생성하고, 공개 패키지를 직접 소비하는 문서 예제 6개를 연결합니다. 별도 Registry wrapper는 추가하지 않습니다.
- 기존 Icon 테스트에서 렌더 스케줄링에 의존하던 중간 단언만 제거했습니다. 아이콘 구현과 최종 색상 검증은 유지합니다.

## 검증

- [x] `bun test:all`: 일반 테스트 1,983개와 Lynx 테스트 319개 통과, Lynx 타입 검사 통과
- [x] Lynx preset 빌드·CSS 생성·공개 패키지 빌드
- [x] 문서 예제·tooling 타입 검사와 docs index 생성
- [x] 문서 예제 6개의 Web/Lynx 번들 빌드
- [x] iOS 26.5 Simulator에서 Solid·Layer·Icon Only·Float Composition·Loading 확인. 기본 Preview의 기존 통과 결과 재사용
- [x] 실제 공개 컴포넌트의 콜백 횟수로 disabled 입력 차단, loading 중 재탭 차단, 종료 후 입력 복구 확인. 임시 검증 consumer 삭제 완료
- [x] 실제 문서 페이지의 Props 표, 6개 코드 탭·미리보기·QR 대상 연결 확인
- [x] `git diff --check`

## 플랫폼 차이와 제한

- Lynx에서는 `bindtap`·`main-thread:bindtap`과 native 접근성 속성을 사용합니다. loading 중에도 클릭을 허용하는 React 참조와 달리 Lynx는 loading 중 탭을 차단합니다.
- Float Composition은 기존 Lynx `Box` 조합으로 300×500 frame의 bottom-center 배치를 구현합니다. 별도 `Float` 컴포넌트는 추가하지 않습니다.
- 웹 미리보기의 아이콘 색상 제약을 문서에 안내했습니다. 실제 Lynx 아이콘 색상은 네이티브에서 확인했습니다.
- Android 검증은 수행하지 않았습니다.

## 릴리스

- `@seed-design/lynx-react`, `@seed-design/lynx-css`: 승인된 `minor` changeset 포함
- PR base: `minor`
- Version Changes PR에서 새 Recipe를 소비하는 `@seed-design/lynx-react`의 `@seed-design/lynx-css` peer dependency 하한을 검토해야 합니다. 이 PR에서는 dependency range를 변경하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - Lynx용 `ContextualFloatingButton` 컴포넌트를 추가했습니다.
  - Solid 및 Layer 변형과 텍스트·아이콘 전용 레이아웃을 지원합니다.
  - 눌림 피드백, 로딩 표시, 비활성 상태 및 접근성 기능을 제공합니다.

- **문서**
  - 설치 방법, 속성, 사용 예시와 다양한 상태별 동작을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->