### PR TITLE
fix(help-bubble): join the shared dismissible layer stack

### DIFF
--- a/.changeset/tidy-bubbles-stack.md
+++ b/.changeset/tidy-bubbles-stack.md
@@ -1,0 +1,10 @@
+---
+"@seed-design/react": patch
+"@seed-design/react-popover": patch
+---
+
+`HelpBubble`의 닫힘 동작을 수정합니다.
+
+- 다이얼로그나 시트 같은 레이어 안에서 연 `HelpBubble`을 Escape 키나 외부 영역 누름으로 닫을 때 바깥 레이어까지 함께 닫히던 문제를 수정합니다. 이제 가장 위에 열린 `HelpBubble`만 닫힙니다.
+- 바깥 레이어가 닫혀도 `HelpBubble`이 열린 채 남던 문제를 수정합니다.
+- 터치 환경에서 외부 영역에 손가락이 닿는 순간 닫히던 동작을, 탭을 마치거나 손가락을 움직였을 때 닫히도록 바꿉니다. Menu, Select와 같은 방식입니다.

--- a/bun.lock
+++ b/bun.lock
@@ -1025,6 +1025,7 @@
         "@floating-ui/react": "^0.27.0",
         "@radix-ui/react-compose-refs": "^1.1.2",
         "@seed-design/dom-utils": "^2.0.1",
+        "@seed-design/react-dismissible-layer": "^1.0.2",
         "@seed-design/react-floating": "^1.0.1",
         "@seed-design/react-primitive": "^2.0.1",
       },

--- a/packages/react-headless/popover/package.json
+++ b/packages/react-headless/popover/package.json
@@ -33,6 +33,7 @@
     "@floating-ui/react": "^0.27.0",
     "@radix-ui/react-compose-refs": "^1.1.2",
     "@seed-design/dom-utils": "^2.0.1",
+    "@seed-design/react-dismissible-layer": "^1.0.2",
     "@seed-design/react-floating": "^1.0.1",
     "@seed-design/react-primitive": "^2.0.1"
   },

--- a/packages/react-headless/popover/src/Popover.tsx
+++ b/packages/react-headless/popover/src/Popover.tsx
@@ -2,6 +2,7 @@
 
 import { composeRefs } from "@radix-ui/react-compose-refs";
 import { mergeProps } from "@seed-design/dom-utils";
+import { DismissibleLayer } from "@seed-design/react-dismissible-layer";
 import { Primitive, type PrimitiveProps } from "@seed-design/react-primitive";
 import type * as React from "react";
 import { forwardRef } from "react";
@@ -47,6 +48,48 @@ export const PopoverTrigger = forwardRef<HTMLButtonElement, PopoverTriggerProps>
 });
 PopoverTrigger.displayName = "PopoverTrigger";
 
+/**
+ * Joins SEED's shared layer stack while the popover is open, so Escape and outside presses
+ * reach only the top-most layer, and an ancestor layer closing (Dialog, Drawer) cascades down
+ * to this one. It wraps the positioner because that is the floating element and the one part
+ * every consumer renders; HelpBubble supplies its own content element inside it.
+ *
+ * `pressBehavior="drag"` matches Menu and Select: a mouse press outside dismisses on
+ * pointerdown, while touch waits for a drag or a completed tap so a finger landing mid-scroll
+ * does not read as a dismiss.
+ */
+function PopoverDismissibleLayer({ children }: { children: React.ReactNode }) {
+  const { open, setOpen, closeOnInteractOutside, floatingContext } = usePopoverContext();
+
+  return (
+    <DismissibleLayer
+      enabled={open}
+      pressBehavior="drag"
+      onEscapeKeyDown={() => setOpen(false)}
+      onPressOutside={() => {
+        if (!closeOnInteractOutside) return;
+
+        setOpen(false);
+      }}
+      onFocusOutside={() => {
+        // Focus leaving the popover is not a dismissal — nothing to do here.
+      }}
+      onCascadeDismiss={() => setOpen(false)}
+      exclude={(target) => {
+        // The reference (trigger or anchor) lives outside the layer's DOM, and the trigger's
+        // `useClick` already toggles the popover shut. Treating it as outside would close the
+        // popover on pointerdown and let the same press reopen it on click.
+        const reference = floatingContext.refs.reference.current;
+        if (!(reference instanceof HTMLElement)) return false;
+
+        return reference.contains(target);
+      }}
+    >
+      {children}
+    </DismissibleLayer>
+  );
+}
+
 export interface PopoverPositionerProps
   extends PrimitiveProps,
     React.HTMLAttributes<HTMLDivElement> {}
