### PR TITLE
docs(lynx): clarify scale feedback support on engine 3.6

### DIFF
--- a/docs/content/lynx/components/accordion.mdx
+++ b/docs/content/lynx/components/accordion.mdx
@@ -3,7 +3,7 @@ title: Accordion
 description: 관련된 정보 섹션을 접고 펼쳐 화면을 간결하게 구성하는 컴포넌트입니다.
 compatibility:
   lynx:
-    engine: "3.9"
+    engine: "3.6"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.5.0, @seed-design/lynx-css@0.9.0" />

--- a/docs/content/lynx/components/action-button.mdx
+++ b/docs/content/lynx/components/action-button.mdx
@@ -3,7 +3,7 @@ title: Action Button
 description: 명확한 액션을 쉽게 수행할 수 있도록 돕는 기본 인터랙션 컴포넌트입니다.
 compatibility:
   lynx:
-    engine: "3.9"
+    engine: "3.6"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/callout.mdx
+++ b/docs/content/lynx/components/callout.mdx
@@ -3,7 +3,7 @@ title: Callout
 description: 사용자에게 중요한 정보나 팁을 시각적으로 강조하여 전달하는 메시지 컴포넌트입니다.
 compatibility:
   lynx:
-    engine: "3.9"
+    engine: "3.6"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.5.0, @seed-design/lynx-css@0.9.0" />

--- a/docs/content/lynx/components/checkbox.mdx
+++ b/docs/content/lynx/components/checkbox.mdx
@@ -3,7 +3,7 @@ title: Checkbox
 description: 사용자가 하나 이상의 옵션을 선택할 수 있게 해주는 컴포넌트입니다. 목록에서 여러 항목을 선택하거나 약관 동의와 같은 선택적 작업에 사용됩니다.
 compatibility:
   lynx:
-    engine: "3.9"
+    engine: "3.6"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/chip.mdx
+++ b/docs/content/lynx/components/chip.mdx
@@ -3,7 +3,7 @@ title: Chip
 description: 사용자가 선택하거나 실행할 수 있는 짧은 값을 표시하는 컴포넌트입니다.
 compatibility:
   lynx:
-    engine: "3.9"
+    engine: "3.6"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.5.0, @seed-design/lynx-css@0.9.0" />

--- a/docs/content/lynx/components/concepts/scale-feedback.mdx
+++ b/docs/content/lynx/components/concepts/scale-feedback.mdx
@@ -4,7 +4,7 @@ description: Lynx에서 Main Thread 기반의 SEED Scale Feedback을 적용하�
 featured: true
 compatibility:
   lynx:
-    engine: "3.9"
+    engine: "3.6"
 ---
 
 SEED의 Scale Feedback은 누르는 동안 요소를 살짝 줄여 입력이 도달했음을 즉시 전달합니다. 고정된 배율을 쓰지 않고 렌더된 크기에서 배율을 계산하므로 작은 아이콘 버튼과 화면 폭을 채우는 요소가 비슷한 눌림 거리로 반응합니다.
@@ -181,7 +181,7 @@ GlobalProps 객체 자체가 없을 때도 기본 동작을 사용합니다. `mo
 
 ## 참고 자료
 
-- [Lynx 3.9 Main Thread Script](https://lynxjs.org/3.9/react/main-thread-script.html)
-- [Lynx Rendering Process and Lifecycle](https://lynxjs.org/3.9/react/lifecycle.html)
+- [Lynx 3.6 Main Thread Script](https://lynxjs.org/3.6/react/main-thread-script.html)
+- [Lynx Rendering Process and Lifecycle](https://lynxjs.org/3.6/react/lifecycle.html)
 - [SEED Scale Foundation](/foundations/feedback/scale)
 - [React Scale Feedback](/react/components/concepts/scale-feedback)

--- a/docs/content/lynx/components/radio-group.mdx
+++ b/docs/content/lynx/components/radio-group.mdx
@@ -3,7 +3,7 @@ title: Radio Group
 description: 사용자가 여러 옵션 중 하나만 선택할 수 있게 하는 라디오 그룹 컴포넌트입니다.
 compatibility:
   lynx:
-    engine: "3.9"
+    engine: "3.6"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/switch.mdx
+++ b/docs/content/lynx/components/switch.mdx
@@ -3,7 +3,7 @@ title: Switch
 description: 특정 설정 및 상태를 즉시 켜거나 끌 수 있도록 하는 컴포넌트입니다.
 compatibility:
   lynx:
-    engine: "3.9"
+    engine: "3.6"
 ---
 
 <AvailableSince packages="@seed-design/lynx-react@0.1.0, @seed-design/lynx-css@0.1.0" />

--- a/docs/content/lynx/components/tabs.mdx
+++ b/docs/content/lynx/components/tabs.mdx
@@ -3,7 +3,7 @@ title: Tabs
 description: 한 화면의 콘텐츠를 탭 단위로 구분하고, 탭 선택이나 좌우 스와이프로 전환하는 컴포넌트입니다.
 compatibility:
   lynx:
-    engine: "3.9"
+    engine: "3.6"
     x-elements:
       - viewpager
       - viewpager-item

--- a/packages/lynx-react/src/hooks/useScaleFeedback.ts
+++ b/packages/lynx-react/src/hooks/useScaleFeedback.ts
@@ -119,7 +119,7 @@ function readScaleFeedbackScale(target: ScaleFeedbackElement | null): number | n
  * The target's transform is owned by this hook. Use a separate content layer
  * when the element already uses translate, rotate, or another transform.
  *
- * Supported on Lynx Engine 3.9 and later. Missing or unknown
+ * Supported on Lynx Engine 3.6 and later. Missing or unknown
  * `GlobalProps.motion` values preserve the default motion; only the exact
  * `"reduced"` value disables scaling.
  */


### PR DESCRIPTION
Scale Feedback의 최소 지원 버전이 3.9로 표시되어 3.6 환경에서 사용할 수 없는 것으로 읽히던 문서를 정정합니다. 사용자의 Lynx Engine 3.6 실기기 동작 확인을 근거로 Scale Feedback과 이를 사용하는 8개 컴포넌트의 지원 배지, 훅 JSDoc을 3.6으로 맞추고 공식 참고 링크도 3.6으로 변경합니다.

Menu의 최소 버전 3.9, 기존 CHANGELOG, 의존성 및 bundle target은 유지합니다. 런타임 코드 변경이 없는 문서·주석 정정으로 changeset은 추가하지 않습니다.

검증:
- 문서 호환성 테스트: 10 pass
- 승인한 10개 파일과 주석 외 코드 변경 없음 확인, git diff --check 통과
- 교체한 공식 3.6 문서 링크 확인
- 네이티브 검증 근거는 사용자의 3.6 실기기 확인이며, 이 PR 작업에서 별도로 재실행하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * Accordion, Action Button, Callout 등 Lynx 컴포넌트의 호환 엔진 버전을 3.9에서 3.6으로 업데이트했습니다.
  * Scale Feedback 문서의 호환 버전과 참고 링크를 업데이트했습니다.
* **문서화**
  * `useScaleFeedback`가 Lynx Engine 3.6 이상에서 지원됨을 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->