### PR TITLE
feat(lynx): add chip tabs with scroll alignment

### DIFF
--- a/.changeset/calm-chips-arrive.md
+++ b/.changeset/calm-chips-arrive.md
@@ -1,0 +1,6 @@
+---
+"@seed-design/lynx-react": minor
+"@seed-design/lynx-css": minor
+---
+
+Lynx 플랫폼에 Chip Tabs 컴포넌트를 추가합니다.

--- a/docs/content/lynx/components/chip-tabs.mdx
+++ b/docs/content/lynx/components/chip-tabs.mdx
@@ -1,0 +1,236 @@
+---
+title: Chip Tabs
+description: Chip 형태로 표현된 탭 컴포넌트입니다. 카테고리나 필터를 선택하여 콘텐츠를 전환할 때 사용합니다.
+compatibility:
+  lynx:
+    engine: "3.9"
+    x-elements:
+      - viewpager
+      - viewpager-item
+---
+
+<AvailableSince packages="@seed-design/lynx-react@0.8.0, @seed-design/lynx-css@0.12.0" />
+
+<LynxComponentExample name="lynx/chip-tabs/preview">
+  ```json doc-gen:file
+  {"file":"examples/lynx/chip-tabs/preview.tsx","codeblock":true}
+  ```
+</LynxComponentExample>
+
+## Installation
+
+```package-install
+npx @seed-design/cli add ui:chip-tabs
+```
+
+<LynxManualInstallation name="chip-tabs" />
+
+## Props
+
+### `ChipTabsRoot`
+
+<react-type-table path="./registry/lynx/ui/chip-tabs.tsx" name="ChipTabsRootProps" />
+
+### `ChipTabsList`
+
+<react-type-table path="./registry/lynx/ui/chip-tabs.tsx" name="ChipTabsListProps" />
+
+### `ChipTabsTrigger`
+
+<react-type-table path="./registry/lynx/ui/chip-tabs.tsx" name="ChipTabsTriggerProps" />
+
+### `ChipTabsCarousel`
+
+<react-type-table path="./registry/lynx/ui/chip-tabs.tsx" name="ChipTabsCarouselProps" />
+
+### `ChipTabsContent`
+
+<react-type-table path="./registry/lynx/ui/chip-tabs.tsx" name="ChipTabsContentProps" />
+
+## Usage
+
+```tsx
+import { useState } from "@lynx-js/react";
+import {
+  ChipTabsList,
+  ChipTabsRoot,
+  ChipTabsTrigger,
+} from "@/components/ui/chip-tabs";
+
+export function App() {
+  const [value, setValue] = useState("1");
+
+  function handleValueChange(nextValue: string) {
+    "background only";
+    setValue(nextValue);
+  }
+
+  return (
+    <>
+      <ChipTabsRoot value={value} onValueChange={handleValueChange}>
+        <ChipTabsList>
+          <ChipTabsTrigger value="1">라벨1</ChipTabsTrigger>
+          <ChipTabsTrigger value="2">라벨2</ChipTabsTrigger>
+          <ChipTabsTrigger value="3">라벨3</ChipTabsTrigger>
+        </ChipTabsList>
+      </ChipTabsRoot>
+      {value === "1" && <text>content 1</text>}
+      {value === "2" && <text>content 2</text>}
+      {value === "3" && <text>content 3</text>}
+    </>
+  );
+}
+```
+
+`ChipTabsRoot`는 `value`와 `onValueChange`로 제어하거나 `defaultValue`로 초기 선택 값을 지정합니다. `ChipTabsTrigger`의 `notification` boolean은 label 옆 6px 간격에 작은 `NotificationBadge`를 표시합니다.
+
+`ChipTabsCarousel`은 Registry에서 `ChipTabsCarouselCamera`를 조립하므로 `ChipTabsContent`만 자식으로 전달합니다. Carousel은 native `<viewpager>`이므로 Carousel 또는 Camera에 앱 레이아웃에 맞는 높이를 명시하고, `swipeable`로 좌우 스와이프를 켭니다. iOS의 화면 왼쪽 가장자리 뒤로가기 제스처를 우선할 범위는 `iosBackGestureEdgeWidth`로 정합니다.
+
+공개 package API에서 Camera의 native `bindchange`, `bindwillchange`, `bindoffsetchange`를 직접 사용해야 할 때는 `ChipTabs.CarouselCamera`를 조합합니다. `onSwipeStart`, `onSwipeEnd`, `onSettle`은 Carousel에 전달해 스와이프 시작·종료·정착을 처리할 수 있습니다.
+
+```tsx
+import { useState } from "@lynx-js/react";
+import { ChipTabs } from "@seed-design/lynx-react";
+
+export function App() {
+  const [lastEvent, setLastEvent] = useState("대기");
+
+  function handleSwipeStart() {
+    "background only";
+    setLastEvent("스와이프 시작");
+  }
+
+  function handleSwipeEnd() {
+    "background only";
+    setLastEvent("스와이프 종료");
+  }
+
+  function handleSettle() {
+    "background only";
+    setLastEvent("정착");
+  }
+
+  return (
+    <ChipTabs.Root defaultValue="1">
+      <ChipTabs.List>
+        <ChipTabs.Trigger value="1">라벨1</ChipTabs.Trigger>
+        <ChipTabs.Trigger value="2">라벨2</ChipTabs.Trigger>
+      </ChipTabs.List>
+      <ChipTabs.Carousel
+        style={{ height: "240px" }}
+        swipeable
+        iosBackGestureEdgeWidth={32}
+        onSwipeStart={handleSwipeStart}
+        onSwipeEnd={handleSwipeEnd}
+        onSettle={handleSettle}
+      >
+        <ChipTabs.CarouselCamera>
+          <ChipTabs.Content value="1"><text>content 1</text></ChipTabs.Content>
+          <ChipTabs.Content value="2"><text>content 2</text></ChipTabs.Content>
+        </ChipTabs.CarouselCamera>
+      </ChipTabs.Carousel>
+      <text>{lastEvent}</text>
+    </ChipTabs.Root>
+  );
+}
+```
+
+## Scroll Alignment
+
+`ChipTabsList`의 `scrollAlign`은 선택한 chip을 가로 목록에 맞추는 방식입니다. `"nearest"`, `"start"`, `"center"`, `"end"`를 사용할 수 있으며 기본값은 `"nearest"`입니다.
+
+- `"start"`, `"center"`, `"end"`는 선택한 chip을 각각 목록의 시작, 가운데, 끝에 맞춥니다.
+- `"nearest"`는 React Web의 최소 스크롤 동작과 같이 선택한 chip이 완전히 보이면 현재 위치를 유지합니다. 왼쪽이 잘렸을 때는 시작 경계까지, 오른쪽이 잘렸을 때는 끝 경계까지 필요한 만큼만 이동하므로 `"end"`처럼 항상 끝에 맞추지 않습니다.
+
+실제 chip의 너비와 위치, viewport를 기준으로 계산하며, 가변 너비 chip도 그대로 유지합니다. 목록의 첫·마지막 항목을 가운데에 맞추기 위해 빈 공간을 추가하지 않고 스크롤 가능한 범위 안에서만 이동하며 항목 순서도 바꾸지 않습니다.
+
+
+아래 예제에서 모드를 고르면 선택을 `라벨1`로 초기화합니다. 그 뒤 `라벨6`을 탭하거나 `6번 선택`을 탭해 controlled `value` 변경에서도 실제 scrollAlign 차이를 확인하세요. `nearest`를 고르면 `scrollAlign` prop을 생략하여 기본 동작도 함께 확인합니다.
+
+<LynxComponentExample name="lynx/chip-tabs/scroll-alignment">
+  ```json doc-gen:file
+  {"file":"examples/lynx/chip-tabs/scroll-alignment.tsx","codeblock":true}
+  ```
+</LynxComponentExample>
+
+`nearest`에서 선택한 chip이 이미 완전히 보인 상태로 다시 선택하면 이동하지 않습니다. 목록을 직접 스크롤한 뒤에도 다음 선택이 필요한 경우에만 이동합니다.
+
+
+## Examples
+
+### Size=Medium
+
+`medium`의 최소 높이는 36px입니다.
+
+<LynxComponentExample name="lynx/chip-tabs/size-medium">
+  ```json doc-gen:file
+  {"file":"examples/lynx/chip-tabs/size-medium.tsx","codeblock":true}
+  ```
+</LynxComponentExample>
+
+### Size=Large
+
+`large`의 최소 높이는 40px입니다.
+
+<LynxComponentExample name="lynx/chip-tabs/size-large">
+  ```json doc-gen:file
+  {"file":"examples/lynx/chip-tabs/size-large.tsx","codeblock":true}
+  ```
+</LynxComponentExample>
+
+### Variant=Neutral Solid
+
+<LynxComponentExample name="lynx/chip-tabs/variant-neutral-solid">
+  ```json doc-gen:file
+  {"file":"examples/lynx/chip-tabs/variant-neutral-solid.tsx","codeblock":true}
+  ```
+</LynxComponentExample>
+
+### Variant=Neutral Outline
+
+<LynxComponentExample name="lynx/chip-tabs/variant-neutral-outline">
+  ```json doc-gen:file
+  {"file":"examples/lynx/chip-tabs/variant-neutral-outline.tsx","codeblock":true}
+  ```
+</LynxComponentExample>
+
+### Notification
+
+<LynxComponentExample name="lynx/chip-tabs/notification">
+  ```json doc-gen:file
+  {"file":"examples/lynx/chip-tabs/notification.tsx","codeblock":true}
+  ```
+</LynxComponentExample>
+
+### With Scroll Fog
+
+`ScrollFog`는 Lynx Registry와 package에서 지원하지 않으므로 가장자리 fade를 제공하지 않습니다.
+
+대신 스크롤 가능한 목록으로 많은 탭을 표시할 수 있습니다. `ChipTabsList`는 native 가로 `scroll-view`를 사용하며, 아래 예제는 최대 너비 360px 안에 15개 라벨을 표시합니다. List의 내부 좌우 padding 16px을 그대로 사용하므로 추가 좌우 padding을 지정하지 않습니다. Web `ScrollFog` 예제의 20px padding은 fog 배치를 위한 값이며 Lynx 목록에 적용하지 않습니다.
+
+<LynxComponentExample name="lynx/chip-tabs/scrollable">
+  ```json doc-gen:file
+  {"file":"examples/lynx/chip-tabs/scrollable.tsx","codeblock":true}
+  ```
+</LynxComponentExample>
+
+## Web Version Differences
+
+| 항목 | React Web | Lynx |
+|---|---|---|
+| 렌더링 요소 | HTML `div`, `button` | 네이티브 `view`, `text`, `scroll-view`, `viewpager` |
+| 탭 선택 이벤트 | `onClick` 기반 | `bindtap` 기반, 공개 상태 이벤트는 `onValueChange` |
+| 콘텐츠 | Root 바깥의 조건부 `div`도 사용 가능 | Root 바깥에서 value에 따른 조건부 native `text`를 렌더링할 수 있음 |
+| 가로 List | CSS overflow | 네이티브 가로 `scroll-view` |
+| Carousel | 웹 Carousel | 네이티브 `<viewpager>` |
+
+React 예제와 마찬가지로 Lynx에서도 Root 바깥에서 선택 값에 따라 조건부 native `text` 콘텐츠를 렌더링할 수 있습니다. 별도 AppBar, 화면 shell, CTA, asset은 제공하지 않습니다.
+
+## Unsupported Lynx Features
+
+- `ScrollFog`와 가장자리 fade
+- 키보드 포커스와 roving focus
+- RTL 순서와 스와이프 방향 반전
+- `lazyMount`, `unmountOnExit`: native viewpager는 모든 page slot을 유지합니다.
+- Carousel의 `loop`, `autoHeight`, `dragThreshold`, `carouselPreventDrag`
+- 콘텐츠 전환 애니메이션

