### PR TITLE
fix(floating): align safe-area positioning with Menu

### DIFF
--- a/.changeset/soft-insets-align.md
+++ b/.changeset/soft-insets-align.md
@@ -1,0 +1,7 @@
+---
+"@seed-design/react-floating": patch
+"@seed-design/react-navigation-menu": patch
+"@seed-design/react": patch
+---
+
+NavigationMenu·HelpBubble·Tooltip이 기기의 상하 safe-area를 침범하지 않도록 배치 계산을 수정합니다.

--- a/examples/stackflow-spa/e2e/fixtures/safe-area.html
+++ b/examples/stackflow-spa/e2e/fixtures/safe-area.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Floating safe area</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./safe-area.tsx"></script>
+  </body>
+</html>

--- a/examples/stackflow-spa/e2e/fixtures/safe-area.tsx
+++ b/examples/stackflow-spa/e2e/fixtures/safe-area.tsx
@@ -1,0 +1,72 @@
+import React, { type CSSProperties } from "react";
+import { createRoot } from "react-dom/client";
+import { usePositionedFloating } from "../../../../packages/react-headless/floating/src";
+import { Menu } from "../../../../packages/react-headless/menu/src";
+import { NavigationMenu } from "../../../../packages/react-headless/navigation-menu/src";
+
+const params = new URLSearchParams(location.search);
+const scenario = params.get("scenario");
+const placement = scenario === "shift" ? "right" : scenario === "size" ? "bottom" : "top";
+const triggerStyle = {
+  position: "fixed",
+  left: 300,
+  top: scenario === "shift" ? 0 : 160,
+  width: 80,
+  height: 24,
+} satisfies CSSProperties;
+const contentStyle = {
+  width: 180,
+  height: scenario === "size" ? 1000 : 100,
+  maxHeight: "var(--seed-menu-available-height)",
+  overflow: "auto",
+  background: "lightblue",
+} satisfies CSSProperties;
+
+function Floating() {
+  const floating = usePositionedFloating({ open: true, placement, overflowPadding: 16, gutter: 8 });
+
+  return (
+    <>
+      <button ref={floating.refs.setReference} style={triggerStyle}>
+        Trigger
+      </button>
+      <div ref={floating.refs.setFloating} data-testid="positioner" style={floating.floatingStyles}>
+        <div style={contentStyle}>Content</div>
+      </div>
+    </>
+  );
+}
+
+function Fixture() {
+  if (params.get("kind") === "floating") return <Floating />;
+
+  if (params.get("kind") === "menu")
+    return (
+      <Menu.Root open placement={placement} overflowPadding={16} gutter={8}>
+        <Menu.Trigger style={triggerStyle}>Trigger</Menu.Trigger>
+        <Menu.Positioner data-testid="positioner">
+          <Menu.Content style={contentStyle}>
+            <Menu.Item>Content</Menu.Item>
+          </Menu.Content>
+        </Menu.Positioner>
+      </Menu.Root>
+    );
+
+  return (
+    <NavigationMenu.Provider value="item">
+      <NavigationMenu.Root value="item" placement={placement} overflowPadding={16} gutter={8}>
+        <NavigationMenu.Trigger style={triggerStyle}>Trigger</NavigationMenu.Trigger>
+        <NavigationMenu.Positioner data-testid="positioner">
+          <NavigationMenu.Content style={contentStyle}>
+            <NavigationMenu.Item>Content</NavigationMenu.Item>
+          </NavigationMenu.Content>
+        </NavigationMenu.Positioner>
+      </NavigationMenu.Root>
+    </NavigationMenu.Provider>
+  );
+}
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Missing fixture root");
+
+createRoot(root).render(<Fixture />);