@@ -55,10 +98,12 @@ export const PopoverPositioner = forwardRef<HTMLDivElement, PopoverPositionerPro
   (props, ref) => {
     const api = usePopoverContext();
     return (
-      <Primitive.div
-        ref={composeRefs(api.refs.positioner, ref)}
-        {...mergeProps(api.positionerProps, props)}
-      />
+      <PopoverDismissibleLayer>
+        <Primitive.div
+          ref={composeRefs(api.refs.positioner, ref)}
+          {...mergeProps(api.positionerProps, props)}
+        />
+      </PopoverDismissibleLayer>
     );
   },
 );
@@ -74,10 +119,12 @@ export const PopoverPositionerPortal = forwardRef<HTMLDivElement, PopoverPositio
 
     return (
       <FloatingPortal id={id} root={root} preserveTabOrder={preserveTabOrder}>
-        <Primitive.div
-          ref={composeRefs(api.refs.positioner, ref)}
-          {...mergeProps(api.positionerProps, otherProps)}
-        />
+        <PopoverDismissibleLayer>
+          <Primitive.div
+            ref={composeRefs(api.refs.positioner, ref)}
+            {...mergeProps(api.positionerProps, otherProps)}
+          />
+        </PopoverDismissibleLayer>
       </FloatingPortal>
     );
   },

