### PR TITLE
fix(lynx): reload Card for FetchBundle CSS HMR

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1753,6 +1753,7 @@
     },
   },
   "patchedDependencies": {
+    "@lynx-js/css-extract-webpack-plugin@0.10.1": "patches/@lynx-js%2Fcss-extract-webpack-plugin@0.10.1.patch",
     "@figma/rest-api-spec@0.36.0": "patches/@figma%2Frest-api-spec@0.36.0.patch",
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "esbuild": "0.27.4"
   },
   "patchedDependencies": {
-    "@figma/rest-api-spec@0.36.0": "patches/@figma%2Frest-api-spec@0.36.0.patch"
+    "@figma/rest-api-spec@0.36.0": "patches/@figma%2Frest-api-spec@0.36.0.patch",
+    "@lynx-js/css-extract-webpack-plugin@0.10.1": "patches/@lynx-js%2Fcss-extract-webpack-plugin@0.10.1.patch"
   }
 }

--- a/patches/@lynx-js%2Fcss-extract-webpack-plugin@0.10.1.patch
+++ b/patches/@lynx-js%2Fcss-extract-webpack-plugin@0.10.1.patch
@@ -1,0 +1,53 @@
+diff --git a/runtime/hotModuleReplacement.cjs b/runtime/hotModuleReplacement.cjs
+index a061e44843cd83b64bab589838e8d6ed2ce7c02d..05e8ea8dc4c71efe1a9f8ec17955f0e73b819591 100644
+--- a/runtime/hotModuleReplacement.cjs
++++ b/runtime/hotModuleReplacement.cjs
+@@ -16,13 +16,38 @@ function debounce(fn, time) {
+   };
+ }
+ 
++let reloadPending = false;
++
+ function updateStyle(cssId = 0) {
++  if (reloadPending) {
++    return;
++  }
++
+   const cssHotUpdateList = __webpack_require__.cssHotUpdateList;
+   if (!cssHotUpdateList) {
+     throw new Error('cssHotUpdateList is not found');
+   }
+ 
+-  for (const [chunkName, cssHotUpdatePath] of cssHotUpdateList) {
++  const chunkEntries = lynx.__chunk_entries__ || {};
++  const loadedUpdates = cssHotUpdateList.filter(
++    ([chunkName]) => typeof chunkEntries[chunkName] === 'string',
++  );
++
++  // FetchBundle adopts stylesheets without registering a TemplateEntry.
++  // The native CSS replacement API only supports TemplateEntry stylesheets.
++  // Reload before dispatching any updates, once across all CSS module timers.
++  if (
++    typeof __LAZY_BUNDLE_FETCHER__ !== 'undefined'
++    && __LAZY_BUNDLE_FETCHER__ === 'FetchBundle'
++    && loadedUpdates.some(([chunkName]) => chunkEntries[chunkName] !== '__Card__')
++  ) {
++    reloadPending = true;
++    console.info('[HMR] Reloading for FetchBundle CSS update.');
++    require('@lynx-js/webpack-dev-transport/reloadApp').reloadPage();
++    return;
++  }
++
++  for (const [chunkName, cssHotUpdatePath] of loadedUpdates) {
+     lynx.requireModuleAsync(
+       // lynx.requireModuleAsync has two level hash and we cannot delete
+       // the LynxGroup level cache here.
+@@ -42,7 +67,7 @@ function updateStyle(cssId = 0) {
+               cssId,
+               content: ret.content,
+               deps: ret.deps,
+-              entry: lynx.__chunk_entries__[chunkName],
++              entry: chunkEntries[chunkName],
+             },
+           });
+         }

--- a/patches/lynx-css-hmr.md
+++ b/patches/lynx-css-hmr.md
@@ -1,0 +1,21 @@
+# FetchBundle CSS HMR 임시 패치
+
+대상은 `@lynx-js/css-extract-webpack-plugin@0.10.1`이다.
+루트 `package.json`과 `bun.lock`의 `patchedDependencies`로 등록하며,
+이 워크트리에서 `bun install`할 때 적용된다.
+
+FetchBundle은 lazy bundle의 스타일시트를 adopt하지만 `TemplateEntry`는 등록하지 않는다.
+현재 PlayLynx의 CSS 교체 API는 `TemplateEntry`를 요구하므로 lazy bundle의 URL을
+전달하면 네이티브 크래시가 발생할 수 있다. 이 패치는 다음과 같이 처리한다.
+
+- 갱신 대상에 로드된 FetchBundle lazy bundle이 있으면 기존 DevTool의 `Page.reload`를 한 번 호출한다.
+- 아직 로드하지 않은 chunk는 갱신하지 않는다.
+- 메인 entry만 갱신하거나 QueryComponent를 사용하는 경우에는 기존 CSS HMR을 유지한다.
+
+Card reload 시 화면의 런타임 상태는 초기화된다. 네이티브 DevTool의 reload API가
+없거나 실패하면 기존 오류 로그를 확인하고 수동으로 reload해야 한다.
+`REACT_LAZY_BUNDLE_FETCHER=QueryComponent` 우회 설정은 필요하지 않다.
+이미 실행 중인 Rspeedy는 패치 적용 후 재시작하고 Card도 다시 열어야 한다.
+
+회귀 검사는 `bun test scripts/lynx-css-hmr.test.ts`로 실행한다.
+업스트림에서 FetchBundle의 CSS HMR을 지원하면 이 패치와 회귀 검사를 재검토한다.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 개발 중 CSS 변경 사항이 이미 로드된 청크에만 적용되도록 개선했습니다.
  - FetchBundle 환경에서 CSS 변경 시 중복 요청과 반복 새로고침을 방지하고 앱을 한 번만 다시 불러옵니다.
  - 메인 엔트리 및 기존 QueryComponent 사용 시 기존 CSS HMR 동작을 유지합니다.

- **문서**
  - CSS HMR 패치의 적용 범위와 개발 중 새로고침 동작을 안내합니다.
  - 패치 적용 후 필요한 재시작 및 화면 재진입 절차를 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->