--- a/examples/stackflow-spa/e2e/floating-safe-area.e2e.ts
+++ b/examples/stackflow-spa/e2e/floating-safe-area.e2e.ts
@@ -1,0 +1,51 @@
+import { expect, test, type Page } from "@playwright/test";
+
+test.use({ viewport: { width: 800, height: 800 } });
+
+async function setInsets(page: Page, top: number, bottom: number) {
+  await page.getByTestId("positioner").evaluate(
+    (element, insets) => {
+      element.style.setProperty("--seed-safe-area-top", `${insets.top}px`);
+      element.style.setProperty("--seed-safe-area-bottom", `${insets.bottom}px`);
+      window.dispatchEvent(new Event("resize"));
+    },
+    { top, bottom },
+  );
+}
+
+async function bounds(page: Page) {
+  return page.getByTestId("positioner").evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return { top: rect.top, bottom: rect.bottom, height: rect.height };
+  });
+}
+
+for (const kind of ["menu", "navigation-menu", "floating"]) {
+  test(`${kind}: shift follows safe area and restores overflowPadding after resize`, async ({
+    page,
+  }) => {
+    await page.goto(`/e2e/fixtures/safe-area.html?kind=${kind}&scenario=shift`);
+    await expect.poll(async () => (await bounds(page)).top).toBe(16);
+    await setInsets(page, 80, 96);
+    await expect.poll(async () => (await bounds(page)).top).toBe(80);
+    await setInsets(page, 0, 0);
+    await expect.poll(async () => (await bounds(page)).top).toBe(16);
+  });
+
+  test(`${kind}: flips when the safe area leaves insufficient space above`, async ({ page }) => {
+    await page.goto(`/e2e/fixtures/safe-area.html?kind=${kind}&scenario=flip`);
+    await expect.poll(async () => (await bounds(page)).bottom).toBeLessThanOrEqual(160);
+    await setInsets(page, 80, 96);
+    await expect.poll(async () => (await bounds(page)).top).toBeGreaterThanOrEqual(184);
+  });
+}
+
+for (const kind of ["menu", "navigation-menu"]) {
+  test(`${kind}: available height excludes the bottom safe area`, async ({ page }) => {
+    await page.goto(`/e2e/fixtures/safe-area.html?kind=${kind}&scenario=size`);
+    await expect.poll(async () => (await bounds(page)).bottom).toBe(784);
+    await setInsets(page, 80, 96);
+    await expect.poll(async () => (await bounds(page)).bottom).toBe(704);
+    await expect.poll(async () => (await bounds(page)).height).toBe(512);
+  });
+}