--- a/packages/react-headless/popover/src/usePopover.test.tsx
+++ b/packages/react-headless/popover/src/usePopover.test.tsx
@@ -1,0 +1,279 @@
+import { DismissibleLayer } from "@seed-design/react-dismissible-layer";
+import { act, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, jest } from "bun:test";
+
+import type * as React from "react";
+
+import {
+  PopoverPositioner,
+  PopoverPositionerPortal,
+  PopoverRoot,
+  PopoverTrigger,
+  type PopoverRootProps,
+} from "./index";
+
+// Flush microtasks so Floating UI position state settles.
+// See: https://floating-ui.com/docs/react#testing
+const waitForPositioning = () => act(async () => {});
+
+// The layer stack registers its outside-press listener a tick after the layer mounts, so a
+// press has to wait for that timer before it counts as a dismissal.
+const waitForLayer = () =>
+  act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  });
+
+/**
+ * Stands in for an ancestor surface that owns a dismissible layer — a Dialog, a BottomSheet,
+ * an AppScreen. What the popover owes it is a registration as its child in the shared stack,
+ * so the raw layer is the mechanism under test rather than a stand-in for one.
+ */
+function AncestorLayer({
+  enabled = true,
+  onEscapeKeyDown = () => {},
+  onPressOutside = () => {},
+  children,
+}: {
+  enabled?: boolean;
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
+  onPressOutside?: (event: PointerEvent | TouchEvent) => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <DismissibleLayer
+      enabled={enabled}
+      onEscapeKeyDown={onEscapeKeyDown}
+      onPressOutside={onPressOutside}
+      onFocusOutside={() => {}}
+      onCascadeDismiss={() => {}}
+    >
+      <div data-testid="ancestor">{children}</div>
+    </DismissibleLayer>
+  );
+}
+
+function BasicPopover({
+  portalled = true,
+  ...props
+}: Omit<PopoverRootProps, "children"> & { portalled?: boolean }) {
+  const Positioner = portalled ? PopoverPositionerPortal : PopoverPositioner;
+
+  return (
+    <PopoverRoot {...props}>
+      <PopoverTrigger>Open Popover</PopoverTrigger>
+      <Positioner>
+        <div>Content</div>
+      </Positioner>
+    </PopoverRoot>
+  );
+}
+
+describe("usePopover", () => {
+  describe("dismissal", () => {
+    it("closes on Escape", async () => {
+      const user = userEvent.setup();
+      const { getByText } = render(<BasicPopover />);
+      await waitForPositioning();
+
+      const trigger = getByText("Open Popover");
+      await user.click(trigger);
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+      await user.keyboard("{Escape}");
+
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("closes on an outside press", async () => {
+      const user = userEvent.setup();
+      const { getByText } = render(
+        <>
+          <BasicPopover />
+          <button type="button">Outside</button>
+        </>,
+      );
+      await waitForPositioning();
+
+      const trigger = getByText("Open Popover");
+      await user.click(trigger);
+      await waitForLayer();
+
+      await user.click(getByText("Outside"));
+
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("stays open on a press inside", async () => {
+      const user = userEvent.setup();
+      const { getByText } = render(<BasicPopover />);
+      await waitForPositioning();
+
+      const trigger = getByText("Open Popover");
+      await user.click(trigger);
+      await waitForLayer();
+
+      await user.click(getByText("Content"));
+
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+    });
+
+    // The trigger sits outside the popover's DOM, so a second press has to toggle it shut
+    // once rather than dismiss it on pointerdown and reopen it on click.
+    it("closes when the trigger is pressed again", async () => {
+      const user = userEvent.setup();
+      const { getByText } = render(<BasicPopover />);
+      await waitForPositioning();
+
+      const trigger = getByText("Open Popover");
+      await user.click(trigger);
+      await waitForLayer();
+
+      await user.click(trigger);
+
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("keeps the popover open on an outside press when closeOnInteractOutside is off", async () => {
+      const user = userEvent.setup();
+      const { getByText } = render(
+        <>
+          <BasicPopover closeOnInteractOutside={false} />
+          <button type="button">Outside</button>
+        </>,
+      );
+      await waitForPositioning();
+
+      const trigger = getByText("Open Popover");
+      await user.click(trigger);
+      await waitForLayer();
+
+      await user.click(getByText("Outside"));
+
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+    });
+
+    // Opting out of outside presses is not opting out of dismissal: Escape is the keyboard
+    // user's only way out, and the opt-out lives in the press handler alone.
+    it("still closes on Escape when closeOnInteractOutside is off", async () => {
+      const user = userEvent.setup();
+      const { getByText } = render(<BasicPopover closeOnInteractOutside={false} />);
+      await waitForPositioning();
+
+      const trigger = getByText("Open Popover");
+      await user.click(trigger);
+
+      await user.keyboard("{Escape}");
+
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+    });
+  });
+
+  // Dismissal resolves against the top-most layer, so a popover opened over a Dialog or a
+  // BottomSheet closes on its own before the surface underneath it hears anything.
+  describe.each([
+    ["PopoverPositioner", false],
+    ["PopoverPositionerPortal", true],
+  ] as const)("layer stack (%s)", (_, portalled) => {
+    it("takes the Escape without disturbing an ancestor layer", async () => {
+      const user = userEvent.setup();
+      const onAncestorEscapeKeyDown = jest.fn();
+      const { getByText } = render(
+        <AncestorLayer onEscapeKeyDown={onAncestorEscapeKeyDown}>
+          <BasicPopover portalled={portalled} />
+        </AncestorLayer>,
+      );
+      await waitForPositioning();
+
+      const trigger = getByText("Open Popover");
+      await user.click(trigger);
+      await user.keyboard("{Escape}");
+
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+      expect(onAncestorEscapeKeyDown).not.toHaveBeenCalled();
+    });
+
+    it("hands the next Escape to the ancestor once it has closed", async () => {
+      const user = userEvent.setup();
+      const onAncestorEscapeKeyDown = jest.fn();
+      const { getByText } = render(
+        <AncestorLayer onEscapeKeyDown={onAncestorEscapeKeyDown}>
+          <BasicPopover portalled={portalled} />
+        </AncestorLayer>,
+      );
+      await waitForPositioning();
+
+      await user.click(getByText("Open Popover"));
+      await user.keyboard("{Escape}");
+      await waitForPositioning();
+
+      await user.keyboard("{Escape}");
+
+      expect(onAncestorEscapeKeyDown).toHaveBeenCalledTimes(1);
+    });
+
+    it("takes an outside press without disturbing an ancestor layer", async () => {
+      const user = userEvent.setup();
+      const onAncestorPressOutside = jest.fn();
+      const { getByText } = render(
+        <>
+          <button type="button">Outside</button>
+          <AncestorLayer onPressOutside={onAncestorPressOutside}>
+            <BasicPopover portalled={portalled} />
+          </AncestorLayer>
+        </>,
+      );
+      await waitForPositioning();
+
+      const trigger = getByText("Open Popover");
+      await user.click(trigger);
+      await waitForLayer();
+
+      await user.click(getByText("Outside"));
+
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+      expect(onAncestorPressOutside).not.toHaveBeenCalled();
+    });
+
+    it("leaves an ancestor layer alone on a press inside the popover", async () => {
+      const user = userEvent.setup();
+      const onAncestorPressOutside = jest.fn();
+      const { getByText } = render(
+        <AncestorLayer onPressOutside={onAncestorPressOutside}>
+          <BasicPopover portalled={portalled} />
+        </AncestorLayer>,
+      );
+      await waitForPositioning();
+
+      const trigger = getByText("Open Popover");
+      await user.click(trigger);
+      await waitForLayer();
+
+      await user.click(getByText("Content"));
+
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+      expect(onAncestorPressOutside).not.toHaveBeenCalled();
+    });
+
+    it("closes when an ancestor layer is dismissed", async () => {
+      const user = userEvent.setup();
+      const { getByText, rerender } = render(
+        <AncestorLayer>
+          <BasicPopover portalled={portalled} />
+        </AncestorLayer>,
+      );
+      await waitForPositioning();
+
+      const trigger = getByText("Open Popover");
+      await user.click(trigger);
+
+      rerender(
+        <AncestorLayer enabled={false}>
+          <BasicPopover portalled={portalled} />
+        </AncestorLayer>,
+      );
+
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+    });
+  });
+});

--- a/packages/react-headless/popover/src/usePopover.ts
+++ b/packages/react-headless/popover/src/usePopover.ts
@@ -1,12 +1,6 @@
-import {
-  useClick,
-  useDismiss,
-  useInteractions,
-  useRole,
-  useTransitionStatus,
-} from "@floating-ui/react";
+import { useClick, useInteractions, useRole, useTransitionStatus } from "@floating-ui/react";
 import { buttonProps, dataAttr, elementProps } from "@seed-design/dom-utils";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import {
   usePositionedFloating,
   type UsePositionedFloatingProps,
@@ -24,7 +18,7 @@ export interface UsePopoverProps extends UsePositionedFloatingProps {
 
 export type UsePopoverReturn = ReturnType<typeof usePopover>;
 
-export function usePopover({ closeOnInteractOutside, ...props }: UsePopoverProps = {}) {
+export function usePopover({ closeOnInteractOutside = true, ...props }: UsePopoverProps = {}) {
   const {
     open,
     onOpenChange,
@@ -38,15 +32,22 @@ export function usePopover({ closeOnInteractOutside, ...props }: UsePopoverProps
     rects,
   } = usePositionedFloating(props);
 
+  const setOpen = useCallback(
+    (nextOpen: boolean) => {
+      onOpenChange?.(nextOpen);
+    },
+    [onOpenChange],
+  );
+
+  // Deliberately absent: floating-ui's `useDismiss`. Dismissal is the layer stack's job (see
+  // `PopoverDismissibleLayer` in Popover.tsx); running both would close the popover twice and
+  // bind an Escape handler that ignores which layer is on top.
   const role = useRole(context);
   const click = useClick(context);
-  const dismiss = useDismiss(context, {
-    outsidePress: closeOnInteractOutside ?? true,
-  });
 
   const { status } = useTransitionStatus(context);
-  const triggerInteractions = useInteractions([role, click, dismiss]);
-  const anchorInteractions = useInteractions([role, dismiss]);
+  const triggerInteractions = useInteractions([role, click]);
+  const anchorInteractions = useInteractions([role]);
 
   const stateProps = useMemo(
     () =>
@@ -63,6 +64,11 @@ export function usePopover({ closeOnInteractOutside, ...props }: UsePopoverProps
   return useMemo(
     () => ({
       open,
+      setOpen,
+      // Handed back rather than consumed here: the outside-press listener lives on the
+      // positioner's DismissibleLayer, which is the element that decides what "outside" is.
+      closeOnInteractOutside,
+      floatingContext: context,
       refs: {
         anchor: refs.setReference as (instance: HTMLElement | null) => void,
         trigger: refs.setReference as (instance: HTMLElement | null) => void,
@@ -93,13 +99,15 @@ export function usePopover({ closeOnInteractOutside, ...props }: UsePopoverProps
         onClick: (e) => {
           if (e.defaultPrevented) return;
 
-          onOpenChange?.(false);
+          setOpen(false);
         },
       }),
     }),
     [
       open,
-      onOpenChange,
+      setOpen,
+      closeOnInteractOutside,
+      context,
       refs,
       stateProps,
       triggerInteractions,

--- a/packages/react/src/components/HelpBubble/HelpBubble.test.tsx
+++ b/packages/react/src/components/HelpBubble/HelpBubble.test.tsx
@@ -1,0 +1,105 @@
+import { act, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, jest } from "bun:test";
+
+import {
+  DialogContent,
+  DialogPositioner,
+  DialogRoot,
+  type DialogRootProps,
+} from "../Dialog/Dialog";
+import {
+  HelpBubbleBody,
+  HelpBubbleContent,
+  HelpBubblePositionerPortal,
+  HelpBubbleRoot,
+  HelpBubbleTitle,
+  HelpBubbleTrigger,
+} from "./HelpBubble";
+
+// Flush microtasks so Floating UI position state settles.
+// See: https://floating-ui.com/docs/react#testing
+const waitForPositioning = () => act(async () => {});
+
+// The layer stack registers its outside-press listener a tick after the layer mounts, so a
+// press has to wait for that timer before it counts as a dismissal.
+const waitForLayer = () =>
+  act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  });
+
+function DialogWithHelpBubble(props: Omit<DialogRootProps, "children">) {
+  return (
+    <DialogRoot {...props}>
+      <DialogPositioner>
+        <DialogContent aria-label="Dialog">
+          <HelpBubbleRoot>
+            <HelpBubbleTrigger>Help</HelpBubbleTrigger>
+            <HelpBubblePositionerPortal>
+              <HelpBubbleContent>
+                <HelpBubbleBody>
+                  <HelpBubbleTitle>Title</HelpBubbleTitle>
+                </HelpBubbleBody>
+              </HelpBubbleContent>
+            </HelpBubblePositionerPortal>
+          </HelpBubbleRoot>
+        </DialogContent>
+      </DialogPositioner>
+    </DialogRoot>
+  );
+}
+
+describe("HelpBubble in a Dialog", () => {
+  it("closes on Escape without closing the Dialog", async () => {
+    const user = userEvent.setup();
+    const onDialogOpenChange = jest.fn();
+    const { getByText } = render(<DialogWithHelpBubble open onOpenChange={onDialogOpenChange} />);
+    await waitForPositioning();
+
+    const trigger = getByText("Help");
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    await user.keyboard("{Escape}");
+
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(onDialogOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("closes on an outside press without closing the Dialog", async () => {
+    const user = userEvent.setup();
+    const onDialogOpenChange = jest.fn();
+    const { getByText } = render(
+      <>
+        <button type="button">Outside</button>
+        <DialogWithHelpBubble open onOpenChange={onDialogOpenChange} />
+      </>,
+    );
+    await waitForPositioning();
+
+    const trigger = getByText("Help");
+    await user.click(trigger);
+    await waitForLayer();
+
+    await user.click(getByText("Outside"));
+
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(onDialogOpenChange).not.toHaveBeenCalled();
+  });
+
+  // `unmountOnExit={false}` keeps the content mounted after close; unmounting it would take the
+  // HelpBubble down whether or not it joined the layer stack.
+  it("closes along with the Dialog", async () => {
+    const user = userEvent.setup();
+    const { getByText, rerender } = render(<DialogWithHelpBubble open unmountOnExit={false} />);
+    await waitForPositioning();
+
+    const trigger = getByText("Help");
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    rerender(<DialogWithHelpBubble open={false} unmountOnExit={false} />);
+
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - Popover가 Escape 키 또는 외부 영역을 눌렀을 때 올바르게 닫힙니다.
  - 중첩된 Popover에서는 최상위 항목만 닫히며, 상위 레이어가 닫힌 뒤 열린 상태로 남지 않습니다.
  - 외부 영역 닫기를 비활성화한 경우에도 Escape 키로는 닫을 수 있습니다.
  - 터치 환경에서 실수로 누르는 즉시 닫히지 않고, 탭을 완료하거나 손가락을 이동한 뒤 외부 영역 닫기가 처리됩니다.
  - Dialog가 닫히면 내부의 HelpBubble도 함께 정리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->