--- a/docs/content/lynx/components/tabs.mdx
+++ b/docs/content/lynx/components/tabs.mdx
@@ -84,6 +84,9 @@ Registry의 `TabsList`는 `Tabs.Indicator`를 자동으로 추가합니다. `Tab
 
 iOS에서는 화면 왼쪽 32px 안에서 시작하는 뒤로가기 제스처를 우선합니다. 앱의 제스처 영역과 맞춰야 한다면 `iosBackGestureEdgeWidth`로 너비를 조정하세요.
 
+`TabsList`의 `scrollAlign`은 선택한 tab을 가로 목록에 맞추는 방식이며 `"nearest"`, `"start"`, `"center"`, `"end"`를 사용할 수 있습니다. 기본값은 `"start"`로 선택한 tab을 목록 시작에 맞춥니다. Chip Tabs의 `ChipTabsList`는 같은 옵션을 지원하지만 기본값이 `"nearest"`입니다.
+
+
 ## Examples
 
 ### Layout Fill (Default)

--- a/docs/examples/lynx/chip-tabs/notification.tsx
+++ b/docs/examples/lynx/chip-tabs/notification.tsx
@@ -1,0 +1,38 @@
+import "./styles";
+
+import { useState } from "@lynx-js/react";
+import { useSeedClassName } from "@seed-design/lynx-react";
+import { ChipTabsList, ChipTabsRoot, ChipTabsTrigger } from "@/components/ui/chip-tabs";
+
+export default function Example() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+  const [value, setValue] = useState("1");
+
+  function handleValueChange(nextValue: string) {
+    "background only";
+    setValue(nextValue);
+  }
+
+  return (
+    <view className={`${seedClassName} docs-lynx-chip-tabs-root`}>
+      <ChipTabsRoot
+        variant="neutralOutline"
+        size="medium"
+        defaultValue="1"
+        value={value}
+        onValueChange={handleValueChange}
+      >
+        <ChipTabsList>
+          <ChipTabsTrigger notification value="1">
+            라벨1
+          </ChipTabsTrigger>
+          <ChipTabsTrigger value="2">라벨2</ChipTabsTrigger>
+          <ChipTabsTrigger value="3">라벨3</ChipTabsTrigger>
+        </ChipTabsList>
+      </ChipTabsRoot>
+      {value === "1" && <text className="chip-tabs-preview__content-text">content 1</text>}
+      {value === "2" && <text className="chip-tabs-preview__content-text">content 2</text>}
+      {value === "3" && <text className="chip-tabs-preview__content-text">content 3</text>}
+    </view>
+  );
+}

--- a/docs/examples/lynx/chip-tabs/preview.css
+++ b/docs/examples/lynx/chip-tabs/preview.css
@@ -1,0 +1,9 @@
+.docs-lynx-chip-tabs-root {
+  height: 100%;
+  background-color: var(--seed-color-bg-layer-default);
+}
+
+.chip-tabs-preview__content-text {
+  color: var(--seed-color-fg-neutral);
+  font-size: 16px;
+}

--- a/docs/examples/lynx/chip-tabs/preview.tsx
+++ b/docs/examples/lynx/chip-tabs/preview.tsx
@@ -1,0 +1,36 @@
+import "./styles";
+
+import { useState } from "@lynx-js/react";
+import { useSeedClassName } from "@seed-design/lynx-react";
+import { ChipTabsList, ChipTabsRoot, ChipTabsTrigger } from "@/components/ui/chip-tabs";
+
+export default function Example() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+  const [value, setValue] = useState("1");
+
+  function handleValueChange(nextValue: string) {
+    "background only";
+    setValue(nextValue);
+  }
+
+  return (
+    <view className={`${seedClassName} docs-lynx-chip-tabs-root`}>
+      <ChipTabsRoot
+        variant="neutralSolid"
+        size="medium"
+        defaultValue="1"
+        value={value}
+        onValueChange={handleValueChange}
+      >
+        <ChipTabsList>
+          <ChipTabsTrigger value="1">라벨1</ChipTabsTrigger>
+          <ChipTabsTrigger value="2">라벨2</ChipTabsTrigger>
+          <ChipTabsTrigger value="3">라벨3</ChipTabsTrigger>
+        </ChipTabsList>
+      </ChipTabsRoot>
+      {value === "1" && <text className="chip-tabs-preview__content-text">content 1</text>}
+      {value === "2" && <text className="chip-tabs-preview__content-text">content 2</text>}
+      {value === "3" && <text className="chip-tabs-preview__content-text">content 3</text>}
+    </view>
+  );
+}

--- a/docs/examples/lynx/chip-tabs/scroll-alignment.tsx
+++ b/docs/examples/lynx/chip-tabs/scroll-alignment.tsx
@@ -1,0 +1,84 @@
+import "./styles";
+
+import { useState } from "@lynx-js/react";
+import { ActionButton, Box, HStack, Text, useSeedClassName, VStack } from "@seed-design/lynx-react";
+import {
+  ChipTabsList,
+  ChipTabsRoot,
+  ChipTabsTrigger,
+  type ChipTabsListProps,
+} from "@/components/ui/chip-tabs";
+
+type ScrollAlign = NonNullable<ChipTabsListProps["scrollAlign"]>;
+
+const ALIGNMENTS: ScrollAlign[] = ["nearest", "start", "center", "end"];
+const LABELS = Array.from({ length: 15 }, (_, index) => String(index + 1));
+
+export default function Example() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+  const [value, setValue] = useState("1");
+  const [scrollAlign, setScrollAlign] = useState<ScrollAlign>("nearest");
+
+  function handleValueChange(nextValue: string) {
+    "background only";
+    setValue(nextValue);
+  }
+
+  function selectScrollAlign(nextScrollAlign: ScrollAlign) {
+    "background only";
+    setScrollAlign(nextScrollAlign);
+    setValue("1");
+  }
+
+  function selectSixthChip() {
+    "background only";
+    setValue("6");
+  }
+
+  return (
+    <view className={`${seedClassName} docs-lynx-chip-tabs-root chip-tabs-scroll-alignment`}>
+      <VStack gap="x3">
+        <HStack className="chip-tabs-scroll-alignment__controls" wrap="wrap" gap="x2" p="x4">
+          {ALIGNMENTS.map((nextScrollAlign) => (
+            <ActionButton
+              key={nextScrollAlign}
+              className={`chip-tabs-scroll-alignment__mode-button chip-tabs-scroll-alignment__mode-button--${nextScrollAlign}`}
+              variant={scrollAlign === nextScrollAlign ? "neutralSolid" : "neutralOutline"}
+              bindtap={() => {
+                "background only";
+                selectScrollAlign(nextScrollAlign);
+              }}
+            >
+              {nextScrollAlign}
+            </ActionButton>
+          ))}
+          <ActionButton
+            className="chip-tabs-scroll-alignment__select-sixth-button"
+            variant="neutralOutline"
+            bindtap={selectSixthChip}
+          >
+            6번 선택
+          </ActionButton>
+        </HStack>
+
+        <Box px="x4">
+          <Text className="chip-tabs-scroll-alignment__selected-value" textStyle="t5Regular">
+            {`선택: 라벨${value}`}
+          </Text>
+        </Box>
+
+        <Box className="chip-tabs-scroll-alignment__list-frame" width="360px" maxWidth="100%">
+          <ChipTabsRoot value={value} onValueChange={handleValueChange}>
+            <ChipTabsList scrollAlign={scrollAlign === "nearest" ? undefined : scrollAlign}>
+              {LABELS.map((label) => (
+                <ChipTabsTrigger key={label} value={label}>
+                  {`라벨${label}`}
+                </ChipTabsTrigger>
+              ))}
+            </ChipTabsList>
+          </ChipTabsRoot>
+        </Box>
+      </VStack>
+    </view>
+  );
+}

--- a/docs/examples/lynx/chip-tabs/scrollable.tsx
+++ b/docs/examples/lynx/chip-tabs/scrollable.tsx
@@ -1,0 +1,32 @@
+import "./styles";
+
+import { useSeedClassName } from "@seed-design/lynx-react";
+import { ChipTabsList, ChipTabsRoot, ChipTabsTrigger } from "@/components/ui/chip-tabs";
+
+export default function Example() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+
+  return (
+    <view className={seedClassName} style={{ maxWidth: "360px" }}>
+      <ChipTabsRoot defaultValue="1">
+        <ChipTabsList>
+          <ChipTabsTrigger value="1">라벨1</ChipTabsTrigger>
+          <ChipTabsTrigger value="2">라벨2</ChipTabsTrigger>
+          <ChipTabsTrigger value="3">라벨3</ChipTabsTrigger>
+          <ChipTabsTrigger value="4">라벨4</ChipTabsTrigger>
+          <ChipTabsTrigger value="5">라벨5</ChipTabsTrigger>
+          <ChipTabsTrigger value="6">라벨6</ChipTabsTrigger>
+          <ChipTabsTrigger value="7">라벨7</ChipTabsTrigger>
+          <ChipTabsTrigger value="8">라벨8</ChipTabsTrigger>
+          <ChipTabsTrigger value="9">라벨9</ChipTabsTrigger>
+          <ChipTabsTrigger value="10">라벨10</ChipTabsTrigger>
+          <ChipTabsTrigger value="11">라벨11</ChipTabsTrigger>
+          <ChipTabsTrigger value="12">라벨12</ChipTabsTrigger>
+          <ChipTabsTrigger value="13">라벨13</ChipTabsTrigger>
+          <ChipTabsTrigger value="14">라벨14</ChipTabsTrigger>
+          <ChipTabsTrigger value="15">라벨15</ChipTabsTrigger>
+        </ChipTabsList>
+      </ChipTabsRoot>
+    </view>
+  );
+}

--- a/docs/examples/lynx/chip-tabs/size-large.tsx
+++ b/docs/examples/lynx/chip-tabs/size-large.tsx
@@ -1,0 +1,36 @@
+import "./styles";
+
+import { useState } from "@lynx-js/react";
+import { useSeedClassName } from "@seed-design/lynx-react";
+import { ChipTabsList, ChipTabsRoot, ChipTabsTrigger } from "@/components/ui/chip-tabs";
+
+export default function Example() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+  const [value, setValue] = useState("1");
+
+  function handleValueChange(nextValue: string) {
+    "background only";
+    setValue(nextValue);
+  }
+
+  return (
+    <view className={`${seedClassName} docs-lynx-chip-tabs-root`}>
+      <ChipTabsRoot
+        variant="neutralSolid"
+        size="large"
+        defaultValue="1"
+        value={value}
+        onValueChange={handleValueChange}
+      >
+        <ChipTabsList>
+          <ChipTabsTrigger value="1">라벨1</ChipTabsTrigger>
+          <ChipTabsTrigger value="2">라벨2</ChipTabsTrigger>
+          <ChipTabsTrigger value="3">라벨3</ChipTabsTrigger>
+        </ChipTabsList>
+      </ChipTabsRoot>
+      {value === "1" && <text className="chip-tabs-preview__content-text">content 1</text>}
+      {value === "2" && <text className="chip-tabs-preview__content-text">content 2</text>}
+      {value === "3" && <text className="chip-tabs-preview__content-text">content 3</text>}
+    </view>
+  );
+}

--- a/docs/examples/lynx/chip-tabs/size-medium.tsx
+++ b/docs/examples/lynx/chip-tabs/size-medium.tsx
@@ -1,0 +1,36 @@
+import "./styles";
+
+import { useState } from "@lynx-js/react";
+import { useSeedClassName } from "@seed-design/lynx-react";
+import { ChipTabsList, ChipTabsRoot, ChipTabsTrigger } from "@/components/ui/chip-tabs";
+
+export default function Example() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+  const [value, setValue] = useState("1");
+
+  function handleValueChange(nextValue: string) {
+    "background only";
+    setValue(nextValue);
+  }
+
+  return (
+    <view className={`${seedClassName} docs-lynx-chip-tabs-root`}>
+      <ChipTabsRoot
+        variant="neutralSolid"
+        size="medium"
+        defaultValue="1"
+        value={value}
+        onValueChange={handleValueChange}
+      >
+        <ChipTabsList>
+          <ChipTabsTrigger value="1">라벨1</ChipTabsTrigger>
+          <ChipTabsTrigger value="2">라벨2</ChipTabsTrigger>
+          <ChipTabsTrigger value="3">라벨3</ChipTabsTrigger>
+        </ChipTabsList>
+      </ChipTabsRoot>
+      {value === "1" && <text className="chip-tabs-preview__content-text">content 1</text>}
+      {value === "2" && <text className="chip-tabs-preview__content-text">content 2</text>}
+      {value === "3" && <text className="chip-tabs-preview__content-text">content 3</text>}
+    </view>
+  );
+}

--- a/docs/examples/lynx/chip-tabs/styles.ts
+++ b/docs/examples/lynx/chip-tabs/styles.ts
@@ -1,0 +1,2 @@
+import "@seed-design/lynx-css/base.css";
+import "./preview.css";

--- a/docs/examples/lynx/chip-tabs/variant-neutral-outline.tsx
+++ b/docs/examples/lynx/chip-tabs/variant-neutral-outline.tsx
@@ -1,0 +1,35 @@
+import "./styles";
+
+import { useState } from "@lynx-js/react";
+import { useSeedClassName } from "@seed-design/lynx-react";
+import { ChipTabsList, ChipTabsRoot, ChipTabsTrigger } from "@/components/ui/chip-tabs";
+
+export default function Example() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+  const [value, setValue] = useState("1");
+
+  function handleValueChange(nextValue: string) {
+    "background only";
+    setValue(nextValue);
+  }
+
+  return (
+    <view className={`${seedClassName} docs-lynx-chip-tabs-root`}>
+      <ChipTabsRoot
+        variant="neutralOutline"
+        defaultValue="1"
+        value={value}
+        onValueChange={handleValueChange}
+      >
+        <ChipTabsList>
+          <ChipTabsTrigger value="1">라벨1</ChipTabsTrigger>
+          <ChipTabsTrigger value="2">라벨2</ChipTabsTrigger>
+          <ChipTabsTrigger value="3">라벨3</ChipTabsTrigger>
+        </ChipTabsList>
+      </ChipTabsRoot>
+      {value === "1" && <text className="chip-tabs-preview__content-text">content 1</text>}
+      {value === "2" && <text className="chip-tabs-preview__content-text">content 2</text>}
+      {value === "3" && <text className="chip-tabs-preview__content-text">content 3</text>}
+    </view>
+  );
+}

--- a/docs/examples/lynx/chip-tabs/variant-neutral-solid.tsx
+++ b/docs/examples/lynx/chip-tabs/variant-neutral-solid.tsx
@@ -1,0 +1,35 @@
+import "./styles";
+
+import { useState } from "@lynx-js/react";
+import { useSeedClassName } from "@seed-design/lynx-react";
+import { ChipTabsList, ChipTabsRoot, ChipTabsTrigger } from "@/components/ui/chip-tabs";
+
+export default function Example() {
+  const seedClassName = useSeedClassName({ colorMode: "system" });
+  const [value, setValue] = useState("1");
+
+  function handleValueChange(nextValue: string) {
+    "background only";
+    setValue(nextValue);
+  }
+
+  return (
+    <view className={`${seedClassName} docs-lynx-chip-tabs-root`}>
+      <ChipTabsRoot
+        variant="neutralSolid"
+        defaultValue="1"
+        value={value}
+        onValueChange={handleValueChange}
+      >
+        <ChipTabsList>
+          <ChipTabsTrigger value="1">라벨1</ChipTabsTrigger>
+          <ChipTabsTrigger value="2">라벨2</ChipTabsTrigger>
+          <ChipTabsTrigger value="3">라벨3</ChipTabsTrigger>
+        </ChipTabsList>
+      </ChipTabsRoot>
+      {value === "1" && <text className="chip-tabs-preview__content-text">content 1</text>}
+      {value === "2" && <text className="chip-tabs-preview__content-text">content 2</text>}
+      {value === "3" && <text className="chip-tabs-preview__content-text">content 3</text>}
+    </view>
+  );
+}

--- a/docs/public/__docs__/index.json
+++ b/docs/public/__docs__/index.json
@@ -2140,6 +2140,19 @@
               "docUrl": "/lynx/components/chip"
             },
             {
+              "id": "chip-tabs",
+              "title": "Chip Tabs",
+              "description": "Chip 형태로 표현된 탭 컴포넌트입니다. 카테고리나 필터를 선택하여 콘텐츠를 전환할 때 사용합니다.",
+              "docUrl": "/lynx/components/chip-tabs",
+              "snippetKey": "lynx/ui:chip-tabs",
+              "snippets": [
+                {
+                  "label": "react",
+                  "path": "chip-tabs.tsx"
+                }
+              ]
+            },
+            {
               "id": "cli",
               "title": "CLI",
               "description": "Lynx 프로젝트에서 SEED CLI를 사용하는 방법을 안내해요.",

--- a/docs/public/__registry__/lynx/ui/chip-tabs.json
+++ b/docs/public/__registry__/lynx/ui/chip-tabs.json
@@ -1,0 +1,16 @@
+{
+  "id": "chip-tabs",
+  "dependencies": [
+    "@seed-design/lynx-react"
+  ],
+  "snippets": [
+    {
+      "path": "chip-tabs.tsx",
+      "content": "/**\n * @file ui:chip-tabs\n * @requires @seed-design/lynx-react@>=0.8.0 <1.0.0\n * @requires @seed-design/lynx-css@>=0.12.0 <1.0.0\n **/\n\nimport { NotificationBadge, ChipTabs as SeedChipTabs } from \"@seed-design/lynx-react\";\nimport { forwardRef } from \"@lynx-js/react\";\n\nexport interface ChipTabsRootProps extends SeedChipTabs.RootProps {}\n\n/**\n * @see https://seed-design.io/lynx/components/chip-tabs\n */\nexport const ChipTabsRoot = SeedChipTabs.Root;\n\nexport interface ChipTabsListProps extends SeedChipTabs.ListProps {}\n\nexport const ChipTabsList = SeedChipTabs.List;\n\nexport interface ChipTabsTriggerProps extends Omit<SeedChipTabs.TriggerProps, \"notification\"> {\n  notification?: boolean;\n}\n\nexport const ChipTabsTrigger = forwardRef<unknown, ChipTabsTriggerProps>((props, ref) => {\n  const { children, notification, ...otherProps } = props;\n\n  return (\n    <SeedChipTabs.Trigger\n      ref={ref}\n      {...otherProps}\n      notification={\n        notification ? (\n          <NotificationBadge size=\"small\" accessibility-elements-hidden={true} />\n        ) : undefined\n      }\n    >\n      {children}\n    </SeedChipTabs.Trigger>\n  );\n});\nChipTabsTrigger.displayName = \"ChipTabsTrigger\";\n\nexport interface ChipTabsCarouselProps extends SeedChipTabs.CarouselProps {}\n\nexport const ChipTabsCarousel = forwardRef<unknown, ChipTabsCarouselProps>((props, ref) => {\n  const { children, ...otherProps } = props;\n\n  return (\n    <SeedChipTabs.Carousel ref={ref} {...otherProps}>\n      <SeedChipTabs.CarouselCamera>{children}</SeedChipTabs.CarouselCamera>\n    </SeedChipTabs.Carousel>\n  );\n});\nChipTabsCarousel.displayName = \"ChipTabsCarousel\";\n\nexport interface ChipTabsContentProps extends SeedChipTabs.ContentProps {}\n\nexport const ChipTabsContent = SeedChipTabs.Content;\n\n/**\n * This file is a snippet from SEED Design, helping you get started quickly with @seed-design/* packages.\n * You can extend this snippet however you want.\n */\n",
+      "dependencies": {
+        "@seed-design/lynx-react": ">=0.8.0 <1.0.0",
+        "@seed-design/lynx-css": ">=0.12.0 <1.0.0"
+      }
+    }
+  ]
+}

--- a/docs/public/__registry__/lynx/ui/index.json
+++ b/docs/public/__registry__/lynx/ui/index.json
@@ -84,6 +84,21 @@
     {
       "snippets": [
         {
+          "path": "chip-tabs.tsx",
+          "dependencies": {
+            "@seed-design/lynx-react": ">=0.8.0 <1.0.0",
+            "@seed-design/lynx-css": ">=0.12.0 <1.0.0"
+          }
+        }
+      ],
+      "id": "chip-tabs",
+      "dependencies": [
+        "@seed-design/lynx-react"
+      ]
+    },
+    {
+      "snippets": [
+        {
           "path": "dialog.tsx",
           "dependencies": {
             "@seed-design/lynx-react": ">=0.8.0 <1.0.0",

--- a/docs/registry/lynx/registry-ui.ts
+++ b/docs/registry/lynx/registry-ui.ts
@@ -25,6 +25,10 @@ const floatingActionButtonPackageRanges = {
   "@seed-design/lynx-react": ">=0.8.0 <1.0.0",
   "@seed-design/lynx-css": ">=0.12.0 <1.0.0",
 };
+const chipTabsPackageRanges = {
+  "@seed-design/lynx-react": ">=0.8.0 <1.0.0",
+  "@seed-design/lynx-css": ">=0.12.0 <1.0.0",
+};
 
 const selectBoxPackageRanges = {
   "@seed-design/lynx-react": ">=0.6.0 <1.0.0",
@@ -112,6 +116,15 @@ export const registryUI: Registry = {
         {
           path: "checkbox.tsx",
           dependencies: fieldPackageRanges,
+        },
+      ],
+    },
+    {
+      id: "chip-tabs",
+      snippets: [
+        {
+          path: "chip-tabs.tsx",
+          dependencies: chipTabsPackageRanges,
         },
       ],
     },

--- a/docs/registry/lynx/ui/chip-tabs.tsx
+++ b/docs/registry/lynx/ui/chip-tabs.tsx
@@ -1,0 +1,53 @@
+import { NotificationBadge, ChipTabs as SeedChipTabs } from "@seed-design/lynx-react";
+import { forwardRef } from "@lynx-js/react";
+
+export interface ChipTabsRootProps extends SeedChipTabs.RootProps {}
+
+/**
+ * @see https://seed-design.io/lynx/components/chip-tabs
+ */
+export const ChipTabsRoot = SeedChipTabs.Root;
+
+export interface ChipTabsListProps extends SeedChipTabs.ListProps {}
+
+export const ChipTabsList = SeedChipTabs.List;
+
+export interface ChipTabsTriggerProps extends Omit<SeedChipTabs.TriggerProps, "notification"> {
+  notification?: boolean;
+}
+
+export const ChipTabsTrigger = forwardRef<unknown, ChipTabsTriggerProps>((props, ref) => {
+  const { children, notification, ...otherProps } = props;
+
+  return (
+    <SeedChipTabs.Trigger
+      ref={ref}
+      {...otherProps}
+      notification={
+        notification ? (
+          <NotificationBadge size="small" accessibility-elements-hidden={true} />
+        ) : undefined
+      }
+    >
+      {children}
+    </SeedChipTabs.Trigger>
+  );
+});
+ChipTabsTrigger.displayName = "ChipTabsTrigger";
+
+export interface ChipTabsCarouselProps extends SeedChipTabs.CarouselProps {}
+
+export const ChipTabsCarousel = forwardRef<unknown, ChipTabsCarouselProps>((props, ref) => {
+  const { children, ...otherProps } = props;
+
+  return (
+    <SeedChipTabs.Carousel ref={ref} {...otherProps}>
+      <SeedChipTabs.CarouselCamera>{children}</SeedChipTabs.CarouselCamera>
+    </SeedChipTabs.Carousel>
+  );
+});
+ChipTabsCarousel.displayName = "ChipTabsCarousel";
+
+export interface ChipTabsContentProps extends SeedChipTabs.ContentProps {}
+
+export const ChipTabsContent = SeedChipTabs.Content;

--- a/examples/lynx-spa/src/seed-design/ui/chip-tabs.tsx
+++ b/examples/lynx-spa/src/seed-design/ui/chip-tabs.tsx
@@ -1,0 +1,48 @@
+import { NotificationBadge, ChipTabs as SeedChipTabs } from "@seed-design/lynx-react";
+import { forwardRef } from "@lynx-js/react";
+
+export interface ChipTabsRootProps extends SeedChipTabs.RootProps {}
+
+export const ChipTabsRoot = SeedChipTabs.Root;
+
+export interface ChipTabsListProps extends SeedChipTabs.ListProps {}
+
+export const ChipTabsList = SeedChipTabs.List;
+
+export interface ChipTabsTriggerProps extends Omit<SeedChipTabs.TriggerProps, "notification"> {
+  notification?: boolean;
+}
+
+export const ChipTabsTrigger = forwardRef<unknown, ChipTabsTriggerProps>((props, ref) => {
+  const { notification, ...otherProps } = props;
+
+  return (
+    <SeedChipTabs.Trigger
+      ref={ref}
+      {...otherProps}
+      notification={
+        notification ? (
+          <NotificationBadge size="small" accessibility-elements-hidden={true} />
+        ) : undefined
+      }
+    />
+  );
+});
+ChipTabsTrigger.displayName = "ChipTabsTrigger";
+
+export interface ChipTabsCarouselProps extends SeedChipTabs.CarouselProps {}
+
+export const ChipTabsCarousel = forwardRef<unknown, ChipTabsCarouselProps>((props, ref) => {
+  const { children, ...otherProps } = props;
+
+  return (
+    <SeedChipTabs.Carousel ref={ref} {...otherProps}>
+      <SeedChipTabs.CarouselCamera>{children}</SeedChipTabs.CarouselCamera>
+    </SeedChipTabs.Carousel>
+  );
+});
+ChipTabsCarousel.displayName = "ChipTabsCarousel";
+
+export interface ChipTabsContentProps extends SeedChipTabs.ContentProps {}
+
+export const ChipTabsContent = SeedChipTabs.Content;

--- a/packages/lynx-css/all.css
+++ b/packages/lynx-css/all.css
@@ -2365,6 +2365,157 @@ text {
   background: var(--seed-color-bg-neutral-weak-pressed);
 }
 
+.seed-chip-tabs__root, .seed-chip-tabs__list {
+  position: relative;
+}
+
+.seed-chip-tabs__listContent {
+  width: max-content;
+  min-width: 100%;
+  padding-left: var(--seed-dimension-x4);
+  padding-right: var(--seed-dimension-x4);
+  flex-flow: row;
+  gap: 8px;
+  display: flex;
+}
+
+.seed-chip-tabs__trigger {
+  justify-content: center;
+  align-items: center;
+  gap: var(--seed-dimension-x1_5);
+  border-radius: var(--seed-radius-full);
+  transition: background-color var(--seed-duration-color-transition) var(--seed-timing-function-easing), box-shadow var(--seed-duration-color-transition) var(--seed-timing-function-easing);
+  flex-direction: row;
+  flex-shrink: 0;
+  display: flex;
+}
+
+.seed-chip-tabs__triggerLabel {
+  font-weight: var(--seed-font-weight-medium);
+  transition-property: color;
+  transition-duration: var(--seed-duration-color-transition);
+  transition-timing-function: var(--seed-timing-function-easing);
+  flex-shrink: 0;
+  display: flex;
+}
+
+.seed-chip-tabs__content {
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.seed-chip-tabs__carousel {
+  display: flex;
+  overflow: hidden;
+}
+
+.seed-chip-tabs__carouselCamera {
+  width: 100%;
+}
+
+.seed-chip-tabs__trigger--size_medium {
+  min-height: 36px;
+  min-width: var(--seed-dimension-x12);
+  padding-left: calc(var(--seed-dimension-x2) + var(--seed-dimension-x1_5));
+  padding-right: calc(var(--seed-dimension-x2) + var(--seed-dimension-x1_5));
+}
+
+.seed-chip-tabs__triggerLabel--size_medium {
+  font-size: var(--seed-font-size-t4);
+  line-height: var(--seed-line-height-t4);
+}
+
+.seed-chip-tabs__trigger--size_large {
+  min-height: 40px;
+  min-width: var(--seed-dimension-x13);
+  padding-left: calc(var(--seed-dimension-x2_5) + var(--seed-dimension-x1_5));
+  padding-right: calc(var(--seed-dimension-x2_5) + var(--seed-dimension-x1_5));
+}
+
+.seed-chip-tabs__triggerLabel--size_large {
+  font-size: var(--seed-font-size-t4);
+  line-height: var(--seed-line-height-t4);
+}
+
+.seed-chip-tabs__trigger--variant_neutralSolid {
+  background-color: var(--seed-color-bg-neutral-weak-alpha);
+}
+
+.seed-chip-tabs__triggerLabel--variant_neutralSolid {
+  color: var(--seed-color-fg-neutral);
+}
+
+.seed-chip-tabs__trigger--variant_neutralOutline {
+  background-color: var(--seed-color-bg-transparent);
+  box-shadow: inset 0 0 0 1px var(--seed-color-stroke-neutral-muted);
+}
+
+.seed-chip-tabs__triggerLabel--variant_neutralOutline {
+  color: var(--seed-color-fg-neutral);
+}
+
+.seed-chip-tabs__root--contentLayout_fill {
+  flex-direction: column;
+  height: 100%;
+  display: flex;
+}
+
+.seed-chip-tabs__carousel--contentLayout_fill {
+  flex: 1;
+}
+
+.seed-chip-tabs__carouselCamera--contentLayout_fill, .seed-chip-tabs__content--contentLayout_fill {
+  height: 100%;
+}
+
+.seed-chip-tabs__list--stickyList_true {
+  z-index: 1;
+  position: sticky;
+  top: 0;
+}
+
+.seed-chip-tabs__content--selected_false {
+  display: none;
+}
+
+.seed-chip-tabs__trigger--variant_neutralSolid-selected_true {
+  background-color: var(--seed-color-bg-neutral-inverted);
+}
+
+.seed-chip-tabs__triggerLabel--variant_neutralSolid-selected_true {
+  color: var(--seed-color-fg-neutral-inverted);
+}
+
+.seed-chip-tabs__trigger--variant_neutralOutline-selected_true {
+  background-color: var(--seed-color-bg-neutral-inverted);
+  box-shadow: inset 0 0 0 1px #0000;
+}
+
+.seed-chip-tabs__triggerLabel--variant_neutralOutline-selected_true {
+  color: var(--seed-color-fg-neutral-inverted);
+}
+
+.seed-chip-tabs__trigger--variant_neutralSolid-selected_false-pressed_true-disabled_false {
+  background-color: var(--seed-color-bg-neutral-weak-alpha-pressed);
+}
+
+.seed-chip-tabs__trigger--variant_neutralOutline-selected_false-pressed_true-disabled_false {
+  background-color: var(--seed-color-bg-transparent-pressed);
+}
+
+.seed-chip-tabs__trigger--variant_neutralSolid-selected_true-pressed_true-disabled_false, .seed-chip-tabs__trigger--variant_neutralOutline-selected_true-pressed_true-disabled_false {
+  background-color: var(--seed-color-bg-neutral-inverted-pressed);
+}
+
+.seed-chip-tabs__trigger--variant_neutralSolid-disabled_true, .seed-chip-tabs__trigger--variant_neutralOutline-disabled_true {
+  opacity: .5;
+}
+
+.seed-chip-tabs__content--selected_false-inCarousel_true {
+  display: flex;
+}
+
 .seed-contextual-floating-button__root {
   border-radius: var(--seed-radius-full);
   width: fit-content;

--- a/packages/lynx-css/recipes/chip-tabs.css
+++ b/packages/lynx-css/recipes/chip-tabs.css
@@ -1,0 +1,135 @@
+.seed-chip-tabs__root {
+    position: relative
+}
+.seed-chip-tabs__list {
+    position: relative
+}
+.seed-chip-tabs__listContent {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    width: max-content;
+    min-width: 100%;
+    gap: 8px;
+    padding-left: var(--seed-dimension-x4);
+    padding-right: var(--seed-dimension-x4)
+}
+.seed-chip-tabs__trigger {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    flex-shrink: 0;
+    gap: var(--seed-dimension-x1_5);
+    border-radius: var(--seed-radius-full);
+    transition: background-color var(--seed-duration-color-transition) var(--seed-timing-function-easing), box-shadow var(--seed-duration-color-transition) var(--seed-timing-function-easing)
+}
+.seed-chip-tabs__triggerLabel {
+    display: flex;
+    flex-shrink: 0;
+    font-weight: var(--seed-font-weight-medium);
+    transition-property: color;
+    transition-duration: var(--seed-duration-color-transition);
+    transition-timing-function: var(--seed-timing-function-easing)
+}
+.seed-chip-tabs__content {
+    width: 100%;
+    min-width: 0px;
+    overflow: hidden
+}
+.seed-chip-tabs__carousel {
+    display: flex;
+    overflow: hidden
+}
+.seed-chip-tabs__carouselCamera {
+    width: 100%
+}
+.seed-chip-tabs__trigger--size_medium {
+    min-height: 36px;
+    min-width: var(--seed-dimension-x12);
+    padding-left: calc(var(--seed-dimension-x2) + var(--seed-dimension-x1_5));
+    padding-right: calc(var(--seed-dimension-x2) + var(--seed-dimension-x1_5))
+}
+.seed-chip-tabs__triggerLabel--size_medium {
+    font-size: var(--seed-font-size-t4);
+    line-height: var(--seed-line-height-t4)
+}
+.seed-chip-tabs__trigger--size_large {
+    min-height: 40px;
+    min-width: var(--seed-dimension-x13);
+    padding-left: calc(var(--seed-dimension-x2_5) + var(--seed-dimension-x1_5));
+    padding-right: calc(var(--seed-dimension-x2_5) + var(--seed-dimension-x1_5))
+}
+.seed-chip-tabs__triggerLabel--size_large {
+    font-size: var(--seed-font-size-t4);
+    line-height: var(--seed-line-height-t4)
+}
+.seed-chip-tabs__trigger--variant_neutralSolid {
+    background-color: var(--seed-color-bg-neutral-weak-alpha)
+}
+.seed-chip-tabs__triggerLabel--variant_neutralSolid {
+    color: var(--seed-color-fg-neutral)
+}
+.seed-chip-tabs__trigger--variant_neutralOutline {
+    background-color: var(--seed-color-bg-transparent);
+    box-shadow: inset 0 0 0 1px var(--seed-color-stroke-neutral-muted)
+}
+.seed-chip-tabs__triggerLabel--variant_neutralOutline {
+    color: var(--seed-color-fg-neutral)
+}
+.seed-chip-tabs__root--contentLayout_fill {
+    display: flex;
+    flex-direction: column;
+    height: 100%
+}
+.seed-chip-tabs__carousel--contentLayout_fill {
+    flex: 1
+}
+.seed-chip-tabs__carouselCamera--contentLayout_fill {
+    height: 100%
+}
+.seed-chip-tabs__content--contentLayout_fill {
+    height: 100%
+}
+.seed-chip-tabs__list--stickyList_true {
+    position: sticky;
+    top: 0px;
+    z-index: 1
+}
+.seed-chip-tabs__content--selected_false {
+    display: none
+}
+.seed-chip-tabs__trigger--variant_neutralSolid-selected_true {
+    background-color: var(--seed-color-bg-neutral-inverted)
+}
+.seed-chip-tabs__triggerLabel--variant_neutralSolid-selected_true {
+    color: var(--seed-color-fg-neutral-inverted)
+}
+.seed-chip-tabs__trigger--variant_neutralOutline-selected_true {
+    background-color: var(--seed-color-bg-neutral-inverted);
+    box-shadow: inset 0 0 0 1px transparent
+}
+.seed-chip-tabs__triggerLabel--variant_neutralOutline-selected_true {
+    color: var(--seed-color-fg-neutral-inverted)
+}
+.seed-chip-tabs__trigger--variant_neutralSolid-selected_false-pressed_true-disabled_false {
+    background-color: var(--seed-color-bg-neutral-weak-alpha-pressed)
+}
+.seed-chip-tabs__trigger--variant_neutralOutline-selected_false-pressed_true-disabled_false {
+    background-color: var(--seed-color-bg-transparent-pressed)
+}
+.seed-chip-tabs__trigger--variant_neutralSolid-selected_true-pressed_true-disabled_false {
+    background-color: var(--seed-color-bg-neutral-inverted-pressed)
+}
+.seed-chip-tabs__trigger--variant_neutralOutline-selected_true-pressed_true-disabled_false {
+    background-color: var(--seed-color-bg-neutral-inverted-pressed)
+}
+.seed-chip-tabs__trigger--variant_neutralSolid-disabled_true {
+    opacity: 0.5
+}
+.seed-chip-tabs__trigger--variant_neutralOutline-disabled_true {
+    opacity: 0.5
+}
+.seed-chip-tabs__content--selected_false-inCarousel_true {
+    display: flex
+}

--- a/packages/lynx-css/recipes/chip-tabs.d.ts
+++ b/packages/lynx-css/recipes/chip-tabs.d.ts
@@ -1,0 +1,52 @@
+declare interface ChipTabsVariant {
+  /**
+  * @default "medium"
+  */
+  size: "medium" | "large";
+/**
+  * @default "neutralSolid"
+  */
+  variant: "neutralSolid" | "neutralOutline";
+/**
+  * @default "hug"
+  */
+  contentLayout: "fill" | "hug";
+/**
+  * @default false
+  */
+  stickyList: boolean;
+/**
+  * @default false
+  */
+  selected: boolean;
+/**
+  * @default false
+  */
+  pressed: boolean;
+/**
+  * @default false
+  */
+  disabled: boolean;
+/**
+  * @default false
+  */
+  inCarousel: boolean;
+}
+
+declare type ChipTabsVariantMap = {
+  [key in keyof ChipTabsVariant]: Array<ChipTabsVariant[key]>;
+};
+
+export declare type ChipTabsVariantProps = Partial<ChipTabsVariant>;
+
+export declare type ChipTabsSlotName = "root" | "list" | "listContent" | "trigger" | "triggerLabel" | "content" | "carousel" | "carouselCamera";
+
+export declare const chipTabsVariantMap: ChipTabsVariantMap;
+
+export declare const chipTabs: ((
+  props?: ChipTabsVariantProps,
+) => Record<ChipTabsSlotName, string>) & {
+  splitVariantProps: <T extends ChipTabsVariantProps>(
+    props: T,
+  ) => [ChipTabsVariantProps, Omit<T, keyof ChipTabsVariantProps>];
+}

--- a/packages/lynx-css/recipes/chip-tabs.mjs
+++ b/packages/lynx-css/recipes/chip-tabs.mjs
@@ -1,0 +1,147 @@
+import './chip-tabs.css';
+import { createClassName, mergeVariants, splitVariantProps } from "./shared.mjs";
+
+const chipTabsSlotNames = [
+  [
+    "root",
+    "seed-chip-tabs__root"
+  ],
+  [
+    "list",
+    "seed-chip-tabs__list"
+  ],
+  [
+    "listContent",
+    "seed-chip-tabs__listContent"
+  ],
+  [
+    "trigger",
+    "seed-chip-tabs__trigger"
+  ],
+  [
+    "triggerLabel",
+    "seed-chip-tabs__triggerLabel"
+  ],
+  [
+    "content",
+    "seed-chip-tabs__content"
+  ],
+  [
+    "carousel",
+    "seed-chip-tabs__carousel"
+  ],
+  [
+    "carouselCamera",
+    "seed-chip-tabs__carouselCamera"
+  ]
+];
+
+const defaultVariant = {
+  "size": "medium",
+  "variant": "neutralSolid",
+  "contentLayout": "hug",
+  "stickyList": false,
+  "selected": false,
+  "pressed": false,
+  "disabled": false,
+  "inCarousel": false
+};
+
+const compoundVariants = [
+  {
+    "variant": "neutralSolid",
+    "selected": true
+  },
+  {
+    "variant": "neutralOutline",
+    "selected": true
+  },
+  {
+    "variant": "neutralSolid",
+    "selected": false,
+    "pressed": true,
+    "disabled": false
+  },
+  {
+    "variant": "neutralOutline",
+    "selected": false,
+    "pressed": true,
+    "disabled": false
+  },
+  {
+    "variant": "neutralSolid",
+    "selected": true,
+    "pressed": true,
+    "disabled": false
+  },
+  {
+    "variant": "neutralOutline",
+    "selected": true,
+    "pressed": true,
+    "disabled": false
+  },
+  {
+    "variant": "neutralSolid",
+    "disabled": true
+  },
+  {
+    "variant": "neutralOutline",
+    "disabled": true
+  },
+  {
+    "selected": false,
+    "inCarousel": true
+  }
+];
+
+export const chipTabsVariantMap = {
+  "size": [
+    "medium",
+    "large"
+  ],
+  "variant": [
+    "neutralSolid",
+    "neutralOutline"
+  ],
+  "contentLayout": [
+    "fill",
+    "hug"
+  ],
+  "stickyList": [
+    true,
+    false
+  ],
+  "selected": [
+    true,
+    false
+  ],
+  "pressed": [
+    true,
+    false
+  ],
+  "disabled": [
+    true,
+    false
+  ],
+  "inCarousel": [
+    true,
+    false
+  ]
+};
+
+export const chipTabsVariantKeys = Object.keys(chipTabsVariantMap);
+
+export function chipTabs(props) {
+  return Object.fromEntries(
+    chipTabsSlotNames.map(([slot, className]) => {
+      return [
+        slot,
+        createClassName(className, mergeVariants(defaultVariant, props), compoundVariants),
+      ];
+    }),
+  );
+}
+
+Object.assign(chipTabs, { splitVariantProps: (props) => splitVariantProps(props, chipTabsVariantMap) });
+
+// @recipe(seed): chip-tabs

--- a/packages/lynx-qvism-preset/src/recipes.ts
+++ b/packages/lynx-qvism-preset/src/recipes.ts
@@ -9,6 +9,7 @@ import checkbox from "./recipes/checkbox";
 import checkboxGroup from "./recipes/checkbox-group";
 import checkmark from "./recipes/checkmark";
 import chip from "./recipes/chip";
+import chipTabs from "./recipes/chip-tabs";
 import contextualFloatingButton from "./recipes/contextual-floating-button";
 import contentDialog from "./recipes/content-dialog";
 import dialog from "./recipes/dialog";
@@ -54,6 +55,7 @@ export const recipes = {
   checkboxGroup,
   checkmark,
   chip,
+  chipTabs,
   contextualFloatingButton,
   contentDialog,
   dialog,

--- a/packages/lynx-qvism-preset/src/recipes/chip-tabs.ts
+++ b/packages/lynx-qvism-preset/src/recipes/chip-tabs.ts
@@ -1,0 +1,270 @@
+import { chipTablist as vars, chip as chipVars } from "../vars/component";
+import { defineSlotRecipe } from "../utils/define";
+
+const chipTabs = defineSlotRecipe({
+  name: "chip-tabs",
+  slots: [
+    "root",
+    "list",
+    "listContent",
+    "trigger",
+    "triggerLabel",
+    "content",
+    "carousel",
+    "carouselCamera",
+  ],
+  base: {
+    root: {
+      position: "relative",
+    },
+    list: {
+      position: "relative",
+    },
+    listContent: {
+      display: "flex",
+      flexDirection: "row",
+      flexWrap: "nowrap",
+      width: "max-content",
+      minWidth: "100%",
+      gap: vars.base.enabled.root.gap,
+      paddingLeft: vars.base.enabled.root.paddingX,
+      paddingRight: vars.base.enabled.root.paddingX,
+    },
+    trigger: {
+      display: "flex",
+      flexDirection: "row",
+      justifyContent: "center",
+      alignItems: "center",
+      flexShrink: 0,
+      gap: chipVars.base.enabled.label.paddingX,
+      borderRadius: chipVars.base.enabled.root.cornerRadius,
+      transition: `background-color ${chipVars.base.enabled.root.colorDuration} ${chipVars.base.enabled.root.colorTimingFunction}, box-shadow ${chipVars.base.enabled.root.colorDuration} ${chipVars.base.enabled.root.colorTimingFunction}`,
+    },
+    triggerLabel: {
+      display: "flex",
+      flexShrink: 0,
+      fontWeight: chipVars.base.enabled.label.fontWeight,
+      transitionProperty: "color",
+      transitionDuration: chipVars.base.enabled.root.colorDuration,
+      transitionTimingFunction: chipVars.base.enabled.root.colorTimingFunction,
+    },
+    content: {
+      width: "100%",
+      minWidth: "0px",
+      overflow: "hidden",
+    },
+    carousel: {
+      display: "flex",
+      overflow: "hidden",
+    },
+    carouselCamera: {
+      width: "100%",
+    },
+  },
+  variants: {
+    size: {
+      medium: {
+        trigger: {
+          minHeight: chipVars.sizeMedium.enabled.root.height,
+          minWidth: chipVars.sizeMediumLayoutWithText.enabled.root.minWidth,
+          paddingLeft: `calc(${chipVars.sizeMedium.enabled.root.paddingX} + ${chipVars.base.enabled.label.paddingX})`,
+          paddingRight: `calc(${chipVars.sizeMedium.enabled.root.paddingX} + ${chipVars.base.enabled.label.paddingX})`,
+        },
+        triggerLabel: {
+          fontSize: chipVars.sizeMedium.enabled.label.fontSize,
+          lineHeight: chipVars.sizeMedium.enabled.label.lineHeight,
+        },
+      },
+      large: {
+        trigger: {
+          minHeight: chipVars.sizeLarge.enabled.root.height,
+          minWidth: chipVars.sizeLargeLayoutWithText.enabled.root.minWidth,
+          paddingLeft: `calc(${chipVars.sizeLarge.enabled.root.paddingX} + ${chipVars.base.enabled.label.paddingX})`,
+          paddingRight: `calc(${chipVars.sizeLarge.enabled.root.paddingX} + ${chipVars.base.enabled.label.paddingX})`,
+        },
+        triggerLabel: {
+          fontSize: chipVars.sizeLarge.enabled.label.fontSize,
+          lineHeight: chipVars.sizeLarge.enabled.label.lineHeight,
+        },
+      },
+    },
+    variant: {
+      neutralSolid: {
+        trigger: {
+          backgroundColor: chipVars.variantSolid.enabled.root.color,
+        },
+        triggerLabel: {
+          color: chipVars.variantSolid.enabled.label.color,
+        },
+      },
+      neutralOutline: {
+        trigger: {
+          backgroundColor: chipVars.variantOutlineStrong.enabled.root.color,
+          boxShadow: `inset 0 0 0 ${chipVars.variantOutlineStrong.enabled.root.strokeWidth} ${chipVars.variantOutlineStrong.enabled.root.strokeColor}`,
+        },
+        triggerLabel: {
+          color: chipVars.variantOutlineStrong.enabled.label.color,
+        },
+      },
+    },
+    contentLayout: {
+      fill: {
+        root: {
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+        },
+        carousel: {
+          flex: 1,
+        },
+        carouselCamera: {
+          height: "100%",
+        },
+        content: {
+          height: "100%",
+        },
+      },
+      hug: {},
+    },
+    stickyList: {
+      true: {
+        list: {
+          position: "sticky",
+          top: "0px",
+          zIndex: 1,
+        },
+      },
+      false: {},
+    },
+    selected: {
+      true: {},
+      false: {
+        content: {
+          display: "none",
+        },
+      },
+    },
+    pressed: {
+      true: {},
+      false: {},
+    },
+    disabled: {
+      true: {},
+      false: {},
+    },
+    inCarousel: {
+      true: {},
+      false: {},
+    },
+  },
+  compoundVariants: [
+    {
+      variant: "neutralSolid",
+      selected: true,
+      css: {
+        trigger: {
+          backgroundColor: chipVars.variantSolid.selected.root.color,
+        },
+        triggerLabel: {
+          color: chipVars.variantSolid.selected.label.color,
+        },
+      },
+    },
+    {
+      variant: "neutralOutline",
+      selected: true,
+      css: {
+        trigger: {
+          backgroundColor: chipVars.variantOutlineStrong.selected.root.color,
+          boxShadow: `inset 0 0 0 ${chipVars.variantOutlineStrong.enabled.root.strokeWidth} transparent`,
+        },
+        triggerLabel: {
+          color: chipVars.variantOutlineStrong.selected.label.color,
+        },
+      },
+    },
+    {
+      variant: "neutralSolid",
+      selected: false,
+      pressed: true,
+      disabled: false,
+      css: {
+        trigger: {
+          backgroundColor: chipVars.variantSolid.pressed.root.color,
+        },
+      },
+    },
+    {
+      variant: "neutralOutline",
+      selected: false,
+      pressed: true,
+      disabled: false,
+      css: {
+        trigger: {
+          backgroundColor: chipVars.variantOutlineStrong.pressed.root.color,
+        },
+      },
+    },
+    {
+      variant: "neutralSolid",
+      selected: true,
+      pressed: true,
+      disabled: false,
+      css: {
+        trigger: {
+          backgroundColor: chipVars.variantSolid.selectedPressed.root.color,
+        },
+      },
+    },
+    {
+      variant: "neutralOutline",
+      selected: true,
+      pressed: true,
+      disabled: false,
+      css: {
+        trigger: {
+          backgroundColor: chipVars.variantOutlineStrong.selectedPressed.root.color,
+        },
+      },
+    },
+    {
+      variant: "neutralSolid",
+      disabled: true,
+      css: {
+        trigger: {
+          opacity: chipVars.variantSolid.disabled.root.opacity,
+        },
+      },
+    },
+    {
+      variant: "neutralOutline",
+      disabled: true,
+      css: {
+        trigger: {
+          opacity: chipVars.variantOutlineStrong.disabled.root.opacity,
+        },
+      },
+    },
+    {
+      selected: false,
+      inCarousel: true,
+      css: {
+        content: {
+          display: "flex",
+        },
+      },
+    },
+  ],
+  defaultVariants: {
+    size: "medium",
+    variant: "neutralSolid",
+    contentLayout: "hug",
+    stickyList: false,
+    selected: false,
+    pressed: false,
+    disabled: false,
+    inCarousel: false,
+  },
+});
+
+export default chipTabs;

--- a/packages/lynx-react/src/components/ChipTabs/ChipTabs.namespace.ts
+++ b/packages/lynx-react/src/components/ChipTabs/ChipTabs.namespace.ts
@@ -1,0 +1,14 @@
+export {
+  ChipTabsCarousel as Carousel,
+  ChipTabsCarouselCamera as CarouselCamera,
+  ChipTabsContent as Content,
+  ChipTabsList as List,
+  ChipTabsRoot as Root,
+  ChipTabsTrigger as Trigger,
+  type ChipTabsCarouselCameraProps as CarouselCameraProps,
+  type ChipTabsCarouselProps as CarouselProps,
+  type ChipTabsContentProps as ContentProps,
+  type ChipTabsListProps as ListProps,
+  type ChipTabsRootProps as RootProps,
+  type ChipTabsTriggerProps as TriggerProps,
+} from "./ChipTabs";

--- a/packages/lynx-react/src/components/ChipTabs/ChipTabs.tsx
+++ b/packages/lynx-react/src/components/ChipTabs/ChipTabs.tsx
@@ -1,0 +1,119 @@
+import * as React from "@lynx-js/react";
+
+import { chipTabs, type ChipTabsVariantProps } from "@seed-design/lynx-css/recipes/chip-tabs";
+
+import { createSlotRecipeContext } from "../../utils/create-slot-recipe-context";
+
+import {
+  TabsCarousel,
+  TabsCarouselCamera,
+  TabsContent,
+  TabsList,
+  TabsRootPrimitive,
+  TabsTrigger,
+  type TabsCarouselCameraProps,
+  type TabsCarouselProps,
+  type TabsContentProps,
+  type TabsListProps,
+  type TabsRootProps,
+  type TabsTriggerProps,
+} from "../Tabs/Tabs";
+
+type ChipTabsRecipeState = Pick<
+  ChipTabsVariantProps,
+  "selected" | "pressed" | "disabled" | "inCarousel"
+>;
+
+const CHIP_TABS_TRIGGER_GAP = 8;
+const { ClassNamesProvider: ChipTabsClassNamesProvider } = createSlotRecipeContext(chipTabs);
+
+type ChipTabsPublicVariantProps = Omit<
+  ChipTabsVariantProps,
+  "selected" | "pressed" | "disabled" | "inCarousel"
+>;
+
+/**
+ * @platform Lynx
+ *
+ * 웹 대비 미지원 기능:
+ * - `lazyMount`, `unmountOnExit`: native viewpager가 모든 page slot을 유지해야 함
+ * - 키보드 포커스와 roving tabindex
+ */
+export interface ChipTabsRootProps
+  extends Omit<TabsRootProps, "size" | "contentLayout" | "stickyList" | "triggerLayout">,
+    ChipTabsPublicVariantProps {}
+
+/**
+ * Chip recipe와 Tabs의 controlled state, horizontal scrolling, and native pager behavior를 결합합니다.
+ */
+export const ChipTabsRoot = React.forwardRef<unknown, ChipTabsRootProps>((props, ref) => {
+  const [variantProps, rootProps] = chipTabs.splitVariantProps(props);
+  const getClassNames = React.useCallback(
+    (state: ChipTabsRecipeState = {}) =>
+      chipTabs({
+        ...variantProps,
+        selected: state.selected,
+        pressed: state.pressed,
+        disabled: state.disabled,
+        inCarousel: state.inCarousel,
+      }),
+    [variantProps],
+  );
+  const recipe = React.useMemo(
+    () => ({
+      getClassNames,
+      triggerGap: CHIP_TABS_TRIGGER_GAP,
+    }),
+    [getClassNames],
+  );
+
+  return (
+    <ChipTabsClassNamesProvider value={getClassNames()}>
+      <TabsRootPrimitive {...rootProps} ref={ref} recipe={recipe} inlineNotification />
+    </ChipTabsClassNamesProvider>
+  );
+});
+ChipTabsRoot.displayName = "ChipTabsRoot";
+
+////////////////////////////////////////////////////////////////////////////////////
+
+export interface ChipTabsListProps extends Omit<TabsListProps, "scrollAlign"> {
+  /** 선택한 chip을 목록 안에서 정렬할 방식입니다. @defaultValue "nearest" */
+  scrollAlign?: TabsListProps["scrollAlign"];
+}
+
+/**
+ * ChipTabs는 이미 보이는 선택 chip을 움직이지 않도록 기본적으로 `"nearest"`를 사용합니다.
+ */
+export const ChipTabsList = React.forwardRef<unknown, ChipTabsListProps>(
+  ({ scrollAlign = "nearest", ...props }, ref) => (
+    <TabsList {...props} ref={ref} scrollAlign={scrollAlign} />
+  ),
+);
+ChipTabsList.displayName = "ChipTabsList";
+
+////////////////////////////////////////////////////////////////////////////////////
+
+/** Native text label and optional inline notification slot을 갖는 chip trigger입니다. */
+export interface ChipTabsTriggerProps extends TabsTriggerProps {}
+
+export const ChipTabsTrigger = TabsTrigger;
+
+////////////////////////////////////////////////////////////////////////////////////
+
+export interface ChipTabsContentProps extends TabsContentProps {}
+
+export const ChipTabsContent = TabsContent;
+
+////////////////////////////////////////////////////////////////////////////////////
+
+/** @platform Lynx native viewpager를 사용하므로 Tabs Carousel의 미지원 prop과 동일합니다. */
+export interface ChipTabsCarouselProps extends TabsCarouselProps {}
+
+export const ChipTabsCarousel = TabsCarousel;
+
+////////////////////////////////////////////////////////////////////////////////////
+
+export interface ChipTabsCarouselCameraProps extends TabsCarouselCameraProps {}
+
+export const ChipTabsCarouselCamera = TabsCarouselCamera;

--- a/packages/lynx-react/src/components/ChipTabs/index.ts
+++ b/packages/lynx-react/src/components/ChipTabs/index.ts
@@ -1,0 +1,16 @@
+export {
+  ChipTabsCarousel,
+  ChipTabsCarouselCamera,
+  ChipTabsContent,
+  ChipTabsList,
+  ChipTabsRoot,
+  ChipTabsTrigger,
+  type ChipTabsCarouselCameraProps,
+  type ChipTabsCarouselProps,
+  type ChipTabsContentProps,
+  type ChipTabsListProps,
+  type ChipTabsRootProps,
+  type ChipTabsTriggerProps,
+} from "./ChipTabs";
+
+export * as ChipTabs from "./ChipTabs.namespace";

--- a/packages/lynx-react/src/components/Tabs/Tabs.test.tsx
+++ b/packages/lynx-react/src/components/Tabs/Tabs.test.tsx
@@ -319,7 +319,7 @@ describe("Tabs", () => {
     expect(container.querySelector(".seed-tabs__content")).not.toBeNull();
   });
 
-  it("closes every native swipe lifecycle when a drag does not change pages", () => {
+  it("starts only for native drags and closes non-changing or cancelled swipes", () => {
     function SwipeLifecycleTabs() {
       const [counts, setCounts] = React.useState({ starts: 0, ends: 0, settles: 0 });
       const isSwiping = counts.starts > counts.ends;
@@ -355,7 +355,13 @@ describe("Tabs", () => {
     const pager = container.querySelector("viewpager")!;
 
     fireEvent.touchstart(pager, {});
+    expect(getByTestId("swipe-state")).toHaveTextContent("idle");
+    fireEvent.touchend(pager, {});
+    expect(getByTestId("swipe-counts")).toHaveTextContent("0/0/0");
+
+    fireEvent.touchstart(pager, {});
     fireViewPagerEvent(pager, "willchange", { index: 1, isDragged: true });
+    expect(getByTestId("swipe-state")).toHaveTextContent("swiping");
     fireViewPagerEvent(pager, "change", { index: 1, isDragged: true });
     fireEvent.touchend(pager, {});
 
@@ -376,6 +382,13 @@ describe("Tabs", () => {
 
     expect(getByTestId("swipe-state")).toHaveTextContent("idle");
     expect(getByTestId("swipe-counts")).toHaveTextContent("3/3/2");
+
+    fireEvent.touchstart(pager, {});
+    fireViewPagerEvent(pager, "willchange", { index: 0, isDragged: true });
+    fireEvent.touchcancel(pager, {});
+    fireEvent.touchend(pager, {});
+    expect(getByTestId("swipe-state")).toHaveTextContent("idle");
+    expect(getByTestId("swipe-counts")).toHaveTextContent("4/4/2");
   });
 
   it("renders carousel camera contents as native viewpager items", () => {

--- a/packages/lynx-react/src/components/Tabs/Tabs.test.tsx
+++ b/packages/lynx-react/src/components/Tabs/Tabs.test.tsx
@@ -1,14 +1,28 @@
 import "@testing-library/jest-dom";
-import { fireEvent, render } from "@lynx-js/react/testing-library";
+import * as React from "@lynx-js/react";
+import { createEvent, fireEvent, render } from "@lynx-js/react/testing-library";
 import { describe, expect, it, vi } from "vitest";
 
 import * as Tabs from "./Tabs.namespace";
+import * as ChipTabs from "../ChipTabs/ChipTabs.namespace";
 import {
   areTabsTransitionsEnabled,
   getTabsLayoutWidth,
   getTabsOrderedItems,
+  getTabsScrollOffset,
   getTabsTriggerRects,
 } from "./Tabs.utils";
+
+function fireViewPagerEvent(
+  pager: Element,
+  eventName: "change" | "willchange",
+  detail: { index: number; isDragged: boolean },
+) {
+  const init = { eventType: "bindEvent", eventName, detail };
+  const event = createEvent(`bindEvent:${eventName}`, pager, init);
+  Object.assign(event, init);
+  fireEvent(pager, event);
+}
 
 function BasicTabs(props: {
   value?: string;
@@ -140,6 +154,121 @@ describe("Tabs", () => {
     expect(rects["three"]?.left).toBe(0);
   });
 
+  it("calculates tab scroll offsets from content insets and measured widths", () => {
+    const geometry = {
+      viewportWidth: 360,
+      contentWidth: 792,
+      contentInsetStart: 16,
+      contentInsetEnd: 16,
+      triggerRect: { left: 320, width: 56 },
+    };
+
+    expect(getTabsScrollOffset({ ...geometry, scrollAlign: "start", currentOffset: 0 })).toBe(320);
+    expect(getTabsScrollOffset({ ...geometry, scrollAlign: "center", currentOffset: 0 })).toBe(184);
+    expect(getTabsScrollOffset({ ...geometry, scrollAlign: "end", currentOffset: 0 })).toBe(48);
+    expect(getTabsScrollOffset({ ...geometry, scrollAlign: "nearest", currentOffset: 0 })).toBe(48);
+    expect(getTabsScrollOffset({ ...geometry, scrollAlign: "nearest", currentOffset: 160 })).toBe(
+      160,
+    );
+    // A trigger can sit inside the desired 16px padding while remaining fully
+    // visible in the actual scroll viewport; nearest must not move it.
+    expect(
+      getTabsScrollOffset({
+        ...geometry,
+        scrollAlign: "nearest",
+        currentOffset: 200,
+        triggerRect: { left: 192, width: 56 },
+      }),
+    ).toBe(200);
+    expect(
+      getTabsScrollOffset({
+        ...geometry,
+        scrollAlign: "nearest",
+        currentOffset: 240,
+        triggerRect: { left: 192, width: 56 },
+      }),
+    ).toBe(192);
+  });
+
+  it("clamps tab scrolling at both content edges without moving a non-scrollable list", () => {
+    const geometry = {
+      viewportWidth: 360,
+      contentWidth: 792,
+      contentInsetStart: 16,
+      contentInsetEnd: 16,
+    };
+
+    expect(
+      getTabsScrollOffset({
+        ...geometry,
+        scrollAlign: "end",
+        currentOffset: 0,
+        triggerRect: { left: 0, width: 56 },
+      }),
+    ).toBe(0);
+    expect(
+      getTabsScrollOffset({
+        ...geometry,
+        scrollAlign: "start",
+        currentOffset: 0,
+        triggerRect: { left: 704, width: 56 },
+      }),
+    ).toBe(432);
+    expect(
+      getTabsScrollOffset({
+        ...geometry,
+        contentWidth: 360,
+        scrollAlign: "center",
+        currentOffset: 144,
+        triggerRect: { left: 320, width: 56 },
+      }),
+    ).toBe(0);
+  });
+
+  it("updates large ChipTabs selection and content without activating disabled triggers", () => {
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <ChipTabs.Root size="large" defaultValue="one" onValueChange={onValueChange}>
+        <ChipTabs.List>
+          <ChipTabs.Trigger value="one" notification={<text>새 알림</text>}>
+            첫 번째
+          </ChipTabs.Trigger>
+          <ChipTabs.Trigger value="two">두 번째</ChipTabs.Trigger>
+          <ChipTabs.Trigger value="three" disabled>
+            세 번째
+          </ChipTabs.Trigger>
+        </ChipTabs.List>
+        <ChipTabs.Content value="one">첫 번째 콘텐츠</ChipTabs.Content>
+        <ChipTabs.Content value="two">두 번째 콘텐츠</ChipTabs.Content>
+        <ChipTabs.Content value="three">세 번째 콘텐츠</ChipTabs.Content>
+      </ChipTabs.Root>,
+    );
+    const triggers = container.querySelectorAll<HTMLElement>(
+      '[accessibility-role-description="tab"]',
+    );
+    const contents = container.querySelectorAll<HTMLElement>(
+      '[accessibility-role-description="tabpanel"]',
+    );
+
+    expect(triggers[0]).toHaveAttribute("accessibility-value", "selected");
+    expect(contents[0]).toHaveAttribute("accessibility-elements-hidden", "false");
+    expect(contents[0]).toHaveTextContent("첫 번째 콘텐츠");
+    expect(container).toHaveTextContent("새 알림");
+
+    fireEvent.tap(triggers[1]);
+
+    expect(onValueChange).toHaveBeenCalledWith("two");
+    expect(triggers[1]).toHaveAttribute("accessibility-value", "selected");
+    expect(contents[1]).toHaveAttribute("accessibility-elements-hidden", "false");
+    expect(contents[1]).toHaveTextContent("두 번째 콘텐츠");
+
+    fireEvent.tap(triggers[2]);
+
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(triggers[1]).toHaveAttribute("accessibility-value", "selected");
+    expect(contents[1]).toHaveAttribute("accessibility-elements-hidden", "false");
+  });
+
   it("does not select a disabled trigger", () => {
     const onValueChange = vi.fn();
     const { container } = render(
@@ -188,6 +317,65 @@ describe("Tabs", () => {
 
     expect(container.querySelector("viewpager-item")).toBeNull();
     expect(container.querySelector(".seed-tabs__content")).not.toBeNull();
+  });
+
+  it("closes every native swipe lifecycle when a drag does not change pages", () => {
+    function SwipeLifecycleTabs() {
+      const [counts, setCounts] = React.useState({ starts: 0, ends: 0, settles: 0 });
+      const isSwiping = counts.starts > counts.ends;
+
+      return (
+        <Tabs.Root defaultValue="one">
+          <Tabs.List>
+            <Tabs.Trigger value="one">첫 번째</Tabs.Trigger>
+            <Tabs.Trigger value="two">두 번째</Tabs.Trigger>
+          </Tabs.List>
+          <Tabs.Carousel
+            swipeable
+            onSwipeStart={() =>
+              setCounts((current) => ({ ...current, starts: current.starts + 1 }))
+            }
+            onSwipeEnd={() => setCounts((current) => ({ ...current, ends: current.ends + 1 }))}
+            onSettle={() => setCounts((current) => ({ ...current, settles: current.settles + 1 }))}
+          >
+            <Tabs.CarouselCamera>
+              <Tabs.Content value="one">첫 번째 콘텐츠</Tabs.Content>
+              <Tabs.Content value="two">두 번째 콘텐츠</Tabs.Content>
+            </Tabs.CarouselCamera>
+          </Tabs.Carousel>
+          <text data-testid="swipe-state">{isSwiping ? "swiping" : "idle"}</text>
+          <text data-testid="swipe-counts">
+            {`${counts.starts}/${counts.ends}/${counts.settles}`}
+          </text>
+        </Tabs.Root>
+      );
+    }
+
+    const { container, getByTestId } = render(<SwipeLifecycleTabs />);
+    const pager = container.querySelector("viewpager")!;
+
+    fireEvent.touchstart(pager, {});
+    fireViewPagerEvent(pager, "willchange", { index: 1, isDragged: true });
+    fireViewPagerEvent(pager, "change", { index: 1, isDragged: true });
+    fireEvent.touchend(pager, {});
+
+    expect(getByTestId("swipe-state")).toHaveTextContent("idle");
+    expect(getByTestId("swipe-counts")).toHaveTextContent("1/1/1");
+
+    fireEvent.touchstart(pager, {});
+    fireViewPagerEvent(pager, "willchange", { index: 1, isDragged: true });
+    fireEvent.touchend(pager, {});
+
+    expect(getByTestId("swipe-state")).toHaveTextContent("idle");
+    expect(getByTestId("swipe-counts")).toHaveTextContent("2/2/1");
+
+    fireEvent.touchstart(pager, {});
+    fireViewPagerEvent(pager, "willchange", { index: 0, isDragged: true });
+    fireViewPagerEvent(pager, "change", { index: 0, isDragged: true });
+    fireEvent.touchend(pager, {});
+
+    expect(getByTestId("swipe-state")).toHaveTextContent("idle");
+    expect(getByTestId("swipe-counts")).toHaveTextContent("3/3/2");
   });
 
   it("renders carousel camera contents as native viewpager items", () => {

--- a/packages/lynx-react/src/components/Tabs/Tabs.tsx
+++ b/packages/lynx-react/src/components/Tabs/Tabs.tsx
@@ -36,7 +36,6 @@ import {
 
 type NativeViewProps = IntrinsicElements["view"];
 type NativeViewPagerProps = IntrinsicElements["viewpager"];
-type TouchStartHandler = NonNullable<NativeViewPagerProps["bindtouchstart"]>;
 type TouchEndHandler = NonNullable<NativeViewPagerProps["bindtouchend"]>;
 type TouchCancelHandler = NonNullable<NativeViewPagerProps["bindtouchcancel"]>;
 type LayoutChangeHandler = NonNullable<NativeViewProps["bindlayoutchange"]>;
@@ -854,7 +853,9 @@ export interface TabsCarouselProps extends LynxStyledElementProps {
   /** iOS 뒤로가기 제스처를 우선하는 화면 왼쪽 가장자리 너비입니다. */
   iosBackGestureEdgeWidth?: number;
   onSettle?: () => void;
+  /** 네이티브 pager가 drag를 감지했을 때 호출합니다. */
   onSwipeStart?: () => void;
+  /** 시작된 스와이프가 끝나거나 취소되면 호출합니다. */
   onSwipeEnd?: () => void;
 }
 
@@ -928,13 +929,6 @@ export const TabsCarouselCamera = React.forwardRef<unknown, TabsCarouselCameraPr
       carouselContext.onSwipeEnd?.();
     }, [carouselContext.onSwipeEnd]);
 
-    const handleTouchStart = React.useCallback<TouchStartHandler>(() => {
-      "background only";
-      if (!carouselContext.swipeable || swipingRef.current) return;
-      swipingRef.current = true;
-      carouselContext.onSwipeStart?.();
-    }, [carouselContext.onSwipeStart, carouselContext.swipeable]);
-
     const handleTouchEnd = React.useCallback<TouchEndHandler>(() => {
       "background only";
       finishSwipe();
@@ -951,9 +945,18 @@ export const TabsCarouselCamera = React.forwardRef<unknown, TabsCarouselCameraPr
         bindwillchange?.(event);
         if (event.detail.isDragged) {
           tabsContext.handlePagerWillChange(event.detail.index);
+          if (carouselContext.swipeable && !swipingRef.current) {
+            swipingRef.current = true;
+            carouselContext.onSwipeStart?.();
+          }
         }
       },
-      [bindwillchange, tabsContext.handlePagerWillChange],
+      [
+        bindwillchange,
+        carouselContext.onSwipeStart,
+        carouselContext.swipeable,
+        tabsContext.handlePagerWillChange,
+      ],
     );
 
     const handleChange = React.useCallback(
@@ -1002,7 +1005,6 @@ export const TabsCarouselCamera = React.forwardRef<unknown, TabsCarouselCameraPr
         {...mergeProps(
           {
             ref: mergedRef,
-            bindtouchstart: handleTouchStart,
             bindtouchend: handleTouchEnd,
             bindtouchcancel: handleTouchCancel,
             bindwillchange: handleWillChange,

--- a/packages/lynx-react/src/components/Tabs/Tabs.tsx
+++ b/packages/lynx-react/src/components/Tabs/Tabs.tsx
@@ -1,4 +1,5 @@
 import { tabs, type TabsVariantProps } from "@seed-design/lynx-css/recipes/tabs";
+import { runOnMainThread } from "@lynx-js/react";
 import * as React from "@lynx-js/react";
 import type {
   IntrinsicElements,
@@ -20,28 +21,91 @@ import type {
   LynxViewProps,
   LynxViewRef,
 } from "../../types";
+import { mergeProps } from "../../utils/merge-props";
 import { createSlotRecipeContext } from "../../utils/create-slot-recipe-context";
 import { Box } from "../Box";
+import { HStack } from "../Stack";
 import {
   areTabsTransitionsEnabled,
   getTabsLayoutWidth,
   getTabsOrderedItems,
+  getTabsScrollOffset,
   getTabsTriggerRects,
   type TabsLayoutRect,
 } from "./Tabs.utils";
-import { mergeProps } from "../../utils/merge-props";
 
 type NativeViewProps = IntrinsicElements["view"];
 type NativeViewPagerProps = IntrinsicElements["viewpager"];
+type TouchStartHandler = NonNullable<NativeViewPagerProps["bindtouchstart"]>;
+type TouchEndHandler = NonNullable<NativeViewPagerProps["bindtouchend"]>;
+type TouchCancelHandler = NonNullable<NativeViewPagerProps["bindtouchcancel"]>;
 type LayoutChangeHandler = NonNullable<NativeViewProps["bindlayoutchange"]>;
+type NativeScrollViewProps = IntrinsicElements["scroll-view"];
+type ScrollViewLayoutChangeHandler = NonNullable<NativeScrollViewProps["bindlayoutchange"]>;
+type ScrollViewHandler = NonNullable<NativeScrollViewProps["bindscroll"]>;
+type ContentSizeChangedHandler = NonNullable<NativeScrollViewProps["bindcontentsizechanged"]>;
+
+type ComputedStyleElement = MainThread.Element & {
+  getComputedStyleProperty?: (name: string) => string;
+};
+
+interface TabsContentInsets {
+  start: number;
+  end: number;
+}
+
+interface TabsScrollMetrics {
+  currentOffset: number;
+  viewportWidth: number | null;
+  contentWidth: number | null;
+  insets: TabsContentInsets | null;
+}
+
+function getTabsContentInsets(
+  contentRef: React.RefObject<ComputedStyleElement | null>,
+): TabsContentInsets | null {
+  "main thread";
+
+  const content = contentRef.current;
+  if (!content || typeof content.getComputedStyleProperty !== "function") return null;
+  // Read used values so Rootage tokens and consumer style overrides share the
+  // same scroll-content origin as the trigger rectangles; do not invent a fallback.
+
+  const start = Number.parseFloat(content.getComputedStyleProperty("padding-left"));
+  const end = Number.parseFloat(content.getComputedStyleProperty("padding-right"));
+  if (!Number.isFinite(start) || !Number.isFinite(end) || start < 0 || end < 0) return null;
+  return { start, end };
+}
 type TriggerRect = TabsLayoutRect;
 type TriggerItem = { value: string; disabled: boolean };
+type TabsSharedClassNames = {
+  root: string;
+  list: string;
+  listContent: string;
+  carousel: string;
+  carouselCamera: string;
+  content: string;
+  trigger: string;
+  triggerLabel: string;
+};
+type TabsRecipeState = {
+  selected?: boolean;
+  pressed?: boolean;
+  disabled?: boolean;
+  inCarousel?: boolean;
+  transitionEnabled?: boolean;
+};
+type TabsRecipeAdapter = {
+  getClassNames: (state?: TabsRecipeState) => TabsSharedClassNames;
+  getIndicatorClassName?: (state?: TabsRecipeState) => string;
+  triggerGap: number;
+};
 type TabsPublicVariantProps = Omit<
   TabsVariantProps,
   "selected" | "disabled" | "inCarousel" | "transitionEnabled"
 >;
 
-const { ClassNamesProvider, useClassNames } = createSlotRecipeContext(tabs);
+const { ClassNamesProvider } = createSlotRecipeContext(tabs);
 
 function invokeSelectTab(pager: NodesRef | null, index: number, smooth: boolean) {
   "background only";
@@ -66,7 +130,10 @@ function invokeScrollToOffset(list: NodesRef | null, offset: number) {
 interface TabsContextValue {
   value: string | undefined;
   visualValue: string | undefined;
-  variantProps: TabsPublicVariantProps;
+  classNames: TabsSharedClassNames;
+  getClassNames: (state?: TabsRecipeState) => TabsSharedClassNames;
+  getIndicatorClassName?: (state?: TabsRecipeState) => string;
+  inlineNotification: boolean;
   items: TriggerItem[];
   pagerValues: string[];
   indicatorIndex: number;
@@ -79,7 +146,6 @@ interface TabsContextValue {
   updateTriggerDisabled: (value: string, disabled: boolean) => void;
   syncTriggerOrder: (values: string[]) => void;
   updateTriggerWidth: (value: string, width: number) => void;
-  setListRef: (ref: NodesRef | null) => void;
   setPagerRef: (ref: NodesRef | null) => void;
   selectValue: (value: string) => void;
   handlePagerWillChange: (index: number) => void;
@@ -135,9 +201,15 @@ export interface TabsRootProps extends TabsPublicVariantProps, LynxStyledElement
   onValueChange?: (value: string) => void;
 }
 
-export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) => {
-  const [variantProps, otherProps] = tabs.splitVariantProps(props);
+interface TabsRootPrimitiveProps extends Omit<TabsRootProps, keyof TabsPublicVariantProps> {
+  recipe: TabsRecipeAdapter;
+  inlineNotification?: boolean;
+}
+
+export const TabsRootPrimitive = React.forwardRef<unknown, TabsRootPrimitiveProps>((props, ref) => {
   const {
+    recipe,
+    inlineNotification = false,
     children,
     className,
     style,
@@ -145,7 +217,7 @@ export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) =>
     defaultValue,
     onValueChange,
     ...nativeProps
-  } = otherProps;
+  } = props;
   const [value, setValueInternal] = useControllableState<string | undefined>({
     value: valueProp,
     defaultValue,
@@ -158,7 +230,6 @@ export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) =>
   const [contentValues, setContentValues] = React.useState<string[]>([]);
   const [indicatorValue, setIndicatorValue] = React.useState<string | undefined>();
   const [triggerWidths, setTriggerWidths] = React.useState<Record<string, number>>({});
-  const listRef = React.useRef<NodesRef | null>(null);
   const pagerRef = React.useRef<NodesRef | null>(null);
   const indicatorRef = React.useMainThreadRef<MainThread.Element>(null);
 
@@ -174,28 +245,19 @@ export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) =>
       getTabsTriggerRects(
         items.map((item) => item.value),
         triggerWidths,
+        recipe.triggerGap,
       ),
-    [items, triggerWidths],
+    [items, recipe.triggerGap, triggerWidths],
   );
   const transitionsEnabled = areTabsTransitionsEnabled(
     items.map((item) => item.value),
     triggerRects,
   );
-  const classNames = tabs({ ...variantProps, transitionEnabled: transitionsEnabled });
+  const getClassNames = recipe.getClassNames;
+  const classNames = getClassNames({ transitionEnabled: transitionsEnabled });
   const visualValue = indicatorValue ?? value;
   const indicatorIndex = items.findIndex((item) => item.value === visualValue);
   const selectedPagerIndex = value === undefined ? -1 : pagerValues.indexOf(value);
-  const selectedRect = value === undefined ? undefined : triggerRects[value];
-  const selectedOffset = selectedRect?.left ?? null;
-
-  const setListNode = React.useCallback(
-    (node: NodesRef | null) => {
-      listRef.current = node;
-      if (node && selectedOffset !== null) invokeScrollToOffset(node, selectedOffset);
-    },
-    [selectedOffset],
-  );
-
   const setPagerNode = React.useCallback(
     (node: NodesRef | null) => {
       pagerRef.current = node;
@@ -283,14 +345,16 @@ export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) =>
     if (selectedPagerIndex >= 0) {
       invokeSelectTab(pagerRef.current, selectedPagerIndex, false);
     }
-    if (selectedOffset !== null) invokeScrollToOffset(listRef.current, selectedOffset);
-  }, [selectedPagerIndex, selectedOffset]);
+  }, [selectedPagerIndex]);
 
   const contextValue = React.useMemo<TabsContextValue>(
     () => ({
       value,
       visualValue,
-      variantProps,
+      classNames,
+      getClassNames,
+      getIndicatorClassName: recipe.getIndicatorClassName,
+      inlineNotification,
       items,
       pagerValues,
       indicatorIndex,
@@ -303,7 +367,6 @@ export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) =>
       updateTriggerDisabled,
       syncTriggerOrder,
       updateTriggerWidth,
-      setListRef: setListNode,
       setPagerRef: setPagerNode,
       selectValue,
       handlePagerWillChange,
@@ -312,7 +375,10 @@ export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) =>
     [
       value,
       visualValue,
-      variantProps,
+      classNames,
+      getClassNames,
+      recipe.getIndicatorClassName,
+      inlineNotification,
       items,
       pagerValues,
       indicatorIndex,
@@ -325,7 +391,6 @@ export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) =>
       updateTriggerDisabled,
       syncTriggerOrder,
       updateTriggerWidth,
-      setListNode,
       setPagerNode,
       selectValue,
       handlePagerWillChange,
@@ -335,16 +400,44 @@ export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) =>
 
   return (
     <TabsContext.Provider value={contextValue}>
-      <ClassNamesProvider value={classNames}>
-        <view
-          {...mergeProps(ref ? { ref: ref as LynxViewRef } : {}, nativeProps)}
-          className={clsx(classNames.root, className)}
-          style={style}
-        >
-          {children}
-        </view>
-      </ClassNamesProvider>
+      <view
+        {...mergeProps(ref ? { ref: ref as LynxViewRef } : {}, nativeProps)}
+        className={clsx(classNames.root, className)}
+        style={style}
+      >
+        {children}
+      </view>
     </TabsContext.Provider>
+  );
+});
+TabsRootPrimitive.displayName = "TabsRootPrimitive";
+
+export const TabsRoot = React.forwardRef<unknown, TabsRootProps>((props, ref) => {
+  const [variantProps, rootProps] = tabs.splitVariantProps(props);
+  const getClassNames = React.useCallback(
+    (state: TabsRecipeState = {}) =>
+      tabs({
+        ...variantProps,
+        selected: state.selected,
+        disabled: state.disabled,
+        inCarousel: state.inCarousel,
+        transitionEnabled: state.transitionEnabled,
+      }),
+    [variantProps],
+  );
+  const recipe = React.useMemo<TabsRecipeAdapter>(
+    () => ({
+      getClassNames,
+      getIndicatorClassName: (state) => getClassNames(state).indicator,
+      triggerGap: 0,
+    }),
+    [getClassNames],
+  );
+
+  return (
+    <ClassNamesProvider value={getClassNames()}>
+      <TabsRootPrimitive {...rootProps} ref={ref} recipe={recipe} />
+    </ClassNamesProvider>
   );
 });
 TabsRoot.displayName = "TabsRoot";
@@ -371,27 +464,157 @@ function getTabsTriggerValues(children: React.ReactNode): string[] {
   return values;
 }
 
-export interface TabsListProps extends LynxStyledElementProps {}
+export interface TabsListProps extends LynxStyledElementProps {
+  /** 선택한 tab을 목록 안에서 정렬할 방식입니다. @defaultValue "start" */
+  scrollAlign?: "nearest" | "start" | "center" | "end";
+}
 
 export const TabsList = React.forwardRef<unknown, TabsListProps>((props, ref) => {
-  const { children, className, style, ...nativeProps } = props;
-  const classNames = useClassNames();
-  const { items, setListRef, syncTriggerOrder } = useTabsContext("TabsList");
+  const { children, className, style, scrollAlign = "start", ...nativeProps } = props;
+  const { classNames, items, syncTriggerOrder, triggerRects, value } = useTabsContext("TabsList");
+  const scrollRef = React.useRef<NodesRef | null>(null);
+  const contentRef = React.useMainThreadRef<ComputedStyleElement | null>(null);
+  const metricsRef = React.useRef<TabsScrollMetrics>({
+    currentOffset: 0,
+    viewportWidth: null,
+    contentWidth: null,
+    insets: null,
+  });
+  const contentInsetRequestRef = React.useRef(0);
+  const selectedValueRef = React.useRef(value);
+  const [geometryRevision, setGeometryRevision] = React.useState(0);
   const triggerOrder = React.useMemo(() => getTabsTriggerValues(children), [children]);
+
+  selectedValueRef.current = value;
 
   React.useEffect(() => {
     "background only";
     syncTriggerOrder(triggerOrder);
   }, [items, syncTriggerOrder, triggerOrder]);
 
+  const requestContentInsets = React.useCallback(() => {
+    "background only";
+    const request = ++contentInsetRequestRef.current;
+    metricsRef.current.insets = null;
+
+    void runOnMainThread<TabsContentInsets | null, typeof getTabsContentInsets>(
+      getTabsContentInsets,
+    )(contentRef).then(
+      (insets) => {
+        "background only";
+        if (request !== contentInsetRequestRef.current || !insets) return;
+
+        metricsRef.current.insets = insets;
+        setGeometryRevision((revision) => revision + 1);
+      },
+      () => {
+        // Missing native measurement intentionally leaves alignment pending.
+      },
+    );
+  }, [contentRef]);
+
+  const handleListLayoutChange = React.useCallback<ScrollViewLayoutChangeHandler>((event) => {
+    "background only";
+    const width = getTabsLayoutWidth(event);
+    if (width !== null && width > 0 && metricsRef.current.viewportWidth !== width) {
+      metricsRef.current.viewportWidth = width;
+      setGeometryRevision((revision) => revision + 1);
+    }
+  }, []);
+
+  const handleContentLayoutChange = React.useCallback<LayoutChangeHandler>(
+    (event) => {
+      "background only";
+      const width = getTabsLayoutWidth(event);
+      if (width !== null && width > 0 && metricsRef.current.contentWidth !== width) {
+        // Layout width is the ListContent border box until scrollWidth reports
+        // the scroll-view content width; the latter replaces this value below.
+        metricsRef.current.contentWidth = width;
+        setGeometryRevision((revision) => revision + 1);
+      }
+      requestContentInsets();
+    },
+    [requestContentInsets],
+  );
+
+  const updateScrollMetrics = React.useCallback(
+    (scrollLeft: number, scrollWidth: number) => {
+      "background only";
+      if (Number.isFinite(scrollLeft)) metricsRef.current.currentOffset = Math.max(0, scrollLeft);
+      if (
+        Number.isFinite(scrollWidth) &&
+        scrollWidth > 0 &&
+        metricsRef.current.contentWidth !== scrollWidth
+      ) {
+        metricsRef.current.contentWidth = scrollWidth;
+        requestContentInsets();
+        setGeometryRevision((revision) => revision + 1);
+      }
+    },
+    [requestContentInsets],
+  );
+
+  const handleScroll = React.useCallback<ScrollViewHandler>(
+    (event) => {
+      "background only";
+      updateScrollMetrics(event.detail.scrollLeft, event.detail.scrollWidth);
+    },
+    [updateScrollMetrics],
+  );
+
+  const handleContentSizeChanged = React.useCallback<ContentSizeChangedHandler>(
+    (event) => {
+      "background only";
+      updateScrollMetrics(event.detail.scrollLeft, event.detail.scrollWidth);
+    },
+    [updateScrollMetrics],
+  );
+
+  React.useEffect(() => {
+    "background only";
+    const selectedRect = value === undefined ? undefined : triggerRects[value];
+    const { currentOffset, viewportWidth, contentWidth, insets } = metricsRef.current;
+    if (
+      !scrollRef.current ||
+      value === undefined ||
+      !selectedRect ||
+      viewportWidth === null ||
+      contentWidth === null ||
+      insets === null
+    ) {
+      return;
+    }
+
+    const targetOffset = getTabsScrollOffset({
+      scrollAlign,
+      currentOffset,
+      viewportWidth,
+      contentWidth,
+      contentInsetStart: insets.start,
+      contentInsetEnd: insets.end,
+      triggerRect: selectedRect,
+    });
+    if (selectedValueRef.current !== value || targetOffset === currentOffset) return;
+
+    invokeScrollToOffset(scrollRef.current, targetOffset);
+  }, [geometryRevision, items, scrollAlign, triggerRects, value]);
+
   const mergedRef = React.useMemo(
-    () => mergeProps({ ref: setListRef }, { ref: ref as LynxViewRef }).ref,
-    [ref, setListRef],
+    () => mergeProps({ ref: scrollRef }, { ref: ref as LynxViewRef }).ref,
+    [ref],
   );
 
   return (
     <scroll-view
-      {...mergeProps({ ref: mergedRef }, nativeProps)}
+      {...mergeProps(
+        {
+          ref: mergedRef,
+          bindlayoutchange: handleListLayoutChange,
+          bindscroll: handleScroll,
+          bindcontentsizechanged: handleContentSizeChanged,
+        },
+        nativeProps,
+      )}
       scroll-orientation="horizontal"
       scroll-bar-enable={false}
       accessibility-element={false}
@@ -399,7 +622,13 @@ export const TabsList = React.forwardRef<unknown, TabsListProps>((props, ref) =>
       className={clsx(classNames.list, className)}
       style={style}
     >
-      <view className={classNames.listContent}>{children}</view>
+      <view
+        className={classNames.listContent}
+        main-thread:ref={contentRef}
+        bindlayoutchange={handleContentLayoutChange}
+      >
+        {children}
+      </view>
     </scroll-view>
   );
 });
@@ -452,13 +681,10 @@ export const TabsTrigger = React.forwardRef<unknown, TabsTriggerProps>((props, r
     },
     [bindtap, context.selectValue, triggerValue],
   );
-  const {
-    pressed: _pressed,
-    bindtouchstart,
-    bindtouchend,
-    bindtouchcancel,
-    ...pressHandlers
-  } = usePressTap({ disabled, onTap: handleTap });
+  const { pressed, bindtouchstart, bindtouchend, bindtouchcancel, ...pressHandlers } = usePressTap({
+    disabled,
+    onTap: handleTap,
+  });
   const { scaleFeedbackTriggerProps, scaleFeedbackTargetProps } = useScaleFeedback({
     disabled,
     onTouchStart: bindtouchstart,
@@ -475,10 +701,10 @@ export const TabsTrigger = React.forwardRef<unknown, TabsTriggerProps>((props, r
     [context.updateTriggerWidth, triggerValue],
   );
 
-  const triggerClasses = tabs({
-    ...context.variantProps,
+  const triggerClasses = context.getClassNames({
     selected: visuallySelected,
     disabled,
+    pressed,
     transitionEnabled: context.transitionsEnabled,
   });
   const label =
@@ -504,10 +730,17 @@ export const TabsTrigger = React.forwardRef<unknown, TabsTriggerProps>((props, r
       style={style}
     >
       {notification ? (
-        <Box position="relative">
-          <text className={triggerClasses.triggerLabel}>{children}</text>
-          {notification}
-        </Box>
+        context.inlineNotification ? (
+          <HStack position="relative" gap="x1_5">
+            <text className={triggerClasses.triggerLabel}>{children}</text>
+            <view accessibility-elements-hidden={true}>{notification}</view>
+          </HStack>
+        ) : (
+          <Box position="relative">
+            <text className={triggerClasses.triggerLabel}>{children}</text>
+            {notification}
+          </Box>
+        )
       ) : (
         <text className={triggerClasses.triggerLabel}>{children}</text>
       )}
@@ -522,8 +755,18 @@ export interface TabsIndicatorProps extends LynxStyledElementProps {}
 
 export const TabsIndicator = React.forwardRef<unknown, TabsIndicatorProps>((props, ref) => {
   const { className, style, ...nativeProps } = props;
-  const classNames = useClassNames();
-  const { indicatorRef, items, indicatorIndex, triggerRects } = useTabsContext("TabsIndicator");
+  const {
+    indicatorRef,
+    items,
+    indicatorIndex,
+    triggerRects,
+    getIndicatorClassName,
+    transitionsEnabled,
+  } = useTabsContext("TabsIndicator");
+  if (!getIndicatorClassName) {
+    throw new Error("<TabsIndicator/> is only supported inside <TabsRoot/>.");
+  }
+  const indicatorClassName = getIndicatorClassName({ transitionEnabled: transitionsEnabled });
   const position = indicatorIndex;
   const lowerIndex = Math.max(0, Math.floor(position));
   const upperIndex = Math.min(items.length - 1, Math.ceil(position));
@@ -545,7 +788,7 @@ export const TabsIndicator = React.forwardRef<unknown, TabsIndicatorProps>((prop
         nativeProps,
       )}
       accessibility-elements-hidden={true}
-      className={clsx(classNames.indicator, className)}
+      className={clsx(indicatorClassName, className)}
       style={
         {
           "--tabs-indicator-x": `${x}px`,
@@ -570,7 +813,7 @@ export const TabsContent = React.forwardRef<unknown, TabsContentProps>((props, r
   const inCarousel = useTabsCarouselCameraContext();
   const selected = tabsContext.value === contentValue;
   const disabled = tabsContext.items.find((item) => item.value === contentValue)?.disabled ?? false;
-  const contentClasses = tabs({ ...tabsContext.variantProps, selected, inCarousel });
+  const contentClasses = tabsContext.getClassNames({ selected, inCarousel });
 
   React.useEffect(() => {
     "background only";
@@ -627,7 +870,7 @@ export const TabsCarousel = React.forwardRef<unknown, TabsCarouselProps>((props,
     onSwipeEnd,
     ...nativeProps
   } = props;
-  const classNames = useClassNames();
+  const { classNames } = useTabsContext("TabsCarousel");
   const contextValue = React.useMemo<TabsCarouselContextValue>(
     () => ({ swipeable, iosBackGestureEdgeWidth, onSettle, onSwipeStart, onSwipeEnd }),
     [swipeable, iosBackGestureEdgeWidth, onSettle, onSwipeStart, onSwipeEnd],
@@ -666,8 +909,8 @@ export const TabsCarouselCamera = React.forwardRef<unknown, TabsCarouselCameraPr
       bindoffsetchange,
       ...nativeProps
     } = props;
-    const classNames = useClassNames();
     const tabsContext = useTabsContext("TabsCarouselCamera");
+    const { classNames } = tabsContext;
     const carouselContext = useTabsCarouselContext("TabsCarouselCamera");
     const swipingRef = React.useRef(false);
     const { indicatorRef, pagerValues, triggerRects } = tabsContext;
@@ -678,19 +921,39 @@ export const TabsCarouselCamera = React.forwardRef<unknown, TabsCarouselCameraPr
       [ref, tabsContext.setPagerRef],
     );
 
+    const finishSwipe = React.useCallback(() => {
+      "background only";
+      if (!swipingRef.current) return;
+      swipingRef.current = false;
+      carouselContext.onSwipeEnd?.();
+    }, [carouselContext.onSwipeEnd]);
+
+    const handleTouchStart = React.useCallback<TouchStartHandler>(() => {
+      "background only";
+      if (!carouselContext.swipeable || swipingRef.current) return;
+      swipingRef.current = true;
+      carouselContext.onSwipeStart?.();
+    }, [carouselContext.onSwipeStart, carouselContext.swipeable]);
+
+    const handleTouchEnd = React.useCallback<TouchEndHandler>(() => {
+      "background only";
+      finishSwipe();
+    }, [finishSwipe]);
+
+    const handleTouchCancel = React.useCallback<TouchCancelHandler>(() => {
+      "background only";
+      finishSwipe();
+    }, [finishSwipe]);
+
     const handleWillChange = React.useCallback(
       (event: ViewPagerWillChangeEvent) => {
         "background only";
         bindwillchange?.(event);
         if (event.detail.isDragged) {
           tabsContext.handlePagerWillChange(event.detail.index);
-          if (!swipingRef.current) {
-            swipingRef.current = true;
-            carouselContext.onSwipeStart?.();
-          }
         }
       },
-      [bindwillchange, carouselContext.onSwipeStart, tabsContext.handlePagerWillChange],
+      [bindwillchange, tabsContext.handlePagerWillChange],
     );
 
     const handleChange = React.useCallback(
@@ -699,17 +962,8 @@ export const TabsCarouselCamera = React.forwardRef<unknown, TabsCarouselCameraPr
         bindchange?.(event);
         tabsContext.handlePagerChange(event.detail.index);
         carouselContext.onSettle?.();
-        if (swipingRef.current || event.detail.isDragged) {
-          swipingRef.current = false;
-          carouselContext.onSwipeEnd?.();
-        }
       },
-      [
-        bindchange,
-        carouselContext.onSettle,
-        carouselContext.onSwipeEnd,
-        tabsContext.handlePagerChange,
-      ],
+      [bindchange, carouselContext.onSettle, tabsContext.handlePagerChange],
     );
 
     const handleOffsetChange = React.useCallback(
@@ -748,6 +1002,9 @@ export const TabsCarouselCamera = React.forwardRef<unknown, TabsCarouselCameraPr
         {...mergeProps(
           {
             ref: mergedRef,
+            bindtouchstart: handleTouchStart,
+            bindtouchend: handleTouchEnd,
+            bindtouchcancel: handleTouchCancel,
             bindwillchange: handleWillChange,
             bindchange: handleChange,
             bindoffsetchange: handleOffsetChange,

--- a/packages/lynx-react/src/components/Tabs/Tabs.utils.ts
+++ b/packages/lynx-react/src/components/Tabs/Tabs.utils.ts
@@ -36,6 +36,7 @@ export function getTabsOrderedItems<T extends { value: string }>(
 export function getTabsTriggerRects(
   values: string[],
   widths: Record<string, number>,
+  triggerGap = 0,
 ): Record<string, TabsLayoutRect> {
   const rects = Object.create(null) as Record<string, TabsLayoutRect>;
   let left = 0;
@@ -49,10 +50,59 @@ export function getTabsTriggerRects(
       continue;
     }
     if (hasCompletePrefix) rects[value] = { left, width };
-    left += width;
+    left += width + triggerGap;
   }
 
   return rects;
+}
+
+/**
+ * Trigger rectangles begin at the first trigger, so they exclude list-content
+ * padding. Scroll offsets are measured from the scroll content edge.
+ */
+export function getTabsScrollOffset({
+  scrollAlign,
+  currentOffset,
+  viewportWidth,
+  contentWidth,
+  contentInsetStart,
+  contentInsetEnd,
+  triggerRect,
+}: {
+  scrollAlign: "nearest" | "start" | "center" | "end";
+  currentOffset: number;
+  viewportWidth: number;
+  contentWidth: number;
+  contentInsetStart: number;
+  contentInsetEnd: number;
+  triggerRect: TabsLayoutRect;
+}): number {
+  const maxOffset = Math.max(0, contentWidth - viewportWidth);
+  const clampOffset = (offset: number) => Math.min(maxOffset, Math.max(0, offset));
+  const clampedCurrentOffset = clampOffset(currentOffset);
+  if (maxOffset === 0) return clampedCurrentOffset;
+
+  const triggerStart = contentInsetStart + triggerRect.left;
+  const triggerEnd = triggerStart + triggerRect.width;
+  if (scrollAlign === "nearest") {
+    // Visibility is the scroll-view's actual viewport. Insets provide the
+    // additional room only after a clipped trigger needs to move.
+    const visibleStart = clampedCurrentOffset;
+    const visibleEnd = clampedCurrentOffset + viewportWidth;
+
+    if (triggerStart >= visibleStart && triggerEnd <= visibleEnd) return clampedCurrentOffset;
+    return clampOffset(
+      triggerStart < visibleStart
+        ? triggerStart - contentInsetStart
+        : triggerEnd + contentInsetEnd - viewportWidth,
+    );
+  }
+
+  if (scrollAlign === "start") return clampOffset(triggerStart - contentInsetStart);
+  if (scrollAlign === "center") {
+    return clampOffset(triggerStart + triggerRect.width / 2 - viewportWidth / 2);
+  }
+  return clampOffset(triggerEnd + contentInsetEnd - viewportWidth);
 }
 
 export function areTabsTransitionsEnabled(

--- a/packages/lynx-react/src/components/Tabs/index.ts
+++ b/packages/lynx-react/src/components/Tabs/index.ts
@@ -1,2 +1,18 @@
-export * from "./Tabs";
+export {
+  TabsCarousel,
+  TabsCarouselCamera,
+  TabsContent,
+  TabsIndicator,
+  TabsList,
+  TabsRoot,
+  TabsTrigger,
+  type TabsCarouselCameraProps,
+  type TabsCarouselProps,
+  type TabsContentProps,
+  type TabsIndicatorProps,
+  type TabsListProps,
+  type TabsRootProps,
+  type TabsTriggerProps,
+} from "./Tabs";
+
 export * as Tabs from "./Tabs.namespace";

--- a/packages/lynx-react/src/components/index.ts
+++ b/packages/lynx-react/src/components/index.ts
@@ -7,6 +7,7 @@ export * from "./BottomSheet";
 export * from "./Callout";
 export * from "./Checkbox";
 export * from "./Chip";
+export * from "./ChipTabs";
 export * from "./Count";
 export * from "./ContextualFloatingButton";
 export * from "./Divider";


### PR DESCRIPTION
## 변경 내용

- Lynx에 Chip Tabs의 Root, List, Trigger, Content, Carousel, CarouselCamera와 타입을 추가합니다.
- 기존 Tabs의 상태·Carousel 구현을 공유하며, Chip Tabs Recipe와 선택·눌림·비활성 스타일을 연결합니다.
- `ChipTabsList.scrollAlign`에 `nearest`, `start`, `center`, `end`를 제공합니다. Chip Tabs의 기본값은 `nearest`, 일반 Tabs의 기본값은 기존 `start`를 유지합니다.
- 스크롤 위치·뷰포트·콘텐츠 너비·inset을 `TabsScrollMetrics`로 묶고, 실제 크기와 스크롤 범위에 맞춰 정렬합니다.
- 페이지가 바뀌지 않는 경계 드래그에서도 Carousel의 `onSwipeEnd`가 호출되도록 수정하고 회귀 테스트를 추가합니다.
- Registry, 문서, 8개 실행 예제와 생성물을 연결합니다. Icon 테스트의 오래된 중간 상태 단언 1개를 제거하고 최종 색상 갱신 검사는 유지합니다.

## 검증

- `bun test:lynx-react`: 타입 검사 및 47개 파일의 321개 테스트 통과.
- Lynx React 패키지 빌드 통과. Recipe/CSS·Registry·문서 인덱스 생성 완료.
- 문서 예제·SPA 타입 검사는 구현 과정에서 통과했으며, 동일 입력의 결과를 재사용했습니다.
- iOS PlayLynx에서 4가지 정렬, 완전히 보이는 항목의 `nearest` no-op, 수동 스크롤 유지, 가변 너비·뷰포트 변경, 양끝 제한, 빠른 선택, 일반 Tabs의 기본 `start`를 확인했습니다.
- iOS 가장자리 동작 검증은 사용자 확인으로 완료했습니다.

## 문서 검증 범위

사용자 요청으로 문서 검증을 중단했으며, 최종 판단은 사용자가 직접 수행합니다. 중단 당시 Web 미리보기에서 `center`/`end` 선택값은 바뀌지만 스크롤이 이동하지 않는 현상을 관찰했습니다. 이를 해결 완료로 표시하지 않습니다. 임시 진단 로그와 효과가 확인되지 않은 문서 대응 실험은 제거하고 네이티브 검증본을 유지했습니다.

문서 검증 중단 요청을 지키기 위해 제출 시 `bun docs:test`, 문서 브라우저 검증, 이를 포함하는 전체 저장소 테스트는 다시 실행하지 않았습니다. Android 실행 검증은 수행하지 않았습니다.

## 릴리스

- 승인된 changeset: `@seed-design/lynx-react` minor, `@seed-design/lynx-css` minor.
- PR base: `minor`.
- Version Changes PR에서 `@seed-design/lynx-react`의 `@seed-design/lynx-css` peer 하한을 새 Chip Tabs Recipe 도입 버전인 `0.12.0` 이상으로 검토해야 합니다. 현재 peer 범위는 수정하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - Lynx 환경에서 사용할 수 있는 Chip Tabs 컴포넌트를 추가했습니다.
  - 중립 솔리드·아웃라인 스타일, 중간·큰 크기, 알림 배지, 스크롤 및 Carousel 구성을 지원합니다.
  - 탭 목록의 스크롤 정렬 옵션으로 `nearest`, `start`, `center`, `end`를 제공합니다.
  - 선택·비활성·스와이프 상태와 콘텐츠 전환 동작을 지원합니다.

- **문서 및 예제**
  - 설치 방법, Props, 사용 패턴과 다양한 설정을 안내하는 문서를 추가했습니다.
  - 크기, 스타일, 알림, 스크롤 정렬별 Lynx 예제를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->