### PR TITLE
feat(skeleton): support line-height tokens for height

### DIFF
--- a/.changeset/tidy-skeleton-scales.md
+++ b/.changeset/tidy-skeleton-scales.md
@@ -1,0 +1,6 @@
+---
+"@seed-design/react": minor
+---
+
+Skeleton의 height에 line-height 토큰을 지원합니다.
+height="lineHeight.t4"처럼 지정해 글자 크기 설정에 맞춰 높이를 조절할 수 있습니다.

--- a/docs/content/react/components/skeleton.mdx
+++ b/docs/content/react/components/skeleton.mdx
@@ -30,6 +30,25 @@ import { Skeleton } from "@seed-design/react";
 
 ## Examples
 
+### Line Height
+
+텍스트를 대체하는 Skeleton에는 `height="lineHeight.t4"`처럼 텍스트와 같은 line-height 토큰을 지정할 수 있습니다.
+
+<ComponentExample name="react/skeleton/line-height">
+  ```json doc-gen:file
+  {
+    "file": "examples/react/skeleton/line-height.tsx",
+    "codeblock": true
+  }
+  ```
+</ComponentExample>
+
+반응형 높이에도 사용할 수 있습니다.
+
+```tsx
+<Skeleton height={{ base: "lineHeight.t4", md: "lineHeight.t5" }} width="full" />
+```
+
 ### Radius
 
 <ComponentExample name="react/skeleton/radius">

--- a/docs/examples/react/skeleton/line-height.tsx
+++ b/docs/examples/react/skeleton/line-height.tsx
@@ -1,0 +1,26 @@
+import { ActionButton, Skeleton, Text, VStack } from "@seed-design/react";
+import { useState } from "react";
+
+export default function SkeletonLineHeight() {
+  const [loading, setLoading] = useState(true);
+
+  return (
+    <VStack gap="x4" width="full">
+      <VStack gap="x2" alignItems="flex-start">
+        {loading ? (
+          <Skeleton height="lineHeight.t7" width="200px" />
+        ) : (
+          <Text textStyle="t7Bold">콘텐츠 제목</Text>
+        )}
+        {loading ? (
+          <Skeleton height="lineHeight.t4" width="250px" />
+        ) : (
+          <Text textStyle="t4Regular">불러온 콘텐츠입니다.</Text>
+        )}
+      </VStack>
+      <ActionButton variant="neutralWeak" onClick={() => setLoading((prev) => !prev)}>
+        {loading ? "콘텐츠 보기" : "Skeleton 보기"}
+      </ActionButton>
+    </VStack>
+  );
+}

--- a/docs/examples/react/skeleton/line-height.tsx
+++ b/docs/examples/react/skeleton/line-height.tsx
@@ -1,11 +1,12 @@
-import { ActionButton, Skeleton, Text, VStack } from "@seed-design/react";
+import { Skeleton, Text, VStack } from "@seed-design/react";
 import { useState } from "react";