--- a/packages/react-headless/floating/src/index.ts
+++ b/packages/react-headless/floating/src/index.ts
@@ -2,7 +2,6 @@ import {
   arrow,
   autoUpdate,
   flip,
-  limitShift,
   offset,
   shift,
   size,
@@ -11,6 +10,7 @@ import {
   type ExtendedRefs,
   type FloatingContext,
   type Middleware,
+  type Padding,
   type Placement,
   type Rect,
   type ReferenceType,
@@ -65,6 +65,11 @@ const defaultPositioningOptions: PositioningOptions = {
   arrowPadding: 4,
 };
 
+const SAFE_AREA_STYLE = {
+  "--seed-safe-area-top": "env(safe-area-inset-top)",
+  "--seed-safe-area-bottom": "env(safe-area-inset-bottom)",
+} as CSSProperties;
+
 function getArrowMiddleware(arrowElement: HTMLElement | null, opts: PositioningOptions) {
   if (!arrowElement) return;
   return arrow({ element: arrowElement, padding: opts.arrowPadding });
@@ -75,26 +80,25 @@ function getOffsetMiddleware(arrowOffset: number, opts: PositioningOptions) {
   return offset(offsetMainAxis);
 }
 
-function getFlipMiddleware(opts: PositioningOptions) {
+function getFlipMiddleware(opts: PositioningOptions, collisionPadding: Padding) {
   if (!opts.flip) return;
   return flip({
-    padding: opts.overflowPadding,
+    padding: collisionPadding,
     fallbackPlacements: opts.flip === true ? undefined : opts.flip,
   });
 }
 
-function getShiftMiddleware(opts: PositioningOptions) {
+function getShiftMiddleware(opts: PositioningOptions, collisionPadding: Padding) {
   if (!opts.slide) return;
   return shift({
     mainAxis: opts.slide,
-    padding: opts.overflowPadding,
-    limiter: limitShift(),
+    padding: collisionPadding,
   });
 }
 
-function getSizeMiddleware(opts: PositioningOptions) {
+function getSizeMiddleware(collisionPadding: Padding) {
   return size({
-    padding: opts.overflowPadding,
+    padding: collisionPadding,
     apply({ availableWidth, elements }) {
       elements.floating.style.setProperty(
         "--seed-popover-available-width",
@@ -162,6 +166,7 @@ export function usePositionedFloating<RT extends ReferenceType = ReferenceType>(
   props: UsePositionedFloatingProps,
 ): UsePositionedFloatingReturn<RT> {
   const options = { ...defaultPositioningOptions, ...props };
+  const { overflowPadding = 8 } = options;
 
   const [open, onOpenChange] = useControllableState({
     prop: props.open,
@@ -170,6 +175,14 @@ export function usePositionedFloating<RT extends ReferenceType = ReferenceType>(
   });
   const [arrowEl, setArrowEl] = useState<HTMLElement | null>(null);
   const [arrowTipEl, setArrowTipEl] = useState<HTMLElement | null>(null);
+  const [safeArea, setSafeArea] = useState({ top: 0, bottom: 0 });
+
+  const collisionPadding = {
+    top: safeArea.top || overflowPadding,
+    right: overflowPadding,
+    bottom: safeArea.bottom || overflowPadding,
+    left: overflowPadding,
+  };
 
   const arrowTipWidth = arrowTipEl?.clientWidth ?? 0;
   const arrowTipHeight = arrowTipEl?.clientHeight ?? 0;
@@ -182,9 +195,9 @@ export function usePositionedFloating<RT extends ReferenceType = ReferenceType>(
     onOpenChange: onOpenChange,
     middleware: [
       getOffsetMiddleware(arrowTipOffset, options),
-      getFlipMiddleware(options),
-      getShiftMiddleware(options),
-      getSizeMiddleware(options),
+      getFlipMiddleware(options, collisionPadding),
+      getShiftMiddleware(options, collisionPadding),
+      getSizeMiddleware(collisionPadding),
       getArrowMiddleware(arrowEl, options),
       rectMiddleware,
     ],
@@ -198,6 +211,31 @@ export function usePositionedFloating<RT extends ReferenceType = ReferenceType>(
 
     return autoUpdate(refs.reference.current, refs.floating.current, context.update);
   }, [open, refs.reference, refs.floating, context]);
+
+  const floatingElement = context.elements.floating;
+
+  useEffect(() => {
+    if (!floatingElement) return;
+
+    const element = floatingElement;
+    function read() {
+      const styles = getComputedStyle(element);
+      setSafeArea({
+        top: Number.parseInt(styles.getPropertyValue("--seed-safe-area-top"), 10) || 0,
+        bottom: Number.parseInt(styles.getPropertyValue("--seed-safe-area-bottom"), 10) || 0,
+      });
+    }
+
+    read();
+    window.addEventListener("resize", read);
+
+    return () => window.removeEventListener("resize", read);
+  }, [floatingElement]);
+
+  const resolvedFloatingStyles = useMemo(
+    () => ({ ...SAFE_AREA_STYLE, ...floatingStyles }),
+    [floatingStyles],
+  );
 
   const [side, alignment] = context.placement.split("-") as [Side, Alignment | undefined];
 
@@ -235,7 +273,7 @@ export function usePositionedFloating<RT extends ReferenceType = ReferenceType>(
       side,
       alignment,
       context,
-      floatingStyles,
+      floatingStyles: resolvedFloatingStyles,
       arrowStyles,
     }),
     [
@@ -248,7 +286,7 @@ export function usePositionedFloating<RT extends ReferenceType = ReferenceType>(
       context,
       side,
       alignment,
-      floatingStyles,
+      resolvedFloatingStyles,
       arrowStyles,
       isPositioned,
       arrowTipWidth,

--- a/packages/react-headless/navigation-menu/src/useNavigationMenu.ts
+++ b/packages/react-headless/navigation-menu/src/useNavigationMenu.ts
@@ -23,6 +23,11 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react"
 
 const MIN_HEIGHT = 200;
 
+const SAFE_AREA_STYLE = {
+  "--seed-safe-area-top": "env(safe-area-inset-top)",
+  "--seed-safe-area-bottom": "env(safe-area-inset-bottom)",
+} as React.CSSProperties;
+
 /** Default open delay (ms) for the `NavigationMenuProvider` delay group. */
 export const DEFAULT_OPEN_DELAY = 200;
 /** Default close delay (ms) for the `NavigationMenuProvider` delay group. */
@@ -158,6 +163,14 @@ export function useNavigationMenuRoot(
   } = root;
 
   const open = openValue === itemValue;
+  const [safeArea, setSafeArea] = useState({ top: 0, bottom: 0 });
+
+  const collisionPadding = {
+    top: safeArea.top || overflowPadding,
+    right: overflowPadding,
+    bottom: safeArea.bottom || overflowPadding,
+    left: overflowPadding,
+  };
 
   // Whether the flyout should manage focus (move it into the content, keep Tab
   // order coherent across the portal, and return focus to the trigger on close).
@@ -206,7 +219,7 @@ export function useNavigationMenuRoot(
     middleware: [
       offset(gutter),
       size({
-        padding: overflowPadding,
+        padding: collisionPadding,
         apply({ availableHeight, elements }) {
           elements.floating.style.setProperty(
             "--seed-menu-available-height",
@@ -214,13 +227,32 @@ export function useNavigationMenuRoot(
           );
         },
       }),
-      flip({ padding: overflowPadding, fallbackStrategy: "initialPlacement" }),
-      shift({ padding: overflowPadding }),
+      flip({ padding: collisionPadding, fallbackStrategy: "initialPlacement" }),
+      shift({ padding: collisionPadding }),
     ],
   });
 
   const { status } = useTransitionStatus(context);
   const mounted = status !== "unmounted";
+  const floatingElement = context.elements.floating;
+
+  useEffect(() => {
+    if (!floatingElement) return;
+
+    const element = floatingElement;
+    function read() {
+      const styles = getComputedStyle(element);
+      setSafeArea({
+        top: Number.parseInt(styles.getPropertyValue("--seed-safe-area-top"), 10) || 0,
+        bottom: Number.parseInt(styles.getPropertyValue("--seed-safe-area-bottom"), 10) || 0,
+      });
+    }
+
+    read();
+    window.addEventListener("resize", read);
+
+    return () => window.removeEventListener("resize", read);
+  }, [floatingElement]);
 
   // Participate in the delay group provided by `NavigationMenuRoot` (a floating-ui
   // `NextFloatingDelayGroup`, shared with `HelpBubbleTooltip`): once any grouped
@@ -307,7 +339,10 @@ export function useNavigationMenuRoot(
 
     positionerProps: elementProps({
       ...stateProps,
-      style: floatingStyles,
+      style: {
+        ...SAFE_AREA_STYLE,
+        ...floatingStyles,
+      },
     }),
 
     contentProps: elementProps({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * NavigationMenu, HelpBubble, Tooltip 등 플로팅 요소가 기기의 상·하단 안전 영역을 침범하지 않도록 위치와 크기 계산을 개선했습니다.
  * 화면 크기나 안전 영역이 변경될 때 요소 위치가 자동으로 조정됩니다.
  * 상단 공간이 부족한 경우 요소가 반대 방향으로 배치되며, 하단 안전 영역을 고려해 사용 가능한 높이를 계산합니다.

* **테스트**
  * 다양한 안전 영역 및 화면 크기 조건에 대한 자동화 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->