+import { Switch } from "seed-design/ui/switch";
 
 export default function SkeletonLineHeight() {
   const [loading, setLoading] = useState(true);
 
   return (
-    <VStack gap="x4" width="full">
+    <VStack gap="x4" align="center">
       <VStack gap="x2" alignItems="flex-start">
         {loading ? (
           <Skeleton height="lineHeight.t7" width="200px" />
@@ -18,9 +19,7 @@ export default function SkeletonLineHeight() {
           <Text textStyle="t4Regular">불러온 콘텐츠입니다.</Text>
         )}
       </VStack>
-      <ActionButton variant="neutralWeak" onClick={() => setLoading((prev) => !prev)}>
-        {loading ? "콘텐츠 보기" : "Skeleton 보기"}
-      </ActionButton>
+      <Switch label="로딩 중" checked={loading} onCheckedChange={setLoading} />
     </VStack>
   );
 }

--- a/docs/stories/Skeleton.stories.tsx
+++ b/docs/stories/Skeleton.stories.tsx
@@ -10,13 +10,28 @@ const meta = preview.meta({
   component: Skeleton,
   decorators: [SeedThemeDecorator],
 });
+
+const conditionMap = {
+  height: {
+    "50px": { height: "50px" },
+    x4: { height: "x4" },
+    "lineHeight.t4": { height: "lineHeight.t4" },
+    "lineHeight.t7": { height: "lineHeight.t7" },
+    "lineHeight.t4Static": { height: "lineHeight.t4Static" },
+  },
+};
+
 const CommonStoryTemplate = meta.story({
   args: {
     width: "100%",
-    height: "50px",
   },
   render: (args, { component }) => (
-    <VariantTable Component={component!} variantMap={skeletonVariantMap} {...args} />
+    <VariantTable
+      Component={component!}
+      variantMap={skeletonVariantMap}
+      conditionMap={conditionMap}
+      {...args}
+    />
   ),
 });
 

--- a/packages/react/src/components/Skeleton/Skeleton.test.tsx
+++ b/packages/react/src/components/Skeleton/Skeleton.test.tsx
@@ -1,0 +1,101 @@
+import { vars } from "@seed-design/css/vars";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "bun:test";
+import { createRef } from "react";
+import { Box } from "../Box/Box";
+import { Skeleton } from "./Skeleton";
+
+describe("Skeleton", () => {
+  it.each(Object.entries(vars.$lineHeight))("resolves lineHeight.%s", (token, value) => {
+    const { getByTestId } = render(
+      <Skeleton data-testid="skeleton" height={`lineHeight.${token}`} />,
+    );
+
+    expect(getByTestId("skeleton").style.getPropertyValue("--seed-box-height-base")).toBe(value);
+  });
+
+  it("supports line-height and dimension tokens in responsive heights", () => {
+    const { getByTestId } = render(
+      <Skeleton
+        data-testid="skeleton"
+        height={{ base: "lineHeight.t4", sm: undefined, md: "lineHeight.t5", lg: "x8" }}
+      />,
+    );
+    const { style } = getByTestId("skeleton");
+
+    expect(style.getPropertyValue("--seed-box-height-base")).toBe(vars.$lineHeight.t4);
+    expect(style.getPropertyValue("--seed-box-height-sm")).toBe("");
+    expect(style.getPropertyValue("--seed-box-height-md")).toBe(vars.$lineHeight.t5);
+    expect(style.getPropertyValue("--seed-box-height-lg")).toBe(vars.$dimension.x8);
+  });
+
+  it.each([
+    [undefined, ""],
+    ["x4", vars.$dimension.x4],
+    ["spacingY.componentDefault", vars.$dimension.spacingY.componentDefault],
+    ["full", "100%"],
+    ["24px", "24px"],
+    ["50%", "50%"],
+    ["var(--custom-height)", "var(--custom-height)"],
+    ["lineHeight.invalid", "lineHeight.invalid"],
+    ["lineHeight.constructor", "lineHeight.constructor"],
+  ])("preserves existing height %s", (height, expected) => {
+    const { getByTestId } = render(<Skeleton data-testid="skeleton" height={height} />);
+
+    expect(getByTestId("skeleton").style.getPropertyValue("--seed-box-height-base")).toBe(expected);
+  });
+
+  it("preserves styles, recipe props, className and ref with asChild", () => {
+    const ref = createRef<HTMLDivElement>();
+    const { getByTestId } = render(
+      <Skeleton
+        ref={ref}
+        asChild
+        height="lineHeight.t4"
+        width="x8"
+        radius="full"
+        tone="magic"
+        className="custom"
+        style={{ height: "32px" }}
+      >
+        <div data-testid="skeleton" />
+      </Skeleton>,
+    );
+    const element = getByTestId("skeleton");
+
+    expect(ref.current === element).toBe(true);
+    expect(element).toHaveClass(
+      "seed-skeleton",
+      "seed-skeleton--radius_full",
+      "seed-skeleton--tone_magic",
+      "custom",
+    );
+    expect(element.style.height).toBe("32px");
+    expect(element.style.getPropertyValue("--seed-box-width-base")).toBe(vars.$dimension.x8);
+    expect(element).not.toHaveAttribute("height");
+    expect(element).not.toHaveAttribute("radius");
+  });
+
+  it("limits line-height token resolution to Skeleton height", () => {
+    const { getByTestId } = render(
+      <>
+        <Skeleton data-testid="skeleton" width="lineHeight.t4" />
+        <Box
+          data-testid="box"
+          height="lineHeight.t4"
+          minHeight="lineHeight.t4"
+          maxHeight="lineHeight.t4"
+        />
+      </>,
+    );
+
+    expect(getByTestId("skeleton").style.getPropertyValue("--seed-box-width-base")).toBe(
+      "lineHeight.t4",
+    );
+    for (const property of ["height", "min-height", "max-height"]) {
+      expect(getByTestId("box").style.getPropertyValue(`--seed-box-${property}-base`)).toBe(
+        "lineHeight.t4",
+      );
+    }
+  });
+});

--- a/packages/react/src/components/Skeleton/Skeleton.test.tsx
+++ b/packages/react/src/components/Skeleton/Skeleton.test.tsx
@@ -2,16 +2,17 @@ import { vars } from "@seed-design/css/vars";
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "bun:test";
 import { createRef } from "react";
-import { Box } from "../Box/Box";
 import { Skeleton } from "./Skeleton";
 
 describe("Skeleton", () => {
-  it.each(Object.entries(vars.$lineHeight))("resolves lineHeight.%s", (token, value) => {
+  it.each(["t4", "t4Static"] as const)("resolves lineHeight.%s", (token) => {
     const { getByTestId } = render(
       <Skeleton data-testid="skeleton" height={`lineHeight.${token}`} />,
     );
 
-    expect(getByTestId("skeleton").style.getPropertyValue("--seed-box-height-base")).toBe(value);
+    expect(getByTestId("skeleton").style.getPropertyValue("--seed-box-height-base")).toBe(
+      vars.$lineHeight[token],
+    );
   });
 
   it("supports line-height and dimension tokens in responsive heights", () => {
@@ -32,10 +33,7 @@ describe("Skeleton", () => {
   it.each([
     [undefined, ""],
     ["x4", vars.$dimension.x4],
-    ["spacingY.componentDefault", vars.$dimension.spacingY.componentDefault],
-    ["full", "100%"],
     ["24px", "24px"],
-    ["50%", "50%"],
     ["var(--custom-height)", "var(--custom-height)"],
     ["lineHeight.invalid", "lineHeight.invalid"],
     ["lineHeight.constructor", "lineHeight.constructor"],
@@ -45,7 +43,7 @@ describe("Skeleton", () => {
     expect(getByTestId("skeleton").style.getPropertyValue("--seed-box-height-base")).toBe(expected);
   });
 
-  it("preserves styles, recipe props, className and ref with asChild", () => {
+  it("preserves styles, className and ref with asChild", () => {
     const ref = createRef<HTMLDivElement>();
     const { getByTestId } = render(
       <Skeleton
@@ -53,8 +51,6 @@ describe("Skeleton", () => {
         asChild
         height="lineHeight.t4"
         width="x8"
-        radius="full"
-        tone="magic"
         className="custom"
         style={{ height: "32px" }}
       >
@@ -63,39 +59,10 @@ describe("Skeleton", () => {
     );
     const element = getByTestId("skeleton");
 
-    expect(ref.current === element).toBe(true);
-    expect(element).toHaveClass(
-      "seed-skeleton",
-      "seed-skeleton--radius_full",
-      "seed-skeleton--tone_magic",
-      "custom",
-    );
+    expect(ref.current).toBe(element);
+    expect(element).toHaveClass("custom");
     expect(element.style.height).toBe("32px");
     expect(element.style.getPropertyValue("--seed-box-width-base")).toBe(vars.$dimension.x8);
     expect(element).not.toHaveAttribute("height");
-    expect(element).not.toHaveAttribute("radius");
-  });
-
-  it("limits line-height token resolution to Skeleton height", () => {
-    const { getByTestId } = render(
-      <>
-        <Skeleton data-testid="skeleton" width="lineHeight.t4" />
-        <Box
-          data-testid="box"
-          height="lineHeight.t4"
-          minHeight="lineHeight.t4"
-          maxHeight="lineHeight.t4"
-        />
-      </>,
-    );
-
-    expect(getByTestId("skeleton").style.getPropertyValue("--seed-box-width-base")).toBe(
-      "lineHeight.t4",
-    );
-    for (const property of ["height", "min-height", "max-height"]) {
-      expect(getByTestId("box").style.getPropertyValue(`--seed-box-${property}-base`)).toBe(
-        "lineHeight.t4",
-      );
-    }
   });
 });

--- a/packages/react/src/components/Skeleton/Skeleton.tsx
+++ b/packages/react/src/components/Skeleton/Skeleton.tsx
@@ -1,15 +1,47 @@
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";
 import { skeleton, type SkeletonVariantProps } from "@seed-design/css/recipes/skeleton";
+import { vars, type LineHeight } from "@seed-design/css/vars";
 import type * as React from "react";
+import { forwardRef } from "react";
+import {
+  isResponsiveObject,
+  type ResponsiveValue,
+  type UnwrapResponsive,
+} from "../../types/responsive";
 import { createRecipeContext } from "../../utils/createRecipeContext";
-import { withStyleProps, type StyleProps } from "../../utils/styled";
+import { useStyleProps, type StyleProps } from "../../utils/styled";
 
 const { withContext } = createRecipeContext(skeleton);
 
 export interface SkeletonProps
   extends SkeletonVariantProps,
     PrimitiveProps,
-    Pick<StyleProps, "height" | "width">,
-    Omit<React.HTMLAttributes<HTMLDivElement>, "color"> {}
+    Pick<StyleProps, "width">,
+    Omit<React.HTMLAttributes<HTMLDivElement>, "color"> {
+  height?: ResponsiveValue<UnwrapResponsive<StyleProps["height"]> | `lineHeight.${LineHeight}`>;
+}
 
-export const Skeleton = withContext<HTMLDivElement, SkeletonProps>(withStyleProps(Primitive.div));
+function handleHeight(height: string | undefined) {
+  if (!height?.startsWith("lineHeight.")) return height;
+
+  const value = vars.$lineHeight[height.slice("lineHeight.".length) as LineHeight];
+
+  return typeof value === "string" ? value : height;
+}
+
+export const Skeleton = withContext<HTMLDivElement, SkeletonProps>(
+  forwardRef<HTMLDivElement, SkeletonProps>(function Skeleton({ height, ...props }, ref) {
+    const { style, restProps } = useStyleProps({
+      ...props,
+      height: isResponsiveObject(height)
+        ? Object.fromEntries(
+            Object.entries(height).map(([key, value]) => [key, handleHeight(value)]),
+          )
+        : handleHeight(height),
+    });
+
+    return <Primitive.div ref={ref} style={style} {...restProps} />;
+  }),
+);
+
+Skeleton.displayName = "Skeleton";

--- a/skills/seed-create-component/references/storybook.md
+++ b/skills/seed-create-component/references/storybook.md
@@ -73,6 +73,29 @@ render: (args, { component }) => (
 
 variant/condition 매핑은 story 밖의 상수로 유지하고 `VariantTable`에 전달한다. mapping 함수가 render 대상 컴포넌트를 받으면 `meta.component` 대신 context의 `component`를 전달한다. wrapper가 상태나 레이아웃을 소유하면 wrapper를 `meta.component`로 지정하거나 기존 명시적 wrapper 전달을 유지한다.
 
+- `variantMap`: Recipe에서 생성한 `*VariantMap`을 전달해 `size`, `tone` 등 Recipe variant를 조합한다.
+- `conditionMap`: 높이, 반응형 값, 여러 prop의 묶음처럼 Recipe 밖의 케이스를 `{ 축: { 케이스명: 전달할 props } }`로 정의한다. 케이스명은 표의 라벨이며 실제 컴포넌트에는 안쪽 props가 전달된다.
+- `VariantTable`은 두 map의 축을 모두 조합한다. prop 값만 다른 케이스는 기존 공통 template의 `conditionMap`을 확장해 네 테마·글자 크기 story에 함께 적용한다. 같은 축이 두 map에 있으면 `conditionMap`이 해당 축의 값 목록과 전달 props를 대체한다.
+
+Skeleton의 높이 케이스를 정의하고 공통 template의 render에 연결하는 예시다.
+
+```tsx
+const conditionMap = {
+  height: {
+    "50px": { height: "50px" },
+    "lineHeight.t4": { height: "lineHeight.t4" },
+    responsive: { height: { base: "lineHeight.t4", md: "lineHeight.t5" } },
+  },
+};
+
+<VariantTable
+  Component={component!}
+  variantMap={skeletonVariantMap}
+  conditionMap={conditionMap}
+  {...args}
+/>
+```
+
 ## custom parameters와 Chromatic
 
 `theme`과 `fontScale` 타입은 `docs/.storybook/preview.ts`의 다음 확장으로 관리한다.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - Skeleton 컴포넌트의 높이에 `lineHeight` 토큰을 사용할 수 있습니다.
  - 텍스트의 글자 크기에 맞춰 높이를 설정할 수 있으며, 반응형 높이도 지원합니다.
  - 픽셀, 비율 등 기존 높이 값도 계속 사용할 수 있습니다.

- **문서**
  - line-height 기반 높이 설정과 반응형 사용 예제가 추가되었습니다.

- **테스트**
  - Skeleton의 line-height 토큰 처리와 다양한 높이 조건에 대한 검증이 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->